### PR TITLE
Relooper opts

### DIFF
--- a/scripts/fuzz_relooper.py
+++ b/scripts/fuzz_relooper.py
@@ -308,7 +308,7 @@ int main() {
   print '^'
   subprocess.check_call(['./fuzz'], stdout=open('fuzz.wast', 'w'))
   print '*'
-  fast_out = subprocess.Popen(['bin/binaryen-shell', 'fuzz.wast'],
+  fast_out = subprocess.Popen(['bin/wasm-shell', 'fuzz.wast'],
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE).communicate()[0]
   print '-'

--- a/src/cfg/Relooper.cpp
+++ b/src/cfg/Relooper.cpp
@@ -568,7 +568,7 @@ void Relooper::Calculate(Block *Entry) {
         Solipsize(*iter, Branch::Break, Loop, InnerBlocks);
       }
       // Finish up
-      Shape *Inner = Process(InnerBlocks, Entries, nullptr);
+      Shape *Inner = Process(InnerBlocks, Entries);
       Loop->Inner = Inner;
       return Loop;
     }
@@ -723,7 +723,7 @@ void Relooper::Calculate(Block *Entry) {
             iter = Next; // increment carefully because Solipsize can remove us
           }
         }
-        Multiple->InnerMap[CurrEntry->Id] = Process(CurrBlocks, CurrEntries, nullptr);
+        Multiple->InnerMap[CurrEntry->Id] = Process(CurrBlocks, CurrEntries);
         // If we are not fused, then our entries will actually be checked
         if (!Fused) {
           CurrEntry->IsCheckedMultipleEntry = true;
@@ -745,13 +745,14 @@ void Relooper::Calculate(Block *Entry) {
     // The Make* functions receive a NextEntries. If they fill it with data, those are the entries for the
     //   ->Next block on them, and the blocks are what remains in Blocks (which Make* modify). In this way
     //   we avoid recursing on Next (imagine a long chain of Simples, if we recursed we could blow the stack).
-    Shape *Process(BlockSet &Blocks, BlockSet& InitialEntries, Shape *Prev) {
+    Shape *Process(BlockSet &Blocks, BlockSet& InitialEntries) {
       PrintDebug("Process() called\n", 0);
       BlockSet *Entries = &InitialEntries;
       BlockSet TempEntries[2];
       int CurrTempIndex = 0;
       BlockSet *NextEntries;
       Shape *Ret = nullptr;
+      Shape *Prev = nullptr;
       #define Make(call) \
         Shape *Temp = call; \
         if (Prev) Prev->Next = Temp; \
@@ -876,7 +877,7 @@ void Relooper::Calculate(Block *Entry) {
 
   BlockSet Entries;
   Entries.insert(Entry);
-  Root = Analyzer(this).Process(AllBlocks, Entries, nullptr);
+  Root = Analyzer(this).Process(AllBlocks, Entries);
   assert(Root);
 }
 

--- a/src/cfg/Relooper.cpp
+++ b/src/cfg/Relooper.cpp
@@ -693,9 +693,8 @@ void Relooper::Calculate(Block *Entry) {
 #endif
     }
 
-    Shape *MakeMultiple(BlockSet &Blocks, BlockSet& Entries, BlockBlockSetMap& IndependentGroups, Shape *Prev, BlockSet &NextEntries) {
+    Shape *MakeMultiple(BlockSet &Blocks, BlockSet& Entries, BlockBlockSetMap& IndependentGroups, BlockSet &NextEntries, bool IsCheckedMultiple) {
       PrintDebug("creating multiple block with %d inner groups\n", IndependentGroups.size());
-      bool Fused = !!(Shape::IsSimple(Prev));
       MultipleShape *Multiple = new MultipleShape();
       Notice(Multiple);
       BlockSet CurrEntries;
@@ -724,8 +723,7 @@ void Relooper::Calculate(Block *Entry) {
           }
         }
         Multiple->InnerMap[CurrEntry->Id] = Process(CurrBlocks, CurrEntries);
-        // If we are not fused, then our entries will actually be checked
-        if (!Fused) {
+        if (IsCheckedMultiple) {
           CurrEntry->IsCheckedMultipleEntry = true;
         }
       }
@@ -855,7 +853,8 @@ void Relooper::Calculate(Block *Entry) {
 
           if (IndependentGroups.size() > 0) {
             // Some groups removable ==> Multiple
-            Make(MakeMultiple(Blocks, *Entries, IndependentGroups, Prev, *NextEntries));
+            //                                                                   checked multiple if prev is not simple (in which case we would be fused)
+            Make(MakeMultiple(Blocks, *Entries, IndependentGroups, *NextEntries, !(Shape::IsSimple(Prev))));
           }
         }
         // No independent groups, must be loopable ==> Loop

--- a/src/cfg/Relooper.h
+++ b/src/cfg/Relooper.h
@@ -53,17 +53,21 @@ public:
   wasm::Binary* makeCheckLabel(wasm::Index value) {
     return makeBinary(wasm::EqInt32, makeGetLabel(), makeConst(wasm::Literal(int32_t(value))));
   }
-  wasm::Break* makeShapeBreak(int id) {
-    return wasm::Builder::makeBreak(getBreakName(id));
+
+  // breaks are on blocks, as they can be specific, we make one wasm block per basic block
+  wasm::Break* makeBlockBreak(int id) {
+    return wasm::Builder::makeBreak(getBlockBreakName(id));
   }
+  // continues are on shapes, as there is one per loop, and if we have more than one
+  // going there, it is irreducible control flow anyhow
   wasm::Break* makeShapeContinue(int id) {
-    return wasm::Builder::makeBreak(getContinueName(id));
+    return wasm::Builder::makeBreak(getShapeContinueName(id));
   }
 
-  wasm::Name getBreakName(int id) {
-    return wasm::Name(std::string("shape$") + std::to_string(id) + "$break");
+  wasm::Name getBlockBreakName(int id) {
+    return wasm::Name(std::string("block$") + std::to_string(id) + "$break");
   }
-  wasm::Name getContinueName(int id) {
+  wasm::Name getShapeContinueName(int id) {
     return wasm::Name(std::string("shape$") + std::to_string(id) + "$continue");
   }
 };
@@ -76,9 +80,7 @@ struct Branch {
   enum FlowType {
     Direct = 0,   // We will directly reach the right location through other means, no need for continue or break
     Break = 1,
-    Continue = 2,
-    Nested = 3    // This code is directly reached, but we must be careful to ensure it is nested in an if - it is not reached
-                  // unconditionally, other code paths exist alongside it that we need to make sure do not intertwine
+    Continue = 2
   };
   Shape *Ancestor; // If not NULL, this shape is the relevant one for purposes of getting to the target block. We break or continue on it
   Branch::FlowType Type; // If Ancestor is not NULL, this says whether to break or continue
@@ -144,12 +146,14 @@ struct InsertOrderedSet
 
   InsertOrderedSet() {}
   InsertOrderedSet(const InsertOrderedSet& other) {
+    *this = other;
+  }
+  InsertOrderedSet& operator=(const InsertOrderedSet& other) {
+    clear();
     for (auto i : other.List) {
       insert(i); // inserting manually creates proper iterators
     }
-  }
-  InsertOrderedSet& operator=(const InsertOrderedSet& other) {
-    abort(); // TODO, watch out for iterators
+    return *this;
   }
 };
 
@@ -241,15 +245,20 @@ struct Block {
 
 // Represents a structured control flow shape, one of
 //
-//  Simple: No control flow at all, just instructions. If several
-//          blocks, then 
+//  Simple: No control flow at all, just instructions in a single
+//          basic block.
 //
-//  Multiple: A shape with more than one entry. If the next block to
-//            be entered is among them, we run it and continue to
-//            the next shape, otherwise we continue immediately to the
-//            next shape.
+//  Multiple: A shape with at least one entry. We may visit one of
+//            the entries, or none, before continuing to the next
+//            shape after this.
 //
-//  Loop: An infinite loop.
+//  Loop: An infinite loop. We assume the property that a loop
+//        will always visit one of its entries, and so for example
+//        we cannot have a loop containing a multiple and nothing
+//        else (since we might not visit any of the multiple's
+//        blocks). Multiple entries are possible for the block,
+//        however, which is necessary for irreducible control
+//        flow, of course.
 //
 
 struct SimpleShape;
@@ -285,7 +294,6 @@ struct SimpleShape : public Shape {
   wasm::Expression* Render(RelooperBuilder& Builder, bool InLoop) override;
 };
 
-// Blocks with the same id were split and are identical, so we just care about ids in Multiple entries
 typedef std::map<int, Shape*> IdShapeMap;
 
 struct MultipleShape : public Shape {
@@ -298,6 +306,8 @@ struct MultipleShape : public Shape {
 
 struct LoopShape : public Shape {
   Shape *Inner;
+
+  BlockSet Entries; // we must visit at least one of these
 
   LoopShape() : Shape(Loop), Inner(NULL) {}
   wasm::Expression* Render(RelooperBuilder& Builder, bool InLoop) override;

--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -15,7 +15,8 @@
  */
 
 //
-// Removes names from locations that are never branched to.
+// Removes names from locations that are never branched to, and
+// merge names when possible (by merging their blocks)
 //
 
 #include <wasm.h>
@@ -30,17 +31,17 @@ struct RemoveUnusedNames : public WalkerPass<PostWalker<RemoveUnusedNames, Visit
 
   // We maintain a list of branches that we saw in children, then when we reach
   // a parent block, we know if it was branched to
-  std::set<Name> branchesSeen;
+  std::map<Name, std::set<Expression*>> branchesSeen;
 
   void visitBreak(Break *curr) {
-    branchesSeen.insert(curr->name);
+    branchesSeen[curr->name].insert(curr);
   }
 
   void visitSwitch(Switch *curr) {
     for (auto name : curr->targets) {
-      branchesSeen.insert(name);
+      branchesSeen[name].insert(curr);
     }
-    branchesSeen.insert(curr->default_);
+    branchesSeen[curr->default_].insert(curr);
   }
 
   void handleBreakTarget(Name& name) {
@@ -54,7 +55,35 @@ struct RemoveUnusedNames : public WalkerPass<PostWalker<RemoveUnusedNames, Visit
   }
 
   void visitBlock(Block *curr) {
+    if (curr->name.is() && curr->list.size() == 1) {
+      auto* child = curr->list[0]->dynCast<Block>();
+      if (child && child->name.is()) {
+        // we have just one child, this block, so breaking out of it goes to the same place as breaking out of us, we just need one name (and block)
+        auto& branches = branchesSeen[curr->name];
+        for (auto* branch : branches) {
+          if (Break* br = branch->dynCast<Break>()) {
+            if (br->name == curr->name) br->name = child->name;
+          } else if (Switch* sw = branch->dynCast<Switch>()) {
+            for (auto& target : sw->targets) {
+              if (target == curr->name) target = child->name;
+            }
+            if (sw->default_ == curr->name) sw->default_ = child->name;
+          } else {
+            WASM_UNREACHABLE();
+          }
+        }
+        replaceCurrent(child);
+      }
+    }
     handleBreakTarget(curr->name);
+    if (curr->name.is() && curr->list.size() == 1) {
+      auto* child = curr->list[0]->dynCast<Loop>();
+      if (child && !child->out.is()) {
+        // we have just one child, this loop, and it lacks an out label. So this block's name is doing just that!
+        child->out = curr->name;
+        replaceCurrent(child);
+      }
+    }
   }
 
   void visitLoop(Loop *curr) {
@@ -67,6 +96,14 @@ struct RemoveUnusedNames : public WalkerPass<PostWalker<RemoveUnusedNames, Visit
       block->name = out;
       block->list.push_back(curr->body);
       replaceCurrent(block);
+    }
+    if (curr->in.is() && !curr->out.is()) {
+      auto* child = curr->body->dynCast<Block>();
+      if (child && child->name.is()) {
+        // we have just one child, this block, and we lack an out label. So we can take the block's!
+        curr->out = child->name;
+        child->name = Name();
+      }
     }
   }
 

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -312,7 +312,12 @@ public:
 
   void doWalkFunction(Function* func) {
     PostWalker<WasmValidator, Visitor<WasmValidator>>::doWalkFunction(func);
-    shouldBeTrue(breakTypes.size() == 0, "break targets", "all break targets must be valid");
+    if (!shouldBeTrue(breakTypes.size() == 0, "break targets", "all break targets must be valid")) {
+      for (auto& target : breakTypes) {
+        std::cerr << " - " << target.first << '\n';
+      }
+      breakTypes.clear();
+    }
   }
 
 private:

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -5237,7 +5237,7 @@
                   (i32.const 24)
                 )
               )
-              (loop $do-out$73 $do-in$74
+              (loop $do-in$74
                 (i32.store
                   (set_local $3
                     (i32.add
@@ -5777,7 +5777,7 @@
               (set_local $2
                 (i32.const 0)
               )
-              (loop $do-out$77 $do-in$78
+              (loop $do-in$78
                 (i32.store offset=12
                   (set_local $1
                     (i32.add

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -5236,7 +5236,7 @@
                   (i32.const 24)
                 )
               )
-              (loop $do-out$73 $do-in$74
+              (loop $do-in$74
                 (i32.store
                   (set_local $3
                     (i32.add
@@ -5776,7 +5776,7 @@
               (set_local $2
                 (i32.const 0)
               )
-              (loop $do-out$77 $do-in$78
+              (loop $do-in$78
                 (i32.store offset=12
                   (set_local $1
                     (i32.add

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -323,80 +323,78 @@
     )
     (block $switch$0
       (block $switch-default$3
-        (block $switch-default$3
-          (block $switch-case$2
-            (block $switch-case$1
-              (br_table $switch-case$1 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-case$2 $switch-default$3
-                (i32.sub
-                  (set_local $2
-                    (i32.and
-                      (get_local $2)
-                      (i32.const 2047)
-                    )
-                  )
-                  (i32.const 0)
-                )
-              )
-            )
-            (i32.store
-              (get_local $1)
-              (if
-                (f64.ne
-                  (get_local $0)
-                  (f64.const 0)
-                )
-                (block
-                  (set_local $0
-                    (call $_frexp
-                      (f64.mul
-                        (get_local $0)
-                        (f64.const 18446744073709551615)
-                      )
-                      (get_local $1)
-                    )
-                  )
-                  (i32.add
-                    (i32.load
-                      (get_local $1)
-                    )
-                    (i32.const -64)
+        (block $switch-case$2
+          (block $switch-case$1
+            (br_table $switch-case$1 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-case$2 $switch-default$3
+              (i32.sub
+                (set_local $2
+                  (i32.and
+                    (get_local $2)
+                    (i32.const 2047)
                   )
                 )
                 (i32.const 0)
               )
             )
-            (br $switch$0
-              (get_local $0)
+          )
+          (i32.store
+            (get_local $1)
+            (if
+              (f64.ne
+                (get_local $0)
+                (f64.const 0)
+              )
+              (block
+                (set_local $0
+                  (call $_frexp
+                    (f64.mul
+                      (get_local $0)
+                      (f64.const 18446744073709551615)
+                    )
+                    (get_local $1)
+                  )
+                )
+                (i32.add
+                  (i32.load
+                    (get_local $1)
+                  )
+                  (i32.const -64)
+                )
+              )
+              (i32.const 0)
             )
           )
           (br $switch$0
             (get_local $0)
           )
         )
-        (i32.store
-          (get_local $1)
-          (i32.add
-            (get_local $2)
-            (i32.const -1022)
-          )
+        (br $switch$0
+          (get_local $0)
         )
-        (i32.store
-          (i32.load
-            (i32.const 24)
-          )
-          (get_local $3)
+      )
+      (i32.store
+        (get_local $1)
+        (i32.add
+          (get_local $2)
+          (i32.const -1022)
         )
-        (i32.store offset=4
-          (i32.load
-            (i32.const 24)
+      )
+      (i32.store
+        (i32.load
+          (i32.const 24)
+        )
+        (get_local $3)
+      )
+      (i32.store offset=4
+        (i32.load
+          (i32.const 24)
+        )
+        (i32.or
+          (i32.and
+            (get_local $4)
+            (i32.const -2146435073)
           )
-          (i32.or
-            (i32.and
-              (get_local $4)
-              (i32.const -2146435073)
-            )
-            (i32.const 1071644672)
-          )
+          (i32.const 1071644672)
         )
       )
       (f64.load
@@ -1494,7 +1492,7 @@
         (i32.const 40)
       )
     )
-    (loop $do-out$0 $do-in$1
+    (loop $do-in$1
       (i32.store
         (get_local $4)
         (i32.const 0)
@@ -3208,41 +3206,39 @@
       )
       (loop $label$break$L9 $label$continue$L9
         (block $switch-default$5
-          (block $switch-default$5
-            (block $switch-case$4
-              (block $switch-case$3
-                (br_table $switch-case$4 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-case$3 $switch-default$5
-                  (i32.sub
-                    (i32.shr_s
-                      (i32.shl
-                        (get_local $1)
-                        (i32.const 24)
-                      )
+          (block $switch-case$4
+            (block $switch-case$3
+              (br_table $switch-case$4 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-case$3 $switch-default$5
+                (i32.sub
+                  (i32.shr_s
+                    (i32.shl
+                      (get_local $1)
                       (i32.const 24)
                     )
-                    (i32.const 0)
+                    (i32.const 24)
                   )
+                  (i32.const 0)
                 )
               )
-              (set_local $54
-                (get_local $5)
-              )
-              (set_local $65
-                (get_local $5)
-              )
-              (set_local $12
-                (i32.const 9)
-              )
-              (br $label$break$L9)
             )
-            (set_local $41
+            (set_local $54
               (get_local $5)
             )
-            (set_local $55
+            (set_local $65
               (get_local $5)
+            )
+            (set_local $12
+              (i32.const 9)
             )
             (br $label$break$L9)
           )
+          (set_local $41
+            (get_local $5)
+          )
+          (set_local $55
+            (get_local $5)
+          )
+          (br $label$break$L9)
         )
         (set_local $1
           (i32.load8_s
@@ -3938,7 +3934,7 @@
                       )
                     )
                   )
-                  (loop $while-out$17 $while-in$18
+                  (loop $while-in$18
                     (set_local $5
                       (i32.add
                         (i32.mul
@@ -4396,114 +4392,63 @@
       (block $label$break$L75
         (block $switch$24
           (block $switch-default$127
-            (block $switch-default$127
-              (block $switch-case$126
-                (block $switch-case$55
-                  (block $switch-case$54
-                    (block $switch-case$53
-                      (block $switch-case$52
-                        (block $switch-case$51
-                          (block $switch-case$50
-                            (block $switch-case$49
-                              (block $switch-case$48
-                                (block $switch-case$47
-                                  (block $switch-case$46
-                                    (block $switch-case$45
-                                      (block $switch-case$44
-                                        (block $switch-case$43
-                                          (block $switch-case$42
-                                            (block $switch-case$41
-                                              (block $switch-case$40
-                                                (block $switch-case$37
-                                                  (block $switch-case$36
-                                                    (block $switch-case$35
-                                                      (block $switch-case$34
-                                                        (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$52 $switch-case$51 $switch-case$50 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$53 $switch-default$127 $switch-case$44 $switch-case$42 $switch-case$126 $switch-case$55 $switch-case$54 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$37 $switch-default$127
-                                                          (i32.sub
-                                                            (set_local $26
-                                                              (select
-                                                                (i32.and
-                                                                  (get_local $1)
-                                                                  (i32.const -33)
-                                                                )
+            (block $switch-case$126
+              (block $switch-case$55
+                (block $switch-case$54
+                  (block $switch-case$53
+                    (block $switch-case$52
+                      (block $switch-case$51
+                        (block $switch-case$50
+                          (block $switch-case$49
+                            (block $switch-case$48
+                              (block $switch-case$47
+                                (block $switch-case$46
+                                  (block $switch-case$45
+                                    (block $switch-case$44
+                                      (block $switch-case$43
+                                        (block $switch-case$42
+                                          (block $switch-case$41
+                                            (block $switch-case$40
+                                              (block $switch-case$37
+                                                (block $switch-case$36
+                                                  (block $switch-case$35
+                                                    (block $switch-case$34
+                                                      (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$52 $switch-case$51 $switch-case$50 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$53 $switch-default$127 $switch-case$44 $switch-case$42 $switch-case$126 $switch-case$55 $switch-case$54 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$37 $switch-default$127
+                                                        (i32.sub
+                                                          (set_local $26
+                                                            (select
+                                                              (i32.and
                                                                 (get_local $1)
-                                                                (get_local $5)
+                                                                (i32.const -33)
                                                               )
+                                                              (get_local $1)
+                                                              (get_local $5)
                                                             )
-                                                            (i32.const 65)
                                                           )
+                                                          (i32.const 65)
                                                         )
                                                       )
-                                                      (block $switch-default$33
-                                                        (block $switch-default$33
-                                                          (block $switch-case$32
-                                                            (block $switch-case$31
-                                                              (block $switch-case$30
-                                                                (block $switch-case$29
-                                                                  (block $switch-case$28
-                                                                    (block $switch-case$27
-                                                                      (block $switch-case$26
-                                                                        (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
-                                                                          (i32.sub
-                                                                            (get_local $13)
-                                                                            (i32.const 0)
-                                                                          )
-                                                                        )
+                                                    )
+                                                    (block $switch-default$33
+                                                      (block $switch-case$32
+                                                        (block $switch-case$31
+                                                          (block $switch-case$30
+                                                            (block $switch-case$29
+                                                              (block $switch-case$28
+                                                                (block $switch-case$27
+                                                                  (block $switch-case$26
+                                                                    (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
+                                                                      (i32.sub
+                                                                        (get_local $13)
+                                                                        (i32.const 0)
                                                                       )
-                                                                      (i32.store
-                                                                        (i32.load
-                                                                          (get_local $19)
-                                                                        )
-                                                                        (get_local $22)
-                                                                      )
-                                                                      (set_local $20
-                                                                        (get_local $9)
-                                                                      )
-                                                                      (set_local $1
-                                                                        (get_local $17)
-                                                                      )
-                                                                      (set_local $8
-                                                                        (get_local $21)
-                                                                      )
-                                                                      (br $label$continue$L1)
                                                                     )
-                                                                    (i32.store
-                                                                      (i32.load
-                                                                        (get_local $19)
-                                                                      )
-                                                                      (get_local $22)
-                                                                    )
-                                                                    (set_local $20
-                                                                      (get_local $9)
-                                                                    )
-                                                                    (set_local $1
-                                                                      (get_local $17)
-                                                                    )
-                                                                    (set_local $8
-                                                                      (get_local $21)
-                                                                    )
-                                                                    (br $label$continue$L1)
                                                                   )
                                                                   (i32.store
-                                                                    (set_local $1
-                                                                      (i32.load
-                                                                        (get_local $19)
-                                                                      )
+                                                                    (i32.load
+                                                                      (get_local $19)
                                                                     )
                                                                     (get_local $22)
-                                                                  )
-                                                                  (i32.store offset=4
-                                                                    (get_local $1)
-                                                                    (i32.shr_s
-                                                                      (i32.shl
-                                                                        (i32.lt_s
-                                                                          (get_local $22)
-                                                                          (i32.const 0)
-                                                                        )
-                                                                        (i32.const 31)
-                                                                      )
-                                                                      (i32.const 31)
-                                                                    )
                                                                   )
                                                                   (set_local $20
                                                                     (get_local $9)
@@ -4516,14 +4461,11 @@
                                                                   )
                                                                   (br $label$continue$L1)
                                                                 )
-                                                                (i32.store16
+                                                                (i32.store
                                                                   (i32.load
                                                                     (get_local $19)
                                                                   )
-                                                                  (i32.and
-                                                                    (get_local $22)
-                                                                    (i32.const 65535)
-                                                                  )
+                                                                  (get_local $22)
                                                                 )
                                                                 (set_local $20
                                                                   (get_local $9)
@@ -4536,13 +4478,25 @@
                                                                 )
                                                                 (br $label$continue$L1)
                                                               )
-                                                              (i32.store8
-                                                                (i32.load
-                                                                  (get_local $19)
+                                                              (i32.store
+                                                                (set_local $1
+                                                                  (i32.load
+                                                                    (get_local $19)
+                                                                  )
                                                                 )
-                                                                (i32.and
-                                                                  (get_local $22)
-                                                                  (i32.const 255)
+                                                                (get_local $22)
+                                                              )
+                                                              (i32.store offset=4
+                                                                (get_local $1)
+                                                                (i32.shr_s
+                                                                  (i32.shl
+                                                                    (i32.lt_s
+                                                                      (get_local $22)
+                                                                      (i32.const 0)
+                                                                    )
+                                                                    (i32.const 31)
+                                                                  )
+                                                                  (i32.const 31)
                                                                 )
                                                               )
                                                               (set_local $20
@@ -4556,11 +4510,14 @@
                                                               )
                                                               (br $label$continue$L1)
                                                             )
-                                                            (i32.store
+                                                            (i32.store16
                                                               (i32.load
                                                                 (get_local $19)
                                                               )
-                                                              (get_local $22)
+                                                              (i32.and
+                                                                (get_local $22)
+                                                                (i32.const 65535)
+                                                              )
                                                             )
                                                             (set_local $20
                                                               (get_local $9)
@@ -4573,25 +4530,13 @@
                                                             )
                                                             (br $label$continue$L1)
                                                           )
-                                                          (i32.store
-                                                            (set_local $1
-                                                              (i32.load
-                                                                (get_local $19)
-                                                              )
+                                                          (i32.store8
+                                                            (i32.load
+                                                              (get_local $19)
                                                             )
-                                                            (get_local $22)
-                                                          )
-                                                          (i32.store offset=4
-                                                            (get_local $1)
-                                                            (i32.shr_s
-                                                              (i32.shl
-                                                                (i32.lt_s
-                                                                  (get_local $22)
-                                                                  (i32.const 0)
-                                                                )
-                                                                (i32.const 31)
-                                                              )
-                                                              (i32.const 31)
+                                                            (i32.and
+                                                              (get_local $22)
+                                                              (i32.const 255)
                                                             )
                                                           )
                                                           (set_local $20
@@ -4605,6 +4550,12 @@
                                                           )
                                                           (br $label$continue$L1)
                                                         )
+                                                        (i32.store
+                                                          (i32.load
+                                                            (get_local $19)
+                                                          )
+                                                          (get_local $22)
+                                                        )
                                                         (set_local $20
                                                           (get_local $9)
                                                         )
@@ -4616,391 +4567,411 @@
                                                         )
                                                         (br $label$continue$L1)
                                                       )
-                                                    )
-                                                    (set_local $46
-                                                      (i32.or
-                                                        (get_local $18)
-                                                        (i32.const 8)
-                                                      )
-                                                    )
-                                                    (set_local $57
-                                                      (select
-                                                        (get_local $10)
-                                                        (i32.const 8)
-                                                        (i32.gt_u
-                                                          (get_local $10)
-                                                          (i32.const 8)
-                                                        )
-                                                      )
-                                                    )
-                                                    (set_local $68
-                                                      (i32.const 120)
-                                                    )
-                                                    (set_local $12
-                                                      (i32.const 64)
-                                                    )
-                                                    (br $switch$24)
-                                                  )
-                                                )
-                                                (set_local $46
-                                                  (get_local $18)
-                                                )
-                                                (set_local $57
-                                                  (get_local $10)
-                                                )
-                                                (set_local $68
-                                                  (get_local $26)
-                                                )
-                                                (set_local $12
-                                                  (i32.const 64)
-                                                )
-                                                (br $switch$24)
-                                              )
-                                              (if
-                                                (i32.and
-                                                  (i32.eq
-                                                    (set_local $5
-                                                      (i32.load
+                                                      (i32.store
                                                         (set_local $1
-                                                          (get_local $19)
+                                                          (i32.load
+                                                            (get_local $19)
+                                                          )
                                                         )
+                                                        (get_local $22)
                                                       )
-                                                    )
-                                                    (i32.const 0)
-                                                  )
-                                                  (i32.eq
-                                                    (set_local $1
-                                                      (i32.load offset=4
+                                                      (i32.store offset=4
                                                         (get_local $1)
-                                                      )
-                                                    )
-                                                    (i32.const 0)
-                                                  )
-                                                )
-                                                (set_local $6
-                                                  (get_local $28)
-                                                )
-                                                (block
-                                                  (set_local $6
-                                                    (get_local $28)
-                                                  )
-                                                  (loop $while-out$38 $while-in$39
-                                                    (i32.store8
-                                                      (set_local $6
-                                                        (i32.add
-                                                          (get_local $6)
-                                                          (i32.const -1)
-                                                        )
-                                                      )
-                                                      (i32.and
-                                                        (i32.or
-                                                          (i32.and
-                                                            (get_local $5)
-                                                            (i32.const 7)
-                                                          )
-                                                          (i32.const 48)
-                                                        )
-                                                        (i32.const 255)
-                                                      )
-                                                    )
-                                                    (if
-                                                      (i32.and
-                                                        (i32.eq
-                                                          (set_local $5
-                                                            (call $_bitshift64Lshr
-                                                              (get_local $5)
-                                                              (get_local $1)
-                                                              (i32.const 3)
+                                                        (i32.shr_s
+                                                          (i32.shl
+                                                            (i32.lt_s
+                                                              (get_local $22)
+                                                              (i32.const 0)
                                                             )
+                                                            (i32.const 31)
                                                           )
-                                                          (i32.const 0)
-                                                        )
-                                                        (i32.eq
-                                                          (set_local $1
-                                                            (i32.load
-                                                              (i32.const 168)
-                                                            )
-                                                          )
-                                                          (i32.const 0)
+                                                          (i32.const 31)
                                                         )
                                                       )
-                                                      (br $while-out$38)
+                                                      (set_local $20
+                                                        (get_local $9)
+                                                      )
+                                                      (set_local $1
+                                                        (get_local $17)
+                                                      )
+                                                      (set_local $8
+                                                        (get_local $21)
+                                                      )
+                                                      (br $label$continue$L1)
                                                     )
-                                                    (br $while-in$39)
+                                                    (set_local $20
+                                                      (get_local $9)
+                                                    )
+                                                    (set_local $1
+                                                      (get_local $17)
+                                                    )
+                                                    (set_local $8
+                                                      (get_local $21)
+                                                    )
+                                                    (br $label$continue$L1)
                                                   )
-                                                )
-                                              )
-                                              (set_local $58
-                                                (if
-                                                  (i32.eq
-                                                    (i32.and
+                                                  (set_local $46
+                                                    (i32.or
                                                       (get_local $18)
                                                       (i32.const 8)
                                                     )
-                                                    (i32.const 0)
                                                   )
-                                                  (block
-                                                    (set_local $34
-                                                      (get_local $18)
-                                                    )
-                                                    (set_local $32
+                                                  (set_local $57
+                                                    (select
                                                       (get_local $10)
-                                                    )
-                                                    (set_local $35
-                                                      (i32.const 0)
-                                                    )
-                                                    (set_local $36
-                                                      (i32.const 4091)
-                                                    )
-                                                    (set_local $12
-                                                      (i32.const 77)
-                                                    )
-                                                    (get_local $6)
-                                                  )
-                                                  (block
-                                                    (set_local $5
-                                                      (i32.lt_s
+                                                      (i32.const 8)
+                                                      (i32.gt_u
                                                         (get_local $10)
-                                                        (set_local $1
-                                                          (i32.add
-                                                            (i32.sub
-                                                              (get_local $71)
-                                                              (get_local $6)
-                                                            )
-                                                            (i32.const 1)
-                                                          )
-                                                        )
+                                                        (i32.const 8)
                                                       )
                                                     )
-                                                    (set_local $34
-                                                      (get_local $18)
-                                                    )
-                                                    (set_local $32
-                                                      (select
-                                                        (get_local $1)
-                                                        (get_local $10)
-                                                        (get_local $5)
-                                                      )
-                                                    )
-                                                    (set_local $35
-                                                      (i32.const 0)
-                                                    )
-                                                    (set_local $36
-                                                      (i32.const 4091)
-                                                    )
-                                                    (set_local $12
-                                                      (i32.const 77)
-                                                    )
-                                                    (get_local $6)
                                                   )
+                                                  (set_local $68
+                                                    (i32.const 120)
+                                                  )
+                                                  (set_local $12
+                                                    (i32.const 64)
+                                                  )
+                                                  (br $switch$24)
                                                 )
+                                              )
+                                              (set_local $46
+                                                (get_local $18)
+                                              )
+                                              (set_local $57
+                                                (get_local $10)
+                                              )
+                                              (set_local $68
+                                                (get_local $26)
+                                              )
+                                              (set_local $12
+                                                (i32.const 64)
                                               )
                                               (br $switch$24)
                                             )
-                                          )
-                                          (set_local $5
-                                            (i32.load
-                                              (set_local $1
-                                                (get_local $19)
-                                              )
-                                            )
-                                          )
-                                          (if
-                                            (i32.lt_s
-                                              (set_local $33
-                                                (i32.load offset=4
-                                                  (get_local $1)
-                                                )
-                                              )
-                                              (i32.const 0)
-                                            )
-                                            (block
-                                              (set_local $1
-                                                (call $_i64Subtract
-                                                  (i32.const 0)
-                                                  (i32.const 0)
-                                                  (get_local $5)
-                                                  (get_local $33)
-                                                )
-                                              )
-                                              (set_local $5
-                                                (i32.load
-                                                  (i32.const 168)
-                                                )
-                                              )
-                                              (i32.store
-                                                (set_local $33
-                                                  (get_local $19)
-                                                )
-                                                (get_local $1)
-                                              )
-                                              (i32.store offset=4
-                                                (get_local $33)
-                                                (get_local $5)
-                                              )
-                                              (set_local $33
-                                                (get_local $1)
-                                              )
-                                              (set_local $59
-                                                (get_local $5)
-                                              )
-                                              (set_local $60
-                                                (i32.const 1)
-                                              )
-                                              (set_local $61
-                                                (i32.const 4091)
-                                              )
-                                              (set_local $12
-                                                (i32.const 76)
-                                              )
-                                              (br $label$break$L75)
-                                            )
-                                          )
-                                          (set_local $33
                                             (if
-                                              (i32.eq
-                                                (i32.and
-                                                  (get_local $18)
-                                                  (i32.const 2048)
+                                              (i32.and
+                                                (i32.eq
+                                                  (set_local $5
+                                                    (i32.load
+                                                      (set_local $1
+                                                        (get_local $19)
+                                                      )
+                                                    )
+                                                  )
+                                                  (i32.const 0)
                                                 )
-                                                (i32.const 0)
+                                                (i32.eq
+                                                  (set_local $1
+                                                    (i32.load offset=4
+                                                      (get_local $1)
+                                                    )
+                                                  )
+                                                  (i32.const 0)
+                                                )
+                                              )
+                                              (set_local $6
+                                                (get_local $28)
                                               )
                                               (block
-                                                (set_local $1
-                                                  (select
-                                                    (i32.const 4091)
-                                                    (i32.const 4093)
-                                                    (i32.eq
-                                                      (set_local $6
+                                                (set_local $6
+                                                  (get_local $28)
+                                                )
+                                                (loop $while-out$38 $while-in$39
+                                                  (i32.store8
+                                                    (set_local $6
+                                                      (i32.add
+                                                        (get_local $6)
+                                                        (i32.const -1)
+                                                      )
+                                                    )
+                                                    (i32.and
+                                                      (i32.or
                                                         (i32.and
-                                                          (get_local $18)
+                                                          (get_local $5)
+                                                          (i32.const 7)
+                                                        )
+                                                        (i32.const 48)
+                                                      )
+                                                      (i32.const 255)
+                                                    )
+                                                  )
+                                                  (if
+                                                    (i32.and
+                                                      (i32.eq
+                                                        (set_local $5
+                                                          (call $_bitshift64Lshr
+                                                            (get_local $5)
+                                                            (get_local $1)
+                                                            (i32.const 3)
+                                                          )
+                                                        )
+                                                        (i32.const 0)
+                                                      )
+                                                      (i32.eq
+                                                        (set_local $1
+                                                          (i32.load
+                                                            (i32.const 168)
+                                                          )
+                                                        )
+                                                        (i32.const 0)
+                                                      )
+                                                    )
+                                                    (br $while-out$38)
+                                                  )
+                                                  (br $while-in$39)
+                                                )
+                                              )
+                                            )
+                                            (set_local $58
+                                              (if
+                                                (i32.eq
+                                                  (i32.and
+                                                    (get_local $18)
+                                                    (i32.const 8)
+                                                  )
+                                                  (i32.const 0)
+                                                )
+                                                (block
+                                                  (set_local $34
+                                                    (get_local $18)
+                                                  )
+                                                  (set_local $32
+                                                    (get_local $10)
+                                                  )
+                                                  (set_local $35
+                                                    (i32.const 0)
+                                                  )
+                                                  (set_local $36
+                                                    (i32.const 4091)
+                                                  )
+                                                  (set_local $12
+                                                    (i32.const 77)
+                                                  )
+                                                  (get_local $6)
+                                                )
+                                                (block
+                                                  (set_local $5
+                                                    (i32.lt_s
+                                                      (get_local $10)
+                                                      (set_local $1
+                                                        (i32.add
+                                                          (i32.sub
+                                                            (get_local $71)
+                                                            (get_local $6)
+                                                          )
                                                           (i32.const 1)
                                                         )
                                                       )
-                                                      (i32.const 0)
                                                     )
                                                   )
-                                                )
-                                                (set_local $59
-                                                  (get_local $33)
-                                                )
-                                                (set_local $60
+                                                  (set_local $34
+                                                    (get_local $18)
+                                                  )
+                                                  (set_local $32
+                                                    (select
+                                                      (get_local $1)
+                                                      (get_local $10)
+                                                      (get_local $5)
+                                                    )
+                                                  )
+                                                  (set_local $35
+                                                    (i32.const 0)
+                                                  )
+                                                  (set_local $36
+                                                    (i32.const 4091)
+                                                  )
+                                                  (set_local $12
+                                                    (i32.const 77)
+                                                  )
                                                   (get_local $6)
                                                 )
-                                                (set_local $61
-                                                  (get_local $1)
-                                                )
-                                                (set_local $12
-                                                  (i32.const 76)
-                                                )
-                                                (get_local $5)
-                                              )
-                                              (block
-                                                (set_local $59
-                                                  (get_local $33)
-                                                )
-                                                (set_local $60
-                                                  (i32.const 1)
-                                                )
-                                                (set_local $61
-                                                  (i32.const 4092)
-                                                )
-                                                (set_local $12
-                                                  (i32.const 76)
-                                                )
-                                                (get_local $5)
                                               )
                                             )
+                                            (br $switch$24)
                                           )
-                                          (br $switch$24)
                                         )
-                                        (set_local $33
+                                        (set_local $5
                                           (i32.load
                                             (set_local $1
                                               (get_local $19)
                                             )
                                           )
                                         )
-                                        (set_local $59
-                                          (i32.load offset=4
-                                            (get_local $1)
+                                        (if
+                                          (i32.lt_s
+                                            (set_local $33
+                                              (i32.load offset=4
+                                                (get_local $1)
+                                              )
+                                            )
+                                            (i32.const 0)
+                                          )
+                                          (block
+                                            (set_local $1
+                                              (call $_i64Subtract
+                                                (i32.const 0)
+                                                (i32.const 0)
+                                                (get_local $5)
+                                                (get_local $33)
+                                              )
+                                            )
+                                            (set_local $5
+                                              (i32.load
+                                                (i32.const 168)
+                                              )
+                                            )
+                                            (i32.store
+                                              (set_local $33
+                                                (get_local $19)
+                                              )
+                                              (get_local $1)
+                                            )
+                                            (i32.store offset=4
+                                              (get_local $33)
+                                              (get_local $5)
+                                            )
+                                            (set_local $33
+                                              (get_local $1)
+                                            )
+                                            (set_local $59
+                                              (get_local $5)
+                                            )
+                                            (set_local $60
+                                              (i32.const 1)
+                                            )
+                                            (set_local $61
+                                              (i32.const 4091)
+                                            )
+                                            (set_local $12
+                                              (i32.const 76)
+                                            )
+                                            (br $label$break$L75)
                                           )
                                         )
-                                        (set_local $60
-                                          (i32.const 0)
-                                        )
-                                        (set_local $61
-                                          (i32.const 4091)
-                                        )
-                                        (set_local $12
-                                          (i32.const 76)
+                                        (set_local $33
+                                          (if
+                                            (i32.eq
+                                              (i32.and
+                                                (get_local $18)
+                                                (i32.const 2048)
+                                              )
+                                              (i32.const 0)
+                                            )
+                                            (block
+                                              (set_local $1
+                                                (select
+                                                  (i32.const 4091)
+                                                  (i32.const 4093)
+                                                  (i32.eq
+                                                    (set_local $6
+                                                      (i32.and
+                                                        (get_local $18)
+                                                        (i32.const 1)
+                                                      )
+                                                    )
+                                                    (i32.const 0)
+                                                  )
+                                                )
+                                              )
+                                              (set_local $59
+                                                (get_local $33)
+                                              )
+                                              (set_local $60
+                                                (get_local $6)
+                                              )
+                                              (set_local $61
+                                                (get_local $1)
+                                              )
+                                              (set_local $12
+                                                (i32.const 76)
+                                              )
+                                              (get_local $5)
+                                            )
+                                            (block
+                                              (set_local $59
+                                                (get_local $33)
+                                              )
+                                              (set_local $60
+                                                (i32.const 1)
+                                              )
+                                              (set_local $61
+                                                (i32.const 4092)
+                                              )
+                                              (set_local $12
+                                                (i32.const 76)
+                                              )
+                                              (get_local $5)
+                                            )
+                                          )
                                         )
                                         (br $switch$24)
                                       )
-                                      (set_local $5
+                                      (set_local $33
                                         (i32.load
                                           (set_local $1
                                             (get_local $19)
                                           )
                                         )
                                       )
-                                      (i32.load offset=4
-                                        (get_local $1)
-                                      )
-                                      (i32.store8
-                                        (get_local $72)
-                                        (i32.and
-                                          (get_local $5)
-                                          (i32.const 255)
+                                      (set_local $59
+                                        (i32.load offset=4
+                                          (get_local $1)
                                         )
                                       )
-                                      (set_local $47
-                                        (get_local $72)
-                                      )
-                                      (set_local $37
-                                        (get_local $7)
-                                      )
-                                      (set_local $42
-                                        (i32.const 1)
-                                      )
-                                      (set_local $43
+                                      (set_local $60
                                         (i32.const 0)
                                       )
-                                      (set_local $48
+                                      (set_local $61
                                         (i32.const 4091)
                                       )
-                                      (set_local $49
-                                        (get_local $28)
+                                      (set_local $12
+                                        (i32.const 76)
                                       )
                                       (br $switch$24)
                                     )
-                                    (set_local $50
-                                      (call $_strerror
-                                        (i32.load
-                                          (call $___errno_location)
-                                        )
-                                      )
-                                    )
-                                    (set_local $12
-                                      (i32.const 82)
-                                    )
-                                    (br $switch$24)
-                                  )
-                                  (set_local $5
-                                    (i32.ne
-                                      (set_local $1
-                                        (i32.load
+                                    (set_local $5
+                                      (i32.load
+                                        (set_local $1
                                           (get_local $19)
                                         )
                                       )
+                                    )
+                                    (i32.load offset=4
+                                      (get_local $1)
+                                    )
+                                    (i32.store8
+                                      (get_local $72)
+                                      (i32.and
+                                        (get_local $5)
+                                        (i32.const 255)
+                                      )
+                                    )
+                                    (set_local $47
+                                      (get_local $72)
+                                    )
+                                    (set_local $37
+                                      (get_local $7)
+                                    )
+                                    (set_local $42
+                                      (i32.const 1)
+                                    )
+                                    (set_local $43
                                       (i32.const 0)
                                     )
+                                    (set_local $48
+                                      (i32.const 4091)
+                                    )
+                                    (set_local $49
+                                      (get_local $28)
+                                    )
+                                    (br $switch$24)
                                   )
                                   (set_local $50
-                                    (select
-                                      (get_local $1)
-                                      (i32.const 4101)
-                                      (get_local $5)
+                                    (call $_strerror
+                                      (i32.load
+                                        (call $___errno_location)
+                                      )
                                     )
                                   )
                                   (set_local $12
@@ -5009,64 +4980,85 @@
                                   (br $switch$24)
                                 )
                                 (set_local $5
-                                  (i32.load
+                                  (i32.ne
                                     (set_local $1
-                                      (get_local $19)
+                                      (i32.load
+                                        (get_local $19)
+                                      )
                                     )
+                                    (i32.const 0)
                                   )
                                 )
-                                (i32.load offset=4
-                                  (get_local $1)
-                                )
-                                (i32.store
-                                  (get_local $73)
-                                  (get_local $5)
-                                )
-                                (i32.store
-                                  (get_local $76)
-                                  (i32.const 0)
-                                )
-                                (i32.store
-                                  (get_local $19)
-                                  (get_local $73)
-                                )
-                                (set_local $69
-                                  (i32.const -1)
+                                (set_local $50
+                                  (select
+                                    (get_local $1)
+                                    (i32.const 4101)
+                                    (get_local $5)
+                                  )
                                 )
                                 (set_local $12
-                                  (i32.const 86)
+                                  (i32.const 82)
                                 )
                                 (br $switch$24)
                               )
-                              (set_local $12
-                                (if
-                                  (i32.eq
-                                    (get_local $10)
-                                    (i32.const 0)
-                                  )
-                                  (block
-                                    (call $_pad
-                                      (get_local $0)
-                                      (i32.const 32)
-                                      (get_local $16)
-                                      (i32.const 0)
-                                      (get_local $18)
-                                    )
-                                    (set_local $38
-                                      (i32.const 0)
-                                    )
-                                    (i32.const 98)
-                                  )
-                                  (block
-                                    (set_local $69
-                                      (get_local $10)
-                                    )
-                                    (i32.const 86)
+                              (set_local $5
+                                (i32.load
+                                  (set_local $1
+                                    (get_local $19)
                                   )
                                 )
                               )
+                              (i32.load offset=4
+                                (get_local $1)
+                              )
+                              (i32.store
+                                (get_local $73)
+                                (get_local $5)
+                              )
+                              (i32.store
+                                (get_local $76)
+                                (i32.const 0)
+                              )
+                              (i32.store
+                                (get_local $19)
+                                (get_local $73)
+                              )
+                              (set_local $69
+                                (i32.const -1)
+                              )
+                              (set_local $12
+                                (i32.const 86)
+                              )
                               (br $switch$24)
                             )
+                            (set_local $12
+                              (if
+                                (i32.eq
+                                  (get_local $10)
+                                  (i32.const 0)
+                                )
+                                (block
+                                  (call $_pad
+                                    (get_local $0)
+                                    (i32.const 32)
+                                    (get_local $16)
+                                    (i32.const 0)
+                                    (get_local $18)
+                                  )
+                                  (set_local $38
+                                    (i32.const 0)
+                                  )
+                                  (i32.const 98)
+                                )
+                                (block
+                                  (set_local $69
+                                    (get_local $10)
+                                  )
+                                  (i32.const 86)
+                                )
+                              )
+                            )
+                            (br $switch$24)
                           )
                         )
                       )
@@ -5074,282 +5066,1990 @@
                   )
                 )
               )
-              (set_local $15
-                (f64.load
-                  (get_local $19)
-                )
+            )
+            (set_local $15
+              (f64.load
+                (get_local $19)
               )
-              (i32.store
-                (get_local $25)
-                (i32.const 0)
-              )
-              (f64.store
-                (i32.load
-                  (i32.const 24)
-                )
-                (get_local $15)
-              )
+            )
+            (i32.store
+              (get_local $25)
+              (i32.const 0)
+            )
+            (f64.store
               (i32.load
-                (i32.load
-                  (i32.const 24)
-                )
+                (i32.const 24)
               )
-              (set_local $51
+              (get_local $15)
+            )
+            (i32.load
+              (i32.load
+                (i32.const 24)
+              )
+            )
+            (set_local $51
+              (if
+                (i32.lt_s
+                  (i32.load offset=4
+                    (i32.load
+                      (i32.const 24)
+                    )
+                  )
+                  (i32.const 0)
+                )
+                (block
+                  (set_local $39
+                    (i32.const 4108)
+                  )
+                  (set_local $15
+                    (f64.neg
+                      (get_local $15)
+                    )
+                  )
+                  (i32.const 1)
+                )
                 (if
-                  (i32.lt_s
-                    (i32.load offset=4
-                      (i32.load
-                        (i32.const 24)
-                      )
+                  (i32.eq
+                    (i32.and
+                      (get_local $18)
+                      (i32.const 2048)
                     )
                     (i32.const 0)
                   )
                   (block
                     (set_local $39
-                      (i32.const 4108)
-                    )
-                    (set_local $15
-                      (f64.neg
-                        (get_local $15)
+                      (select
+                        (i32.const 4109)
+                        (i32.const 4114)
+                        (i32.eq
+                          (set_local $1
+                            (i32.and
+                              (get_local $18)
+                              (i32.const 1)
+                            )
+                          )
+                          (i32.const 0)
+                        )
                       )
+                    )
+                    (get_local $1)
+                  )
+                  (block
+                    (set_local $39
+                      (i32.const 4111)
                     )
                     (i32.const 1)
                   )
-                  (if
-                    (i32.eq
-                      (i32.and
-                        (get_local $18)
-                        (i32.const 2048)
+                )
+              )
+            )
+            (f64.store
+              (i32.load
+                (i32.const 24)
+              )
+              (get_local $15)
+            )
+            (i32.load
+              (i32.load
+                (i32.const 24)
+              )
+            )
+            (set_local $20
+              (get_local $9)
+            )
+            (set_local $1
+              (block $do-once$56
+                (if
+                  (i32.or
+                    (i32.lt_u
+                      (set_local $1
+                        (i32.and
+                          (i32.load offset=4
+                            (i32.load
+                              (i32.const 24)
+                            )
+                          )
+                          (i32.const 2146435072)
+                        )
+                      )
+                      (i32.const 2146435072)
+                    )
+                    (i32.and
+                      (i32.eq
+                        (get_local $1)
+                        (i32.const 2146435072)
                       )
                       (i32.const 0)
                     )
-                    (block
-                      (set_local $39
-                        (select
-                          (i32.const 4109)
-                          (i32.const 4114)
-                          (i32.eq
+                  )
+                  (block
+                    (if
+                      (set_local $5
+                        (f64.ne
+                          (set_local $15
+                            (f64.mul
+                              (call $_frexpl
+                                (get_local $15)
+                                (get_local $25)
+                              )
+                              (f64.const 2)
+                            )
+                          )
+                          (f64.const 0)
+                        )
+                      )
+                      (i32.store
+                        (get_local $25)
+                        (i32.add
+                          (i32.load
+                            (get_local $25)
+                          )
+                          (i32.const -1)
+                        )
+                      )
+                    )
+                    (if
+                      (i32.eq
+                        (set_local $14
+                          (i32.or
+                            (get_local $26)
+                            (i32.const 32)
+                          )
+                        )
+                        (i32.const 97)
+                      )
+                      (block
+                        (set_local $9
+                          (select
+                            (get_local $39)
+                            (i32.add
+                              (get_local $39)
+                              (i32.const 9)
+                            )
+                            (i32.eq
+                              (set_local $6
+                                (i32.and
+                                  (get_local $26)
+                                  (i32.const 32)
+                                )
+                              )
+                              (i32.const 0)
+                            )
+                          )
+                        )
+                        (set_local $7
+                          (i32.or
+                            (get_local $51)
+                            (i32.const 2)
+                          )
+                        )
+                        (set_local $15
+                          (if
+                            (i32.or
+                              (i32.gt_u
+                                (get_local $10)
+                                (i32.const 11)
+                              )
+                              (i32.eq
+                                (set_local $1
+                                  (i32.sub
+                                    (i32.const 12)
+                                    (get_local $10)
+                                  )
+                                )
+                                (i32.const 0)
+                              )
+                            )
+                            (get_local $15)
+                            (block
+                              (set_local $30
+                                (f64.const 8)
+                              )
+                              (loop $while-out$60 $while-in$61
+                                (set_local $30
+                                  (f64.mul
+                                    (get_local $30)
+                                    (f64.const 16)
+                                  )
+                                )
+                                (if
+                                  (i32.eq
+                                    (set_local $1
+                                      (i32.add
+                                        (get_local $1)
+                                        (i32.const -1)
+                                      )
+                                    )
+                                    (i32.const 0)
+                                  )
+                                  (br $while-out$60)
+                                )
+                                (br $while-in$61)
+                              )
+                              (select
+                                (f64.neg
+                                  (f64.add
+                                    (get_local $30)
+                                    (f64.sub
+                                      (f64.neg
+                                        (get_local $15)
+                                      )
+                                      (get_local $30)
+                                    )
+                                  )
+                                )
+                                (f64.sub
+                                  (f64.add
+                                    (get_local $15)
+                                    (get_local $30)
+                                  )
+                                  (get_local $30)
+                                )
+                                (i32.eq
+                                  (i32.shr_s
+                                    (i32.shl
+                                      (i32.load8_s
+                                        (get_local $9)
+                                      )
+                                      (i32.const 24)
+                                    )
+                                    (i32.const 24)
+                                  )
+                                  (i32.const 45)
+                                )
+                              )
+                            )
+                          )
+                        )
+                        (set_local $5
+                          (i32.lt_s
                             (set_local $1
+                              (i32.load
+                                (get_local $25)
+                              )
+                            )
+                            (i32.const 0)
+                          )
+                        )
+                        (set_local $5
+                          (i32.shr_s
+                            (i32.shl
+                              (i32.lt_s
+                                (set_local $8
+                                  (select
+                                    (i32.sub
+                                      (i32.const 0)
+                                      (get_local $1)
+                                    )
+                                    (get_local $1)
+                                    (get_local $5)
+                                  )
+                                )
+                                (i32.const 0)
+                              )
+                              (i32.const 31)
+                            )
+                            (i32.const 31)
+                          )
+                        )
+                        (i32.store8
+                          (i32.add
+                            (set_local $5
+                              (if
+                                (i32.eq
+                                  (set_local $5
+                                    (call $_fmt_u
+                                      (get_local $8)
+                                      (get_local $5)
+                                      (get_local $52)
+                                    )
+                                  )
+                                  (get_local $52)
+                                )
+                                (block
+                                  (i32.store8
+                                    (get_local $74)
+                                    (i32.const 48)
+                                  )
+                                  (get_local $74)
+                                )
+                                (get_local $5)
+                              )
+                            )
+                            (i32.const -1)
+                          )
+                          (i32.and
+                            (i32.add
                               (i32.and
-                                (get_local $18)
-                                (i32.const 1)
+                                (i32.shr_s
+                                  (get_local $1)
+                                  (i32.const 31)
+                                )
+                                (i32.const 2)
+                              )
+                              (i32.const 43)
+                            )
+                            (i32.const 255)
+                          )
+                        )
+                        (i32.store8
+                          (set_local $8
+                            (i32.add
+                              (get_local $5)
+                              (i32.const -2)
+                            )
+                          )
+                          (i32.and
+                            (i32.add
+                              (get_local $26)
+                              (i32.const 15)
+                            )
+                            (i32.const 255)
+                          )
+                        )
+                        (set_local $5
+                          (i32.lt_s
+                            (get_local $10)
+                            (i32.const 1)
+                          )
+                        )
+                        (set_local $13
+                          (i32.eq
+                            (i32.and
+                              (get_local $18)
+                              (i32.const 8)
+                            )
+                            (i32.const 0)
+                          )
+                        )
+                        (set_local $11
+                          (get_local $29)
+                        )
+                        (loop $while-out$62 $while-in$63
+                          (i32.store8
+                            (get_local $11)
+                            (i32.and
+                              (i32.or
+                                (i32.and
+                                  (i32.load8_s
+                                    (i32.add
+                                      (set_local $1
+                                        (call_import $f64-to-int
+                                          (get_local $15)
+                                        )
+                                      )
+                                      (i32.const 4075)
+                                    )
+                                  )
+                                  (i32.const 255)
+                                )
+                                (get_local $6)
+                              )
+                              (i32.const 255)
+                            )
+                          )
+                          (set_local $15
+                            (f64.mul
+                              (f64.sub
+                                (get_local $15)
+                                (f64.convert_s/i32
+                                  (get_local $1)
+                                )
+                              )
+                              (f64.const 16)
+                            )
+                          )
+                          (set_local $11
+                            (block $do-once$64
+                              (if
+                                (i32.eq
+                                  (i32.sub
+                                    (set_local $1
+                                      (i32.add
+                                        (get_local $11)
+                                        (i32.const 1)
+                                      )
+                                    )
+                                    (get_local $64)
+                                  )
+                                  (i32.const 1)
+                                )
+                                (block
+                                  (br_if $do-once$64
+                                    (get_local $1)
+                                    (i32.and
+                                      (get_local $13)
+                                      (i32.and
+                                        (get_local $5)
+                                        (f64.eq
+                                          (get_local $15)
+                                          (f64.const 0)
+                                        )
+                                      )
+                                    )
+                                  )
+                                  (i32.store8
+                                    (get_local $1)
+                                    (i32.const 46)
+                                  )
+                                  (i32.add
+                                    (get_local $11)
+                                    (i32.const 2)
+                                  )
+                                )
+                                (get_local $1)
+                              )
+                            )
+                          )
+                          (if
+                            (f64.eq
+                              (get_local $15)
+                              (f64.const 0)
+                            )
+                            (block
+                              (set_local $1
+                                (get_local $11)
+                              )
+                              (br $while-out$62)
+                            )
+                          )
+                          (br $while-in$63)
+                        )
+                        (set_local $5
+                          (i32.and
+                            (i32.ne
+                              (get_local $10)
+                              (i32.const 0)
+                            )
+                            (i32.lt_s
+                              (i32.add
+                                (get_local $78)
+                                (get_local $1)
+                              )
+                              (get_local $10)
+                            )
+                          )
+                        )
+                        (call $_pad
+                          (get_local $0)
+                          (i32.const 32)
+                          (get_local $16)
+                          (set_local $5
+                            (i32.add
+                              (set_local $6
+                                (select
+                                  (i32.sub
+                                    (i32.add
+                                      (get_local $79)
+                                      (get_local $10)
+                                    )
+                                    (get_local $8)
+                                  )
+                                  (i32.add
+                                    (i32.sub
+                                      (get_local $77)
+                                      (get_local $8)
+                                    )
+                                    (get_local $1)
+                                  )
+                                  (get_local $5)
+                                )
+                              )
+                              (get_local $7)
+                            )
+                          )
+                          (get_local $18)
+                        )
+                        (if
+                          (i32.eq
+                            (i32.and
+                              (i32.load
+                                (get_local $0)
+                              )
+                              (i32.const 32)
+                            )
+                            (i32.const 0)
+                          )
+                          (call $___fwritex
+                            (get_local $9)
+                            (get_local $7)
+                            (get_local $0)
+                          )
+                        )
+                        (call $_pad
+                          (get_local $0)
+                          (i32.const 48)
+                          (get_local $16)
+                          (get_local $5)
+                          (i32.xor
+                            (get_local $18)
+                            (i32.const 65536)
+                          )
+                        )
+                        (set_local $1
+                          (i32.sub
+                            (get_local $1)
+                            (get_local $64)
+                          )
+                        )
+                        (if
+                          (i32.eq
+                            (i32.and
+                              (i32.load
+                                (get_local $0)
+                              )
+                              (i32.const 32)
+                            )
+                            (i32.const 0)
+                          )
+                          (call $___fwritex
+                            (get_local $29)
+                            (get_local $1)
+                            (get_local $0)
+                          )
+                        )
+                        (call $_pad
+                          (get_local $0)
+                          (i32.const 48)
+                          (i32.sub
+                            (get_local $6)
+                            (i32.add
+                              (get_local $1)
+                              (set_local $1
+                                (i32.sub
+                                  (get_local $40)
+                                  (get_local $8)
+                                )
+                              )
+                            )
+                          )
+                          (i32.const 0)
+                          (i32.const 0)
+                        )
+                        (if
+                          (i32.eq
+                            (i32.and
+                              (i32.load
+                                (get_local $0)
+                              )
+                              (i32.const 32)
+                            )
+                            (i32.const 0)
+                          )
+                          (call $___fwritex
+                            (get_local $8)
+                            (get_local $1)
+                            (get_local $0)
+                          )
+                        )
+                        (call $_pad
+                          (get_local $0)
+                          (i32.const 32)
+                          (get_local $16)
+                          (get_local $5)
+                          (i32.xor
+                            (get_local $18)
+                            (i32.const 8192)
+                          )
+                        )
+                        (br $do-once$56
+                          (select
+                            (get_local $16)
+                            (get_local $5)
+                            (i32.lt_s
+                              (get_local $5)
+                              (get_local $16)
+                            )
+                          )
+                        )
+                      )
+                    )
+                    (set_local $1
+                      (select
+                        (i32.const 6)
+                        (get_local $10)
+                        (i32.lt_s
+                          (get_local $10)
+                          (i32.const 0)
+                        )
+                      )
+                    )
+                    (set_local $62
+                      (set_local $9
+                        (select
+                          (get_local $80)
+                          (get_local $81)
+                          (i32.lt_s
+                            (if
+                              (get_local $5)
+                              (block
+                                (i32.store
+                                  (get_local $25)
+                                  (set_local $5
+                                    (i32.add
+                                      (i32.load
+                                        (get_local $25)
+                                      )
+                                      (i32.const -28)
+                                    )
+                                  )
+                                )
+                                (set_local $15
+                                  (f64.mul
+                                    (get_local $15)
+                                    (f64.const 268435456)
+                                  )
+                                )
+                                (get_local $5)
+                              )
+                              (i32.load
+                                (get_local $25)
                               )
                             )
                             (i32.const 0)
                           )
                         )
                       )
-                      (get_local $1)
                     )
-                    (block
-                      (set_local $39
-                        (i32.const 4111)
-                      )
-                      (i32.const 1)
+                    (set_local $7
+                      (get_local $9)
                     )
-                  )
-                )
-              )
-              (f64.store
-                (i32.load
-                  (i32.const 24)
-                )
-                (get_local $15)
-              )
-              (i32.load
-                (i32.load
-                  (i32.const 24)
-                )
-              )
-              (set_local $20
-                (get_local $9)
-              )
-              (set_local $1
-                (block $do-once$56
-                  (if
-                    (i32.or
-                      (i32.lt_u
-                        (set_local $1
-                          (i32.and
-                            (i32.load offset=4
-                              (i32.load
-                                (i32.const 24)
-                              )
-                            )
-                            (i32.const 2146435072)
+                    (loop $while-out$66 $while-in$67
+                      (i32.store
+                        (get_local $7)
+                        (set_local $5
+                          (call_import $f64-to-int
+                            (get_local $15)
                           )
                         )
-                        (i32.const 2146435072)
                       )
-                      (i32.and
-                        (i32.eq
-                          (get_local $1)
-                          (i32.const 2146435072)
+                      (set_local $7
+                        (i32.add
+                          (get_local $7)
+                          (i32.const 4)
+                        )
+                      )
+                      (if
+                        (f64.eq
+                          (set_local $15
+                            (f64.mul
+                              (f64.sub
+                                (get_local $15)
+                                (f64.convert_u/i32
+                                  (get_local $5)
+                                )
+                              )
+                              (f64.const 1e9)
+                            )
+                          )
+                          (f64.const 0)
+                        )
+                        (block
+                          (set_local $6
+                            (get_local $7)
+                          )
+                          (br $while-out$66)
+                        )
+                      )
+                      (br $while-in$67)
+                    )
+                    (if
+                      (i32.gt_s
+                        (set_local $5
+                          (i32.load
+                            (get_local $25)
+                          )
                         )
                         (i32.const 0)
                       )
-                    )
-                    (block
-                      (if
-                        (set_local $5
-                          (f64.ne
-                            (set_local $15
-                              (f64.mul
-                                (call $_frexpl
-                                  (get_local $15)
-                                  (get_local $25)
-                                )
-                                (f64.const 2)
+                      (block
+                        (set_local $8
+                          (get_local $9)
+                        )
+                        (set_local $13
+                          (get_local $6)
+                        )
+                        (loop $while-out$68 $while-in$69
+                          (set_local $11
+                            (select
+                              (i32.const 29)
+                              (get_local $5)
+                              (i32.gt_s
+                                (get_local $5)
+                                (i32.const 29)
                               )
                             )
-                            (f64.const 0)
+                          )
+                          (set_local $7
+                            (block $do-once$70
+                              (if
+                                (i32.lt_u
+                                  (set_local $7
+                                    (i32.add
+                                      (get_local $13)
+                                      (i32.const -4)
+                                    )
+                                  )
+                                  (get_local $8)
+                                )
+                                (get_local $8)
+                                (block
+                                  (set_local $5
+                                    (i32.const 0)
+                                  )
+                                  (set_local $10
+                                    (get_local $7)
+                                  )
+                                  (loop $while-out$72 $while-in$73
+                                    (set_local $6
+                                      (call $___uremdi3
+                                        (set_local $5
+                                          (call $_i64Add
+                                            (call $_bitshift64Shl
+                                              (i32.load
+                                                (get_local $10)
+                                              )
+                                              (i32.const 0)
+                                              (get_local $11)
+                                            )
+                                            (i32.load
+                                              (i32.const 168)
+                                            )
+                                            (get_local $5)
+                                            (i32.const 0)
+                                          )
+                                        )
+                                        (set_local $7
+                                          (i32.load
+                                            (i32.const 168)
+                                          )
+                                        )
+                                        (i32.const 1000000000)
+                                        (i32.const 0)
+                                      )
+                                    )
+                                    (i32.load
+                                      (i32.const 168)
+                                    )
+                                    (i32.store
+                                      (get_local $10)
+                                      (get_local $6)
+                                    )
+                                    (set_local $5
+                                      (call $___udivdi3
+                                        (get_local $5)
+                                        (get_local $7)
+                                        (i32.const 1000000000)
+                                        (i32.const 0)
+                                      )
+                                    )
+                                    (i32.load
+                                      (i32.const 168)
+                                    )
+                                    (if
+                                      (i32.lt_u
+                                        (set_local $7
+                                          (i32.add
+                                            (get_local $10)
+                                            (i32.const -4)
+                                          )
+                                        )
+                                        (get_local $8)
+                                      )
+                                      (br $while-out$72)
+                                      (set_local $10
+                                        (get_local $7)
+                                      )
+                                    )
+                                    (br $while-in$73)
+                                  )
+                                  (br_if $do-once$70
+                                    (get_local $8)
+                                    (i32.eq
+                                      (get_local $5)
+                                      (i32.const 0)
+                                    )
+                                  )
+                                  (i32.store
+                                    (set_local $7
+                                      (i32.add
+                                        (get_local $8)
+                                        (i32.const -4)
+                                      )
+                                    )
+                                    (get_local $5)
+                                  )
+                                  (get_local $7)
+                                )
+                              )
+                            )
+                          )
+                          (loop $while-out$74 $while-in$75
+                            (if
+                              (i32.le_u
+                                (get_local $13)
+                                (get_local $7)
+                              )
+                              (br $while-out$74)
+                            )
+                            (if
+                              (i32.eq
+                                (i32.load
+                                  (set_local $5
+                                    (i32.add
+                                      (get_local $13)
+                                      (i32.const -4)
+                                    )
+                                  )
+                                )
+                                (i32.const 0)
+                              )
+                              (set_local $13
+                                (get_local $5)
+                              )
+                              (br $while-out$74)
+                            )
+                            (br $while-in$75)
+                          )
+                          (i32.store
+                            (get_local $25)
+                            (set_local $5
+                              (i32.sub
+                                (i32.load
+                                  (get_local $25)
+                                )
+                                (get_local $11)
+                              )
+                            )
+                          )
+                          (if
+                            (i32.gt_s
+                              (get_local $5)
+                              (i32.const 0)
+                            )
+                            (set_local $8
+                              (get_local $7)
+                            )
+                            (block
+                              (set_local $6
+                                (get_local $13)
+                              )
+                              (br $while-out$68)
+                            )
+                          )
+                          (br $while-in$69)
+                        )
+                      )
+                      (set_local $7
+                        (get_local $9)
+                      )
+                    )
+                    (if
+                      (i32.lt_s
+                        (get_local $5)
+                        (i32.const 0)
+                      )
+                      (block
+                        (set_local $8
+                          (i32.add
+                            (i32.and
+                              (call_import $i32s-div
+                                (i32.add
+                                  (get_local $1)
+                                  (i32.const 25)
+                                )
+                                (i32.const 9)
+                              )
+                              (i32.const -1)
+                            )
+                            (i32.const 1)
                           )
                         )
-                        (i32.store
-                          (get_local $25)
-                          (i32.add
-                            (i32.load
-                              (get_local $25)
-                            )
-                            (i32.const -1)
+                        (set_local $10
+                          (i32.eq
+                            (get_local $14)
+                            (i32.const 102)
                           )
+                        )
+                        (set_local $23
+                          (get_local $6)
+                        )
+                        (loop $while-out$76 $while-in$77
+                          (set_local $5
+                            (i32.gt_s
+                              (set_local $6
+                                (i32.sub
+                                  (i32.const 0)
+                                  (get_local $5)
+                                )
+                              )
+                              (i32.const 9)
+                            )
+                          )
+                          (set_local $13
+                            (select
+                              (i32.const 9)
+                              (get_local $6)
+                              (get_local $5)
+                            )
+                          )
+                          (set_local $11
+                            (block $do-once$78
+                              (if
+                                (i32.lt_u
+                                  (get_local $7)
+                                  (get_local $23)
+                                )
+                                (block
+                                  (set_local $70
+                                    (i32.add
+                                      (i32.shl
+                                        (i32.const 1)
+                                        (get_local $13)
+                                      )
+                                      (i32.const -1)
+                                    )
+                                  )
+                                  (set_local $27
+                                    (i32.shr_u
+                                      (i32.const 1000000000)
+                                      (get_local $13)
+                                    )
+                                  )
+                                  (set_local $11
+                                    (i32.const 0)
+                                  )
+                                  (set_local $17
+                                    (get_local $7)
+                                  )
+                                  (loop $while-out$80 $while-in$81
+                                    (set_local $6
+                                      (i32.and
+                                        (set_local $5
+                                          (i32.load
+                                            (get_local $17)
+                                          )
+                                        )
+                                        (get_local $70)
+                                      )
+                                    )
+                                    (i32.store
+                                      (get_local $17)
+                                      (i32.add
+                                        (i32.shr_u
+                                          (get_local $5)
+                                          (get_local $13)
+                                        )
+                                        (get_local $11)
+                                      )
+                                    )
+                                    (set_local $11
+                                      (i32.mul
+                                        (get_local $6)
+                                        (get_local $27)
+                                      )
+                                    )
+                                    (if
+                                      (i32.ge_u
+                                        (set_local $17
+                                          (i32.add
+                                            (get_local $17)
+                                            (i32.const 4)
+                                          )
+                                        )
+                                        (get_local $23)
+                                      )
+                                      (br $while-out$80)
+                                    )
+                                    (br $while-in$81)
+                                  )
+                                  (set_local $5
+                                    (select
+                                      (i32.add
+                                        (get_local $7)
+                                        (i32.const 4)
+                                      )
+                                      (get_local $7)
+                                      (i32.eq
+                                        (i32.load
+                                          (get_local $7)
+                                        )
+                                        (i32.const 0)
+                                      )
+                                    )
+                                  )
+                                  (if
+                                    (i32.eq
+                                      (get_local $11)
+                                      (i32.const 0)
+                                    )
+                                    (br $do-once$78
+                                      (get_local $5)
+                                    )
+                                  )
+                                  (i32.store
+                                    (get_local $23)
+                                    (get_local $11)
+                                  )
+                                  (set_local $23
+                                    (i32.add
+                                      (get_local $23)
+                                      (i32.const 4)
+                                    )
+                                  )
+                                  (get_local $5)
+                                )
+                                (select
+                                  (i32.add
+                                    (get_local $7)
+                                    (i32.const 4)
+                                  )
+                                  (get_local $7)
+                                  (i32.eq
+                                    (i32.load
+                                      (get_local $7)
+                                    )
+                                    (i32.const 0)
+                                  )
+                                )
+                              )
+                            )
+                          )
+                          (set_local $5
+                            (i32.gt_s
+                              (i32.shr_s
+                                (i32.sub
+                                  (get_local $23)
+                                  (set_local $7
+                                    (select
+                                      (get_local $9)
+                                      (get_local $11)
+                                      (get_local $10)
+                                    )
+                                  )
+                                )
+                                (i32.const 2)
+                              )
+                              (get_local $8)
+                            )
+                          )
+                          (set_local $6
+                            (select
+                              (i32.add
+                                (get_local $7)
+                                (i32.shl
+                                  (get_local $8)
+                                  (i32.const 2)
+                                )
+                              )
+                              (get_local $23)
+                              (get_local $5)
+                            )
+                          )
+                          (i32.store
+                            (get_local $25)
+                            (set_local $5
+                              (i32.add
+                                (i32.load
+                                  (get_local $25)
+                                )
+                                (get_local $13)
+                              )
+                            )
+                          )
+                          (if
+                            (i32.lt_s
+                              (get_local $5)
+                              (i32.const 0)
+                            )
+                            (block
+                              (set_local $7
+                                (get_local $11)
+                              )
+                              (set_local $23
+                                (get_local $6)
+                              )
+                            )
+                            (block
+                              (set_local $7
+                                (get_local $11)
+                              )
+                              (set_local $27
+                                (get_local $6)
+                              )
+                              (br $while-out$76)
+                            )
+                          )
+                          (br $while-in$77)
+                        )
+                      )
+                      (set_local $27
+                        (get_local $6)
+                      )
+                    )
+                    (block $do-once$82
+                      (if
+                        (i32.lt_u
+                          (get_local $7)
+                          (get_local $27)
+                        )
+                        (block
+                          (set_local $6
+                            (i32.mul
+                              (i32.shr_s
+                                (i32.sub
+                                  (get_local $62)
+                                  (get_local $7)
+                                )
+                                (i32.const 2)
+                              )
+                              (i32.const 9)
+                            )
+                          )
+                          (if
+                            (i32.lt_u
+                              (set_local $5
+                                (i32.load
+                                  (get_local $7)
+                                )
+                              )
+                              (i32.const 10)
+                            )
+                            (block
+                              (set_local $13
+                                (get_local $6)
+                              )
+                              (br $do-once$82)
+                            )
+                            (set_local $8
+                              (i32.const 10)
+                            )
+                          )
+                          (loop $while-out$84 $while-in$85
+                            (set_local $6
+                              (i32.add
+                                (get_local $6)
+                                (i32.const 1)
+                              )
+                            )
+                            (if
+                              (i32.lt_u
+                                (get_local $5)
+                                (set_local $8
+                                  (i32.mul
+                                    (get_local $8)
+                                    (i32.const 10)
+                                  )
+                                )
+                              )
+                              (block
+                                (set_local $13
+                                  (get_local $6)
+                                )
+                                (br $while-out$84)
+                              )
+                            )
+                            (br $while-in$85)
+                          )
+                        )
+                        (set_local $13
+                          (i32.const 0)
+                        )
+                      )
+                    )
+                    (set_local $7
+                      (if
+                        (i32.lt_s
+                          (set_local $5
+                            (i32.add
+                              (i32.sub
+                                (get_local $1)
+                                (select
+                                  (get_local $13)
+                                  (i32.const 0)
+                                  (i32.ne
+                                    (get_local $14)
+                                    (i32.const 102)
+                                  )
+                                )
+                              )
+                              (i32.shr_s
+                                (i32.shl
+                                  (i32.and
+                                    (set_local $70
+                                      (i32.ne
+                                        (get_local $1)
+                                        (i32.const 0)
+                                      )
+                                    )
+                                    (set_local $8
+                                      (i32.eq
+                                        (get_local $14)
+                                        (i32.const 103)
+                                      )
+                                    )
+                                  )
+                                  (i32.const 31)
+                                )
+                                (i32.const 31)
+                              )
+                            )
+                          )
+                          (i32.add
+                            (i32.mul
+                              (i32.shr_s
+                                (i32.sub
+                                  (get_local $27)
+                                  (get_local $62)
+                                )
+                                (i32.const 2)
+                              )
+                              (i32.const 9)
+                            )
+                            (i32.const -9)
+                          )
+                        )
+                        (block
+                          (set_local $6
+                            (i32.add
+                              (i32.add
+                                (get_local $9)
+                                (i32.const 4)
+                              )
+                              (i32.shl
+                                (i32.add
+                                  (i32.and
+                                    (call_import $i32s-div
+                                      (set_local $5
+                                        (i32.add
+                                          (get_local $5)
+                                          (i32.const 9216)
+                                        )
+                                      )
+                                      (i32.const 9)
+                                    )
+                                    (i32.const -1)
+                                  )
+                                  (i32.const -1024)
+                                )
+                                (i32.const 2)
+                              )
+                            )
+                          )
+                          (if
+                            (i32.lt_s
+                              (set_local $11
+                                (i32.add
+                                  (i32.and
+                                    (call_import $i32s-rem
+                                      (get_local $5)
+                                      (i32.const 9)
+                                    )
+                                    (i32.const -1)
+                                  )
+                                  (i32.const 1)
+                                )
+                              )
+                              (i32.const 9)
+                            )
+                            (block
+                              (set_local $5
+                                (i32.const 10)
+                              )
+                              (loop $while-out$86 $while-in$87
+                                (set_local $5
+                                  (i32.mul
+                                    (get_local $5)
+                                    (i32.const 10)
+                                  )
+                                )
+                                (if
+                                  (i32.eq
+                                    (set_local $11
+                                      (i32.add
+                                        (get_local $11)
+                                        (i32.const 1)
+                                      )
+                                    )
+                                    (i32.const 9)
+                                  )
+                                  (block
+                                    (set_local $17
+                                      (get_local $5)
+                                    )
+                                    (br $while-out$86)
+                                  )
+                                )
+                                (br $while-in$87)
+                              )
+                            )
+                            (set_local $17
+                              (i32.const 10)
+                            )
+                          )
+                          (block $do-once$88
+                            (if
+                              (i32.eqz
+                                (i32.and
+                                  (set_local $11
+                                    (i32.eq
+                                      (i32.add
+                                        (get_local $6)
+                                        (i32.const 4)
+                                      )
+                                      (get_local $27)
+                                    )
+                                  )
+                                  (i32.eq
+                                    (set_local $14
+                                      (i32.and
+                                        (call_import $i32u-rem
+                                          (set_local $5
+                                            (i32.load
+                                              (get_local $6)
+                                            )
+                                          )
+                                          (get_local $17)
+                                        )
+                                        (i32.const -1)
+                                      )
+                                    )
+                                    (i32.const 0)
+                                  )
+                                )
+                              )
+                              (block
+                                (set_local $15
+                                  (select
+                                    (f64.const 9007199254740992)
+                                    (f64.const 9007199254740994)
+                                    (i32.eq
+                                      (i32.and
+                                        (i32.and
+                                          (call_import $i32u-div
+                                            (get_local $5)
+                                            (get_local $17)
+                                          )
+                                          (i32.const -1)
+                                        )
+                                        (i32.const 1)
+                                      )
+                                      (i32.const 0)
+                                    )
+                                  )
+                                )
+                                (set_local $30
+                                  (if
+                                    (i32.lt_u
+                                      (get_local $14)
+                                      (set_local $10
+                                        (i32.and
+                                          (call_import $i32s-div
+                                            (get_local $17)
+                                            (i32.const 2)
+                                          )
+                                          (i32.const -1)
+                                        )
+                                      )
+                                    )
+                                    (f64.const 0.5)
+                                    (select
+                                      (f64.const 1)
+                                      (f64.const 1.5)
+                                      (i32.and
+                                        (get_local $11)
+                                        (i32.eq
+                                          (get_local $14)
+                                          (get_local $10)
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                                (set_local $15
+                                  (block $do-once$90
+                                    (if
+                                      (i32.eq
+                                        (get_local $51)
+                                        (i32.const 0)
+                                      )
+                                      (get_local $15)
+                                      (block
+                                        (if
+                                          (i32.ne
+                                            (i32.shr_s
+                                              (i32.shl
+                                                (i32.load8_s
+                                                  (get_local $39)
+                                                )
+                                                (i32.const 24)
+                                              )
+                                              (i32.const 24)
+                                            )
+                                            (i32.const 45)
+                                          )
+                                          (br $do-once$90
+                                            (get_local $15)
+                                          )
+                                        )
+                                        (set_local $30
+                                          (f64.neg
+                                            (get_local $30)
+                                          )
+                                        )
+                                        (f64.neg
+                                          (get_local $15)
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                                (i32.store
+                                  (get_local $6)
+                                  (set_local $5
+                                    (i32.sub
+                                      (get_local $5)
+                                      (get_local $14)
+                                    )
+                                  )
+                                )
+                                (if
+                                  (f64.eq
+                                    (f64.add
+                                      (get_local $15)
+                                      (get_local $30)
+                                    )
+                                    (get_local $15)
+                                  )
+                                  (br $do-once$88)
+                                )
+                                (i32.store
+                                  (get_local $6)
+                                  (set_local $5
+                                    (i32.add
+                                      (get_local $5)
+                                      (get_local $17)
+                                    )
+                                  )
+                                )
+                                (if
+                                  (i32.gt_u
+                                    (get_local $5)
+                                    (i32.const 999999999)
+                                  )
+                                  (loop $while-out$92 $while-in$93
+                                    (i32.store
+                                      (get_local $6)
+                                      (i32.const 0)
+                                    )
+                                    (set_local $7
+                                      (if
+                                        (i32.lt_u
+                                          (set_local $6
+                                            (i32.add
+                                              (get_local $6)
+                                              (i32.const -4)
+                                            )
+                                          )
+                                          (get_local $7)
+                                        )
+                                        (block
+                                          (i32.store
+                                            (set_local $5
+                                              (i32.add
+                                                (get_local $7)
+                                                (i32.const -4)
+                                              )
+                                            )
+                                            (i32.const 0)
+                                          )
+                                          (get_local $5)
+                                        )
+                                        (get_local $7)
+                                      )
+                                    )
+                                    (i32.store
+                                      (get_local $6)
+                                      (set_local $5
+                                        (i32.add
+                                          (i32.load
+                                            (get_local $6)
+                                          )
+                                          (i32.const 1)
+                                        )
+                                      )
+                                    )
+                                    (if
+                                      (i32.le_u
+                                        (get_local $5)
+                                        (i32.const 999999999)
+                                      )
+                                      (br $while-out$92)
+                                    )
+                                    (br $while-in$93)
+                                  )
+                                )
+                                (set_local $11
+                                  (i32.mul
+                                    (i32.shr_s
+                                      (i32.sub
+                                        (get_local $62)
+                                        (get_local $7)
+                                      )
+                                      (i32.const 2)
+                                    )
+                                    (i32.const 9)
+                                  )
+                                )
+                                (if
+                                  (i32.lt_u
+                                    (set_local $5
+                                      (i32.load
+                                        (get_local $7)
+                                      )
+                                    )
+                                    (i32.const 10)
+                                  )
+                                  (block
+                                    (set_local $13
+                                      (get_local $11)
+                                    )
+                                    (br $do-once$88)
+                                  )
+                                  (set_local $10
+                                    (i32.const 10)
+                                  )
+                                )
+                                (loop $while-out$94 $while-in$95
+                                  (set_local $11
+                                    (i32.add
+                                      (get_local $11)
+                                      (i32.const 1)
+                                    )
+                                  )
+                                  (if
+                                    (i32.lt_u
+                                      (get_local $5)
+                                      (set_local $10
+                                        (i32.mul
+                                          (get_local $10)
+                                          (i32.const 10)
+                                        )
+                                      )
+                                    )
+                                    (block
+                                      (set_local $13
+                                        (get_local $11)
+                                      )
+                                      (br $while-out$94)
+                                    )
+                                  )
+                                  (br $while-in$95)
+                                )
+                              )
+                            )
+                          )
+                          (set_local $6
+                            (i32.gt_u
+                              (get_local $27)
+                              (set_local $5
+                                (i32.add
+                                  (get_local $6)
+                                  (i32.const 4)
+                                )
+                              )
+                            )
+                          )
+                          (set_local $6
+                            (select
+                              (get_local $5)
+                              (get_local $27)
+                              (get_local $6)
+                            )
+                          )
+                          (get_local $7)
+                        )
+                        (block
+                          (set_local $6
+                            (get_local $27)
+                          )
+                          (get_local $7)
+                        )
+                      )
+                    )
+                    (set_local $27
+                      (i32.sub
+                        (i32.const 0)
+                        (get_local $13)
+                      )
+                    )
+                    (loop $while-out$96 $while-in$97
+                      (if
+                        (i32.le_u
+                          (get_local $6)
+                          (get_local $7)
+                        )
+                        (block
+                          (set_local $11
+                            (i32.const 0)
+                          )
+                          (set_local $23
+                            (get_local $6)
+                          )
+                          (br $while-out$96)
                         )
                       )
                       (if
                         (i32.eq
-                          (set_local $14
-                            (i32.or
-                              (get_local $26)
-                              (i32.const 32)
+                          (i32.load
+                            (set_local $5
+                              (i32.add
+                                (get_local $6)
+                                (i32.const -4)
+                              )
                             )
                           )
-                          (i32.const 97)
+                          (i32.const 0)
+                        )
+                        (set_local $6
+                          (get_local $5)
                         )
                         (block
-                          (set_local $9
-                            (select
-                              (get_local $39)
-                              (i32.add
-                                (get_local $39)
-                                (i32.const 9)
-                              )
-                              (i32.eq
-                                (set_local $6
-                                  (i32.and
-                                    (get_local $26)
-                                    (i32.const 32)
+                          (set_local $11
+                            (i32.const 1)
+                          )
+                          (set_local $23
+                            (get_local $6)
+                          )
+                          (br $while-out$96)
+                        )
+                      )
+                      (br $while-in$97)
+                    )
+                    (set_local $8
+                      (block $do-once$98
+                        (if
+                          (get_local $8)
+                          (block
+                            (set_local $8
+                              (if
+                                (i32.and
+                                  (i32.gt_s
+                                    (set_local $1
+                                      (i32.add
+                                        (i32.xor
+                                          (i32.and
+                                            (get_local $70)
+                                            (i32.const 1)
+                                          )
+                                          (i32.const 1)
+                                        )
+                                        (get_local $1)
+                                      )
+                                    )
+                                    (get_local $13)
                                   )
+                                  (i32.gt_s
+                                    (get_local $13)
+                                    (i32.const -5)
+                                  )
+                                )
+                                (block
+                                  (set_local $10
+                                    (i32.add
+                                      (get_local $26)
+                                      (i32.const -1)
+                                    )
+                                  )
+                                  (i32.sub
+                                    (i32.add
+                                      (get_local $1)
+                                      (i32.const -1)
+                                    )
+                                    (get_local $13)
+                                  )
+                                )
+                                (block
+                                  (set_local $10
+                                    (i32.add
+                                      (get_local $26)
+                                      (i32.const -2)
+                                    )
+                                  )
+                                  (i32.add
+                                    (get_local $1)
+                                    (i32.const -1)
+                                  )
+                                )
+                              )
+                            )
+                            (if
+                              (i32.ne
+                                (set_local $1
+                                  (i32.and
+                                    (get_local $18)
+                                    (i32.const 8)
+                                  )
+                                )
+                                (i32.const 0)
+                              )
+                              (block
+                                (set_local $14
+                                  (get_local $8)
+                                )
+                                (set_local $26
+                                  (get_local $10)
+                                )
+                                (br $do-once$98
+                                  (get_local $1)
+                                )
+                              )
+                            )
+                            (block $do-once$100
+                              (if
+                                (get_local $11)
+                                (block
+                                  (if
+                                    (i32.eq
+                                      (set_local $1
+                                        (i32.load
+                                          (i32.add
+                                            (get_local $23)
+                                            (i32.const -4)
+                                          )
+                                        )
+                                      )
+                                      (i32.const 0)
+                                    )
+                                    (block
+                                      (set_local $6
+                                        (i32.const 9)
+                                      )
+                                      (br $do-once$100)
+                                    )
+                                  )
+                                  (if
+                                    (i32.eq
+                                      (i32.and
+                                        (call_import $i32u-rem
+                                          (get_local $1)
+                                          (i32.const 10)
+                                        )
+                                        (i32.const -1)
+                                      )
+                                      (i32.const 0)
+                                    )
+                                    (block
+                                      (set_local $5
+                                        (i32.const 10)
+                                      )
+                                      (set_local $6
+                                        (i32.const 0)
+                                      )
+                                    )
+                                    (block
+                                      (set_local $6
+                                        (i32.const 0)
+                                      )
+                                      (br $do-once$100)
+                                    )
+                                  )
+                                  (loop $while-out$102 $while-in$103
+                                    (set_local $6
+                                      (i32.add
+                                        (get_local $6)
+                                        (i32.const 1)
+                                      )
+                                    )
+                                    (if
+                                      (i32.ne
+                                        (i32.and
+                                          (call_import $i32u-rem
+                                            (get_local $1)
+                                            (set_local $5
+                                              (i32.mul
+                                                (get_local $5)
+                                                (i32.const 10)
+                                              )
+                                            )
+                                          )
+                                          (i32.const -1)
+                                        )
+                                        (i32.const 0)
+                                      )
+                                      (br $while-out$102)
+                                    )
+                                    (br $while-in$103)
+                                  )
+                                )
+                                (set_local $6
+                                  (i32.const 9)
+                                )
+                              )
+                            )
+                            (set_local $1
+                              (i32.add
+                                (i32.mul
+                                  (i32.shr_s
+                                    (i32.sub
+                                      (get_local $23)
+                                      (get_local $62)
+                                    )
+                                    (i32.const 2)
+                                  )
+                                  (i32.const 9)
+                                )
+                                (i32.const -9)
+                              )
+                            )
+                            (if
+                              (i32.eq
+                                (i32.or
+                                  (get_local $10)
+                                  (i32.const 32)
+                                )
+                                (i32.const 102)
+                              )
+                              (block
+                                (set_local $1
+                                  (i32.lt_s
+                                    (set_local $5
+                                      (i32.sub
+                                        (get_local $1)
+                                        (get_local $6)
+                                      )
+                                    )
+                                    (i32.const 0)
+                                  )
+                                )
+                                (set_local $5
+                                  (i32.lt_s
+                                    (get_local $8)
+                                    (set_local $1
+                                      (select
+                                        (i32.const 0)
+                                        (get_local $5)
+                                        (get_local $1)
+                                      )
+                                    )
+                                  )
+                                )
+                                (set_local $14
+                                  (select
+                                    (get_local $8)
+                                    (get_local $1)
+                                    (get_local $5)
+                                  )
+                                )
+                                (set_local $26
+                                  (get_local $10)
+                                )
+                                (i32.const 0)
+                              )
+                              (block
+                                (set_local $1
+                                  (i32.lt_s
+                                    (set_local $5
+                                      (i32.sub
+                                        (i32.add
+                                          (get_local $1)
+                                          (get_local $13)
+                                        )
+                                        (get_local $6)
+                                      )
+                                    )
+                                    (i32.const 0)
+                                  )
+                                )
+                                (set_local $5
+                                  (i32.lt_s
+                                    (get_local $8)
+                                    (set_local $1
+                                      (select
+                                        (i32.const 0)
+                                        (get_local $5)
+                                        (get_local $1)
+                                      )
+                                    )
+                                  )
+                                )
+                                (set_local $14
+                                  (select
+                                    (get_local $8)
+                                    (get_local $1)
+                                    (get_local $5)
+                                  )
+                                )
+                                (set_local $26
+                                  (get_local $10)
                                 )
                                 (i32.const 0)
                               )
                             )
                           )
-                          (set_local $7
+                          (block
+                            (set_local $14
+                              (get_local $1)
+                            )
+                            (i32.and
+                              (get_local $18)
+                              (i32.const 8)
+                            )
+                          )
+                        )
+                      )
+                    )
+                    (set_local $17
+                      (i32.and
+                        (i32.ne
+                          (set_local $1
                             (i32.or
-                              (get_local $51)
-                              (i32.const 2)
+                              (get_local $14)
+                              (get_local $8)
                             )
                           )
-                          (set_local $15
-                            (if
-                              (i32.or
-                                (i32.gt_u
-                                  (get_local $10)
-                                  (i32.const 11)
-                                )
-                                (i32.eq
-                                  (set_local $1
-                                    (i32.sub
-                                      (i32.const 12)
-                                      (get_local $10)
-                                    )
-                                  )
-                                  (i32.const 0)
-                                )
-                              )
-                              (get_local $15)
-                              (block
-                                (set_local $30
-                                  (f64.const 8)
-                                )
-                                (loop $while-out$60 $while-in$61
-                                  (set_local $30
-                                    (f64.mul
-                                      (get_local $30)
-                                      (f64.const 16)
-                                    )
-                                  )
-                                  (if
-                                    (i32.eq
-                                      (set_local $1
-                                        (i32.add
-                                          (get_local $1)
-                                          (i32.const -1)
-                                        )
-                                      )
-                                      (i32.const 0)
-                                    )
-                                    (br $while-out$60)
-                                  )
-                                  (br $while-in$61)
-                                )
-                                (select
-                                  (f64.neg
-                                    (f64.add
-                                      (get_local $30)
-                                      (f64.sub
-                                        (f64.neg
-                                          (get_local $15)
-                                        )
-                                        (get_local $30)
-                                      )
-                                    )
-                                  )
-                                  (f64.sub
-                                    (f64.add
-                                      (get_local $15)
-                                      (get_local $30)
-                                    )
-                                    (get_local $30)
-                                  )
-                                  (i32.eq
-                                    (i32.shr_s
-                                      (i32.shl
-                                        (i32.load8_s
-                                          (get_local $9)
-                                        )
-                                        (i32.const 24)
-                                      )
-                                      (i32.const 24)
-                                    )
-                                    (i32.const 45)
-                                  )
-                                )
-                              )
+                          (i32.const 0)
+                        )
+                        (i32.const 1)
+                      )
+                    )
+                    (set_local $13
+                      (if
+                        (set_local $10
+                          (i32.eq
+                            (i32.or
+                              (get_local $26)
+                              (i32.const 32)
                             )
+                            (i32.const 102)
                           )
-                          (set_local $5
-                            (i32.lt_s
-                              (set_local $1
-                                (i32.load
-                                  (get_local $25)
-                                )
-                              )
+                        )
+                        (block
+                          (set_local $6
+                            (select
+                              (get_local $13)
                               (i32.const 0)
+                              (i32.gt_s
+                                (get_local $13)
+                                (i32.const 0)
+                              )
                             )
                           )
+                          (i32.const 0)
+                        )
+                        (block
                           (set_local $5
                             (i32.shr_s
                               (i32.shl
                                 (i32.lt_s
-                                  (set_local $8
+                                  (set_local $6
                                     (select
-                                      (i32.sub
+                                      (get_local $27)
+                                      (get_local $13)
+                                      (i32.lt_s
+                                        (get_local $13)
                                         (i32.const 0)
-                                        (get_local $1)
                                       )
-                                      (get_local $1)
-                                      (get_local $5)
                                     )
                                   )
                                   (i32.const 0)
@@ -5359,37 +7059,55 @@
                               (i32.const 31)
                             )
                           )
-                          (i32.store8
-                            (i32.add
-                              (set_local $5
-                                (if
-                                  (i32.eq
-                                    (set_local $5
-                                      (call $_fmt_u
-                                        (get_local $8)
-                                        (get_local $5)
-                                        (get_local $52)
-                                      )
-                                    )
+                          (if
+                            (i32.lt_s
+                              (i32.sub
+                                (get_local $40)
+                                (set_local $5
+                                  (call $_fmt_u
+                                    (get_local $6)
+                                    (get_local $5)
                                     (get_local $52)
                                   )
-                                  (block
-                                    (i32.store8
-                                      (get_local $74)
-                                      (i32.const 48)
-                                    )
-                                    (get_local $74)
-                                  )
-                                  (get_local $5)
                                 )
                               )
+                              (i32.const 2)
+                            )
+                            (loop $while-out$104 $while-in$105
+                              (i32.store8
+                                (set_local $5
+                                  (i32.add
+                                    (get_local $5)
+                                    (i32.const -1)
+                                  )
+                                )
+                                (i32.const 48)
+                              )
+                              (if
+                                (i32.lt_s
+                                  (i32.sub
+                                    (get_local $40)
+                                    (get_local $5)
+                                  )
+                                  (i32.const 2)
+                                )
+                                (get_local $5)
+                                (br $while-out$104)
+                              )
+                              (br $while-in$105)
+                            )
+                            (get_local $5)
+                          )
+                          (i32.store8
+                            (i32.add
+                              (get_local $5)
                               (i32.const -1)
                             )
                             (i32.and
                               (i32.add
                                 (i32.and
                                   (i32.shr_s
-                                    (get_local $1)
+                                    (get_local $13)
                                     (i32.const 31)
                                   )
                                   (i32.const 2)
@@ -5400,1878 +7118,265 @@
                             )
                           )
                           (i32.store8
-                            (set_local $8
+                            (set_local $5
                               (i32.add
                                 (get_local $5)
                                 (i32.const -2)
                               )
                             )
                             (i32.and
-                              (i32.add
-                                (get_local $26)
-                                (i32.const 15)
-                              )
+                              (get_local $26)
                               (i32.const 255)
                             )
                           )
-                          (set_local $5
-                            (i32.lt_s
-                              (get_local $10)
-                              (i32.const 1)
-                            )
-                          )
-                          (set_local $13
-                            (i32.eq
-                              (i32.and
-                                (get_local $18)
-                                (i32.const 8)
-                              )
-                              (i32.const 0)
-                            )
-                          )
-                          (set_local $11
-                            (get_local $29)
-                          )
-                          (loop $while-out$62 $while-in$63
-                            (i32.store8
-                              (get_local $11)
-                              (i32.and
-                                (i32.or
-                                  (i32.and
-                                    (i32.load8_s
-                                      (i32.add
-                                        (set_local $1
-                                          (call_import $f64-to-int
-                                            (get_local $15)
-                                          )
-                                        )
-                                        (i32.const 4075)
-                                      )
-                                    )
-                                    (i32.const 255)
-                                  )
-                                  (get_local $6)
-                                )
-                                (i32.const 255)
-                              )
-                            )
-                            (set_local $15
-                              (f64.mul
-                                (f64.sub
-                                  (get_local $15)
-                                  (f64.convert_s/i32
-                                    (get_local $1)
-                                  )
-                                )
-                                (f64.const 16)
-                              )
-                            )
-                            (set_local $11
-                              (block $do-once$64
-                                (if
-                                  (i32.eq
-                                    (i32.sub
-                                      (set_local $1
-                                        (i32.add
-                                          (get_local $11)
-                                          (i32.const 1)
-                                        )
-                                      )
-                                      (get_local $64)
-                                    )
-                                    (i32.const 1)
-                                  )
-                                  (block
-                                    (br_if $do-once$64
-                                      (get_local $1)
-                                      (i32.and
-                                        (get_local $13)
-                                        (i32.and
-                                          (get_local $5)
-                                          (f64.eq
-                                            (get_local $15)
-                                            (f64.const 0)
-                                          )
-                                        )
-                                      )
-                                    )
-                                    (i32.store8
-                                      (get_local $1)
-                                      (i32.const 46)
-                                    )
-                                    (i32.add
-                                      (get_local $11)
-                                      (i32.const 2)
-                                    )
-                                  )
-                                  (get_local $1)
-                                )
-                              )
-                            )
-                            (if
-                              (f64.eq
-                                (get_local $15)
-                                (f64.const 0)
-                              )
-                              (block
-                                (set_local $1
-                                  (get_local $11)
-                                )
-                                (br $while-out$62)
-                              )
-                            )
-                            (br $while-in$63)
-                          )
-                          (set_local $5
-                            (i32.and
-                              (i32.ne
-                                (get_local $10)
-                                (i32.const 0)
-                              )
-                              (i32.lt_s
-                                (i32.add
-                                  (get_local $78)
-                                  (get_local $1)
-                                )
-                                (get_local $10)
-                              )
-                            )
-                          )
-                          (call $_pad
-                            (get_local $0)
-                            (i32.const 32)
-                            (get_local $16)
-                            (set_local $5
-                              (i32.add
-                                (set_local $6
-                                  (select
-                                    (i32.sub
-                                      (i32.add
-                                        (get_local $79)
-                                        (get_local $10)
-                                      )
-                                      (get_local $8)
-                                    )
-                                    (i32.add
-                                      (i32.sub
-                                        (get_local $77)
-                                        (get_local $8)
-                                      )
-                                      (get_local $1)
-                                    )
-                                    (get_local $5)
-                                  )
-                                )
-                                (get_local $7)
-                              )
-                            )
-                            (get_local $18)
-                          )
-                          (if
-                            (i32.eq
-                              (i32.and
-                                (i32.load
-                                  (get_local $0)
-                                )
-                                (i32.const 32)
-                              )
-                              (i32.const 0)
-                            )
-                            (call $___fwritex
-                              (get_local $9)
-                              (get_local $7)
-                              (get_local $0)
-                            )
-                          )
-                          (call $_pad
-                            (get_local $0)
-                            (i32.const 48)
-                            (get_local $16)
-                            (get_local $5)
-                            (i32.xor
-                              (get_local $18)
-                              (i32.const 65536)
-                            )
-                          )
-                          (set_local $1
+                          (set_local $6
                             (i32.sub
-                              (get_local $1)
-                              (get_local $64)
-                            )
-                          )
-                          (if
-                            (i32.eq
-                              (i32.and
-                                (i32.load
-                                  (get_local $0)
-                                )
-                                (i32.const 32)
-                              )
-                              (i32.const 0)
-                            )
-                            (call $___fwritex
-                              (get_local $29)
-                              (get_local $1)
-                              (get_local $0)
-                            )
-                          )
-                          (call $_pad
-                            (get_local $0)
-                            (i32.const 48)
-                            (i32.sub
-                              (get_local $6)
-                              (i32.add
-                                (get_local $1)
-                                (set_local $1
-                                  (i32.sub
-                                    (get_local $40)
-                                    (get_local $8)
-                                  )
-                                )
-                              )
-                            )
-                            (i32.const 0)
-                            (i32.const 0)
-                          )
-                          (if
-                            (i32.eq
-                              (i32.and
-                                (i32.load
-                                  (get_local $0)
-                                )
-                                (i32.const 32)
-                              )
-                              (i32.const 0)
-                            )
-                            (call $___fwritex
-                              (get_local $8)
-                              (get_local $1)
-                              (get_local $0)
-                            )
-                          )
-                          (call $_pad
-                            (get_local $0)
-                            (i32.const 32)
-                            (get_local $16)
-                            (get_local $5)
-                            (i32.xor
-                              (get_local $18)
-                              (i32.const 8192)
-                            )
-                          )
-                          (br $do-once$56
-                            (select
-                              (get_local $16)
+                              (get_local $40)
                               (get_local $5)
-                              (i32.lt_s
-                                (get_local $5)
-                                (get_local $16)
-                              )
                             )
                           )
-                        )
-                      )
-                      (set_local $1
-                        (select
-                          (i32.const 6)
-                          (get_local $10)
-                          (i32.lt_s
-                            (get_local $10)
-                            (i32.const 0)
-                          )
-                        )
-                      )
-                      (set_local $62
-                        (set_local $9
-                          (select
-                            (get_local $80)
-                            (get_local $81)
-                            (i32.lt_s
-                              (if
-                                (get_local $5)
-                                (block
-                                  (i32.store
-                                    (get_local $25)
-                                    (set_local $5
-                                      (i32.add
-                                        (i32.load
-                                          (get_local $25)
-                                        )
-                                        (i32.const -28)
-                                      )
-                                    )
-                                  )
-                                  (set_local $15
-                                    (f64.mul
-                                      (get_local $15)
-                                      (f64.const 268435456)
-                                    )
-                                  )
-                                  (get_local $5)
-                                )
-                                (i32.load
-                                  (get_local $25)
-                                )
-                              )
-                              (i32.const 0)
-                            )
-                          )
-                        )
-                      )
-                      (set_local $7
-                        (get_local $9)
-                      )
-                      (loop $while-out$66 $while-in$67
-                        (i32.store
-                          (get_local $7)
-                          (set_local $5
-                            (call_import $f64-to-int
-                              (get_local $15)
-                            )
-                          )
-                        )
-                        (set_local $7
-                          (i32.add
-                            (get_local $7)
-                            (i32.const 4)
-                          )
-                        )
-                        (if
-                          (f64.eq
-                            (set_local $15
-                              (f64.mul
-                                (f64.sub
-                                  (get_local $15)
-                                  (f64.convert_u/i32
-                                    (get_local $5)
-                                  )
-                                )
-                                (f64.const 1e9)
-                              )
-                            )
-                            (f64.const 0)
-                          )
-                          (block
-                            (set_local $6
-                              (get_local $7)
-                            )
-                            (br $while-out$66)
-                          )
-                        )
-                        (br $while-in$67)
-                      )
-                      (if
-                        (i32.gt_s
-                          (set_local $5
-                            (i32.load
-                              (get_local $25)
-                            )
-                          )
-                          (i32.const 0)
-                        )
-                        (block
-                          (set_local $8
-                            (get_local $9)
-                          )
-                          (set_local $13
-                            (get_local $6)
-                          )
-                          (loop $while-out$68 $while-in$69
-                            (set_local $11
-                              (select
-                                (i32.const 29)
-                                (get_local $5)
-                                (i32.gt_s
-                                  (get_local $5)
-                                  (i32.const 29)
-                                )
-                              )
-                            )
-                            (set_local $7
-                              (block $do-once$70
-                                (if
-                                  (i32.lt_u
-                                    (set_local $7
-                                      (i32.add
-                                        (get_local $13)
-                                        (i32.const -4)
-                                      )
-                                    )
-                                    (get_local $8)
-                                  )
-                                  (get_local $8)
-                                  (block
-                                    (set_local $5
-                                      (i32.const 0)
-                                    )
-                                    (set_local $10
-                                      (get_local $7)
-                                    )
-                                    (loop $while-out$72 $while-in$73
-                                      (set_local $6
-                                        (call $___uremdi3
-                                          (set_local $5
-                                            (call $_i64Add
-                                              (call $_bitshift64Shl
-                                                (i32.load
-                                                  (get_local $10)
-                                                )
-                                                (i32.const 0)
-                                                (get_local $11)
-                                              )
-                                              (i32.load
-                                                (i32.const 168)
-                                              )
-                                              (get_local $5)
-                                              (i32.const 0)
-                                            )
-                                          )
-                                          (set_local $7
-                                            (i32.load
-                                              (i32.const 168)
-                                            )
-                                          )
-                                          (i32.const 1000000000)
-                                          (i32.const 0)
-                                        )
-                                      )
-                                      (i32.load
-                                        (i32.const 168)
-                                      )
-                                      (i32.store
-                                        (get_local $10)
-                                        (get_local $6)
-                                      )
-                                      (set_local $5
-                                        (call $___udivdi3
-                                          (get_local $5)
-                                          (get_local $7)
-                                          (i32.const 1000000000)
-                                          (i32.const 0)
-                                        )
-                                      )
-                                      (i32.load
-                                        (i32.const 168)
-                                      )
-                                      (if
-                                        (i32.lt_u
-                                          (set_local $7
-                                            (i32.add
-                                              (get_local $10)
-                                              (i32.const -4)
-                                            )
-                                          )
-                                          (get_local $8)
-                                        )
-                                        (br $while-out$72)
-                                        (set_local $10
-                                          (get_local $7)
-                                        )
-                                      )
-                                      (br $while-in$73)
-                                    )
-                                    (br_if $do-once$70
-                                      (get_local $8)
-                                      (i32.eq
-                                        (get_local $5)
-                                        (i32.const 0)
-                                      )
-                                    )
-                                    (i32.store
-                                      (set_local $7
-                                        (i32.add
-                                          (get_local $8)
-                                          (i32.const -4)
-                                        )
-                                      )
-                                      (get_local $5)
-                                    )
-                                    (get_local $7)
-                                  )
-                                )
-                              )
-                            )
-                            (loop $while-out$74 $while-in$75
-                              (if
-                                (i32.le_u
-                                  (get_local $13)
-                                  (get_local $7)
-                                )
-                                (br $while-out$74)
-                              )
-                              (if
-                                (i32.eq
-                                  (i32.load
-                                    (set_local $5
-                                      (i32.add
-                                        (get_local $13)
-                                        (i32.const -4)
-                                      )
-                                    )
-                                  )
-                                  (i32.const 0)
-                                )
-                                (set_local $13
-                                  (get_local $5)
-                                )
-                                (br $while-out$74)
-                              )
-                              (br $while-in$75)
-                            )
-                            (i32.store
-                              (get_local $25)
-                              (set_local $5
-                                (i32.sub
-                                  (i32.load
-                                    (get_local $25)
-                                  )
-                                  (get_local $11)
-                                )
-                              )
-                            )
-                            (if
-                              (i32.gt_s
-                                (get_local $5)
-                                (i32.const 0)
-                              )
-                              (set_local $8
-                                (get_local $7)
-                              )
-                              (block
-                                (set_local $6
-                                  (get_local $13)
-                                )
-                                (br $while-out$68)
-                              )
-                            )
-                            (br $while-in$69)
-                          )
-                        )
-                        (set_local $7
-                          (get_local $9)
-                        )
-                      )
-                      (if
-                        (i32.lt_s
                           (get_local $5)
-                          (i32.const 0)
                         )
-                        (block
-                          (set_local $8
+                      )
+                    )
+                    (call $_pad
+                      (get_local $0)
+                      (i32.const 32)
+                      (get_local $16)
+                      (set_local $6
+                        (i32.add
+                          (i32.add
                             (i32.add
-                              (i32.and
-                                (call_import $i32s-div
-                                  (i32.add
-                                    (get_local $1)
-                                    (i32.const 25)
-                                  )
-                                  (i32.const 9)
-                                )
-                                (i32.const -1)
+                              (i32.add
+                                (get_local $51)
+                                (i32.const 1)
                               )
-                              (i32.const 1)
-                            )
-                          )
-                          (set_local $10
-                            (i32.eq
                               (get_local $14)
-                              (i32.const 102)
                             )
+                            (get_local $17)
                           )
-                          (set_local $23
-                            (get_local $6)
-                          )
-                          (loop $while-out$76 $while-in$77
-                            (set_local $5
-                              (i32.gt_s
-                                (set_local $6
-                                  (i32.sub
-                                    (i32.const 0)
-                                    (get_local $5)
-                                  )
-                                )
-                                (i32.const 9)
-                              )
-                            )
-                            (set_local $13
-                              (select
-                                (i32.const 9)
-                                (get_local $6)
-                                (get_local $5)
-                              )
-                            )
-                            (set_local $11
-                              (block $do-once$78
-                                (if
-                                  (i32.lt_u
-                                    (get_local $7)
-                                    (get_local $23)
-                                  )
-                                  (block
-                                    (set_local $70
-                                      (i32.add
-                                        (i32.shl
-                                          (i32.const 1)
-                                          (get_local $13)
-                                        )
-                                        (i32.const -1)
-                                      )
-                                    )
-                                    (set_local $27
-                                      (i32.shr_u
-                                        (i32.const 1000000000)
-                                        (get_local $13)
-                                      )
-                                    )
-                                    (set_local $11
-                                      (i32.const 0)
-                                    )
-                                    (set_local $17
-                                      (get_local $7)
-                                    )
-                                    (loop $while-out$80 $while-in$81
-                                      (set_local $6
-                                        (i32.and
-                                          (set_local $5
-                                            (i32.load
-                                              (get_local $17)
-                                            )
-                                          )
-                                          (get_local $70)
-                                        )
-                                      )
-                                      (i32.store
-                                        (get_local $17)
-                                        (i32.add
-                                          (i32.shr_u
-                                            (get_local $5)
-                                            (get_local $13)
-                                          )
-                                          (get_local $11)
-                                        )
-                                      )
-                                      (set_local $11
-                                        (i32.mul
-                                          (get_local $6)
-                                          (get_local $27)
-                                        )
-                                      )
-                                      (if
-                                        (i32.ge_u
-                                          (set_local $17
-                                            (i32.add
-                                              (get_local $17)
-                                              (i32.const 4)
-                                            )
-                                          )
-                                          (get_local $23)
-                                        )
-                                        (br $while-out$80)
-                                      )
-                                      (br $while-in$81)
-                                    )
-                                    (set_local $5
-                                      (select
-                                        (i32.add
-                                          (get_local $7)
-                                          (i32.const 4)
-                                        )
-                                        (get_local $7)
-                                        (i32.eq
-                                          (i32.load
-                                            (get_local $7)
-                                          )
-                                          (i32.const 0)
-                                        )
-                                      )
-                                    )
-                                    (if
-                                      (i32.eq
-                                        (get_local $11)
-                                        (i32.const 0)
-                                      )
-                                      (br $do-once$78
-                                        (get_local $5)
-                                      )
-                                    )
-                                    (i32.store
-                                      (get_local $23)
-                                      (get_local $11)
-                                    )
-                                    (set_local $23
-                                      (i32.add
-                                        (get_local $23)
-                                        (i32.const 4)
-                                      )
-                                    )
-                                    (get_local $5)
-                                  )
-                                  (select
-                                    (i32.add
-                                      (get_local $7)
-                                      (i32.const 4)
-                                    )
-                                    (get_local $7)
-                                    (i32.eq
-                                      (i32.load
-                                        (get_local $7)
-                                      )
-                                      (i32.const 0)
-                                    )
-                                  )
-                                )
-                              )
-                            )
-                            (set_local $5
-                              (i32.gt_s
-                                (i32.shr_s
-                                  (i32.sub
-                                    (get_local $23)
-                                    (set_local $7
-                                      (select
-                                        (get_local $9)
-                                        (get_local $11)
-                                        (get_local $10)
-                                      )
-                                    )
-                                  )
-                                  (i32.const 2)
-                                )
-                                (get_local $8)
-                              )
-                            )
-                            (set_local $6
-                              (select
-                                (i32.add
-                                  (get_local $7)
-                                  (i32.shl
-                                    (get_local $8)
-                                    (i32.const 2)
-                                  )
-                                )
-                                (get_local $23)
-                                (get_local $5)
-                              )
-                            )
-                            (i32.store
-                              (get_local $25)
-                              (set_local $5
-                                (i32.add
-                                  (i32.load
-                                    (get_local $25)
-                                  )
-                                  (get_local $13)
-                                )
-                              )
-                            )
-                            (if
-                              (i32.lt_s
-                                (get_local $5)
-                                (i32.const 0)
-                              )
-                              (block
-                                (set_local $7
-                                  (get_local $11)
-                                )
-                                (set_local $23
-                                  (get_local $6)
-                                )
-                              )
-                              (block
-                                (set_local $7
-                                  (get_local $11)
-                                )
-                                (set_local $27
-                                  (get_local $6)
-                                )
-                                (br $while-out$76)
-                              )
-                            )
-                            (br $while-in$77)
-                          )
-                        )
-                        (set_local $27
                           (get_local $6)
                         )
                       )
-                      (block $do-once$82
-                        (if
-                          (i32.lt_u
-                            (get_local $7)
-                            (get_local $27)
+                      (get_local $18)
+                    )
+                    (if
+                      (i32.eq
+                        (i32.and
+                          (i32.load
+                            (get_local $0)
                           )
-                          (block
-                            (set_local $6
-                              (i32.mul
-                                (i32.shr_s
-                                  (i32.sub
-                                    (get_local $62)
-                                    (get_local $7)
-                                  )
-                                  (i32.const 2)
-                                )
-                                (i32.const 9)
-                              )
-                            )
-                            (if
-                              (i32.lt_u
-                                (set_local $5
-                                  (i32.load
-                                    (get_local $7)
-                                  )
-                                )
-                                (i32.const 10)
-                              )
-                              (block
-                                (set_local $13
-                                  (get_local $6)
-                                )
-                                (br $do-once$82)
-                              )
-                              (set_local $8
-                                (i32.const 10)
-                              )
-                            )
-                            (loop $while-out$84 $while-in$85
-                              (set_local $6
-                                (i32.add
-                                  (get_local $6)
-                                  (i32.const 1)
-                                )
-                              )
-                              (if
-                                (i32.lt_u
-                                  (get_local $5)
-                                  (set_local $8
-                                    (i32.mul
-                                      (get_local $8)
-                                      (i32.const 10)
-                                    )
-                                  )
-                                )
-                                (block
-                                  (set_local $13
-                                    (get_local $6)
-                                  )
-                                  (br $while-out$84)
-                                )
-                              )
-                              (br $while-in$85)
-                            )
-                          )
-                          (set_local $13
-                            (i32.const 0)
-                          )
+                          (i32.const 32)
                         )
+                        (i32.const 0)
                       )
-                      (set_local $7
-                        (if
-                          (i32.lt_s
-                            (set_local $5
-                              (i32.add
-                                (i32.sub
-                                  (get_local $1)
-                                  (select
-                                    (get_local $13)
-                                    (i32.const 0)
-                                    (i32.ne
-                                      (get_local $14)
-                                      (i32.const 102)
-                                    )
-                                  )
-                                )
-                                (i32.shr_s
-                                  (i32.shl
-                                    (i32.and
-                                      (set_local $70
-                                        (i32.ne
-                                          (get_local $1)
-                                          (i32.const 0)
-                                        )
-                                      )
-                                      (set_local $8
-                                        (i32.eq
-                                          (get_local $14)
-                                          (i32.const 103)
-                                        )
-                                      )
-                                    )
-                                    (i32.const 31)
-                                  )
-                                  (i32.const 31)
+                      (call $___fwritex
+                        (get_local $39)
+                        (get_local $51)
+                        (get_local $0)
+                      )
+                    )
+                    (call $_pad
+                      (get_local $0)
+                      (i32.const 48)
+                      (get_local $16)
+                      (get_local $6)
+                      (i32.xor
+                        (get_local $18)
+                        (i32.const 65536)
+                      )
+                    )
+                    (block $do-once$106
+                      (if
+                        (get_local $10)
+                        (block
+                          (set_local $7
+                            (set_local $8
+                              (select
+                                (get_local $9)
+                                (get_local $7)
+                                (i32.gt_u
+                                  (get_local $7)
+                                  (get_local $9)
                                 )
                               )
-                            )
-                            (i32.add
-                              (i32.mul
-                                (i32.shr_s
-                                  (i32.sub
-                                    (get_local $27)
-                                    (get_local $62)
-                                  )
-                                  (i32.const 2)
-                                )
-                                (i32.const 9)
-                              )
-                              (i32.const -9)
                             )
                           )
-                          (block
-                            (set_local $6
-                              (i32.add
-                                (i32.add
-                                  (get_local $9)
-                                  (i32.const 4)
+                          (loop $while-out$108 $while-in$109
+                            (set_local $5
+                              (call $_fmt_u
+                                (i32.load
+                                  (get_local $7)
                                 )
-                                (i32.shl
-                                  (i32.add
-                                    (i32.and
-                                      (call_import $i32s-div
-                                        (set_local $5
-                                          (i32.add
-                                            (get_local $5)
-                                            (i32.const 9216)
-                                          )
-                                        )
-                                        (i32.const 9)
-                                      )
-                                      (i32.const -1)
-                                    )
-                                    (i32.const -1024)
-                                  )
-                                  (i32.const 2)
-                                )
+                                (i32.const 0)
+                                (get_local $45)
                               )
                             )
-                            (if
-                              (i32.lt_s
-                                (set_local $11
-                                  (i32.add
-                                    (i32.and
-                                      (call_import $i32s-rem
-                                        (get_local $5)
-                                        (i32.const 9)
-                                      )
-                                      (i32.const -1)
-                                    )
-                                    (i32.const 1)
-                                  )
-                                )
-                                (i32.const 9)
-                              )
-                              (block
-                                (set_local $5
-                                  (i32.const 10)
-                                )
-                                (loop $while-out$86 $while-in$87
-                                  (set_local $5
-                                    (i32.mul
-                                      (get_local $5)
-                                      (i32.const 10)
-                                    )
-                                  )
-                                  (if
-                                    (i32.eq
-                                      (set_local $11
-                                        (i32.add
-                                          (get_local $11)
-                                          (i32.const 1)
-                                        )
-                                      )
-                                      (i32.const 9)
-                                    )
-                                    (block
-                                      (set_local $17
-                                        (get_local $5)
-                                      )
-                                      (br $while-out$86)
-                                    )
-                                  )
-                                  (br $while-in$87)
-                                )
-                              )
-                              (set_local $17
-                                (i32.const 10)
-                              )
-                            )
-                            (block $do-once$88
+                            (block $do-once$110
                               (if
-                                (i32.eqz
-                                  (i32.and
-                                    (set_local $11
-                                      (i32.eq
-                                        (i32.add
-                                          (get_local $6)
-                                          (i32.const 4)
-                                        )
-                                        (get_local $27)
-                                      )
+                                (i32.eq
+                                  (get_local $7)
+                                  (get_local $8)
+                                )
+                                (block
+                                  (if
+                                    (i32.ne
+                                      (get_local $5)
+                                      (get_local $45)
                                     )
-                                    (i32.eq
-                                      (set_local $14
-                                        (i32.and
-                                          (call_import $i32u-rem
-                                            (set_local $5
-                                              (i32.load
-                                                (get_local $6)
-                                              )
-                                            )
-                                            (get_local $17)
-                                          )
-                                          (i32.const -1)
-                                        )
-                                      )
-                                      (i32.const 0)
-                                    )
+                                    (br $do-once$110)
+                                  )
+                                  (i32.store8
+                                    (get_local $53)
+                                    (i32.const 48)
+                                  )
+                                  (set_local $5
+                                    (get_local $53)
                                   )
                                 )
                                 (block
-                                  (set_local $15
-                                    (select
-                                      (f64.const 9007199254740992)
-                                      (f64.const 9007199254740994)
-                                      (i32.eq
-                                        (i32.and
-                                          (i32.and
-                                            (call_import $i32u-div
-                                              (get_local $5)
-                                              (get_local $17)
-                                            )
-                                            (i32.const -1)
-                                          )
-                                          (i32.const 1)
-                                        )
-                                        (i32.const 0)
-                                      )
-                                    )
-                                  )
-                                  (set_local $30
-                                    (if
-                                      (i32.lt_u
-                                        (get_local $14)
-                                        (set_local $10
-                                          (i32.and
-                                            (call_import $i32s-div
-                                              (get_local $17)
-                                              (i32.const 2)
-                                            )
-                                            (i32.const -1)
-                                          )
-                                        )
-                                      )
-                                      (f64.const 0.5)
-                                      (select
-                                        (f64.const 1)
-                                        (f64.const 1.5)
-                                        (i32.and
-                                          (get_local $11)
-                                          (i32.eq
-                                            (get_local $14)
-                                            (get_local $10)
-                                          )
-                                        )
-                                      )
-                                    )
-                                  )
-                                  (set_local $15
-                                    (block $do-once$90
-                                      (if
-                                        (i32.eq
-                                          (get_local $51)
-                                          (i32.const 0)
-                                        )
-                                        (get_local $15)
-                                        (block
-                                          (if
-                                            (i32.ne
-                                              (i32.shr_s
-                                                (i32.shl
-                                                  (i32.load8_s
-                                                    (get_local $39)
-                                                  )
-                                                  (i32.const 24)
-                                                )
-                                                (i32.const 24)
-                                              )
-                                              (i32.const 45)
-                                            )
-                                            (br $do-once$90
-                                              (get_local $15)
-                                            )
-                                          )
-                                          (set_local $30
-                                            (f64.neg
-                                              (get_local $30)
-                                            )
-                                          )
-                                          (f64.neg
-                                            (get_local $15)
-                                          )
-                                        )
-                                      )
-                                    )
-                                  )
-                                  (i32.store
-                                    (get_local $6)
-                                    (set_local $5
-                                      (i32.sub
-                                        (get_local $5)
-                                        (get_local $14)
-                                      )
-                                    )
-                                  )
-                                  (if
-                                    (f64.eq
-                                      (f64.add
-                                        (get_local $15)
-                                        (get_local $30)
-                                      )
-                                      (get_local $15)
-                                    )
-                                    (br $do-once$88)
-                                  )
-                                  (i32.store
-                                    (get_local $6)
-                                    (set_local $5
-                                      (i32.add
-                                        (get_local $5)
-                                        (get_local $17)
-                                      )
-                                    )
-                                  )
                                   (if
                                     (i32.gt_u
                                       (get_local $5)
-                                      (i32.const 999999999)
+                                      (get_local $29)
                                     )
-                                    (loop $while-out$92 $while-in$93
-                                      (i32.store
-                                        (get_local $6)
-                                        (i32.const 0)
-                                      )
-                                      (set_local $7
-                                        (if
-                                          (i32.lt_u
-                                            (set_local $6
-                                              (i32.add
-                                                (get_local $6)
-                                                (i32.const -4)
-                                              )
-                                            )
-                                            (get_local $7)
-                                          )
-                                          (block
-                                            (i32.store
-                                              (set_local $5
-                                                (i32.add
-                                                  (get_local $7)
-                                                  (i32.const -4)
-                                                )
-                                              )
-                                              (i32.const 0)
-                                            )
-                                            (get_local $5)
-                                          )
-                                          (get_local $7)
-                                        )
-                                      )
-                                      (i32.store
-                                        (get_local $6)
-                                        (set_local $5
-                                          (i32.add
-                                            (i32.load
-                                              (get_local $6)
-                                            )
-                                            (i32.const 1)
-                                          )
-                                        )
-                                      )
-                                      (if
-                                        (i32.le_u
-                                          (get_local $5)
-                                          (i32.const 999999999)
-                                        )
-                                        (br $while-out$92)
-                                      )
-                                      (br $while-in$93)
-                                    )
+                                    (get_local $5)
+                                    (br $do-once$110)
                                   )
-                                  (set_local $11
-                                    (i32.mul
-                                      (i32.shr_s
-                                        (i32.sub
-                                          (get_local $62)
-                                          (get_local $7)
-                                        )
-                                        (i32.const 2)
-                                      )
-                                      (i32.const 9)
-                                    )
-                                  )
-                                  (if
-                                    (i32.lt_u
+                                  (loop $while-out$112 $while-in$113
+                                    (i32.store8
                                       (set_local $5
-                                        (i32.load
-                                          (get_local $7)
-                                        )
-                                      )
-                                      (i32.const 10)
-                                    )
-                                    (block
-                                      (set_local $13
-                                        (get_local $11)
-                                      )
-                                      (br $do-once$88)
-                                    )
-                                    (set_local $10
-                                      (i32.const 10)
-                                    )
-                                  )
-                                  (loop $while-out$94 $while-in$95
-                                    (set_local $11
-                                      (i32.add
-                                        (get_local $11)
-                                        (i32.const 1)
-                                      )
-                                    )
-                                    (if
-                                      (i32.lt_u
-                                        (get_local $5)
-                                        (set_local $10
-                                          (i32.mul
-                                            (get_local $10)
-                                            (i32.const 10)
-                                          )
-                                        )
-                                      )
-                                      (block
-                                        (set_local $13
-                                          (get_local $11)
-                                        )
-                                        (br $while-out$94)
-                                      )
-                                    )
-                                    (br $while-in$95)
-                                  )
-                                )
-                              )
-                            )
-                            (set_local $6
-                              (i32.gt_u
-                                (get_local $27)
-                                (set_local $5
-                                  (i32.add
-                                    (get_local $6)
-                                    (i32.const 4)
-                                  )
-                                )
-                              )
-                            )
-                            (set_local $6
-                              (select
-                                (get_local $5)
-                                (get_local $27)
-                                (get_local $6)
-                              )
-                            )
-                            (get_local $7)
-                          )
-                          (block
-                            (set_local $6
-                              (get_local $27)
-                            )
-                            (get_local $7)
-                          )
-                        )
-                      )
-                      (set_local $27
-                        (i32.sub
-                          (i32.const 0)
-                          (get_local $13)
-                        )
-                      )
-                      (loop $while-out$96 $while-in$97
-                        (if
-                          (i32.le_u
-                            (get_local $6)
-                            (get_local $7)
-                          )
-                          (block
-                            (set_local $11
-                              (i32.const 0)
-                            )
-                            (set_local $23
-                              (get_local $6)
-                            )
-                            (br $while-out$96)
-                          )
-                        )
-                        (if
-                          (i32.eq
-                            (i32.load
-                              (set_local $5
-                                (i32.add
-                                  (get_local $6)
-                                  (i32.const -4)
-                                )
-                              )
-                            )
-                            (i32.const 0)
-                          )
-                          (set_local $6
-                            (get_local $5)
-                          )
-                          (block
-                            (set_local $11
-                              (i32.const 1)
-                            )
-                            (set_local $23
-                              (get_local $6)
-                            )
-                            (br $while-out$96)
-                          )
-                        )
-                        (br $while-in$97)
-                      )
-                      (set_local $8
-                        (block $do-once$98
-                          (if
-                            (get_local $8)
-                            (block
-                              (set_local $8
-                                (if
-                                  (i32.and
-                                    (i32.gt_s
-                                      (set_local $1
                                         (i32.add
-                                          (i32.xor
-                                            (i32.and
-                                              (get_local $70)
-                                              (i32.const 1)
-                                            )
-                                            (i32.const 1)
-                                          )
-                                          (get_local $1)
-                                        )
-                                      )
-                                      (get_local $13)
-                                    )
-                                    (i32.gt_s
-                                      (get_local $13)
-                                      (i32.const -5)
-                                    )
-                                  )
-                                  (block
-                                    (set_local $10
-                                      (i32.add
-                                        (get_local $26)
-                                        (i32.const -1)
-                                      )
-                                    )
-                                    (i32.sub
-                                      (i32.add
-                                        (get_local $1)
-                                        (i32.const -1)
-                                      )
-                                      (get_local $13)
-                                    )
-                                  )
-                                  (block
-                                    (set_local $10
-                                      (i32.add
-                                        (get_local $26)
-                                        (i32.const -2)
-                                      )
-                                    )
-                                    (i32.add
-                                      (get_local $1)
-                                      (i32.const -1)
-                                    )
-                                  )
-                                )
-                              )
-                              (if
-                                (i32.ne
-                                  (set_local $1
-                                    (i32.and
-                                      (get_local $18)
-                                      (i32.const 8)
-                                    )
-                                  )
-                                  (i32.const 0)
-                                )
-                                (block
-                                  (set_local $14
-                                    (get_local $8)
-                                  )
-                                  (set_local $26
-                                    (get_local $10)
-                                  )
-                                  (br $do-once$98
-                                    (get_local $1)
-                                  )
-                                )
-                              )
-                              (block $do-once$100
-                                (if
-                                  (get_local $11)
-                                  (block
-                                    (if
-                                      (i32.eq
-                                        (set_local $1
-                                          (i32.load
-                                            (i32.add
-                                              (get_local $23)
-                                              (i32.const -4)
-                                            )
-                                          )
-                                        )
-                                        (i32.const 0)
-                                      )
-                                      (block
-                                        (set_local $6
-                                          (i32.const 9)
-                                        )
-                                        (br $do-once$100)
-                                      )
-                                    )
-                                    (if
-                                      (i32.eq
-                                        (i32.and
-                                          (call_import $i32u-rem
-                                            (get_local $1)
-                                            (i32.const 10)
-                                          )
+                                          (get_local $5)
                                           (i32.const -1)
                                         )
-                                        (i32.const 0)
                                       )
-                                      (block
-                                        (set_local $5
-                                          (i32.const 10)
-                                        )
-                                        (set_local $6
-                                          (i32.const 0)
-                                        )
-                                      )
-                                      (block
-                                        (set_local $6
-                                          (i32.const 0)
-                                        )
-                                        (br $do-once$100)
-                                      )
-                                    )
-                                    (loop $while-out$102 $while-in$103
-                                      (set_local $6
-                                        (i32.add
-                                          (get_local $6)
-                                          (i32.const 1)
-                                        )
-                                      )
-                                      (if
-                                        (i32.ne
-                                          (i32.and
-                                            (call_import $i32u-rem
-                                              (get_local $1)
-                                              (set_local $5
-                                                (i32.mul
-                                                  (get_local $5)
-                                                  (i32.const 10)
-                                                )
-                                              )
-                                            )
-                                            (i32.const -1)
-                                          )
-                                          (i32.const 0)
-                                        )
-                                        (br $while-out$102)
-                                      )
-                                      (br $while-in$103)
-                                    )
-                                  )
-                                  (set_local $6
-                                    (i32.const 9)
-                                  )
-                                )
-                              )
-                              (set_local $1
-                                (i32.add
-                                  (i32.mul
-                                    (i32.shr_s
-                                      (i32.sub
-                                        (get_local $23)
-                                        (get_local $62)
-                                      )
-                                      (i32.const 2)
-                                    )
-                                    (i32.const 9)
-                                  )
-                                  (i32.const -9)
-                                )
-                              )
-                              (if
-                                (i32.eq
-                                  (i32.or
-                                    (get_local $10)
-                                    (i32.const 32)
-                                  )
-                                  (i32.const 102)
-                                )
-                                (block
-                                  (set_local $1
-                                    (i32.lt_s
-                                      (set_local $5
-                                        (i32.sub
-                                          (get_local $1)
-                                          (get_local $6)
-                                        )
-                                      )
-                                      (i32.const 0)
-                                    )
-                                  )
-                                  (set_local $5
-                                    (i32.lt_s
-                                      (get_local $8)
-                                      (set_local $1
-                                        (select
-                                          (i32.const 0)
-                                          (get_local $5)
-                                          (get_local $1)
-                                        )
-                                      )
-                                    )
-                                  )
-                                  (set_local $14
-                                    (select
-                                      (get_local $8)
-                                      (get_local $1)
-                                      (get_local $5)
-                                    )
-                                  )
-                                  (set_local $26
-                                    (get_local $10)
-                                  )
-                                  (i32.const 0)
-                                )
-                                (block
-                                  (set_local $1
-                                    (i32.lt_s
-                                      (set_local $5
-                                        (i32.sub
-                                          (i32.add
-                                            (get_local $1)
-                                            (get_local $13)
-                                          )
-                                          (get_local $6)
-                                        )
-                                      )
-                                      (i32.const 0)
-                                    )
-                                  )
-                                  (set_local $5
-                                    (i32.lt_s
-                                      (get_local $8)
-                                      (set_local $1
-                                        (select
-                                          (i32.const 0)
-                                          (get_local $5)
-                                          (get_local $1)
-                                        )
-                                      )
-                                    )
-                                  )
-                                  (set_local $14
-                                    (select
-                                      (get_local $8)
-                                      (get_local $1)
-                                      (get_local $5)
-                                    )
-                                  )
-                                  (set_local $26
-                                    (get_local $10)
-                                  )
-                                  (i32.const 0)
-                                )
-                              )
-                            )
-                            (block
-                              (set_local $14
-                                (get_local $1)
-                              )
-                              (i32.and
-                                (get_local $18)
-                                (i32.const 8)
-                              )
-                            )
-                          )
-                        )
-                      )
-                      (set_local $17
-                        (i32.and
-                          (i32.ne
-                            (set_local $1
-                              (i32.or
-                                (get_local $14)
-                                (get_local $8)
-                              )
-                            )
-                            (i32.const 0)
-                          )
-                          (i32.const 1)
-                        )
-                      )
-                      (set_local $13
-                        (if
-                          (set_local $10
-                            (i32.eq
-                              (i32.or
-                                (get_local $26)
-                                (i32.const 32)
-                              )
-                              (i32.const 102)
-                            )
-                          )
-                          (block
-                            (set_local $6
-                              (select
-                                (get_local $13)
-                                (i32.const 0)
-                                (i32.gt_s
-                                  (get_local $13)
-                                  (i32.const 0)
-                                )
-                              )
-                            )
-                            (i32.const 0)
-                          )
-                          (block
-                            (set_local $5
-                              (i32.shr_s
-                                (i32.shl
-                                  (i32.lt_s
-                                    (set_local $6
-                                      (select
-                                        (get_local $27)
-                                        (get_local $13)
-                                        (i32.lt_s
-                                          (get_local $13)
-                                          (i32.const 0)
-                                        )
-                                      )
-                                    )
-                                    (i32.const 0)
-                                  )
-                                  (i32.const 31)
-                                )
-                                (i32.const 31)
-                              )
-                            )
-                            (if
-                              (i32.lt_s
-                                (i32.sub
-                                  (get_local $40)
-                                  (set_local $5
-                                    (call $_fmt_u
-                                      (get_local $6)
-                                      (get_local $5)
-                                      (get_local $52)
-                                    )
-                                  )
-                                )
-                                (i32.const 2)
-                              )
-                              (loop $while-out$104 $while-in$105
-                                (i32.store8
-                                  (set_local $5
-                                    (i32.add
-                                      (get_local $5)
-                                      (i32.const -1)
-                                    )
-                                  )
-                                  (i32.const 48)
-                                )
-                                (if
-                                  (i32.lt_s
-                                    (i32.sub
-                                      (get_local $40)
-                                      (get_local $5)
-                                    )
-                                    (i32.const 2)
-                                  )
-                                  (get_local $5)
-                                  (br $while-out$104)
-                                )
-                                (br $while-in$105)
-                              )
-                              (get_local $5)
-                            )
-                            (i32.store8
-                              (i32.add
-                                (get_local $5)
-                                (i32.const -1)
-                              )
-                              (i32.and
-                                (i32.add
-                                  (i32.and
-                                    (i32.shr_s
-                                      (get_local $13)
-                                      (i32.const 31)
-                                    )
-                                    (i32.const 2)
-                                  )
-                                  (i32.const 43)
-                                )
-                                (i32.const 255)
-                              )
-                            )
-                            (i32.store8
-                              (set_local $5
-                                (i32.add
-                                  (get_local $5)
-                                  (i32.const -2)
-                                )
-                              )
-                              (i32.and
-                                (get_local $26)
-                                (i32.const 255)
-                              )
-                            )
-                            (set_local $6
-                              (i32.sub
-                                (get_local $40)
-                                (get_local $5)
-                              )
-                            )
-                            (get_local $5)
-                          )
-                        )
-                      )
-                      (call $_pad
-                        (get_local $0)
-                        (i32.const 32)
-                        (get_local $16)
-                        (set_local $6
-                          (i32.add
-                            (i32.add
-                              (i32.add
-                                (i32.add
-                                  (get_local $51)
-                                  (i32.const 1)
-                                )
-                                (get_local $14)
-                              )
-                              (get_local $17)
-                            )
-                            (get_local $6)
-                          )
-                        )
-                        (get_local $18)
-                      )
-                      (if
-                        (i32.eq
-                          (i32.and
-                            (i32.load
-                              (get_local $0)
-                            )
-                            (i32.const 32)
-                          )
-                          (i32.const 0)
-                        )
-                        (call $___fwritex
-                          (get_local $39)
-                          (get_local $51)
-                          (get_local $0)
-                        )
-                      )
-                      (call $_pad
-                        (get_local $0)
-                        (i32.const 48)
-                        (get_local $16)
-                        (get_local $6)
-                        (i32.xor
-                          (get_local $18)
-                          (i32.const 65536)
-                        )
-                      )
-                      (block $do-once$106
-                        (if
-                          (get_local $10)
-                          (block
-                            (set_local $7
-                              (set_local $8
-                                (select
-                                  (get_local $9)
-                                  (get_local $7)
-                                  (i32.gt_u
-                                    (get_local $7)
-                                    (get_local $9)
-                                  )
-                                )
-                              )
-                            )
-                            (loop $while-out$108 $while-in$109
-                              (set_local $5
-                                (call $_fmt_u
-                                  (i32.load
-                                    (get_local $7)
-                                  )
-                                  (i32.const 0)
-                                  (get_local $45)
-                                )
-                              )
-                              (block $do-once$110
-                                (if
-                                  (i32.eq
-                                    (get_local $7)
-                                    (get_local $8)
-                                  )
-                                  (block
-                                    (if
-                                      (i32.ne
-                                        (get_local $5)
-                                        (get_local $45)
-                                      )
-                                      (br $do-once$110)
-                                    )
-                                    (i32.store8
-                                      (get_local $53)
                                       (i32.const 48)
                                     )
-                                    (set_local $5
-                                      (get_local $53)
-                                    )
-                                  )
-                                  (block
                                     (if
                                       (i32.gt_u
                                         (get_local $5)
                                         (get_local $29)
                                       )
                                       (get_local $5)
-                                      (br $do-once$110)
+                                      (br $while-out$112)
                                     )
-                                    (loop $while-out$112 $while-in$113
-                                      (i32.store8
-                                        (set_local $5
-                                          (i32.add
-                                            (get_local $5)
-                                            (i32.const -1)
-                                          )
-                                        )
-                                        (i32.const 48)
-                                      )
-                                      (if
-                                        (i32.gt_u
-                                          (get_local $5)
-                                          (get_local $29)
-                                        )
-                                        (get_local $5)
-                                        (br $while-out$112)
-                                      )
-                                      (br $while-in$113)
-                                    )
+                                    (br $while-in$113)
                                   )
                                 )
+                              )
+                            )
+                            (if
+                              (i32.eq
+                                (i32.and
+                                  (i32.load
+                                    (get_local $0)
+                                  )
+                                  (i32.const 32)
+                                )
+                                (i32.const 0)
+                              )
+                              (call $___fwritex
+                                (get_local $5)
+                                (i32.sub
+                                  (get_local $75)
+                                  (get_local $5)
+                                )
+                                (get_local $0)
+                              )
+                            )
+                            (if
+                              (i32.gt_u
+                                (set_local $7
+                                  (i32.add
+                                    (get_local $7)
+                                    (i32.const 4)
+                                  )
+                                )
+                                (get_local $9)
+                              )
+                              (block
+                                (set_local $5
+                                  (get_local $7)
+                                )
+                                (br $while-out$108)
+                              )
+                              (get_local $7)
+                            )
+                            (br $while-in$109)
+                          )
+                          (block $do-once$114
+                            (if
+                              (i32.ne
+                                (get_local $1)
+                                (i32.const 0)
+                              )
+                              (block
+                                (br_if $do-once$114
+                                  (i32.ne
+                                    (i32.and
+                                      (i32.load
+                                        (get_local $0)
+                                      )
+                                      (i32.const 32)
+                                    )
+                                    (i32.const 0)
+                                  )
+                                )
+                                (call $___fwritex
+                                  (i32.const 4143)
+                                  (i32.const 1)
+                                  (get_local $0)
+                                )
+                              )
+                            )
+                          )
+                          (if
+                            (i32.and
+                              (i32.gt_s
+                                (get_local $14)
+                                (i32.const 0)
+                              )
+                              (i32.lt_u
+                                (get_local $5)
+                                (get_local $23)
+                              )
+                            )
+                            (loop $while-out$116 $while-in$117
+                              (if
+                                (i32.gt_u
+                                  (set_local $1
+                                    (call $_fmt_u
+                                      (i32.load
+                                        (get_local $5)
+                                      )
+                                      (i32.const 0)
+                                      (get_local $45)
+                                    )
+                                  )
+                                  (get_local $29)
+                                )
+                                (loop $while-out$118 $while-in$119
+                                  (i32.store8
+                                    (set_local $1
+                                      (i32.add
+                                        (get_local $1)
+                                        (i32.const -1)
+                                      )
+                                    )
+                                    (i32.const 48)
+                                  )
+                                  (if
+                                    (i32.gt_u
+                                      (get_local $1)
+                                      (get_local $29)
+                                    )
+                                    (get_local $1)
+                                    (br $while-out$118)
+                                  )
+                                  (br $while-in$119)
+                                )
+                                (get_local $1)
                               )
                               (if
                                 (i32.eq
@@ -7284,106 +7389,217 @@
                                   (i32.const 0)
                                 )
                                 (call $___fwritex
-                                  (get_local $5)
-                                  (i32.sub
-                                    (get_local $75)
-                                    (get_local $5)
+                                  (get_local $1)
+                                  (select
+                                    (i32.const 9)
+                                    (get_local $14)
+                                    (i32.gt_s
+                                      (get_local $14)
+                                      (i32.const 9)
+                                    )
                                   )
                                   (get_local $0)
                                 )
                               )
+                              (set_local $1
+                                (i32.add
+                                  (get_local $14)
+                                  (i32.const -9)
+                                )
+                              )
                               (if
-                                (i32.gt_u
-                                  (set_local $7
-                                    (i32.add
-                                      (get_local $7)
-                                      (i32.const 4)
-                                    )
+                                (i32.and
+                                  (i32.gt_s
+                                    (get_local $14)
+                                    (i32.const 9)
                                   )
-                                  (get_local $9)
+                                  (i32.lt_u
+                                    (set_local $5
+                                      (i32.add
+                                        (get_local $5)
+                                        (i32.const 4)
+                                      )
+                                    )
+                                    (get_local $23)
+                                  )
+                                )
+                                (set_local $14
+                                  (get_local $1)
                                 )
                                 (block
-                                  (set_local $5
-                                    (get_local $7)
+                                  (set_local $14
+                                    (get_local $1)
                                   )
-                                  (br $while-out$108)
+                                  (br $while-out$116)
                                 )
+                              )
+                              (br $while-in$117)
+                            )
+                            (get_local $14)
+                          )
+                          (call $_pad
+                            (get_local $0)
+                            (i32.const 48)
+                            (i32.add
+                              (get_local $14)
+                              (i32.const 9)
+                            )
+                            (i32.const 9)
+                            (i32.const 0)
+                          )
+                        )
+                        (block
+                          (set_local $11
+                            (select
+                              (get_local $23)
+                              (i32.add
+                                (get_local $7)
+                                (i32.const 4)
+                              )
+                              (get_local $11)
+                            )
+                          )
+                          (if
+                            (i32.gt_s
+                              (get_local $14)
+                              (i32.const -1)
+                            )
+                            (block
+                              (set_local $9
+                                (i32.eq
+                                  (get_local $8)
+                                  (i32.const 0)
+                                )
+                              )
+                              (set_local $5
                                 (get_local $7)
                               )
-                              (br $while-in$109)
-                            )
-                            (block $do-once$114
-                              (if
-                                (i32.ne
-                                  (get_local $1)
-                                  (i32.const 0)
-                                )
-                                (block
-                                  (br_if $do-once$114
-                                    (i32.ne
-                                      (i32.and
-                                        (i32.load
-                                          (get_local $0)
+                              (loop $while-out$120 $while-in$121
+                                (set_local $8
+                                  (if
+                                    (i32.eq
+                                      (set_local $1
+                                        (call $_fmt_u
+                                          (i32.load
+                                            (get_local $5)
+                                          )
+                                          (i32.const 0)
+                                          (get_local $45)
                                         )
-                                        (i32.const 32)
                                       )
-                                      (i32.const 0)
+                                      (get_local $45)
                                     )
-                                  )
-                                  (call $___fwritex
-                                    (i32.const 4143)
-                                    (i32.const 1)
-                                    (get_local $0)
-                                  )
-                                )
-                              )
-                            )
-                            (if
-                              (i32.and
-                                (i32.gt_s
-                                  (get_local $14)
-                                  (i32.const 0)
-                                )
-                                (i32.lt_u
-                                  (get_local $5)
-                                  (get_local $23)
-                                )
-                              )
-                              (loop $while-out$116 $while-in$117
-                                (if
-                                  (i32.gt_u
-                                    (set_local $1
-                                      (call $_fmt_u
-                                        (i32.load
-                                          (get_local $5)
-                                        )
-                                        (i32.const 0)
-                                        (get_local $45)
+                                    (block
+                                      (i32.store8
+                                        (get_local $53)
+                                        (i32.const 48)
                                       )
+                                      (get_local $53)
                                     )
-                                    (get_local $29)
+                                    (get_local $1)
                                   )
-                                  (loop $while-out$118 $while-in$119
-                                    (i32.store8
+                                )
+                                (block $do-once$122
+                                  (if
+                                    (i32.eq
+                                      (get_local $5)
+                                      (get_local $7)
+                                    )
+                                    (block
                                       (set_local $1
                                         (i32.add
-                                          (get_local $1)
-                                          (i32.const -1)
+                                          (get_local $8)
+                                          (i32.const 1)
                                         )
                                       )
-                                      (i32.const 48)
-                                    )
-                                    (if
-                                      (i32.gt_u
-                                        (get_local $1)
-                                        (get_local $29)
+                                      (if
+                                        (i32.eq
+                                          (i32.and
+                                            (i32.load
+                                              (get_local $0)
+                                            )
+                                            (i32.const 32)
+                                          )
+                                          (i32.const 0)
+                                        )
+                                        (call $___fwritex
+                                          (get_local $8)
+                                          (i32.const 1)
+                                          (get_local $0)
+                                        )
                                       )
-                                      (get_local $1)
-                                      (br $while-out$118)
+                                      (if
+                                        (i32.and
+                                          (get_local $9)
+                                          (i32.lt_s
+                                            (get_local $14)
+                                            (i32.const 1)
+                                          )
+                                        )
+                                        (br $do-once$122)
+                                      )
+                                      (if
+                                        (i32.ne
+                                          (i32.and
+                                            (i32.load
+                                              (get_local $0)
+                                            )
+                                            (i32.const 32)
+                                          )
+                                          (i32.const 0)
+                                        )
+                                        (br $do-once$122)
+                                      )
+                                      (call $___fwritex
+                                        (i32.const 4143)
+                                        (i32.const 1)
+                                        (get_local $0)
+                                      )
                                     )
-                                    (br $while-in$119)
+                                    (block
+                                      (if
+                                        (i32.gt_u
+                                          (get_local $8)
+                                          (get_local $29)
+                                        )
+                                        (set_local $1
+                                          (get_local $8)
+                                        )
+                                        (block
+                                          (set_local $1
+                                            (get_local $8)
+                                          )
+                                          (br $do-once$122)
+                                        )
+                                      )
+                                      (loop $while-out$124 $while-in$125
+                                        (i32.store8
+                                          (set_local $1
+                                            (i32.add
+                                              (get_local $1)
+                                              (i32.const -1)
+                                            )
+                                          )
+                                          (i32.const 48)
+                                        )
+                                        (if
+                                          (i32.gt_u
+                                            (get_local $1)
+                                            (get_local $29)
+                                          )
+                                          (get_local $1)
+                                          (br $while-out$124)
+                                        )
+                                        (br $while-in$125)
+                                      )
+                                    )
                                   )
-                                  (get_local $1)
+                                )
+                                (set_local $8
+                                  (i32.sub
+                                    (get_local $75)
+                                    (get_local $1)
+                                  )
                                 )
                                 (if
                                   (i32.eq
@@ -7398,456 +7614,232 @@
                                   (call $___fwritex
                                     (get_local $1)
                                     (select
-                                      (i32.const 9)
+                                      (get_local $8)
                                       (get_local $14)
                                       (i32.gt_s
                                         (get_local $14)
-                                        (i32.const 9)
+                                        (get_local $8)
                                       )
                                     )
                                     (get_local $0)
-                                  )
-                                )
-                                (set_local $1
-                                  (i32.add
-                                    (get_local $14)
-                                    (i32.const -9)
                                   )
                                 )
                                 (if
-                                  (i32.and
-                                    (i32.gt_s
-                                      (get_local $14)
-                                      (i32.const 9)
-                                    )
-                                    (i32.lt_u
-                                      (set_local $5
-                                        (i32.add
-                                          (get_local $5)
-                                          (i32.const 4)
-                                        )
-                                      )
-                                      (get_local $23)
-                                    )
-                                  )
-                                  (set_local $14
-                                    (get_local $1)
-                                  )
-                                  (block
-                                    (set_local $14
-                                      (get_local $1)
-                                    )
-                                    (br $while-out$116)
-                                  )
-                                )
-                                (br $while-in$117)
-                              )
-                              (get_local $14)
-                            )
-                            (call $_pad
-                              (get_local $0)
-                              (i32.const 48)
-                              (i32.add
-                                (get_local $14)
-                                (i32.const 9)
-                              )
-                              (i32.const 9)
-                              (i32.const 0)
-                            )
-                          )
-                          (block
-                            (set_local $11
-                              (select
-                                (get_local $23)
-                                (i32.add
-                                  (get_local $7)
-                                  (i32.const 4)
-                                )
-                                (get_local $11)
-                              )
-                            )
-                            (if
-                              (i32.gt_s
-                                (get_local $14)
-                                (i32.const -1)
-                              )
-                              (block
-                                (set_local $9
-                                  (i32.eq
-                                    (get_local $8)
-                                    (i32.const 0)
-                                  )
-                                )
-                                (set_local $5
-                                  (get_local $7)
-                                )
-                                (loop $while-out$120 $while-in$121
-                                  (set_local $8
-                                    (if
-                                      (i32.eq
-                                        (set_local $1
-                                          (call $_fmt_u
-                                            (i32.load
-                                              (get_local $5)
-                                            )
-                                            (i32.const 0)
-                                            (get_local $45)
-                                          )
-                                        )
-                                        (get_local $45)
-                                      )
-                                      (block
-                                        (i32.store8
-                                          (get_local $53)
-                                          (i32.const 48)
-                                        )
-                                        (get_local $53)
-                                      )
-                                      (get_local $1)
-                                    )
-                                  )
-                                  (block $do-once$122
-                                    (if
-                                      (i32.eq
-                                        (get_local $5)
-                                        (get_local $7)
-                                      )
-                                      (block
-                                        (set_local $1
+                                  (i32.eqz
+                                    (i32.and
+                                      (i32.lt_u
+                                        (set_local $5
                                           (i32.add
-                                            (get_local $8)
-                                            (i32.const 1)
+                                            (get_local $5)
+                                            (i32.const 4)
                                           )
                                         )
-                                        (if
-                                          (i32.eq
-                                            (i32.and
-                                              (i32.load
-                                                (get_local $0)
-                                              )
-                                              (i32.const 32)
-                                            )
-                                            (i32.const 0)
-                                          )
-                                          (call $___fwritex
-                                            (get_local $8)
-                                            (i32.const 1)
-                                            (get_local $0)
-                                          )
-                                        )
-                                        (if
-                                          (i32.and
-                                            (get_local $9)
-                                            (i32.lt_s
-                                              (get_local $14)
-                                              (i32.const 1)
-                                            )
-                                          )
-                                          (br $do-once$122)
-                                        )
-                                        (if
-                                          (i32.ne
-                                            (i32.and
-                                              (i32.load
-                                                (get_local $0)
-                                              )
-                                              (i32.const 32)
-                                            )
-                                            (i32.const 0)
-                                          )
-                                          (br $do-once$122)
-                                        )
-                                        (call $___fwritex
-                                          (i32.const 4143)
-                                          (i32.const 1)
-                                          (get_local $0)
-                                        )
+                                        (get_local $11)
                                       )
-                                      (block
-                                        (if
-                                          (i32.gt_u
-                                            (get_local $8)
-                                            (get_local $29)
-                                          )
-                                          (set_local $1
+                                      (i32.gt_s
+                                        (set_local $14
+                                          (i32.sub
+                                            (get_local $14)
                                             (get_local $8)
                                           )
-                                          (block
-                                            (set_local $1
-                                              (get_local $8)
-                                            )
-                                            (br $do-once$122)
-                                          )
                                         )
-                                        (loop $while-out$124 $while-in$125
-                                          (i32.store8
-                                            (set_local $1
-                                              (i32.add
-                                                (get_local $1)
-                                                (i32.const -1)
-                                              )
-                                            )
-                                            (i32.const 48)
-                                          )
-                                          (if
-                                            (i32.gt_u
-                                              (get_local $1)
-                                              (get_local $29)
-                                            )
-                                            (get_local $1)
-                                            (br $while-out$124)
-                                          )
-                                          (br $while-in$125)
-                                        )
+                                        (i32.const -1)
                                       )
                                     )
                                   )
-                                  (set_local $8
-                                    (i32.sub
-                                      (get_local $75)
-                                      (get_local $1)
-                                    )
-                                  )
-                                  (if
-                                    (i32.eq
-                                      (i32.and
-                                        (i32.load
-                                          (get_local $0)
-                                        )
-                                        (i32.const 32)
-                                      )
-                                      (i32.const 0)
-                                    )
-                                    (call $___fwritex
-                                      (get_local $1)
-                                      (select
-                                        (get_local $8)
-                                        (get_local $14)
-                                        (i32.gt_s
-                                          (get_local $14)
-                                          (get_local $8)
-                                        )
-                                      )
-                                      (get_local $0)
-                                    )
-                                  )
-                                  (if
-                                    (i32.eqz
-                                      (i32.and
-                                        (i32.lt_u
-                                          (set_local $5
-                                            (i32.add
-                                              (get_local $5)
-                                              (i32.const 4)
-                                            )
-                                          )
-                                          (get_local $11)
-                                        )
-                                        (i32.gt_s
-                                          (set_local $14
-                                            (i32.sub
-                                              (get_local $14)
-                                              (get_local $8)
-                                            )
-                                          )
-                                          (i32.const -1)
-                                        )
-                                      )
-                                    )
-                                    (br $while-out$120)
-                                  )
-                                  (br $while-in$121)
+                                  (br $while-out$120)
                                 )
-                              )
-                              (get_local $14)
-                            )
-                            (call $_pad
-                              (get_local $0)
-                              (i32.const 48)
-                              (i32.add
-                                (get_local $14)
-                                (i32.const 18)
-                              )
-                              (i32.const 18)
-                              (i32.const 0)
-                            )
-                            (br_if $do-once$106
-                              (i32.ne
-                                (i32.and
-                                  (i32.load
-                                    (get_local $0)
-                                  )
-                                  (i32.const 32)
-                                )
-                                (i32.const 0)
+                                (br $while-in$121)
                               )
                             )
-                            (call $___fwritex
-                              (get_local $13)
-                              (i32.sub
-                                (get_local $40)
-                                (get_local $13)
-                              )
-                              (get_local $0)
-                            )
+                            (get_local $14)
                           )
-                        )
-                      )
-                      (call $_pad
-                        (get_local $0)
-                        (i32.const 32)
-                        (get_local $16)
-                        (get_local $6)
-                        (i32.xor
-                          (get_local $18)
-                          (i32.const 8192)
-                        )
-                      )
-                      (select
-                        (get_local $16)
-                        (get_local $6)
-                        (i32.lt_s
-                          (get_local $6)
-                          (get_local $16)
-                        )
-                      )
-                    )
-                    (block
-                      (set_local $5
-                        (select
-                          (i32.const 4127)
-                          (i32.const 4131)
-                          (set_local $8
+                          (call $_pad
+                            (get_local $0)
+                            (i32.const 48)
+                            (i32.add
+                              (get_local $14)
+                              (i32.const 18)
+                            )
+                            (i32.const 18)
+                            (i32.const 0)
+                          )
+                          (br_if $do-once$106
                             (i32.ne
                               (i32.and
-                                (get_local $26)
+                                (i32.load
+                                  (get_local $0)
+                                )
                                 (i32.const 32)
                               )
                               (i32.const 0)
                             )
                           )
+                          (call $___fwritex
+                            (get_local $13)
+                            (i32.sub
+                              (get_local $40)
+                              (get_local $13)
+                            )
+                            (get_local $0)
+                          )
                         )
                       )
-                      (set_local $6
+                    )
+                    (call $_pad
+                      (get_local $0)
+                      (i32.const 32)
+                      (get_local $16)
+                      (get_local $6)
+                      (i32.xor
+                        (get_local $18)
+                        (i32.const 8192)
+                      )
+                    )
+                    (select
+                      (get_local $16)
+                      (get_local $6)
+                      (i32.lt_s
+                        (get_local $6)
+                        (get_local $16)
+                      )
+                    )
+                  )
+                  (block
+                    (set_local $5
+                      (select
+                        (i32.const 4127)
+                        (i32.const 4131)
+                        (set_local $8
+                          (i32.ne
+                            (i32.and
+                              (get_local $26)
+                              (i32.const 32)
+                            )
+                            (i32.const 0)
+                          )
+                        )
+                      )
+                    )
+                    (set_local $6
+                      (select
+                        (i32.const 0)
+                        (get_local $51)
+                        (set_local $1
+                          (i32.or
+                            (f64.ne
+                              (get_local $15)
+                              (get_local $15)
+                            )
+                            (i32.const 0)
+                          )
+                        )
+                      )
+                    )
+                    (set_local $8
+                      (select
                         (select
-                          (i32.const 0)
-                          (get_local $51)
-                          (set_local $1
-                            (i32.or
-                              (f64.ne
-                                (get_local $15)
-                                (get_local $15)
+                          (i32.const 4135)
+                          (i32.const 4139)
+                          (get_local $8)
+                        )
+                        (get_local $5)
+                        (get_local $1)
+                      )
+                    )
+                    (call $_pad
+                      (get_local $0)
+                      (i32.const 32)
+                      (get_local $16)
+                      (set_local $5
+                        (i32.add
+                          (get_local $6)
+                          (i32.const 3)
+                        )
+                      )
+                      (get_local $7)
+                    )
+                    (if
+                      (i32.eq
+                        (i32.and
+                          (if
+                            (i32.eq
+                              (i32.and
+                                (set_local $1
+                                  (i32.load
+                                    (get_local $0)
+                                  )
+                                )
+                                (i32.const 32)
                               )
                               (i32.const 0)
                             )
-                          )
-                        )
-                      )
-                      (set_local $8
-                        (select
-                          (select
-                            (i32.const 4135)
-                            (i32.const 4139)
-                            (get_local $8)
-                          )
-                          (get_local $5)
-                          (get_local $1)
-                        )
-                      )
-                      (call $_pad
-                        (get_local $0)
-                        (i32.const 32)
-                        (get_local $16)
-                        (set_local $5
-                          (i32.add
-                            (get_local $6)
-                            (i32.const 3)
-                          )
-                        )
-                        (get_local $7)
-                      )
-                      (if
-                        (i32.eq
-                          (i32.and
-                            (if
-                              (i32.eq
-                                (i32.and
-                                  (set_local $1
-                                    (i32.load
-                                      (get_local $0)
-                                    )
-                                  )
-                                  (i32.const 32)
-                                )
-                                (i32.const 0)
+                            (block
+                              (call $___fwritex
+                                (get_local $39)
+                                (get_local $6)
+                                (get_local $0)
                               )
-                              (block
-                                (call $___fwritex
-                                  (get_local $39)
-                                  (get_local $6)
-                                  (get_local $0)
-                                )
-                                (i32.load
-                                  (get_local $0)
-                                )
+                              (i32.load
+                                (get_local $0)
                               )
-                              (get_local $1)
                             )
-                            (i32.const 32)
+                            (get_local $1)
                           )
-                          (i32.const 0)
+                          (i32.const 32)
                         )
-                        (call $___fwritex
-                          (get_local $8)
-                          (i32.const 3)
-                          (get_local $0)
-                        )
+                        (i32.const 0)
                       )
-                      (call $_pad
+                      (call $___fwritex
+                        (get_local $8)
+                        (i32.const 3)
                         (get_local $0)
-                        (i32.const 32)
-                        (get_local $16)
-                        (get_local $5)
-                        (i32.xor
-                          (get_local $18)
-                          (i32.const 8192)
-                        )
                       )
-                      (select
-                        (get_local $16)
+                    )
+                    (call $_pad
+                      (get_local $0)
+                      (i32.const 32)
+                      (get_local $16)
+                      (get_local $5)
+                      (i32.xor
+                        (get_local $18)
+                        (i32.const 8192)
+                      )
+                    )
+                    (select
+                      (get_local $16)
+                      (get_local $5)
+                      (i32.lt_s
                         (get_local $5)
-                        (i32.lt_s
-                          (get_local $5)
-                          (get_local $16)
-                        )
+                        (get_local $16)
                       )
                     )
                   )
                 )
               )
-              (set_local $8
-                (get_local $21)
-              )
-              (br $label$continue$L1)
             )
-            (set_local $47
-              (get_local $20)
+            (set_local $8
+              (get_local $21)
             )
-            (set_local $37
-              (get_local $18)
-            )
-            (set_local $42
-              (get_local $10)
-            )
-            (set_local $43
-              (i32.const 0)
-            )
-            (set_local $48
-              (i32.const 4091)
-            )
-            (set_local $49
-              (get_local $28)
-            )
+            (br $label$continue$L1)
+          )
+          (set_local $47
+            (get_local $20)
+          )
+          (set_local $37
+            (get_local $18)
+          )
+          (set_local $42
+            (get_local $10)
+          )
+          (set_local $43
+            (i32.const 0)
+          )
+          (set_local $48
+            (i32.const 4091)
+          )
+          (set_local $49
+            (get_local $28)
           )
         )
       )
@@ -8747,51 +8739,22 @@
           (i32.const 20)
         )
         (block $switch-default$14
-          (block $switch-default$14
-            (block $switch-case$13
-              (block $switch-case$12
-                (block $switch-case$11
-                  (block $switch-case$10
-                    (block $switch-case$9
-                      (block $switch-case$8
-                        (block $switch-case$7
-                          (block $switch-case$6
-                            (block $switch-case$5
-                              (block $switch-case$4
-                                (br_table $switch-case$4 $switch-case$5 $switch-case$6 $switch-case$7 $switch-case$8 $switch-case$9 $switch-case$10 $switch-case$11 $switch-case$12 $switch-case$13 $switch-default$14
-                                  (i32.sub
-                                    (get_local $1)
-                                    (i32.const 9)
-                                  )
-                                )
-                              )
-                              (set_local $3
-                                (i32.load
-                                  (set_local $1
-                                    (i32.and
-                                      (i32.add
-                                        (i32.load
-                                          (get_local $2)
-                                        )
-                                        (i32.const 3)
-                                      )
-                                      (i32.const -4)
-                                    )
-                                  )
-                                )
-                              )
-                              (i32.store
-                                (get_local $2)
-                                (i32.add
+          (block $switch-case$13
+            (block $switch-case$12
+              (block $switch-case$11
+                (block $switch-case$10
+                  (block $switch-case$9
+                    (block $switch-case$8
+                      (block $switch-case$7
+                        (block $switch-case$6
+                          (block $switch-case$5
+                            (block $switch-case$4
+                              (br_table $switch-case$4 $switch-case$5 $switch-case$6 $switch-case$7 $switch-case$8 $switch-case$9 $switch-case$10 $switch-case$11 $switch-case$12 $switch-case$13 $switch-default$14
+                                (i32.sub
                                   (get_local $1)
-                                  (i32.const 4)
+                                  (i32.const 9)
                                 )
                               )
-                              (i32.store
-                                (get_local $0)
-                                (get_local $3)
-                              )
-                              (br $label$break$L1)
                             )
                             (set_local $3
                               (i32.load
@@ -8818,19 +8781,6 @@
                             (i32.store
                               (get_local $0)
                               (get_local $3)
-                            )
-                            (i32.store offset=4
-                              (get_local $0)
-                              (i32.shr_s
-                                (i32.shl
-                                  (i32.lt_s
-                                    (get_local $3)
-                                    (i32.const 0)
-                                  )
-                                  (i32.const 31)
-                                )
-                                (i32.const 31)
-                              )
                             )
                             (br $label$break$L1)
                           )
@@ -8862,101 +8812,87 @@
                           )
                           (i32.store offset=4
                             (get_local $0)
-                            (i32.const 0)
+                            (i32.shr_s
+                              (i32.shl
+                                (i32.lt_s
+                                  (get_local $3)
+                                  (i32.const 0)
+                                )
+                                (i32.const 31)
+                              )
+                              (i32.const 31)
+                            )
                           )
                           (br $label$break$L1)
                         )
-                        (set_local $5
+                        (set_local $3
                           (i32.load
-                            (set_local $3
-                              (set_local $1
-                                (i32.and
-                                  (i32.add
-                                    (i32.load
-                                      (get_local $2)
-                                    )
-                                    (i32.const 7)
+                            (set_local $1
+                              (i32.and
+                                (i32.add
+                                  (i32.load
+                                    (get_local $2)
                                   )
-                                  (i32.const -8)
+                                  (i32.const 3)
                                 )
+                                (i32.const -4)
                               )
                             )
-                          )
-                        )
-                        (set_local $3
-                          (i32.load offset=4
-                            (get_local $3)
                           )
                         )
                         (i32.store
                           (get_local $2)
                           (i32.add
                             (get_local $1)
-                            (i32.const 8)
+                            (i32.const 4)
                           )
                         )
                         (i32.store
                           (get_local $0)
-                          (get_local $5)
+                          (get_local $3)
                         )
                         (i32.store offset=4
                           (get_local $0)
-                          (get_local $3)
+                          (i32.const 0)
                         )
                         (br $label$break$L1)
                       )
-                      (set_local $3
+                      (set_local $5
                         (i32.load
-                          (set_local $1
-                            (i32.and
-                              (i32.add
-                                (i32.load
-                                  (get_local $2)
+                          (set_local $3
+                            (set_local $1
+                              (i32.and
+                                (i32.add
+                                  (i32.load
+                                    (get_local $2)
+                                  )
+                                  (i32.const 7)
                                 )
-                                (i32.const 3)
+                                (i32.const -8)
                               )
-                              (i32.const -4)
                             )
                           )
+                        )
+                      )
+                      (set_local $3
+                        (i32.load offset=4
+                          (get_local $3)
                         )
                       )
                       (i32.store
                         (get_local $2)
                         (i32.add
                           (get_local $1)
-                          (i32.const 4)
-                        )
-                      )
-                      (set_local $2
-                        (i32.shr_s
-                          (i32.shl
-                            (i32.lt_s
-                              (set_local $1
-                                (i32.shr_s
-                                  (i32.shl
-                                    (i32.and
-                                      (get_local $3)
-                                      (i32.const 65535)
-                                    )
-                                    (i32.const 16)
-                                  )
-                                  (i32.const 16)
-                                )
-                              )
-                              (i32.const 0)
-                            )
-                            (i32.const 31)
-                          )
-                          (i32.const 31)
+                          (i32.const 8)
                         )
                       )
                       (i32.store
                         (get_local $0)
-                        (get_local $1)
+                        (get_local $5)
                       )
                       (i32.store offset=4
                         (get_local $0)
-                        (get_local $2)
+                        (get_local $3)
                       )
                       (br $label$break$L1)
                     )
@@ -8982,16 +8918,36 @@
                         (i32.const 4)
                       )
                     )
+                    (set_local $2
+                      (i32.shr_s
+                        (i32.shl
+                          (i32.lt_s
+                            (set_local $1
+                              (i32.shr_s
+                                (i32.shl
+                                  (i32.and
+                                    (get_local $3)
+                                    (i32.const 65535)
+                                  )
+                                  (i32.const 16)
+                                )
+                                (i32.const 16)
+                              )
+                            )
+                            (i32.const 0)
+                          )
+                          (i32.const 31)
+                        )
+                        (i32.const 31)
+                      )
+                    )
                     (i32.store
                       (get_local $0)
-                      (i32.and
-                        (get_local $3)
-                        (i32.const 65535)
-                      )
+                      (get_local $1)
                     )
                     (i32.store offset=4
                       (get_local $0)
-                      (i32.const 0)
+                      (get_local $2)
                     )
                     (br $label$break$L1)
                   )
@@ -9017,36 +8973,16 @@
                       (i32.const 4)
                     )
                   )
-                  (set_local $2
-                    (i32.shr_s
-                      (i32.shl
-                        (i32.lt_s
-                          (set_local $1
-                            (i32.shr_s
-                              (i32.shl
-                                (i32.and
-                                  (get_local $3)
-                                  (i32.const 255)
-                                )
-                                (i32.const 24)
-                              )
-                              (i32.const 24)
-                            )
-                          )
-                          (i32.const 0)
-                        )
-                        (i32.const 31)
-                      )
-                      (i32.const 31)
-                    )
-                  )
                   (i32.store
                     (get_local $0)
-                    (get_local $1)
+                    (i32.and
+                      (get_local $3)
+                      (i32.const 65535)
+                    )
                   )
                   (i32.store offset=4
                     (get_local $0)
-                    (get_local $2)
+                    (i32.const 0)
                   )
                   (br $label$break$L1)
                 )
@@ -9072,30 +9008,50 @@
                     (i32.const 4)
                   )
                 )
+                (set_local $2
+                  (i32.shr_s
+                    (i32.shl
+                      (i32.lt_s
+                        (set_local $1
+                          (i32.shr_s
+                            (i32.shl
+                              (i32.and
+                                (get_local $3)
+                                (i32.const 255)
+                              )
+                              (i32.const 24)
+                            )
+                            (i32.const 24)
+                          )
+                        )
+                        (i32.const 0)
+                      )
+                      (i32.const 31)
+                    )
+                    (i32.const 31)
+                  )
+                )
                 (i32.store
                   (get_local $0)
-                  (i32.and
-                    (get_local $3)
-                    (i32.const 255)
-                  )
+                  (get_local $1)
                 )
                 (i32.store offset=4
                   (get_local $0)
-                  (i32.const 0)
+                  (get_local $2)
                 )
                 (br $label$break$L1)
               )
-              (set_local $4
-                (f64.load
+              (set_local $3
+                (i32.load
                   (set_local $1
                     (i32.and
                       (i32.add
                         (i32.load
                           (get_local $2)
                         )
-                        (i32.const 7)
+                        (i32.const 3)
                       )
-                      (i32.const -8)
+                      (i32.const -4)
                     )
                   )
                 )
@@ -9104,12 +9060,19 @@
                 (get_local $2)
                 (i32.add
                   (get_local $1)
-                  (i32.const 8)
+                  (i32.const 4)
                 )
               )
-              (f64.store
+              (i32.store
                 (get_local $0)
-                (get_local $4)
+                (i32.and
+                  (get_local $3)
+                  (i32.const 255)
+                )
+              )
+              (i32.store offset=4
+                (get_local $0)
+                (i32.const 0)
               )
               (br $label$break$L1)
             )
@@ -9139,6 +9102,33 @@
               (get_local $0)
               (get_local $4)
             )
+            (br $label$break$L1)
+          )
+          (set_local $4
+            (f64.load
+              (set_local $1
+                (i32.and
+                  (i32.add
+                    (i32.load
+                      (get_local $2)
+                    )
+                    (i32.const 7)
+                  )
+                  (i32.const -8)
+                )
+              )
+            )
+          )
+          (i32.store
+            (get_local $2)
+            (i32.add
+              (get_local $1)
+              (i32.const 8)
+            )
+          )
+          (f64.store
+            (get_local $0)
+            (get_local $4)
           )
         )
       )

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -4389,960 +4389,2648 @@
           )
         )
       )
-      (block $label$break$L75
-        (block $switch$24
-          (block $switch-default$127
-            (block $switch-case$126
-              (block $switch-case$55
-                (block $switch-case$54
-                  (block $switch-case$53
-                    (block $switch-case$52
-                      (block $switch-case$51
-                        (block $switch-case$50
-                          (block $switch-case$49
-                            (block $switch-case$48
-                              (block $switch-case$47
-                                (block $switch-case$46
-                                  (block $switch-case$45
-                                    (block $switch-case$44
-                                      (block $switch-case$43
-                                        (block $switch-case$42
-                                          (block $switch-case$41
-                                            (block $switch-case$40
-                                              (block $switch-case$37
-                                                (block $switch-case$36
-                                                  (block $switch-case$35
-                                                    (block $switch-case$34
-                                                      (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$52 $switch-case$51 $switch-case$50 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$53 $switch-default$127 $switch-case$44 $switch-case$42 $switch-case$126 $switch-case$55 $switch-case$54 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$37 $switch-default$127
-                                                        (i32.sub
-                                                          (set_local $26
-                                                            (select
-                                                              (i32.and
-                                                                (get_local $1)
-                                                                (i32.const -33)
-                                                              )
-                                                              (get_local $1)
-                                                              (get_local $5)
-                                                            )
-                                                          )
-                                                          (i32.const 65)
-                                                        )
-                                                      )
-                                                    )
-                                                    (block $switch-default$33
-                                                      (block $switch-case$32
-                                                        (block $switch-case$31
-                                                          (block $switch-case$30
-                                                            (block $switch-case$29
-                                                              (block $switch-case$28
-                                                                (block $switch-case$27
-                                                                  (block $switch-case$26
-                                                                    (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
-                                                                      (i32.sub
-                                                                        (get_local $13)
-                                                                        (i32.const 0)
-                                                                      )
-                                                                    )
-                                                                  )
-                                                                  (i32.store
-                                                                    (i32.load
-                                                                      (get_local $19)
-                                                                    )
-                                                                    (get_local $22)
-                                                                  )
-                                                                  (set_local $20
-                                                                    (get_local $9)
-                                                                  )
-                                                                  (set_local $1
-                                                                    (get_local $17)
-                                                                  )
-                                                                  (set_local $8
-                                                                    (get_local $21)
-                                                                  )
-                                                                  (br $label$continue$L1)
-                                                                )
-                                                                (i32.store
-                                                                  (i32.load
-                                                                    (get_local $19)
-                                                                  )
-                                                                  (get_local $22)
-                                                                )
-                                                                (set_local $20
-                                                                  (get_local $9)
-                                                                )
-                                                                (set_local $1
-                                                                  (get_local $17)
-                                                                )
-                                                                (set_local $8
-                                                                  (get_local $21)
-                                                                )
-                                                                (br $label$continue$L1)
-                                                              )
-                                                              (i32.store
-                                                                (set_local $1
-                                                                  (i32.load
-                                                                    (get_local $19)
-                                                                  )
-                                                                )
-                                                                (get_local $22)
-                                                              )
-                                                              (i32.store offset=4
-                                                                (get_local $1)
-                                                                (i32.shr_s
-                                                                  (i32.shl
-                                                                    (i32.lt_s
-                                                                      (get_local $22)
-                                                                      (i32.const 0)
-                                                                    )
-                                                                    (i32.const 31)
-                                                                  )
-                                                                  (i32.const 31)
-                                                                )
-                                                              )
-                                                              (set_local $20
-                                                                (get_local $9)
-                                                              )
-                                                              (set_local $1
-                                                                (get_local $17)
-                                                              )
-                                                              (set_local $8
-                                                                (get_local $21)
-                                                              )
-                                                              (br $label$continue$L1)
-                                                            )
-                                                            (i32.store16
-                                                              (i32.load
-                                                                (get_local $19)
-                                                              )
-                                                              (i32.and
-                                                                (get_local $22)
-                                                                (i32.const 65535)
-                                                              )
-                                                            )
-                                                            (set_local $20
-                                                              (get_local $9)
-                                                            )
-                                                            (set_local $1
-                                                              (get_local $17)
-                                                            )
-                                                            (set_local $8
-                                                              (get_local $21)
-                                                            )
-                                                            (br $label$continue$L1)
-                                                          )
-                                                          (i32.store8
-                                                            (i32.load
-                                                              (get_local $19)
-                                                            )
-                                                            (i32.and
-                                                              (get_local $22)
-                                                              (i32.const 255)
-                                                            )
-                                                          )
-                                                          (set_local $20
-                                                            (get_local $9)
-                                                          )
-                                                          (set_local $1
-                                                            (get_local $17)
-                                                          )
-                                                          (set_local $8
-                                                            (get_local $21)
-                                                          )
-                                                          (br $label$continue$L1)
-                                                        )
-                                                        (i32.store
-                                                          (i32.load
-                                                            (get_local $19)
-                                                          )
-                                                          (get_local $22)
-                                                        )
-                                                        (set_local $20
-                                                          (get_local $9)
-                                                        )
-                                                        (set_local $1
-                                                          (get_local $17)
-                                                        )
-                                                        (set_local $8
-                                                          (get_local $21)
-                                                        )
-                                                        (br $label$continue$L1)
-                                                      )
-                                                      (i32.store
-                                                        (set_local $1
-                                                          (i32.load
-                                                            (get_local $19)
-                                                          )
-                                                        )
-                                                        (get_local $22)
-                                                      )
-                                                      (i32.store offset=4
-                                                        (get_local $1)
-                                                        (i32.shr_s
-                                                          (i32.shl
-                                                            (i32.lt_s
-                                                              (get_local $22)
-                                                              (i32.const 0)
-                                                            )
-                                                            (i32.const 31)
-                                                          )
-                                                          (i32.const 31)
-                                                        )
-                                                      )
-                                                      (set_local $20
-                                                        (get_local $9)
-                                                      )
-                                                      (set_local $1
-                                                        (get_local $17)
-                                                      )
-                                                      (set_local $8
-                                                        (get_local $21)
-                                                      )
-                                                      (br $label$continue$L1)
-                                                    )
-                                                    (set_local $20
-                                                      (get_local $9)
-                                                    )
-                                                    (set_local $1
-                                                      (get_local $17)
-                                                    )
-                                                    (set_local $8
-                                                      (get_local $21)
-                                                    )
-                                                    (br $label$continue$L1)
-                                                  )
-                                                  (set_local $46
-                                                    (i32.or
-                                                      (get_local $18)
-                                                      (i32.const 8)
-                                                    )
-                                                  )
-                                                  (set_local $57
-                                                    (select
-                                                      (get_local $10)
-                                                      (i32.const 8)
-                                                      (i32.gt_u
-                                                        (get_local $10)
-                                                        (i32.const 8)
-                                                      )
-                                                    )
-                                                  )
-                                                  (set_local $68
-                                                    (i32.const 120)
-                                                  )
-                                                  (set_local $12
-                                                    (i32.const 64)
-                                                  )
-                                                  (br $switch$24)
-                                                )
-                                              )
-                                              (set_local $46
-                                                (get_local $18)
-                                              )
-                                              (set_local $57
-                                                (get_local $10)
-                                              )
-                                              (set_local $68
-                                                (get_local $26)
-                                              )
-                                              (set_local $12
-                                                (i32.const 64)
-                                              )
-                                              (br $switch$24)
-                                            )
-                                            (if
-                                              (i32.and
-                                                (i32.eq
-                                                  (set_local $5
-                                                    (i32.load
-                                                      (set_local $1
-                                                        (get_local $19)
-                                                      )
-                                                    )
-                                                  )
-                                                  (i32.const 0)
-                                                )
-                                                (i32.eq
-                                                  (set_local $1
-                                                    (i32.load offset=4
-                                                      (get_local $1)
-                                                    )
-                                                  )
-                                                  (i32.const 0)
-                                                )
-                                              )
-                                              (set_local $6
-                                                (get_local $28)
-                                              )
-                                              (block
-                                                (set_local $6
-                                                  (get_local $28)
-                                                )
-                                                (loop $while-out$38 $while-in$39
-                                                  (i32.store8
-                                                    (set_local $6
-                                                      (i32.add
-                                                        (get_local $6)
-                                                        (i32.const -1)
-                                                      )
-                                                    )
-                                                    (i32.and
-                                                      (i32.or
-                                                        (i32.and
-                                                          (get_local $5)
-                                                          (i32.const 7)
-                                                        )
-                                                        (i32.const 48)
-                                                      )
-                                                      (i32.const 255)
-                                                    )
-                                                  )
-                                                  (if
-                                                    (i32.and
-                                                      (i32.eq
-                                                        (set_local $5
-                                                          (call $_bitshift64Lshr
-                                                            (get_local $5)
-                                                            (get_local $1)
-                                                            (i32.const 3)
-                                                          )
-                                                        )
-                                                        (i32.const 0)
-                                                      )
-                                                      (i32.eq
-                                                        (set_local $1
-                                                          (i32.load
-                                                            (i32.const 168)
-                                                          )
-                                                        )
-                                                        (i32.const 0)
-                                                      )
-                                                    )
-                                                    (br $while-out$38)
-                                                  )
-                                                  (br $while-in$39)
-                                                )
-                                              )
-                                            )
-                                            (set_local $58
-                                              (if
-                                                (i32.eq
-                                                  (i32.and
-                                                    (get_local $18)
-                                                    (i32.const 8)
-                                                  )
-                                                  (i32.const 0)
-                                                )
-                                                (block
-                                                  (set_local $34
-                                                    (get_local $18)
-                                                  )
-                                                  (set_local $32
-                                                    (get_local $10)
-                                                  )
-                                                  (set_local $35
+      (block $switch$24
+        (block $switch-default$127
+          (block $switch-case$49
+            (block $switch-case$48
+              (block $switch-case$47
+                (block $switch-case$46
+                  (block $switch-case$45
+                    (block $switch-case$44
+                      (block $switch-case$43
+                        (block $switch-case$41
+                          (block $switch-case$40
+                            (block $switch-case$36
+                              (block $switch-case$35
+                                (block $switch-case$34
+                                  (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$49 $switch-case$49 $switch-case$49 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$49 $switch-default$127 $switch-case$44 $switch-case$41 $switch-case$49 $switch-case$49 $switch-case$49 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127
+                                    (i32.sub
+                                      (set_local $26
+                                        (select
+                                          (i32.and
+                                            (get_local $1)
+                                            (i32.const -33)
+                                          )
+                                          (get_local $1)
+                                          (get_local $5)
+                                        )
+                                      )
+                                      (i32.const 65)
+                                    )
+                                  )
+                                )
+                                (block $switch-default$33
+                                  (block $switch-case$32
+                                    (block $switch-case$31
+                                      (block $switch-case$30
+                                        (block $switch-case$29
+                                          (block $switch-case$28
+                                            (block $switch-case$27
+                                              (block $switch-case$26
+                                                (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
+                                                  (i32.sub
+                                                    (get_local $13)
                                                     (i32.const 0)
                                                   )
-                                                  (set_local $36
-                                                    (i32.const 4091)
-                                                  )
-                                                  (set_local $12
-                                                    (i32.const 77)
-                                                  )
-                                                  (get_local $6)
-                                                )
-                                                (block
-                                                  (set_local $5
-                                                    (i32.lt_s
-                                                      (get_local $10)
-                                                      (set_local $1
-                                                        (i32.add
-                                                          (i32.sub
-                                                            (get_local $71)
-                                                            (get_local $6)
-                                                          )
-                                                          (i32.const 1)
-                                                        )
-                                                      )
-                                                    )
-                                                  )
-                                                  (set_local $34
-                                                    (get_local $18)
-                                                  )
-                                                  (set_local $32
-                                                    (select
-                                                      (get_local $1)
-                                                      (get_local $10)
-                                                      (get_local $5)
-                                                    )
-                                                  )
-                                                  (set_local $35
-                                                    (i32.const 0)
-                                                  )
-                                                  (set_local $36
-                                                    (i32.const 4091)
-                                                  )
-                                                  (set_local $12
-                                                    (i32.const 77)
-                                                  )
-                                                  (get_local $6)
                                                 )
                                               )
-                                            )
-                                            (br $switch$24)
-                                          )
-                                        )
-                                        (set_local $5
-                                          (i32.load
-                                            (set_local $1
-                                              (get_local $19)
-                                            )
-                                          )
-                                        )
-                                        (if
-                                          (i32.lt_s
-                                            (set_local $33
-                                              (i32.load offset=4
-                                                (get_local $1)
+                                              (i32.store
+                                                (i32.load
+                                                  (get_local $19)
+                                                )
+                                                (get_local $22)
                                               )
-                                            )
-                                            (i32.const 0)
-                                          )
-                                          (block
-                                            (set_local $1
-                                              (call $_i64Subtract
-                                                (i32.const 0)
-                                                (i32.const 0)
-                                                (get_local $5)
-                                                (get_local $33)
+                                              (set_local $20
+                                                (get_local $9)
                                               )
-                                            )
-                                            (set_local $5
-                                              (i32.load
-                                                (i32.const 168)
+                                              (set_local $1
+                                                (get_local $17)
                                               )
+                                              (set_local $8
+                                                (get_local $21)
+                                              )
+                                              (br $label$continue$L1)
                                             )
                                             (i32.store
-                                              (set_local $33
+                                              (i32.load
                                                 (get_local $19)
                                               )
-                                              (get_local $1)
+                                              (get_local $22)
                                             )
-                                            (i32.store offset=4
-                                              (get_local $33)
-                                              (get_local $5)
+                                            (set_local $20
+                                              (get_local $9)
                                             )
-                                            (set_local $33
-                                              (get_local $1)
+                                            (set_local $1
+                                              (get_local $17)
                                             )
-                                            (set_local $59
-                                              (get_local $5)
+                                            (set_local $8
+                                              (get_local $21)
                                             )
-                                            (set_local $60
-                                              (i32.const 1)
-                                            )
-                                            (set_local $61
-                                              (i32.const 4091)
-                                            )
-                                            (set_local $12
-                                              (i32.const 76)
-                                            )
-                                            (br $label$break$L75)
+                                            (br $label$continue$L1)
                                           )
-                                        )
-                                        (set_local $33
-                                          (if
-                                            (i32.eq
-                                              (i32.and
-                                                (get_local $18)
-                                                (i32.const 2048)
+                                          (i32.store
+                                            (set_local $1
+                                              (i32.load
+                                                (get_local $19)
                                               )
-                                              (i32.const 0)
                                             )
-                                            (block
-                                              (set_local $1
-                                                (select
-                                                  (i32.const 4091)
-                                                  (i32.const 4093)
-                                                  (i32.eq
-                                                    (set_local $6
-                                                      (i32.and
-                                                        (get_local $18)
-                                                        (i32.const 1)
-                                                      )
-                                                    )
-                                                    (i32.const 0)
-                                                  )
+                                            (get_local $22)
+                                          )
+                                          (i32.store offset=4
+                                            (get_local $1)
+                                            (i32.shr_s
+                                              (i32.shl
+                                                (i32.lt_s
+                                                  (get_local $22)
+                                                  (i32.const 0)
                                                 )
+                                                (i32.const 31)
                                               )
-                                              (set_local $59
-                                                (get_local $33)
-                                              )
-                                              (set_local $60
-                                                (get_local $6)
-                                              )
-                                              (set_local $61
-                                                (get_local $1)
-                                              )
-                                              (set_local $12
-                                                (i32.const 76)
-                                              )
-                                              (get_local $5)
-                                            )
-                                            (block
-                                              (set_local $59
-                                                (get_local $33)
-                                              )
-                                              (set_local $60
-                                                (i32.const 1)
-                                              )
-                                              (set_local $61
-                                                (i32.const 4092)
-                                              )
-                                              (set_local $12
-                                                (i32.const 76)
-                                              )
-                                              (get_local $5)
+                                              (i32.const 31)
                                             )
                                           )
-                                        )
-                                        (br $switch$24)
-                                      )
-                                      (set_local $33
-                                        (i32.load
+                                          (set_local $20
+                                            (get_local $9)
+                                          )
                                           (set_local $1
+                                            (get_local $17)
+                                          )
+                                          (set_local $8
+                                            (get_local $21)
+                                          )
+                                          (br $label$continue$L1)
+                                        )
+                                        (i32.store16
+                                          (i32.load
                                             (get_local $19)
                                           )
+                                          (i32.and
+                                            (get_local $22)
+                                            (i32.const 65535)
+                                          )
                                         )
-                                      )
-                                      (set_local $59
-                                        (i32.load offset=4
-                                          (get_local $1)
+                                        (set_local $20
+                                          (get_local $9)
                                         )
-                                      )
-                                      (set_local $60
-                                        (i32.const 0)
-                                      )
-                                      (set_local $61
-                                        (i32.const 4091)
-                                      )
-                                      (set_local $12
-                                        (i32.const 76)
-                                      )
-                                      (br $switch$24)
-                                    )
-                                    (set_local $5
-                                      (i32.load
                                         (set_local $1
+                                          (get_local $17)
+                                        )
+                                        (set_local $8
+                                          (get_local $21)
+                                        )
+                                        (br $label$continue$L1)
+                                      )
+                                      (i32.store8
+                                        (i32.load
                                           (get_local $19)
                                         )
+                                        (i32.and
+                                          (get_local $22)
+                                          (i32.const 255)
+                                        )
                                       )
-                                    )
-                                    (i32.load offset=4
-                                      (get_local $1)
-                                    )
-                                    (i32.store8
-                                      (get_local $72)
-                                      (i32.and
-                                        (get_local $5)
-                                        (i32.const 255)
+                                      (set_local $20
+                                        (get_local $9)
                                       )
+                                      (set_local $1
+                                        (get_local $17)
+                                      )
+                                      (set_local $8
+                                        (get_local $21)
+                                      )
+                                      (br $label$continue$L1)
                                     )
-                                    (set_local $47
-                                      (get_local $72)
-                                    )
-                                    (set_local $37
-                                      (get_local $7)
-                                    )
-                                    (set_local $42
-                                      (i32.const 1)
-                                    )
-                                    (set_local $43
-                                      (i32.const 0)
-                                    )
-                                    (set_local $48
-                                      (i32.const 4091)
-                                    )
-                                    (set_local $49
-                                      (get_local $28)
-                                    )
-                                    (br $switch$24)
-                                  )
-                                  (set_local $50
-                                    (call $_strerror
+                                    (i32.store
                                       (i32.load
-                                        (call $___errno_location)
+                                        (get_local $19)
                                       )
+                                      (get_local $22)
                                     )
+                                    (set_local $20
+                                      (get_local $9)
+                                    )
+                                    (set_local $1
+                                      (get_local $17)
+                                    )
+                                    (set_local $8
+                                      (get_local $21)
+                                    )
+                                    (br $label$continue$L1)
                                   )
-                                  (set_local $12
-                                    (i32.const 82)
-                                  )
-                                  (br $switch$24)
-                                )
-                                (set_local $5
-                                  (i32.ne
+                                  (i32.store
                                     (set_local $1
                                       (i32.load
                                         (get_local $19)
                                       )
                                     )
-                                    (i32.const 0)
+                                    (get_local $22)
                                   )
-                                )
-                                (set_local $50
-                                  (select
+                                  (i32.store offset=4
                                     (get_local $1)
-                                    (i32.const 4101)
-                                    (get_local $5)
+                                    (i32.shr_s
+                                      (i32.shl
+                                        (i32.lt_s
+                                          (get_local $22)
+                                          (i32.const 0)
+                                        )
+                                        (i32.const 31)
+                                      )
+                                      (i32.const 31)
+                                    )
                                   )
-                                )
-                                (set_local $12
-                                  (i32.const 82)
-                                )
-                                (br $switch$24)
-                              )
-                              (set_local $5
-                                (i32.load
+                                  (set_local $20
+                                    (get_local $9)
+                                  )
                                   (set_local $1
-                                    (get_local $19)
+                                    (get_local $17)
+                                  )
+                                  (set_local $8
+                                    (get_local $21)
+                                  )
+                                  (br $label$continue$L1)
+                                )
+                                (set_local $20
+                                  (get_local $9)
+                                )
+                                (set_local $1
+                                  (get_local $17)
+                                )
+                                (set_local $8
+                                  (get_local $21)
+                                )
+                                (br $label$continue$L1)
+                              )
+                              (set_local $46
+                                (i32.or
+                                  (get_local $18)
+                                  (i32.const 8)
+                                )
+                              )
+                              (set_local $57
+                                (select
+                                  (get_local $10)
+                                  (i32.const 8)
+                                  (i32.gt_u
+                                    (get_local $10)
+                                    (i32.const 8)
                                   )
                                 )
                               )
-                              (i32.load offset=4
-                                (get_local $1)
-                              )
-                              (i32.store
-                                (get_local $73)
-                                (get_local $5)
-                              )
-                              (i32.store
-                                (get_local $76)
-                                (i32.const 0)
-                              )
-                              (i32.store
-                                (get_local $19)
-                                (get_local $73)
-                              )
-                              (set_local $69
-                                (i32.const -1)
+                              (set_local $68
+                                (i32.const 120)
                               )
                               (set_local $12
-                                (i32.const 86)
+                                (i32.const 64)
                               )
                               (br $switch$24)
                             )
+                            (set_local $46
+                              (get_local $18)
+                            )
+                            (set_local $57
+                              (get_local $10)
+                            )
+                            (set_local $68
+                              (get_local $26)
+                            )
                             (set_local $12
-                              (if
-                                (i32.eq
+                              (i32.const 64)
+                            )
+                            (br $switch$24)
+                          )
+                          (if
+                            (i32.and
+                              (i32.eq
+                                (set_local $5
+                                  (i32.load
+                                    (set_local $1
+                                      (get_local $19)
+                                    )
+                                  )
+                                )
+                                (i32.const 0)
+                              )
+                              (i32.eq
+                                (set_local $1
+                                  (i32.load offset=4
+                                    (get_local $1)
+                                  )
+                                )
+                                (i32.const 0)
+                              )
+                            )
+                            (set_local $6
+                              (get_local $28)
+                            )
+                            (block
+                              (set_local $6
+                                (get_local $28)
+                              )
+                              (loop $while-out$38 $while-in$39
+                                (i32.store8
+                                  (set_local $6
+                                    (i32.add
+                                      (get_local $6)
+                                      (i32.const -1)
+                                    )
+                                  )
+                                  (i32.and
+                                    (i32.or
+                                      (i32.and
+                                        (get_local $5)
+                                        (i32.const 7)
+                                      )
+                                      (i32.const 48)
+                                    )
+                                    (i32.const 255)
+                                  )
+                                )
+                                (if
+                                  (i32.and
+                                    (i32.eq
+                                      (set_local $5
+                                        (call $_bitshift64Lshr
+                                          (get_local $5)
+                                          (get_local $1)
+                                          (i32.const 3)
+                                        )
+                                      )
+                                      (i32.const 0)
+                                    )
+                                    (i32.eq
+                                      (set_local $1
+                                        (i32.load
+                                          (i32.const 168)
+                                        )
+                                      )
+                                      (i32.const 0)
+                                    )
+                                  )
+                                  (br $while-out$38)
+                                )
+                                (br $while-in$39)
+                              )
+                            )
+                          )
+                          (set_local $58
+                            (if
+                              (i32.eq
+                                (i32.and
+                                  (get_local $18)
+                                  (i32.const 8)
+                                )
+                                (i32.const 0)
+                              )
+                              (block
+                                (set_local $34
+                                  (get_local $18)
+                                )
+                                (set_local $32
                                   (get_local $10)
+                                )
+                                (set_local $35
                                   (i32.const 0)
                                 )
-                                (block
-                                  (call $_pad
-                                    (get_local $0)
-                                    (i32.const 32)
-                                    (get_local $16)
-                                    (i32.const 0)
-                                    (get_local $18)
-                                  )
-                                  (set_local $38
-                                    (i32.const 0)
-                                  )
-                                  (i32.const 98)
+                                (set_local $36
+                                  (i32.const 4091)
                                 )
-                                (block
-                                  (set_local $69
-                                    (get_local $10)
-                                  )
-                                  (i32.const 86)
+                                (set_local $12
+                                  (i32.const 77)
                                 )
+                                (get_local $6)
                               )
+                              (block
+                                (set_local $5
+                                  (i32.lt_s
+                                    (get_local $10)
+                                    (set_local $1
+                                      (i32.add
+                                        (i32.sub
+                                          (get_local $71)
+                                          (get_local $6)
+                                        )
+                                        (i32.const 1)
+                                      )
+                                    )
+                                  )
+                                )
+                                (set_local $34
+                                  (get_local $18)
+                                )
+                                (set_local $32
+                                  (select
+                                    (get_local $1)
+                                    (get_local $10)
+                                    (get_local $5)
+                                  )
+                                )
+                                (set_local $35
+                                  (i32.const 0)
+                                )
+                                (set_local $36
+                                  (i32.const 4091)
+                                )
+                                (set_local $12
+                                  (i32.const 77)
+                                )
+                                (get_local $6)
+                              )
+                            )
+                          )
+                          (br $switch$24)
+                        )
+                        (set_local $5
+                          (i32.load
+                            (set_local $1
+                              (get_local $19)
+                            )
+                          )
+                        )
+                        (if
+                          (i32.lt_s
+                            (set_local $33
+                              (i32.load offset=4
+                                (get_local $1)
+                              )
+                            )
+                            (i32.const 0)
+                          )
+                          (block
+                            (set_local $1
+                              (call $_i64Subtract
+                                (i32.const 0)
+                                (i32.const 0)
+                                (get_local $5)
+                                (get_local $33)
+                              )
+                            )
+                            (set_local $5
+                              (i32.load
+                                (i32.const 168)
+                              )
+                            )
+                            (i32.store
+                              (set_local $33
+                                (get_local $19)
+                              )
+                              (get_local $1)
+                            )
+                            (i32.store offset=4
+                              (get_local $33)
+                              (get_local $5)
+                            )
+                            (set_local $33
+                              (get_local $1)
+                            )
+                            (set_local $59
+                              (get_local $5)
+                            )
+                            (set_local $60
+                              (i32.const 1)
+                            )
+                            (set_local $61
+                              (i32.const 4091)
+                            )
+                            (set_local $12
+                              (i32.const 76)
                             )
                             (br $switch$24)
                           )
                         )
+                        (set_local $33
+                          (if
+                            (i32.eq
+                              (i32.and
+                                (get_local $18)
+                                (i32.const 2048)
+                              )
+                              (i32.const 0)
+                            )
+                            (block
+                              (set_local $1
+                                (select
+                                  (i32.const 4091)
+                                  (i32.const 4093)
+                                  (i32.eq
+                                    (set_local $6
+                                      (i32.and
+                                        (get_local $18)
+                                        (i32.const 1)
+                                      )
+                                    )
+                                    (i32.const 0)
+                                  )
+                                )
+                              )
+                              (set_local $59
+                                (get_local $33)
+                              )
+                              (set_local $60
+                                (get_local $6)
+                              )
+                              (set_local $61
+                                (get_local $1)
+                              )
+                              (set_local $12
+                                (i32.const 76)
+                              )
+                              (get_local $5)
+                            )
+                            (block
+                              (set_local $59
+                                (get_local $33)
+                              )
+                              (set_local $60
+                                (i32.const 1)
+                              )
+                              (set_local $61
+                                (i32.const 4092)
+                              )
+                              (set_local $12
+                                (i32.const 76)
+                              )
+                              (get_local $5)
+                            )
+                          )
+                        )
+                        (br $switch$24)
+                      )
+                      (set_local $33
+                        (i32.load
+                          (set_local $1
+                            (get_local $19)
+                          )
+                        )
+                      )
+                      (set_local $59
+                        (i32.load offset=4
+                          (get_local $1)
+                        )
+                      )
+                      (set_local $60
+                        (i32.const 0)
+                      )
+                      (set_local $61
+                        (i32.const 4091)
+                      )
+                      (set_local $12
+                        (i32.const 76)
+                      )
+                      (br $switch$24)
+                    )
+                    (set_local $5
+                      (i32.load
+                        (set_local $1
+                          (get_local $19)
+                        )
+                      )
+                    )
+                    (i32.load offset=4
+                      (get_local $1)
+                    )
+                    (i32.store8
+                      (get_local $72)
+                      (i32.and
+                        (get_local $5)
+                        (i32.const 255)
+                      )
+                    )
+                    (set_local $47
+                      (get_local $72)
+                    )
+                    (set_local $37
+                      (get_local $7)
+                    )
+                    (set_local $42
+                      (i32.const 1)
+                    )
+                    (set_local $43
+                      (i32.const 0)
+                    )
+                    (set_local $48
+                      (i32.const 4091)
+                    )
+                    (set_local $49
+                      (get_local $28)
+                    )
+                    (br $switch$24)
+                  )
+                  (set_local $50
+                    (call $_strerror
+                      (i32.load
+                        (call $___errno_location)
                       )
                     )
                   )
+                  (set_local $12
+                    (i32.const 82)
+                  )
+                  (br $switch$24)
+                )
+                (set_local $5
+                  (i32.ne
+                    (set_local $1
+                      (i32.load
+                        (get_local $19)
+                      )
+                    )
+                    (i32.const 0)
+                  )
+                )
+                (set_local $50
+                  (select
+                    (get_local $1)
+                    (i32.const 4101)
+                    (get_local $5)
+                  )
+                )
+                (set_local $12
+                  (i32.const 82)
+                )
+                (br $switch$24)
+              )
+              (set_local $5
+                (i32.load
+                  (set_local $1
+                    (get_local $19)
+                  )
+                )
+              )
+              (i32.load offset=4
+                (get_local $1)
+              )
+              (i32.store
+                (get_local $73)
+                (get_local $5)
+              )
+              (i32.store
+                (get_local $76)
+                (i32.const 0)
+              )
+              (i32.store
+                (get_local $19)
+                (get_local $73)
+              )
+              (set_local $69
+                (i32.const -1)
+              )
+              (set_local $12
+                (i32.const 86)
+              )
+              (br $switch$24)
+            )
+            (set_local $12
+              (if
+                (i32.eq
+                  (get_local $10)
+                  (i32.const 0)
+                )
+                (block
+                  (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $16)
+                    (i32.const 0)
+                    (get_local $18)
+                  )
+                  (set_local $38
+                    (i32.const 0)
+                  )
+                  (i32.const 98)
+                )
+                (block
+                  (set_local $69
+                    (get_local $10)
+                  )
+                  (i32.const 86)
                 )
               )
             )
-            (set_local $15
-              (f64.load
-                (get_local $19)
-              )
+            (br $switch$24)
+          )
+          (set_local $15
+            (f64.load
+              (get_local $19)
             )
-            (i32.store
-              (get_local $25)
-              (i32.const 0)
-            )
-            (f64.store
-              (i32.load
-                (i32.const 24)
-              )
-              (get_local $15)
-            )
+          )
+          (i32.store
+            (get_local $25)
+            (i32.const 0)
+          )
+          (f64.store
             (i32.load
-              (i32.load
-                (i32.const 24)
-              )
+              (i32.const 24)
             )
-            (set_local $51
+            (get_local $15)
+          )
+          (i32.load
+            (i32.load
+              (i32.const 24)
+            )
+          )
+          (set_local $51
+            (if
+              (i32.lt_s
+                (i32.load offset=4
+                  (i32.load
+                    (i32.const 24)
+                  )
+                )
+                (i32.const 0)
+              )
+              (block
+                (set_local $39
+                  (i32.const 4108)
+                )
+                (set_local $15
+                  (f64.neg
+                    (get_local $15)
+                  )
+                )
+                (i32.const 1)
+              )
               (if
-                (i32.lt_s
-                  (i32.load offset=4
-                    (i32.load
-                      (i32.const 24)
-                    )
+                (i32.eq
+                  (i32.and
+                    (get_local $18)
+                    (i32.const 2048)
                   )
                   (i32.const 0)
                 )
                 (block
                   (set_local $39
-                    (i32.const 4108)
-                  )
-                  (set_local $15
-                    (f64.neg
-                      (get_local $15)
+                    (select
+                      (i32.const 4109)
+                      (i32.const 4114)
+                      (i32.eq
+                        (set_local $1
+                          (i32.and
+                            (get_local $18)
+                            (i32.const 1)
+                          )
+                        )
+                        (i32.const 0)
+                      )
                     )
+                  )
+                  (get_local $1)
+                )
+                (block
+                  (set_local $39
+                    (i32.const 4111)
                   )
                   (i32.const 1)
                 )
-                (if
-                  (i32.eq
-                    (i32.and
-                      (get_local $18)
-                      (i32.const 2048)
+              )
+            )
+          )
+          (f64.store
+            (i32.load
+              (i32.const 24)
+            )
+            (get_local $15)
+          )
+          (i32.load
+            (i32.load
+              (i32.const 24)
+            )
+          )
+          (set_local $20
+            (get_local $9)
+          )
+          (set_local $1
+            (block $do-once$56
+              (if
+                (i32.or
+                  (i32.lt_u
+                    (set_local $1
+                      (i32.and
+                        (i32.load offset=4
+                          (i32.load
+                            (i32.const 24)
+                          )
+                        )
+                        (i32.const 2146435072)
+                      )
+                    )
+                    (i32.const 2146435072)
+                  )
+                  (i32.and
+                    (i32.eq
+                      (get_local $1)
+                      (i32.const 2146435072)
                     )
                     (i32.const 0)
                   )
-                  (block
-                    (set_local $39
-                      (select
-                        (i32.const 4109)
-                        (i32.const 4114)
-                        (i32.eq
+                )
+                (block
+                  (if
+                    (set_local $5
+                      (f64.ne
+                        (set_local $15
+                          (f64.mul
+                            (call $_frexpl
+                              (get_local $15)
+                              (get_local $25)
+                            )
+                            (f64.const 2)
+                          )
+                        )
+                        (f64.const 0)
+                      )
+                    )
+                    (i32.store
+                      (get_local $25)
+                      (i32.add
+                        (i32.load
+                          (get_local $25)
+                        )
+                        (i32.const -1)
+                      )
+                    )
+                  )
+                  (if
+                    (i32.eq
+                      (set_local $14
+                        (i32.or
+                          (get_local $26)
+                          (i32.const 32)
+                        )
+                      )
+                      (i32.const 97)
+                    )
+                    (block
+                      (set_local $9
+                        (select
+                          (get_local $39)
+                          (i32.add
+                            (get_local $39)
+                            (i32.const 9)
+                          )
+                          (i32.eq
+                            (set_local $6
+                              (i32.and
+                                (get_local $26)
+                                (i32.const 32)
+                              )
+                            )
+                            (i32.const 0)
+                          )
+                        )
+                      )
+                      (set_local $7
+                        (i32.or
+                          (get_local $51)
+                          (i32.const 2)
+                        )
+                      )
+                      (set_local $15
+                        (if
+                          (i32.or
+                            (i32.gt_u
+                              (get_local $10)
+                              (i32.const 11)
+                            )
+                            (i32.eq
+                              (set_local $1
+                                (i32.sub
+                                  (i32.const 12)
+                                  (get_local $10)
+                                )
+                              )
+                              (i32.const 0)
+                            )
+                          )
+                          (get_local $15)
+                          (block
+                            (set_local $30
+                              (f64.const 8)
+                            )
+                            (loop $while-out$60 $while-in$61
+                              (set_local $30
+                                (f64.mul
+                                  (get_local $30)
+                                  (f64.const 16)
+                                )
+                              )
+                              (if
+                                (i32.eq
+                                  (set_local $1
+                                    (i32.add
+                                      (get_local $1)
+                                      (i32.const -1)
+                                    )
+                                  )
+                                  (i32.const 0)
+                                )
+                                (br $while-out$60)
+                              )
+                              (br $while-in$61)
+                            )
+                            (select
+                              (f64.neg
+                                (f64.add
+                                  (get_local $30)
+                                  (f64.sub
+                                    (f64.neg
+                                      (get_local $15)
+                                    )
+                                    (get_local $30)
+                                  )
+                                )
+                              )
+                              (f64.sub
+                                (f64.add
+                                  (get_local $15)
+                                  (get_local $30)
+                                )
+                                (get_local $30)
+                              )
+                              (i32.eq
+                                (i32.shr_s
+                                  (i32.shl
+                                    (i32.load8_s
+                                      (get_local $9)
+                                    )
+                                    (i32.const 24)
+                                  )
+                                  (i32.const 24)
+                                )
+                                (i32.const 45)
+                              )
+                            )
+                          )
+                        )
+                      )
+                      (set_local $5
+                        (i32.lt_s
                           (set_local $1
+                            (i32.load
+                              (get_local $25)
+                            )
+                          )
+                          (i32.const 0)
+                        )
+                      )
+                      (set_local $5
+                        (i32.shr_s
+                          (i32.shl
+                            (i32.lt_s
+                              (set_local $8
+                                (select
+                                  (i32.sub
+                                    (i32.const 0)
+                                    (get_local $1)
+                                  )
+                                  (get_local $1)
+                                  (get_local $5)
+                                )
+                              )
+                              (i32.const 0)
+                            )
+                            (i32.const 31)
+                          )
+                          (i32.const 31)
+                        )
+                      )
+                      (i32.store8
+                        (i32.add
+                          (set_local $5
+                            (if
+                              (i32.eq
+                                (set_local $5
+                                  (call $_fmt_u
+                                    (get_local $8)
+                                    (get_local $5)
+                                    (get_local $52)
+                                  )
+                                )
+                                (get_local $52)
+                              )
+                              (block
+                                (i32.store8
+                                  (get_local $74)
+                                  (i32.const 48)
+                                )
+                                (get_local $74)
+                              )
+                              (get_local $5)
+                            )
+                          )
+                          (i32.const -1)
+                        )
+                        (i32.and
+                          (i32.add
                             (i32.and
-                              (get_local $18)
-                              (i32.const 1)
+                              (i32.shr_s
+                                (get_local $1)
+                                (i32.const 31)
+                              )
+                              (i32.const 2)
+                            )
+                            (i32.const 43)
+                          )
+                          (i32.const 255)
+                        )
+                      )
+                      (i32.store8
+                        (set_local $8
+                          (i32.add
+                            (get_local $5)
+                            (i32.const -2)
+                          )
+                        )
+                        (i32.and
+                          (i32.add
+                            (get_local $26)
+                            (i32.const 15)
+                          )
+                          (i32.const 255)
+                        )
+                      )
+                      (set_local $5
+                        (i32.lt_s
+                          (get_local $10)
+                          (i32.const 1)
+                        )
+                      )
+                      (set_local $13
+                        (i32.eq
+                          (i32.and
+                            (get_local $18)
+                            (i32.const 8)
+                          )
+                          (i32.const 0)
+                        )
+                      )
+                      (set_local $11
+                        (get_local $29)
+                      )
+                      (loop $while-out$62 $while-in$63
+                        (i32.store8
+                          (get_local $11)
+                          (i32.and
+                            (i32.or
+                              (i32.and
+                                (i32.load8_s
+                                  (i32.add
+                                    (set_local $1
+                                      (call_import $f64-to-int
+                                        (get_local $15)
+                                      )
+                                    )
+                                    (i32.const 4075)
+                                  )
+                                )
+                                (i32.const 255)
+                              )
+                              (get_local $6)
+                            )
+                            (i32.const 255)
+                          )
+                        )
+                        (set_local $15
+                          (f64.mul
+                            (f64.sub
+                              (get_local $15)
+                              (f64.convert_s/i32
+                                (get_local $1)
+                              )
+                            )
+                            (f64.const 16)
+                          )
+                        )
+                        (set_local $11
+                          (block $do-once$64
+                            (if
+                              (i32.eq
+                                (i32.sub
+                                  (set_local $1
+                                    (i32.add
+                                      (get_local $11)
+                                      (i32.const 1)
+                                    )
+                                  )
+                                  (get_local $64)
+                                )
+                                (i32.const 1)
+                              )
+                              (block
+                                (br_if $do-once$64
+                                  (get_local $1)
+                                  (i32.and
+                                    (get_local $13)
+                                    (i32.and
+                                      (get_local $5)
+                                      (f64.eq
+                                        (get_local $15)
+                                        (f64.const 0)
+                                      )
+                                    )
+                                  )
+                                )
+                                (i32.store8
+                                  (get_local $1)
+                                  (i32.const 46)
+                                )
+                                (i32.add
+                                  (get_local $11)
+                                  (i32.const 2)
+                                )
+                              )
+                              (get_local $1)
+                            )
+                          )
+                        )
+                        (if
+                          (f64.eq
+                            (get_local $15)
+                            (f64.const 0)
+                          )
+                          (block
+                            (set_local $1
+                              (get_local $11)
+                            )
+                            (br $while-out$62)
+                          )
+                        )
+                        (br $while-in$63)
+                      )
+                      (set_local $5
+                        (i32.and
+                          (i32.ne
+                            (get_local $10)
+                            (i32.const 0)
+                          )
+                          (i32.lt_s
+                            (i32.add
+                              (get_local $78)
+                              (get_local $1)
+                            )
+                            (get_local $10)
+                          )
+                        )
+                      )
+                      (call $_pad
+                        (get_local $0)
+                        (i32.const 32)
+                        (get_local $16)
+                        (set_local $5
+                          (i32.add
+                            (set_local $6
+                              (select
+                                (i32.sub
+                                  (i32.add
+                                    (get_local $79)
+                                    (get_local $10)
+                                  )
+                                  (get_local $8)
+                                )
+                                (i32.add
+                                  (i32.sub
+                                    (get_local $77)
+                                    (get_local $8)
+                                  )
+                                  (get_local $1)
+                                )
+                                (get_local $5)
+                              )
+                            )
+                            (get_local $7)
+                          )
+                        )
+                        (get_local $18)
+                      )
+                      (if
+                        (i32.eq
+                          (i32.and
+                            (i32.load
+                              (get_local $0)
+                            )
+                            (i32.const 32)
+                          )
+                          (i32.const 0)
+                        )
+                        (call $___fwritex
+                          (get_local $9)
+                          (get_local $7)
+                          (get_local $0)
+                        )
+                      )
+                      (call $_pad
+                        (get_local $0)
+                        (i32.const 48)
+                        (get_local $16)
+                        (get_local $5)
+                        (i32.xor
+                          (get_local $18)
+                          (i32.const 65536)
+                        )
+                      )
+                      (set_local $1
+                        (i32.sub
+                          (get_local $1)
+                          (get_local $64)
+                        )
+                      )
+                      (if
+                        (i32.eq
+                          (i32.and
+                            (i32.load
+                              (get_local $0)
+                            )
+                            (i32.const 32)
+                          )
+                          (i32.const 0)
+                        )
+                        (call $___fwritex
+                          (get_local $29)
+                          (get_local $1)
+                          (get_local $0)
+                        )
+                      )
+                      (call $_pad
+                        (get_local $0)
+                        (i32.const 48)
+                        (i32.sub
+                          (get_local $6)
+                          (i32.add
+                            (get_local $1)
+                            (set_local $1
+                              (i32.sub
+                                (get_local $40)
+                                (get_local $8)
+                              )
+                            )
+                          )
+                        )
+                        (i32.const 0)
+                        (i32.const 0)
+                      )
+                      (if
+                        (i32.eq
+                          (i32.and
+                            (i32.load
+                              (get_local $0)
+                            )
+                            (i32.const 32)
+                          )
+                          (i32.const 0)
+                        )
+                        (call $___fwritex
+                          (get_local $8)
+                          (get_local $1)
+                          (get_local $0)
+                        )
+                      )
+                      (call $_pad
+                        (get_local $0)
+                        (i32.const 32)
+                        (get_local $16)
+                        (get_local $5)
+                        (i32.xor
+                          (get_local $18)
+                          (i32.const 8192)
+                        )
+                      )
+                      (br $do-once$56
+                        (select
+                          (get_local $16)
+                          (get_local $5)
+                          (i32.lt_s
+                            (get_local $5)
+                            (get_local $16)
+                          )
+                        )
+                      )
+                    )
+                  )
+                  (set_local $1
+                    (select
+                      (i32.const 6)
+                      (get_local $10)
+                      (i32.lt_s
+                        (get_local $10)
+                        (i32.const 0)
+                      )
+                    )
+                  )
+                  (set_local $62
+                    (set_local $9
+                      (select
+                        (get_local $80)
+                        (get_local $81)
+                        (i32.lt_s
+                          (if
+                            (get_local $5)
+                            (block
+                              (i32.store
+                                (get_local $25)
+                                (set_local $5
+                                  (i32.add
+                                    (i32.load
+                                      (get_local $25)
+                                    )
+                                    (i32.const -28)
+                                  )
+                                )
+                              )
+                              (set_local $15
+                                (f64.mul
+                                  (get_local $15)
+                                  (f64.const 268435456)
+                                )
+                              )
+                              (get_local $5)
+                            )
+                            (i32.load
+                              (get_local $25)
                             )
                           )
                           (i32.const 0)
                         )
                       )
                     )
-                    (get_local $1)
                   )
-                  (block
-                    (set_local $39
-                      (i32.const 4111)
-                    )
-                    (i32.const 1)
+                  (set_local $7
+                    (get_local $9)
                   )
-                )
-              )
-            )
-            (f64.store
-              (i32.load
-                (i32.const 24)
-              )
-              (get_local $15)
-            )
-            (i32.load
-              (i32.load
-                (i32.const 24)
-              )
-            )
-            (set_local $20
-              (get_local $9)
-            )
-            (set_local $1
-              (block $do-once$56
-                (if
-                  (i32.or
-                    (i32.lt_u
-                      (set_local $1
-                        (i32.and
-                          (i32.load offset=4
-                            (i32.load
-                              (i32.const 24)
-                            )
-                          )
-                          (i32.const 2146435072)
+                  (loop $while-out$66 $while-in$67
+                    (i32.store
+                      (get_local $7)
+                      (set_local $5
+                        (call_import $f64-to-int
+                          (get_local $15)
                         )
                       )
-                      (i32.const 2146435072)
                     )
-                    (i32.and
-                      (i32.eq
-                        (get_local $1)
-                        (i32.const 2146435072)
+                    (set_local $7
+                      (i32.add
+                        (get_local $7)
+                        (i32.const 4)
+                      )
+                    )
+                    (if
+                      (f64.eq
+                        (set_local $15
+                          (f64.mul
+                            (f64.sub
+                              (get_local $15)
+                              (f64.convert_u/i32
+                                (get_local $5)
+                              )
+                            )
+                            (f64.const 1e9)
+                          )
+                        )
+                        (f64.const 0)
+                      )
+                      (block
+                        (set_local $6
+                          (get_local $7)
+                        )
+                        (br $while-out$66)
+                      )
+                    )
+                    (br $while-in$67)
+                  )
+                  (if
+                    (i32.gt_s
+                      (set_local $5
+                        (i32.load
+                          (get_local $25)
+                        )
                       )
                       (i32.const 0)
                     )
-                  )
-                  (block
-                    (if
-                      (set_local $5
-                        (f64.ne
-                          (set_local $15
-                            (f64.mul
-                              (call $_frexpl
-                                (get_local $15)
-                                (get_local $25)
-                              )
-                              (f64.const 2)
+                    (block
+                      (set_local $8
+                        (get_local $9)
+                      )
+                      (set_local $13
+                        (get_local $6)
+                      )
+                      (loop $while-out$68 $while-in$69
+                        (set_local $11
+                          (select
+                            (i32.const 29)
+                            (get_local $5)
+                            (i32.gt_s
+                              (get_local $5)
+                              (i32.const 29)
                             )
                           )
-                          (f64.const 0)
+                        )
+                        (set_local $7
+                          (block $do-once$70
+                            (if
+                              (i32.lt_u
+                                (set_local $7
+                                  (i32.add
+                                    (get_local $13)
+                                    (i32.const -4)
+                                  )
+                                )
+                                (get_local $8)
+                              )
+                              (get_local $8)
+                              (block
+                                (set_local $5
+                                  (i32.const 0)
+                                )
+                                (set_local $10
+                                  (get_local $7)
+                                )
+                                (loop $while-out$72 $while-in$73
+                                  (set_local $6
+                                    (call $___uremdi3
+                                      (set_local $5
+                                        (call $_i64Add
+                                          (call $_bitshift64Shl
+                                            (i32.load
+                                              (get_local $10)
+                                            )
+                                            (i32.const 0)
+                                            (get_local $11)
+                                          )
+                                          (i32.load
+                                            (i32.const 168)
+                                          )
+                                          (get_local $5)
+                                          (i32.const 0)
+                                        )
+                                      )
+                                      (set_local $7
+                                        (i32.load
+                                          (i32.const 168)
+                                        )
+                                      )
+                                      (i32.const 1000000000)
+                                      (i32.const 0)
+                                    )
+                                  )
+                                  (i32.load
+                                    (i32.const 168)
+                                  )
+                                  (i32.store
+                                    (get_local $10)
+                                    (get_local $6)
+                                  )
+                                  (set_local $5
+                                    (call $___udivdi3
+                                      (get_local $5)
+                                      (get_local $7)
+                                      (i32.const 1000000000)
+                                      (i32.const 0)
+                                    )
+                                  )
+                                  (i32.load
+                                    (i32.const 168)
+                                  )
+                                  (if
+                                    (i32.lt_u
+                                      (set_local $7
+                                        (i32.add
+                                          (get_local $10)
+                                          (i32.const -4)
+                                        )
+                                      )
+                                      (get_local $8)
+                                    )
+                                    (br $while-out$72)
+                                    (set_local $10
+                                      (get_local $7)
+                                    )
+                                  )
+                                  (br $while-in$73)
+                                )
+                                (br_if $do-once$70
+                                  (get_local $8)
+                                  (i32.eq
+                                    (get_local $5)
+                                    (i32.const 0)
+                                  )
+                                )
+                                (i32.store
+                                  (set_local $7
+                                    (i32.add
+                                      (get_local $8)
+                                      (i32.const -4)
+                                    )
+                                  )
+                                  (get_local $5)
+                                )
+                                (get_local $7)
+                              )
+                            )
+                          )
+                        )
+                        (loop $while-out$74 $while-in$75
+                          (if
+                            (i32.le_u
+                              (get_local $13)
+                              (get_local $7)
+                            )
+                            (br $while-out$74)
+                          )
+                          (if
+                            (i32.eq
+                              (i32.load
+                                (set_local $5
+                                  (i32.add
+                                    (get_local $13)
+                                    (i32.const -4)
+                                  )
+                                )
+                              )
+                              (i32.const 0)
+                            )
+                            (set_local $13
+                              (get_local $5)
+                            )
+                            (br $while-out$74)
+                          )
+                          (br $while-in$75)
+                        )
+                        (i32.store
+                          (get_local $25)
+                          (set_local $5
+                            (i32.sub
+                              (i32.load
+                                (get_local $25)
+                              )
+                              (get_local $11)
+                            )
+                          )
+                        )
+                        (if
+                          (i32.gt_s
+                            (get_local $5)
+                            (i32.const 0)
+                          )
+                          (set_local $8
+                            (get_local $7)
+                          )
+                          (block
+                            (set_local $6
+                              (get_local $13)
+                            )
+                            (br $while-out$68)
+                          )
+                        )
+                        (br $while-in$69)
+                      )
+                    )
+                    (set_local $7
+                      (get_local $9)
+                    )
+                  )
+                  (if
+                    (i32.lt_s
+                      (get_local $5)
+                      (i32.const 0)
+                    )
+                    (block
+                      (set_local $8
+                        (i32.add
+                          (i32.and
+                            (call_import $i32s-div
+                              (i32.add
+                                (get_local $1)
+                                (i32.const 25)
+                              )
+                              (i32.const 9)
+                            )
+                            (i32.const -1)
+                          )
+                          (i32.const 1)
                         )
                       )
-                      (i32.store
-                        (get_local $25)
-                        (i32.add
-                          (i32.load
-                            (get_local $25)
-                          )
-                          (i32.const -1)
+                      (set_local $10
+                        (i32.eq
+                          (get_local $14)
+                          (i32.const 102)
                         )
+                      )
+                      (set_local $23
+                        (get_local $6)
+                      )
+                      (loop $while-out$76 $while-in$77
+                        (set_local $5
+                          (i32.gt_s
+                            (set_local $6
+                              (i32.sub
+                                (i32.const 0)
+                                (get_local $5)
+                              )
+                            )
+                            (i32.const 9)
+                          )
+                        )
+                        (set_local $13
+                          (select
+                            (i32.const 9)
+                            (get_local $6)
+                            (get_local $5)
+                          )
+                        )
+                        (set_local $11
+                          (block $do-once$78
+                            (if
+                              (i32.lt_u
+                                (get_local $7)
+                                (get_local $23)
+                              )
+                              (block
+                                (set_local $70
+                                  (i32.add
+                                    (i32.shl
+                                      (i32.const 1)
+                                      (get_local $13)
+                                    )
+                                    (i32.const -1)
+                                  )
+                                )
+                                (set_local $27
+                                  (i32.shr_u
+                                    (i32.const 1000000000)
+                                    (get_local $13)
+                                  )
+                                )
+                                (set_local $11
+                                  (i32.const 0)
+                                )
+                                (set_local $17
+                                  (get_local $7)
+                                )
+                                (loop $while-out$80 $while-in$81
+                                  (set_local $6
+                                    (i32.and
+                                      (set_local $5
+                                        (i32.load
+                                          (get_local $17)
+                                        )
+                                      )
+                                      (get_local $70)
+                                    )
+                                  )
+                                  (i32.store
+                                    (get_local $17)
+                                    (i32.add
+                                      (i32.shr_u
+                                        (get_local $5)
+                                        (get_local $13)
+                                      )
+                                      (get_local $11)
+                                    )
+                                  )
+                                  (set_local $11
+                                    (i32.mul
+                                      (get_local $6)
+                                      (get_local $27)
+                                    )
+                                  )
+                                  (if
+                                    (i32.ge_u
+                                      (set_local $17
+                                        (i32.add
+                                          (get_local $17)
+                                          (i32.const 4)
+                                        )
+                                      )
+                                      (get_local $23)
+                                    )
+                                    (br $while-out$80)
+                                  )
+                                  (br $while-in$81)
+                                )
+                                (set_local $5
+                                  (select
+                                    (i32.add
+                                      (get_local $7)
+                                      (i32.const 4)
+                                    )
+                                    (get_local $7)
+                                    (i32.eq
+                                      (i32.load
+                                        (get_local $7)
+                                      )
+                                      (i32.const 0)
+                                    )
+                                  )
+                                )
+                                (if
+                                  (i32.eq
+                                    (get_local $11)
+                                    (i32.const 0)
+                                  )
+                                  (br $do-once$78
+                                    (get_local $5)
+                                  )
+                                )
+                                (i32.store
+                                  (get_local $23)
+                                  (get_local $11)
+                                )
+                                (set_local $23
+                                  (i32.add
+                                    (get_local $23)
+                                    (i32.const 4)
+                                  )
+                                )
+                                (get_local $5)
+                              )
+                              (select
+                                (i32.add
+                                  (get_local $7)
+                                  (i32.const 4)
+                                )
+                                (get_local $7)
+                                (i32.eq
+                                  (i32.load
+                                    (get_local $7)
+                                  )
+                                  (i32.const 0)
+                                )
+                              )
+                            )
+                          )
+                        )
+                        (set_local $5
+                          (i32.gt_s
+                            (i32.shr_s
+                              (i32.sub
+                                (get_local $23)
+                                (set_local $7
+                                  (select
+                                    (get_local $9)
+                                    (get_local $11)
+                                    (get_local $10)
+                                  )
+                                )
+                              )
+                              (i32.const 2)
+                            )
+                            (get_local $8)
+                          )
+                        )
+                        (set_local $6
+                          (select
+                            (i32.add
+                              (get_local $7)
+                              (i32.shl
+                                (get_local $8)
+                                (i32.const 2)
+                              )
+                            )
+                            (get_local $23)
+                            (get_local $5)
+                          )
+                        )
+                        (i32.store
+                          (get_local $25)
+                          (set_local $5
+                            (i32.add
+                              (i32.load
+                                (get_local $25)
+                              )
+                              (get_local $13)
+                            )
+                          )
+                        )
+                        (if
+                          (i32.lt_s
+                            (get_local $5)
+                            (i32.const 0)
+                          )
+                          (block
+                            (set_local $7
+                              (get_local $11)
+                            )
+                            (set_local $23
+                              (get_local $6)
+                            )
+                          )
+                          (block
+                            (set_local $7
+                              (get_local $11)
+                            )
+                            (set_local $27
+                              (get_local $6)
+                            )
+                            (br $while-out$76)
+                          )
+                        )
+                        (br $while-in$77)
+                      )
+                    )
+                    (set_local $27
+                      (get_local $6)
+                    )
+                  )
+                  (block $do-once$82
+                    (if
+                      (i32.lt_u
+                        (get_local $7)
+                        (get_local $27)
+                      )
+                      (block
+                        (set_local $6
+                          (i32.mul
+                            (i32.shr_s
+                              (i32.sub
+                                (get_local $62)
+                                (get_local $7)
+                              )
+                              (i32.const 2)
+                            )
+                            (i32.const 9)
+                          )
+                        )
+                        (if
+                          (i32.lt_u
+                            (set_local $5
+                              (i32.load
+                                (get_local $7)
+                              )
+                            )
+                            (i32.const 10)
+                          )
+                          (block
+                            (set_local $13
+                              (get_local $6)
+                            )
+                            (br $do-once$82)
+                          )
+                          (set_local $8
+                            (i32.const 10)
+                          )
+                        )
+                        (loop $while-out$84 $while-in$85
+                          (set_local $6
+                            (i32.add
+                              (get_local $6)
+                              (i32.const 1)
+                            )
+                          )
+                          (if
+                            (i32.lt_u
+                              (get_local $5)
+                              (set_local $8
+                                (i32.mul
+                                  (get_local $8)
+                                  (i32.const 10)
+                                )
+                              )
+                            )
+                            (block
+                              (set_local $13
+                                (get_local $6)
+                              )
+                              (br $while-out$84)
+                            )
+                          )
+                          (br $while-in$85)
+                        )
+                      )
+                      (set_local $13
+                        (i32.const 0)
+                      )
+                    )
+                  )
+                  (set_local $7
+                    (if
+                      (i32.lt_s
+                        (set_local $5
+                          (i32.add
+                            (i32.sub
+                              (get_local $1)
+                              (select
+                                (get_local $13)
+                                (i32.const 0)
+                                (i32.ne
+                                  (get_local $14)
+                                  (i32.const 102)
+                                )
+                              )
+                            )
+                            (i32.shr_s
+                              (i32.shl
+                                (i32.and
+                                  (set_local $70
+                                    (i32.ne
+                                      (get_local $1)
+                                      (i32.const 0)
+                                    )
+                                  )
+                                  (set_local $8
+                                    (i32.eq
+                                      (get_local $14)
+                                      (i32.const 103)
+                                    )
+                                  )
+                                )
+                                (i32.const 31)
+                              )
+                              (i32.const 31)
+                            )
+                          )
+                        )
+                        (i32.add
+                          (i32.mul
+                            (i32.shr_s
+                              (i32.sub
+                                (get_local $27)
+                                (get_local $62)
+                              )
+                              (i32.const 2)
+                            )
+                            (i32.const 9)
+                          )
+                          (i32.const -9)
+                        )
+                      )
+                      (block
+                        (set_local $6
+                          (i32.add
+                            (i32.add
+                              (get_local $9)
+                              (i32.const 4)
+                            )
+                            (i32.shl
+                              (i32.add
+                                (i32.and
+                                  (call_import $i32s-div
+                                    (set_local $5
+                                      (i32.add
+                                        (get_local $5)
+                                        (i32.const 9216)
+                                      )
+                                    )
+                                    (i32.const 9)
+                                  )
+                                  (i32.const -1)
+                                )
+                                (i32.const -1024)
+                              )
+                              (i32.const 2)
+                            )
+                          )
+                        )
+                        (if
+                          (i32.lt_s
+                            (set_local $11
+                              (i32.add
+                                (i32.and
+                                  (call_import $i32s-rem
+                                    (get_local $5)
+                                    (i32.const 9)
+                                  )
+                                  (i32.const -1)
+                                )
+                                (i32.const 1)
+                              )
+                            )
+                            (i32.const 9)
+                          )
+                          (block
+                            (set_local $5
+                              (i32.const 10)
+                            )
+                            (loop $while-out$86 $while-in$87
+                              (set_local $5
+                                (i32.mul
+                                  (get_local $5)
+                                  (i32.const 10)
+                                )
+                              )
+                              (if
+                                (i32.eq
+                                  (set_local $11
+                                    (i32.add
+                                      (get_local $11)
+                                      (i32.const 1)
+                                    )
+                                  )
+                                  (i32.const 9)
+                                )
+                                (block
+                                  (set_local $17
+                                    (get_local $5)
+                                  )
+                                  (br $while-out$86)
+                                )
+                              )
+                              (br $while-in$87)
+                            )
+                          )
+                          (set_local $17
+                            (i32.const 10)
+                          )
+                        )
+                        (block $do-once$88
+                          (if
+                            (i32.eqz
+                              (i32.and
+                                (set_local $11
+                                  (i32.eq
+                                    (i32.add
+                                      (get_local $6)
+                                      (i32.const 4)
+                                    )
+                                    (get_local $27)
+                                  )
+                                )
+                                (i32.eq
+                                  (set_local $14
+                                    (i32.and
+                                      (call_import $i32u-rem
+                                        (set_local $5
+                                          (i32.load
+                                            (get_local $6)
+                                          )
+                                        )
+                                        (get_local $17)
+                                      )
+                                      (i32.const -1)
+                                    )
+                                  )
+                                  (i32.const 0)
+                                )
+                              )
+                            )
+                            (block
+                              (set_local $15
+                                (select
+                                  (f64.const 9007199254740992)
+                                  (f64.const 9007199254740994)
+                                  (i32.eq
+                                    (i32.and
+                                      (i32.and
+                                        (call_import $i32u-div
+                                          (get_local $5)
+                                          (get_local $17)
+                                        )
+                                        (i32.const -1)
+                                      )
+                                      (i32.const 1)
+                                    )
+                                    (i32.const 0)
+                                  )
+                                )
+                              )
+                              (set_local $30
+                                (if
+                                  (i32.lt_u
+                                    (get_local $14)
+                                    (set_local $10
+                                      (i32.and
+                                        (call_import $i32s-div
+                                          (get_local $17)
+                                          (i32.const 2)
+                                        )
+                                        (i32.const -1)
+                                      )
+                                    )
+                                  )
+                                  (f64.const 0.5)
+                                  (select
+                                    (f64.const 1)
+                                    (f64.const 1.5)
+                                    (i32.and
+                                      (get_local $11)
+                                      (i32.eq
+                                        (get_local $14)
+                                        (get_local $10)
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                              (set_local $15
+                                (block $do-once$90
+                                  (if
+                                    (i32.eq
+                                      (get_local $51)
+                                      (i32.const 0)
+                                    )
+                                    (get_local $15)
+                                    (block
+                                      (if
+                                        (i32.ne
+                                          (i32.shr_s
+                                            (i32.shl
+                                              (i32.load8_s
+                                                (get_local $39)
+                                              )
+                                              (i32.const 24)
+                                            )
+                                            (i32.const 24)
+                                          )
+                                          (i32.const 45)
+                                        )
+                                        (br $do-once$90
+                                          (get_local $15)
+                                        )
+                                      )
+                                      (set_local $30
+                                        (f64.neg
+                                          (get_local $30)
+                                        )
+                                      )
+                                      (f64.neg
+                                        (get_local $15)
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                              (i32.store
+                                (get_local $6)
+                                (set_local $5
+                                  (i32.sub
+                                    (get_local $5)
+                                    (get_local $14)
+                                  )
+                                )
+                              )
+                              (if
+                                (f64.eq
+                                  (f64.add
+                                    (get_local $15)
+                                    (get_local $30)
+                                  )
+                                  (get_local $15)
+                                )
+                                (br $do-once$88)
+                              )
+                              (i32.store
+                                (get_local $6)
+                                (set_local $5
+                                  (i32.add
+                                    (get_local $5)
+                                    (get_local $17)
+                                  )
+                                )
+                              )
+                              (if
+                                (i32.gt_u
+                                  (get_local $5)
+                                  (i32.const 999999999)
+                                )
+                                (loop $while-out$92 $while-in$93
+                                  (i32.store
+                                    (get_local $6)
+                                    (i32.const 0)
+                                  )
+                                  (set_local $7
+                                    (if
+                                      (i32.lt_u
+                                        (set_local $6
+                                          (i32.add
+                                            (get_local $6)
+                                            (i32.const -4)
+                                          )
+                                        )
+                                        (get_local $7)
+                                      )
+                                      (block
+                                        (i32.store
+                                          (set_local $5
+                                            (i32.add
+                                              (get_local $7)
+                                              (i32.const -4)
+                                            )
+                                          )
+                                          (i32.const 0)
+                                        )
+                                        (get_local $5)
+                                      )
+                                      (get_local $7)
+                                    )
+                                  )
+                                  (i32.store
+                                    (get_local $6)
+                                    (set_local $5
+                                      (i32.add
+                                        (i32.load
+                                          (get_local $6)
+                                        )
+                                        (i32.const 1)
+                                      )
+                                    )
+                                  )
+                                  (if
+                                    (i32.le_u
+                                      (get_local $5)
+                                      (i32.const 999999999)
+                                    )
+                                    (br $while-out$92)
+                                  )
+                                  (br $while-in$93)
+                                )
+                              )
+                              (set_local $11
+                                (i32.mul
+                                  (i32.shr_s
+                                    (i32.sub
+                                      (get_local $62)
+                                      (get_local $7)
+                                    )
+                                    (i32.const 2)
+                                  )
+                                  (i32.const 9)
+                                )
+                              )
+                              (if
+                                (i32.lt_u
+                                  (set_local $5
+                                    (i32.load
+                                      (get_local $7)
+                                    )
+                                  )
+                                  (i32.const 10)
+                                )
+                                (block
+                                  (set_local $13
+                                    (get_local $11)
+                                  )
+                                  (br $do-once$88)
+                                )
+                                (set_local $10
+                                  (i32.const 10)
+                                )
+                              )
+                              (loop $while-out$94 $while-in$95
+                                (set_local $11
+                                  (i32.add
+                                    (get_local $11)
+                                    (i32.const 1)
+                                  )
+                                )
+                                (if
+                                  (i32.lt_u
+                                    (get_local $5)
+                                    (set_local $10
+                                      (i32.mul
+                                        (get_local $10)
+                                        (i32.const 10)
+                                      )
+                                    )
+                                  )
+                                  (block
+                                    (set_local $13
+                                      (get_local $11)
+                                    )
+                                    (br $while-out$94)
+                                  )
+                                )
+                                (br $while-in$95)
+                              )
+                            )
+                          )
+                        )
+                        (set_local $6
+                          (i32.gt_u
+                            (get_local $27)
+                            (set_local $5
+                              (i32.add
+                                (get_local $6)
+                                (i32.const 4)
+                              )
+                            )
+                          )
+                        )
+                        (set_local $6
+                          (select
+                            (get_local $5)
+                            (get_local $27)
+                            (get_local $6)
+                          )
+                        )
+                        (get_local $7)
+                      )
+                      (block
+                        (set_local $6
+                          (get_local $27)
+                        )
+                        (get_local $7)
+                      )
+                    )
+                  )
+                  (set_local $27
+                    (i32.sub
+                      (i32.const 0)
+                      (get_local $13)
+                    )
+                  )
+                  (loop $while-out$96 $while-in$97
+                    (if
+                      (i32.le_u
+                        (get_local $6)
+                        (get_local $7)
+                      )
+                      (block
+                        (set_local $11
+                          (i32.const 0)
+                        )
+                        (set_local $23
+                          (get_local $6)
+                        )
+                        (br $while-out$96)
                       )
                     )
                     (if
                       (i32.eq
-                        (set_local $14
-                          (i32.or
-                            (get_local $26)
-                            (i32.const 32)
+                        (i32.load
+                          (set_local $5
+                            (i32.add
+                              (get_local $6)
+                              (i32.const -4)
+                            )
                           )
                         )
-                        (i32.const 97)
+                        (i32.const 0)
+                      )
+                      (set_local $6
+                        (get_local $5)
                       )
                       (block
-                        (set_local $9
-                          (select
-                            (get_local $39)
-                            (i32.add
-                              (get_local $39)
-                              (i32.const 9)
-                            )
-                            (i32.eq
-                              (set_local $6
-                                (i32.and
-                                  (get_local $26)
-                                  (i32.const 32)
+                        (set_local $11
+                          (i32.const 1)
+                        )
+                        (set_local $23
+                          (get_local $6)
+                        )
+                        (br $while-out$96)
+                      )
+                    )
+                    (br $while-in$97)
+                  )
+                  (set_local $8
+                    (block $do-once$98
+                      (if
+                        (get_local $8)
+                        (block
+                          (set_local $8
+                            (if
+                              (i32.and
+                                (i32.gt_s
+                                  (set_local $1
+                                    (i32.add
+                                      (i32.xor
+                                        (i32.and
+                                          (get_local $70)
+                                          (i32.const 1)
+                                        )
+                                        (i32.const 1)
+                                      )
+                                      (get_local $1)
+                                    )
+                                  )
+                                  (get_local $13)
                                 )
+                                (i32.gt_s
+                                  (get_local $13)
+                                  (i32.const -5)
+                                )
+                              )
+                              (block
+                                (set_local $10
+                                  (i32.add
+                                    (get_local $26)
+                                    (i32.const -1)
+                                  )
+                                )
+                                (i32.sub
+                                  (i32.add
+                                    (get_local $1)
+                                    (i32.const -1)
+                                  )
+                                  (get_local $13)
+                                )
+                              )
+                              (block
+                                (set_local $10
+                                  (i32.add
+                                    (get_local $26)
+                                    (i32.const -2)
+                                  )
+                                )
+                                (i32.add
+                                  (get_local $1)
+                                  (i32.const -1)
+                                )
+                              )
+                            )
+                          )
+                          (if
+                            (i32.ne
+                              (set_local $1
+                                (i32.and
+                                  (get_local $18)
+                                  (i32.const 8)
+                                )
+                              )
+                              (i32.const 0)
+                            )
+                            (block
+                              (set_local $14
+                                (get_local $8)
+                              )
+                              (set_local $26
+                                (get_local $10)
+                              )
+                              (br $do-once$98
+                                (get_local $1)
+                              )
+                            )
+                          )
+                          (block $do-once$100
+                            (if
+                              (get_local $11)
+                              (block
+                                (if
+                                  (i32.eq
+                                    (set_local $1
+                                      (i32.load
+                                        (i32.add
+                                          (get_local $23)
+                                          (i32.const -4)
+                                        )
+                                      )
+                                    )
+                                    (i32.const 0)
+                                  )
+                                  (block
+                                    (set_local $6
+                                      (i32.const 9)
+                                    )
+                                    (br $do-once$100)
+                                  )
+                                )
+                                (if
+                                  (i32.eq
+                                    (i32.and
+                                      (call_import $i32u-rem
+                                        (get_local $1)
+                                        (i32.const 10)
+                                      )
+                                      (i32.const -1)
+                                    )
+                                    (i32.const 0)
+                                  )
+                                  (block
+                                    (set_local $5
+                                      (i32.const 10)
+                                    )
+                                    (set_local $6
+                                      (i32.const 0)
+                                    )
+                                  )
+                                  (block
+                                    (set_local $6
+                                      (i32.const 0)
+                                    )
+                                    (br $do-once$100)
+                                  )
+                                )
+                                (loop $while-out$102 $while-in$103
+                                  (set_local $6
+                                    (i32.add
+                                      (get_local $6)
+                                      (i32.const 1)
+                                    )
+                                  )
+                                  (if
+                                    (i32.ne
+                                      (i32.and
+                                        (call_import $i32u-rem
+                                          (get_local $1)
+                                          (set_local $5
+                                            (i32.mul
+                                              (get_local $5)
+                                              (i32.const 10)
+                                            )
+                                          )
+                                        )
+                                        (i32.const -1)
+                                      )
+                                      (i32.const 0)
+                                    )
+                                    (br $while-out$102)
+                                  )
+                                  (br $while-in$103)
+                                )
+                              )
+                              (set_local $6
+                                (i32.const 9)
+                              )
+                            )
+                          )
+                          (set_local $1
+                            (i32.add
+                              (i32.mul
+                                (i32.shr_s
+                                  (i32.sub
+                                    (get_local $23)
+                                    (get_local $62)
+                                  )
+                                  (i32.const 2)
+                                )
+                                (i32.const 9)
+                              )
+                              (i32.const -9)
+                            )
+                          )
+                          (if
+                            (i32.eq
+                              (i32.or
+                                (get_local $10)
+                                (i32.const 32)
+                              )
+                              (i32.const 102)
+                            )
+                            (block
+                              (set_local $1
+                                (i32.lt_s
+                                  (set_local $5
+                                    (i32.sub
+                                      (get_local $1)
+                                      (get_local $6)
+                                    )
+                                  )
+                                  (i32.const 0)
+                                )
+                              )
+                              (set_local $5
+                                (i32.lt_s
+                                  (get_local $8)
+                                  (set_local $1
+                                    (select
+                                      (i32.const 0)
+                                      (get_local $5)
+                                      (get_local $1)
+                                    )
+                                  )
+                                )
+                              )
+                              (set_local $14
+                                (select
+                                  (get_local $8)
+                                  (get_local $1)
+                                  (get_local $5)
+                                )
+                              )
+                              (set_local $26
+                                (get_local $10)
+                              )
+                              (i32.const 0)
+                            )
+                            (block
+                              (set_local $1
+                                (i32.lt_s
+                                  (set_local $5
+                                    (i32.sub
+                                      (i32.add
+                                        (get_local $1)
+                                        (get_local $13)
+                                      )
+                                      (get_local $6)
+                                    )
+                                  )
+                                  (i32.const 0)
+                                )
+                              )
+                              (set_local $5
+                                (i32.lt_s
+                                  (get_local $8)
+                                  (set_local $1
+                                    (select
+                                      (i32.const 0)
+                                      (get_local $5)
+                                      (get_local $1)
+                                    )
+                                  )
+                                )
+                              )
+                              (set_local $14
+                                (select
+                                  (get_local $8)
+                                  (get_local $1)
+                                  (get_local $5)
+                                )
+                              )
+                              (set_local $26
+                                (get_local $10)
                               )
                               (i32.const 0)
                             )
                           )
                         )
-                        (set_local $7
+                        (block
+                          (set_local $14
+                            (get_local $1)
+                          )
+                          (i32.and
+                            (get_local $18)
+                            (i32.const 8)
+                          )
+                        )
+                      )
+                    )
+                  )
+                  (set_local $17
+                    (i32.and
+                      (i32.ne
+                        (set_local $1
                           (i32.or
-                            (get_local $51)
-                            (i32.const 2)
+                            (get_local $14)
+                            (get_local $8)
                           )
                         )
-                        (set_local $15
-                          (if
-                            (i32.or
-                              (i32.gt_u
-                                (get_local $10)
-                                (i32.const 11)
-                              )
-                              (i32.eq
-                                (set_local $1
-                                  (i32.sub
-                                    (i32.const 12)
-                                    (get_local $10)
-                                  )
-                                )
-                                (i32.const 0)
-                              )
-                            )
-                            (get_local $15)
-                            (block
-                              (set_local $30
-                                (f64.const 8)
-                              )
-                              (loop $while-out$60 $while-in$61
-                                (set_local $30
-                                  (f64.mul
-                                    (get_local $30)
-                                    (f64.const 16)
-                                  )
-                                )
-                                (if
-                                  (i32.eq
-                                    (set_local $1
-                                      (i32.add
-                                        (get_local $1)
-                                        (i32.const -1)
-                                      )
-                                    )
-                                    (i32.const 0)
-                                  )
-                                  (br $while-out$60)
-                                )
-                                (br $while-in$61)
-                              )
-                              (select
-                                (f64.neg
-                                  (f64.add
-                                    (get_local $30)
-                                    (f64.sub
-                                      (f64.neg
-                                        (get_local $15)
-                                      )
-                                      (get_local $30)
-                                    )
-                                  )
-                                )
-                                (f64.sub
-                                  (f64.add
-                                    (get_local $15)
-                                    (get_local $30)
-                                  )
-                                  (get_local $30)
-                                )
-                                (i32.eq
-                                  (i32.shr_s
-                                    (i32.shl
-                                      (i32.load8_s
-                                        (get_local $9)
-                                      )
-                                      (i32.const 24)
-                                    )
-                                    (i32.const 24)
-                                  )
-                                  (i32.const 45)
-                                )
-                              )
-                            )
+                        (i32.const 0)
+                      )
+                      (i32.const 1)
+                    )
+                  )
+                  (set_local $13
+                    (if
+                      (set_local $10
+                        (i32.eq
+                          (i32.or
+                            (get_local $26)
+                            (i32.const 32)
                           )
+                          (i32.const 102)
                         )
-                        (set_local $5
-                          (i32.lt_s
-                            (set_local $1
-                              (i32.load
-                                (get_local $25)
-                              )
-                            )
+                      )
+                      (block
+                        (set_local $6
+                          (select
+                            (get_local $13)
                             (i32.const 0)
+                            (i32.gt_s
+                              (get_local $13)
+                              (i32.const 0)
+                            )
                           )
                         )
+                        (i32.const 0)
+                      )
+                      (block
                         (set_local $5
                           (i32.shr_s
                             (i32.shl
                               (i32.lt_s
-                                (set_local $8
+                                (set_local $6
                                   (select
-                                    (i32.sub
+                                    (get_local $27)
+                                    (get_local $13)
+                                    (i32.lt_s
+                                      (get_local $13)
                                       (i32.const 0)
-                                      (get_local $1)
                                     )
-                                    (get_local $1)
-                                    (get_local $5)
                                   )
                                 )
                                 (i32.const 0)
@@ -5352,37 +7040,55 @@
                             (i32.const 31)
                           )
                         )
-                        (i32.store8
-                          (i32.add
-                            (set_local $5
-                              (if
-                                (i32.eq
-                                  (set_local $5
-                                    (call $_fmt_u
-                                      (get_local $8)
-                                      (get_local $5)
-                                      (get_local $52)
-                                    )
-                                  )
+                        (if
+                          (i32.lt_s
+                            (i32.sub
+                              (get_local $40)
+                              (set_local $5
+                                (call $_fmt_u
+                                  (get_local $6)
+                                  (get_local $5)
                                   (get_local $52)
                                 )
-                                (block
-                                  (i32.store8
-                                    (get_local $74)
-                                    (i32.const 48)
-                                  )
-                                  (get_local $74)
-                                )
-                                (get_local $5)
                               )
                             )
+                            (i32.const 2)
+                          )
+                          (loop $while-out$104 $while-in$105
+                            (i32.store8
+                              (set_local $5
+                                (i32.add
+                                  (get_local $5)
+                                  (i32.const -1)
+                                )
+                              )
+                              (i32.const 48)
+                            )
+                            (if
+                              (i32.lt_s
+                                (i32.sub
+                                  (get_local $40)
+                                  (get_local $5)
+                                )
+                                (i32.const 2)
+                              )
+                              (get_local $5)
+                              (br $while-out$104)
+                            )
+                            (br $while-in$105)
+                          )
+                          (get_local $5)
+                        )
+                        (i32.store8
+                          (i32.add
+                            (get_local $5)
                             (i32.const -1)
                           )
                           (i32.and
                             (i32.add
                               (i32.and
                                 (i32.shr_s
-                                  (get_local $1)
+                                  (get_local $13)
                                   (i32.const 31)
                                 )
                                 (i32.const 2)
@@ -5393,1878 +7099,265 @@
                           )
                         )
                         (i32.store8
-                          (set_local $8
+                          (set_local $5
                             (i32.add
                               (get_local $5)
                               (i32.const -2)
                             )
                           )
                           (i32.and
-                            (i32.add
-                              (get_local $26)
-                              (i32.const 15)
-                            )
+                            (get_local $26)
                             (i32.const 255)
                           )
                         )
-                        (set_local $5
-                          (i32.lt_s
-                            (get_local $10)
-                            (i32.const 1)
-                          )
-                        )
-                        (set_local $13
-                          (i32.eq
-                            (i32.and
-                              (get_local $18)
-                              (i32.const 8)
-                            )
-                            (i32.const 0)
-                          )
-                        )
-                        (set_local $11
-                          (get_local $29)
-                        )
-                        (loop $while-out$62 $while-in$63
-                          (i32.store8
-                            (get_local $11)
-                            (i32.and
-                              (i32.or
-                                (i32.and
-                                  (i32.load8_s
-                                    (i32.add
-                                      (set_local $1
-                                        (call_import $f64-to-int
-                                          (get_local $15)
-                                        )
-                                      )
-                                      (i32.const 4075)
-                                    )
-                                  )
-                                  (i32.const 255)
-                                )
-                                (get_local $6)
-                              )
-                              (i32.const 255)
-                            )
-                          )
-                          (set_local $15
-                            (f64.mul
-                              (f64.sub
-                                (get_local $15)
-                                (f64.convert_s/i32
-                                  (get_local $1)
-                                )
-                              )
-                              (f64.const 16)
-                            )
-                          )
-                          (set_local $11
-                            (block $do-once$64
-                              (if
-                                (i32.eq
-                                  (i32.sub
-                                    (set_local $1
-                                      (i32.add
-                                        (get_local $11)
-                                        (i32.const 1)
-                                      )
-                                    )
-                                    (get_local $64)
-                                  )
-                                  (i32.const 1)
-                                )
-                                (block
-                                  (br_if $do-once$64
-                                    (get_local $1)
-                                    (i32.and
-                                      (get_local $13)
-                                      (i32.and
-                                        (get_local $5)
-                                        (f64.eq
-                                          (get_local $15)
-                                          (f64.const 0)
-                                        )
-                                      )
-                                    )
-                                  )
-                                  (i32.store8
-                                    (get_local $1)
-                                    (i32.const 46)
-                                  )
-                                  (i32.add
-                                    (get_local $11)
-                                    (i32.const 2)
-                                  )
-                                )
-                                (get_local $1)
-                              )
-                            )
-                          )
-                          (if
-                            (f64.eq
-                              (get_local $15)
-                              (f64.const 0)
-                            )
-                            (block
-                              (set_local $1
-                                (get_local $11)
-                              )
-                              (br $while-out$62)
-                            )
-                          )
-                          (br $while-in$63)
-                        )
-                        (set_local $5
-                          (i32.and
-                            (i32.ne
-                              (get_local $10)
-                              (i32.const 0)
-                            )
-                            (i32.lt_s
-                              (i32.add
-                                (get_local $78)
-                                (get_local $1)
-                              )
-                              (get_local $10)
-                            )
-                          )
-                        )
-                        (call $_pad
-                          (get_local $0)
-                          (i32.const 32)
-                          (get_local $16)
-                          (set_local $5
-                            (i32.add
-                              (set_local $6
-                                (select
-                                  (i32.sub
-                                    (i32.add
-                                      (get_local $79)
-                                      (get_local $10)
-                                    )
-                                    (get_local $8)
-                                  )
-                                  (i32.add
-                                    (i32.sub
-                                      (get_local $77)
-                                      (get_local $8)
-                                    )
-                                    (get_local $1)
-                                  )
-                                  (get_local $5)
-                                )
-                              )
-                              (get_local $7)
-                            )
-                          )
-                          (get_local $18)
-                        )
-                        (if
-                          (i32.eq
-                            (i32.and
-                              (i32.load
-                                (get_local $0)
-                              )
-                              (i32.const 32)
-                            )
-                            (i32.const 0)
-                          )
-                          (call $___fwritex
-                            (get_local $9)
-                            (get_local $7)
-                            (get_local $0)
-                          )
-                        )
-                        (call $_pad
-                          (get_local $0)
-                          (i32.const 48)
-                          (get_local $16)
-                          (get_local $5)
-                          (i32.xor
-                            (get_local $18)
-                            (i32.const 65536)
-                          )
-                        )
-                        (set_local $1
+                        (set_local $6
                           (i32.sub
-                            (get_local $1)
-                            (get_local $64)
-                          )
-                        )
-                        (if
-                          (i32.eq
-                            (i32.and
-                              (i32.load
-                                (get_local $0)
-                              )
-                              (i32.const 32)
-                            )
-                            (i32.const 0)
-                          )
-                          (call $___fwritex
-                            (get_local $29)
-                            (get_local $1)
-                            (get_local $0)
-                          )
-                        )
-                        (call $_pad
-                          (get_local $0)
-                          (i32.const 48)
-                          (i32.sub
-                            (get_local $6)
-                            (i32.add
-                              (get_local $1)
-                              (set_local $1
-                                (i32.sub
-                                  (get_local $40)
-                                  (get_local $8)
-                                )
-                              )
-                            )
-                          )
-                          (i32.const 0)
-                          (i32.const 0)
-                        )
-                        (if
-                          (i32.eq
-                            (i32.and
-                              (i32.load
-                                (get_local $0)
-                              )
-                              (i32.const 32)
-                            )
-                            (i32.const 0)
-                          )
-                          (call $___fwritex
-                            (get_local $8)
-                            (get_local $1)
-                            (get_local $0)
-                          )
-                        )
-                        (call $_pad
-                          (get_local $0)
-                          (i32.const 32)
-                          (get_local $16)
-                          (get_local $5)
-                          (i32.xor
-                            (get_local $18)
-                            (i32.const 8192)
-                          )
-                        )
-                        (br $do-once$56
-                          (select
-                            (get_local $16)
+                            (get_local $40)
                             (get_local $5)
-                            (i32.lt_s
-                              (get_local $5)
-                              (get_local $16)
-                            )
                           )
                         )
-                      )
-                    )
-                    (set_local $1
-                      (select
-                        (i32.const 6)
-                        (get_local $10)
-                        (i32.lt_s
-                          (get_local $10)
-                          (i32.const 0)
-                        )
-                      )
-                    )
-                    (set_local $62
-                      (set_local $9
-                        (select
-                          (get_local $80)
-                          (get_local $81)
-                          (i32.lt_s
-                            (if
-                              (get_local $5)
-                              (block
-                                (i32.store
-                                  (get_local $25)
-                                  (set_local $5
-                                    (i32.add
-                                      (i32.load
-                                        (get_local $25)
-                                      )
-                                      (i32.const -28)
-                                    )
-                                  )
-                                )
-                                (set_local $15
-                                  (f64.mul
-                                    (get_local $15)
-                                    (f64.const 268435456)
-                                  )
-                                )
-                                (get_local $5)
-                              )
-                              (i32.load
-                                (get_local $25)
-                              )
-                            )
-                            (i32.const 0)
-                          )
-                        )
-                      )
-                    )
-                    (set_local $7
-                      (get_local $9)
-                    )
-                    (loop $while-out$66 $while-in$67
-                      (i32.store
-                        (get_local $7)
-                        (set_local $5
-                          (call_import $f64-to-int
-                            (get_local $15)
-                          )
-                        )
-                      )
-                      (set_local $7
-                        (i32.add
-                          (get_local $7)
-                          (i32.const 4)
-                        )
-                      )
-                      (if
-                        (f64.eq
-                          (set_local $15
-                            (f64.mul
-                              (f64.sub
-                                (get_local $15)
-                                (f64.convert_u/i32
-                                  (get_local $5)
-                                )
-                              )
-                              (f64.const 1e9)
-                            )
-                          )
-                          (f64.const 0)
-                        )
-                        (block
-                          (set_local $6
-                            (get_local $7)
-                          )
-                          (br $while-out$66)
-                        )
-                      )
-                      (br $while-in$67)
-                    )
-                    (if
-                      (i32.gt_s
-                        (set_local $5
-                          (i32.load
-                            (get_local $25)
-                          )
-                        )
-                        (i32.const 0)
-                      )
-                      (block
-                        (set_local $8
-                          (get_local $9)
-                        )
-                        (set_local $13
-                          (get_local $6)
-                        )
-                        (loop $while-out$68 $while-in$69
-                          (set_local $11
-                            (select
-                              (i32.const 29)
-                              (get_local $5)
-                              (i32.gt_s
-                                (get_local $5)
-                                (i32.const 29)
-                              )
-                            )
-                          )
-                          (set_local $7
-                            (block $do-once$70
-                              (if
-                                (i32.lt_u
-                                  (set_local $7
-                                    (i32.add
-                                      (get_local $13)
-                                      (i32.const -4)
-                                    )
-                                  )
-                                  (get_local $8)
-                                )
-                                (get_local $8)
-                                (block
-                                  (set_local $5
-                                    (i32.const 0)
-                                  )
-                                  (set_local $10
-                                    (get_local $7)
-                                  )
-                                  (loop $while-out$72 $while-in$73
-                                    (set_local $6
-                                      (call $___uremdi3
-                                        (set_local $5
-                                          (call $_i64Add
-                                            (call $_bitshift64Shl
-                                              (i32.load
-                                                (get_local $10)
-                                              )
-                                              (i32.const 0)
-                                              (get_local $11)
-                                            )
-                                            (i32.load
-                                              (i32.const 168)
-                                            )
-                                            (get_local $5)
-                                            (i32.const 0)
-                                          )
-                                        )
-                                        (set_local $7
-                                          (i32.load
-                                            (i32.const 168)
-                                          )
-                                        )
-                                        (i32.const 1000000000)
-                                        (i32.const 0)
-                                      )
-                                    )
-                                    (i32.load
-                                      (i32.const 168)
-                                    )
-                                    (i32.store
-                                      (get_local $10)
-                                      (get_local $6)
-                                    )
-                                    (set_local $5
-                                      (call $___udivdi3
-                                        (get_local $5)
-                                        (get_local $7)
-                                        (i32.const 1000000000)
-                                        (i32.const 0)
-                                      )
-                                    )
-                                    (i32.load
-                                      (i32.const 168)
-                                    )
-                                    (if
-                                      (i32.lt_u
-                                        (set_local $7
-                                          (i32.add
-                                            (get_local $10)
-                                            (i32.const -4)
-                                          )
-                                        )
-                                        (get_local $8)
-                                      )
-                                      (br $while-out$72)
-                                      (set_local $10
-                                        (get_local $7)
-                                      )
-                                    )
-                                    (br $while-in$73)
-                                  )
-                                  (br_if $do-once$70
-                                    (get_local $8)
-                                    (i32.eq
-                                      (get_local $5)
-                                      (i32.const 0)
-                                    )
-                                  )
-                                  (i32.store
-                                    (set_local $7
-                                      (i32.add
-                                        (get_local $8)
-                                        (i32.const -4)
-                                      )
-                                    )
-                                    (get_local $5)
-                                  )
-                                  (get_local $7)
-                                )
-                              )
-                            )
-                          )
-                          (loop $while-out$74 $while-in$75
-                            (if
-                              (i32.le_u
-                                (get_local $13)
-                                (get_local $7)
-                              )
-                              (br $while-out$74)
-                            )
-                            (if
-                              (i32.eq
-                                (i32.load
-                                  (set_local $5
-                                    (i32.add
-                                      (get_local $13)
-                                      (i32.const -4)
-                                    )
-                                  )
-                                )
-                                (i32.const 0)
-                              )
-                              (set_local $13
-                                (get_local $5)
-                              )
-                              (br $while-out$74)
-                            )
-                            (br $while-in$75)
-                          )
-                          (i32.store
-                            (get_local $25)
-                            (set_local $5
-                              (i32.sub
-                                (i32.load
-                                  (get_local $25)
-                                )
-                                (get_local $11)
-                              )
-                            )
-                          )
-                          (if
-                            (i32.gt_s
-                              (get_local $5)
-                              (i32.const 0)
-                            )
-                            (set_local $8
-                              (get_local $7)
-                            )
-                            (block
-                              (set_local $6
-                                (get_local $13)
-                              )
-                              (br $while-out$68)
-                            )
-                          )
-                          (br $while-in$69)
-                        )
-                      )
-                      (set_local $7
-                        (get_local $9)
-                      )
-                    )
-                    (if
-                      (i32.lt_s
                         (get_local $5)
-                        (i32.const 0)
                       )
-                      (block
-                        (set_local $8
+                    )
+                  )
+                  (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $16)
+                    (set_local $6
+                      (i32.add
+                        (i32.add
                           (i32.add
-                            (i32.and
-                              (call_import $i32s-div
-                                (i32.add
-                                  (get_local $1)
-                                  (i32.const 25)
-                                )
-                                (i32.const 9)
-                              )
-                              (i32.const -1)
+                            (i32.add
+                              (get_local $51)
+                              (i32.const 1)
                             )
-                            (i32.const 1)
-                          )
-                        )
-                        (set_local $10
-                          (i32.eq
                             (get_local $14)
-                            (i32.const 102)
                           )
+                          (get_local $17)
                         )
-                        (set_local $23
-                          (get_local $6)
-                        )
-                        (loop $while-out$76 $while-in$77
-                          (set_local $5
-                            (i32.gt_s
-                              (set_local $6
-                                (i32.sub
-                                  (i32.const 0)
-                                  (get_local $5)
-                                )
-                              )
-                              (i32.const 9)
-                            )
-                          )
-                          (set_local $13
-                            (select
-                              (i32.const 9)
-                              (get_local $6)
-                              (get_local $5)
-                            )
-                          )
-                          (set_local $11
-                            (block $do-once$78
-                              (if
-                                (i32.lt_u
-                                  (get_local $7)
-                                  (get_local $23)
-                                )
-                                (block
-                                  (set_local $70
-                                    (i32.add
-                                      (i32.shl
-                                        (i32.const 1)
-                                        (get_local $13)
-                                      )
-                                      (i32.const -1)
-                                    )
-                                  )
-                                  (set_local $27
-                                    (i32.shr_u
-                                      (i32.const 1000000000)
-                                      (get_local $13)
-                                    )
-                                  )
-                                  (set_local $11
-                                    (i32.const 0)
-                                  )
-                                  (set_local $17
-                                    (get_local $7)
-                                  )
-                                  (loop $while-out$80 $while-in$81
-                                    (set_local $6
-                                      (i32.and
-                                        (set_local $5
-                                          (i32.load
-                                            (get_local $17)
-                                          )
-                                        )
-                                        (get_local $70)
-                                      )
-                                    )
-                                    (i32.store
-                                      (get_local $17)
-                                      (i32.add
-                                        (i32.shr_u
-                                          (get_local $5)
-                                          (get_local $13)
-                                        )
-                                        (get_local $11)
-                                      )
-                                    )
-                                    (set_local $11
-                                      (i32.mul
-                                        (get_local $6)
-                                        (get_local $27)
-                                      )
-                                    )
-                                    (if
-                                      (i32.ge_u
-                                        (set_local $17
-                                          (i32.add
-                                            (get_local $17)
-                                            (i32.const 4)
-                                          )
-                                        )
-                                        (get_local $23)
-                                      )
-                                      (br $while-out$80)
-                                    )
-                                    (br $while-in$81)
-                                  )
-                                  (set_local $5
-                                    (select
-                                      (i32.add
-                                        (get_local $7)
-                                        (i32.const 4)
-                                      )
-                                      (get_local $7)
-                                      (i32.eq
-                                        (i32.load
-                                          (get_local $7)
-                                        )
-                                        (i32.const 0)
-                                      )
-                                    )
-                                  )
-                                  (if
-                                    (i32.eq
-                                      (get_local $11)
-                                      (i32.const 0)
-                                    )
-                                    (br $do-once$78
-                                      (get_local $5)
-                                    )
-                                  )
-                                  (i32.store
-                                    (get_local $23)
-                                    (get_local $11)
-                                  )
-                                  (set_local $23
-                                    (i32.add
-                                      (get_local $23)
-                                      (i32.const 4)
-                                    )
-                                  )
-                                  (get_local $5)
-                                )
-                                (select
-                                  (i32.add
-                                    (get_local $7)
-                                    (i32.const 4)
-                                  )
-                                  (get_local $7)
-                                  (i32.eq
-                                    (i32.load
-                                      (get_local $7)
-                                    )
-                                    (i32.const 0)
-                                  )
-                                )
-                              )
-                            )
-                          )
-                          (set_local $5
-                            (i32.gt_s
-                              (i32.shr_s
-                                (i32.sub
-                                  (get_local $23)
-                                  (set_local $7
-                                    (select
-                                      (get_local $9)
-                                      (get_local $11)
-                                      (get_local $10)
-                                    )
-                                  )
-                                )
-                                (i32.const 2)
-                              )
-                              (get_local $8)
-                            )
-                          )
-                          (set_local $6
-                            (select
-                              (i32.add
-                                (get_local $7)
-                                (i32.shl
-                                  (get_local $8)
-                                  (i32.const 2)
-                                )
-                              )
-                              (get_local $23)
-                              (get_local $5)
-                            )
-                          )
-                          (i32.store
-                            (get_local $25)
-                            (set_local $5
-                              (i32.add
-                                (i32.load
-                                  (get_local $25)
-                                )
-                                (get_local $13)
-                              )
-                            )
-                          )
-                          (if
-                            (i32.lt_s
-                              (get_local $5)
-                              (i32.const 0)
-                            )
-                            (block
-                              (set_local $7
-                                (get_local $11)
-                              )
-                              (set_local $23
-                                (get_local $6)
-                              )
-                            )
-                            (block
-                              (set_local $7
-                                (get_local $11)
-                              )
-                              (set_local $27
-                                (get_local $6)
-                              )
-                              (br $while-out$76)
-                            )
-                          )
-                          (br $while-in$77)
-                        )
-                      )
-                      (set_local $27
                         (get_local $6)
                       )
                     )
-                    (block $do-once$82
-                      (if
-                        (i32.lt_u
-                          (get_local $7)
-                          (get_local $27)
+                    (get_local $18)
+                  )
+                  (if
+                    (i32.eq
+                      (i32.and
+                        (i32.load
+                          (get_local $0)
                         )
-                        (block
-                          (set_local $6
-                            (i32.mul
-                              (i32.shr_s
-                                (i32.sub
-                                  (get_local $62)
-                                  (get_local $7)
-                                )
-                                (i32.const 2)
-                              )
-                              (i32.const 9)
-                            )
-                          )
-                          (if
-                            (i32.lt_u
-                              (set_local $5
-                                (i32.load
-                                  (get_local $7)
-                                )
-                              )
-                              (i32.const 10)
-                            )
-                            (block
-                              (set_local $13
-                                (get_local $6)
-                              )
-                              (br $do-once$82)
-                            )
-                            (set_local $8
-                              (i32.const 10)
-                            )
-                          )
-                          (loop $while-out$84 $while-in$85
-                            (set_local $6
-                              (i32.add
-                                (get_local $6)
-                                (i32.const 1)
-                              )
-                            )
-                            (if
-                              (i32.lt_u
-                                (get_local $5)
-                                (set_local $8
-                                  (i32.mul
-                                    (get_local $8)
-                                    (i32.const 10)
-                                  )
-                                )
-                              )
-                              (block
-                                (set_local $13
-                                  (get_local $6)
-                                )
-                                (br $while-out$84)
-                              )
-                            )
-                            (br $while-in$85)
-                          )
-                        )
-                        (set_local $13
-                          (i32.const 0)
-                        )
+                        (i32.const 32)
                       )
+                      (i32.const 0)
                     )
-                    (set_local $7
-                      (if
-                        (i32.lt_s
-                          (set_local $5
-                            (i32.add
-                              (i32.sub
-                                (get_local $1)
-                                (select
-                                  (get_local $13)
-                                  (i32.const 0)
-                                  (i32.ne
-                                    (get_local $14)
-                                    (i32.const 102)
-                                  )
-                                )
-                              )
-                              (i32.shr_s
-                                (i32.shl
-                                  (i32.and
-                                    (set_local $70
-                                      (i32.ne
-                                        (get_local $1)
-                                        (i32.const 0)
-                                      )
-                                    )
-                                    (set_local $8
-                                      (i32.eq
-                                        (get_local $14)
-                                        (i32.const 103)
-                                      )
-                                    )
-                                  )
-                                  (i32.const 31)
-                                )
-                                (i32.const 31)
+                    (call $___fwritex
+                      (get_local $39)
+                      (get_local $51)
+                      (get_local $0)
+                    )
+                  )
+                  (call $_pad
+                    (get_local $0)
+                    (i32.const 48)
+                    (get_local $16)
+                    (get_local $6)
+                    (i32.xor
+                      (get_local $18)
+                      (i32.const 65536)
+                    )
+                  )
+                  (block $do-once$106
+                    (if
+                      (get_local $10)
+                      (block
+                        (set_local $7
+                          (set_local $8
+                            (select
+                              (get_local $9)
+                              (get_local $7)
+                              (i32.gt_u
+                                (get_local $7)
+                                (get_local $9)
                               )
                             )
-                          )
-                          (i32.add
-                            (i32.mul
-                              (i32.shr_s
-                                (i32.sub
-                                  (get_local $27)
-                                  (get_local $62)
-                                )
-                                (i32.const 2)
-                              )
-                              (i32.const 9)
-                            )
-                            (i32.const -9)
                           )
                         )
-                        (block
-                          (set_local $6
-                            (i32.add
-                              (i32.add
-                                (get_local $9)
-                                (i32.const 4)
+                        (loop $while-out$108 $while-in$109
+                          (set_local $5
+                            (call $_fmt_u
+                              (i32.load
+                                (get_local $7)
                               )
-                              (i32.shl
-                                (i32.add
-                                  (i32.and
-                                    (call_import $i32s-div
-                                      (set_local $5
-                                        (i32.add
-                                          (get_local $5)
-                                          (i32.const 9216)
-                                        )
-                                      )
-                                      (i32.const 9)
-                                    )
-                                    (i32.const -1)
-                                  )
-                                  (i32.const -1024)
-                                )
-                                (i32.const 2)
-                              )
+                              (i32.const 0)
+                              (get_local $45)
                             )
                           )
-                          (if
-                            (i32.lt_s
-                              (set_local $11
-                                (i32.add
-                                  (i32.and
-                                    (call_import $i32s-rem
-                                      (get_local $5)
-                                      (i32.const 9)
-                                    )
-                                    (i32.const -1)
-                                  )
-                                  (i32.const 1)
-                                )
-                              )
-                              (i32.const 9)
-                            )
-                            (block
-                              (set_local $5
-                                (i32.const 10)
-                              )
-                              (loop $while-out$86 $while-in$87
-                                (set_local $5
-                                  (i32.mul
-                                    (get_local $5)
-                                    (i32.const 10)
-                                  )
-                                )
-                                (if
-                                  (i32.eq
-                                    (set_local $11
-                                      (i32.add
-                                        (get_local $11)
-                                        (i32.const 1)
-                                      )
-                                    )
-                                    (i32.const 9)
-                                  )
-                                  (block
-                                    (set_local $17
-                                      (get_local $5)
-                                    )
-                                    (br $while-out$86)
-                                  )
-                                )
-                                (br $while-in$87)
-                              )
-                            )
-                            (set_local $17
-                              (i32.const 10)
-                            )
-                          )
-                          (block $do-once$88
+                          (block $do-once$110
                             (if
-                              (i32.eqz
-                                (i32.and
-                                  (set_local $11
-                                    (i32.eq
-                                      (i32.add
-                                        (get_local $6)
-                                        (i32.const 4)
-                                      )
-                                      (get_local $27)
-                                    )
+                              (i32.eq
+                                (get_local $7)
+                                (get_local $8)
+                              )
+                              (block
+                                (if
+                                  (i32.ne
+                                    (get_local $5)
+                                    (get_local $45)
                                   )
-                                  (i32.eq
-                                    (set_local $14
-                                      (i32.and
-                                        (call_import $i32u-rem
-                                          (set_local $5
-                                            (i32.load
-                                              (get_local $6)
-                                            )
-                                          )
-                                          (get_local $17)
-                                        )
-                                        (i32.const -1)
-                                      )
-                                    )
-                                    (i32.const 0)
-                                  )
+                                  (br $do-once$110)
+                                )
+                                (i32.store8
+                                  (get_local $53)
+                                  (i32.const 48)
+                                )
+                                (set_local $5
+                                  (get_local $53)
                                 )
                               )
                               (block
-                                (set_local $15
-                                  (select
-                                    (f64.const 9007199254740992)
-                                    (f64.const 9007199254740994)
-                                    (i32.eq
-                                      (i32.and
-                                        (i32.and
-                                          (call_import $i32u-div
-                                            (get_local $5)
-                                            (get_local $17)
-                                          )
-                                          (i32.const -1)
-                                        )
-                                        (i32.const 1)
-                                      )
-                                      (i32.const 0)
-                                    )
-                                  )
-                                )
-                                (set_local $30
-                                  (if
-                                    (i32.lt_u
-                                      (get_local $14)
-                                      (set_local $10
-                                        (i32.and
-                                          (call_import $i32s-div
-                                            (get_local $17)
-                                            (i32.const 2)
-                                          )
-                                          (i32.const -1)
-                                        )
-                                      )
-                                    )
-                                    (f64.const 0.5)
-                                    (select
-                                      (f64.const 1)
-                                      (f64.const 1.5)
-                                      (i32.and
-                                        (get_local $11)
-                                        (i32.eq
-                                          (get_local $14)
-                                          (get_local $10)
-                                        )
-                                      )
-                                    )
-                                  )
-                                )
-                                (set_local $15
-                                  (block $do-once$90
-                                    (if
-                                      (i32.eq
-                                        (get_local $51)
-                                        (i32.const 0)
-                                      )
-                                      (get_local $15)
-                                      (block
-                                        (if
-                                          (i32.ne
-                                            (i32.shr_s
-                                              (i32.shl
-                                                (i32.load8_s
-                                                  (get_local $39)
-                                                )
-                                                (i32.const 24)
-                                              )
-                                              (i32.const 24)
-                                            )
-                                            (i32.const 45)
-                                          )
-                                          (br $do-once$90
-                                            (get_local $15)
-                                          )
-                                        )
-                                        (set_local $30
-                                          (f64.neg
-                                            (get_local $30)
-                                          )
-                                        )
-                                        (f64.neg
-                                          (get_local $15)
-                                        )
-                                      )
-                                    )
-                                  )
-                                )
-                                (i32.store
-                                  (get_local $6)
-                                  (set_local $5
-                                    (i32.sub
-                                      (get_local $5)
-                                      (get_local $14)
-                                    )
-                                  )
-                                )
-                                (if
-                                  (f64.eq
-                                    (f64.add
-                                      (get_local $15)
-                                      (get_local $30)
-                                    )
-                                    (get_local $15)
-                                  )
-                                  (br $do-once$88)
-                                )
-                                (i32.store
-                                  (get_local $6)
-                                  (set_local $5
-                                    (i32.add
-                                      (get_local $5)
-                                      (get_local $17)
-                                    )
-                                  )
-                                )
                                 (if
                                   (i32.gt_u
                                     (get_local $5)
-                                    (i32.const 999999999)
+                                    (get_local $29)
                                   )
-                                  (loop $while-out$92 $while-in$93
-                                    (i32.store
-                                      (get_local $6)
-                                      (i32.const 0)
-                                    )
-                                    (set_local $7
-                                      (if
-                                        (i32.lt_u
-                                          (set_local $6
-                                            (i32.add
-                                              (get_local $6)
-                                              (i32.const -4)
-                                            )
-                                          )
-                                          (get_local $7)
-                                        )
-                                        (block
-                                          (i32.store
-                                            (set_local $5
-                                              (i32.add
-                                                (get_local $7)
-                                                (i32.const -4)
-                                              )
-                                            )
-                                            (i32.const 0)
-                                          )
-                                          (get_local $5)
-                                        )
-                                        (get_local $7)
-                                      )
-                                    )
-                                    (i32.store
-                                      (get_local $6)
-                                      (set_local $5
-                                        (i32.add
-                                          (i32.load
-                                            (get_local $6)
-                                          )
-                                          (i32.const 1)
-                                        )
-                                      )
-                                    )
-                                    (if
-                                      (i32.le_u
-                                        (get_local $5)
-                                        (i32.const 999999999)
-                                      )
-                                      (br $while-out$92)
-                                    )
-                                    (br $while-in$93)
-                                  )
+                                  (get_local $5)
+                                  (br $do-once$110)
                                 )
-                                (set_local $11
-                                  (i32.mul
-                                    (i32.shr_s
-                                      (i32.sub
-                                        (get_local $62)
-                                        (get_local $7)
-                                      )
-                                      (i32.const 2)
-                                    )
-                                    (i32.const 9)
-                                  )
-                                )
-                                (if
-                                  (i32.lt_u
+                                (loop $while-out$112 $while-in$113
+                                  (i32.store8
                                     (set_local $5
-                                      (i32.load
-                                        (get_local $7)
-                                      )
-                                    )
-                                    (i32.const 10)
-                                  )
-                                  (block
-                                    (set_local $13
-                                      (get_local $11)
-                                    )
-                                    (br $do-once$88)
-                                  )
-                                  (set_local $10
-                                    (i32.const 10)
-                                  )
-                                )
-                                (loop $while-out$94 $while-in$95
-                                  (set_local $11
-                                    (i32.add
-                                      (get_local $11)
-                                      (i32.const 1)
-                                    )
-                                  )
-                                  (if
-                                    (i32.lt_u
-                                      (get_local $5)
-                                      (set_local $10
-                                        (i32.mul
-                                          (get_local $10)
-                                          (i32.const 10)
-                                        )
-                                      )
-                                    )
-                                    (block
-                                      (set_local $13
-                                        (get_local $11)
-                                      )
-                                      (br $while-out$94)
-                                    )
-                                  )
-                                  (br $while-in$95)
-                                )
-                              )
-                            )
-                          )
-                          (set_local $6
-                            (i32.gt_u
-                              (get_local $27)
-                              (set_local $5
-                                (i32.add
-                                  (get_local $6)
-                                  (i32.const 4)
-                                )
-                              )
-                            )
-                          )
-                          (set_local $6
-                            (select
-                              (get_local $5)
-                              (get_local $27)
-                              (get_local $6)
-                            )
-                          )
-                          (get_local $7)
-                        )
-                        (block
-                          (set_local $6
-                            (get_local $27)
-                          )
-                          (get_local $7)
-                        )
-                      )
-                    )
-                    (set_local $27
-                      (i32.sub
-                        (i32.const 0)
-                        (get_local $13)
-                      )
-                    )
-                    (loop $while-out$96 $while-in$97
-                      (if
-                        (i32.le_u
-                          (get_local $6)
-                          (get_local $7)
-                        )
-                        (block
-                          (set_local $11
-                            (i32.const 0)
-                          )
-                          (set_local $23
-                            (get_local $6)
-                          )
-                          (br $while-out$96)
-                        )
-                      )
-                      (if
-                        (i32.eq
-                          (i32.load
-                            (set_local $5
-                              (i32.add
-                                (get_local $6)
-                                (i32.const -4)
-                              )
-                            )
-                          )
-                          (i32.const 0)
-                        )
-                        (set_local $6
-                          (get_local $5)
-                        )
-                        (block
-                          (set_local $11
-                            (i32.const 1)
-                          )
-                          (set_local $23
-                            (get_local $6)
-                          )
-                          (br $while-out$96)
-                        )
-                      )
-                      (br $while-in$97)
-                    )
-                    (set_local $8
-                      (block $do-once$98
-                        (if
-                          (get_local $8)
-                          (block
-                            (set_local $8
-                              (if
-                                (i32.and
-                                  (i32.gt_s
-                                    (set_local $1
                                       (i32.add
-                                        (i32.xor
-                                          (i32.and
-                                            (get_local $70)
-                                            (i32.const 1)
-                                          )
-                                          (i32.const 1)
-                                        )
-                                        (get_local $1)
-                                      )
-                                    )
-                                    (get_local $13)
-                                  )
-                                  (i32.gt_s
-                                    (get_local $13)
-                                    (i32.const -5)
-                                  )
-                                )
-                                (block
-                                  (set_local $10
-                                    (i32.add
-                                      (get_local $26)
-                                      (i32.const -1)
-                                    )
-                                  )
-                                  (i32.sub
-                                    (i32.add
-                                      (get_local $1)
-                                      (i32.const -1)
-                                    )
-                                    (get_local $13)
-                                  )
-                                )
-                                (block
-                                  (set_local $10
-                                    (i32.add
-                                      (get_local $26)
-                                      (i32.const -2)
-                                    )
-                                  )
-                                  (i32.add
-                                    (get_local $1)
-                                    (i32.const -1)
-                                  )
-                                )
-                              )
-                            )
-                            (if
-                              (i32.ne
-                                (set_local $1
-                                  (i32.and
-                                    (get_local $18)
-                                    (i32.const 8)
-                                  )
-                                )
-                                (i32.const 0)
-                              )
-                              (block
-                                (set_local $14
-                                  (get_local $8)
-                                )
-                                (set_local $26
-                                  (get_local $10)
-                                )
-                                (br $do-once$98
-                                  (get_local $1)
-                                )
-                              )
-                            )
-                            (block $do-once$100
-                              (if
-                                (get_local $11)
-                                (block
-                                  (if
-                                    (i32.eq
-                                      (set_local $1
-                                        (i32.load
-                                          (i32.add
-                                            (get_local $23)
-                                            (i32.const -4)
-                                          )
-                                        )
-                                      )
-                                      (i32.const 0)
-                                    )
-                                    (block
-                                      (set_local $6
-                                        (i32.const 9)
-                                      )
-                                      (br $do-once$100)
-                                    )
-                                  )
-                                  (if
-                                    (i32.eq
-                                      (i32.and
-                                        (call_import $i32u-rem
-                                          (get_local $1)
-                                          (i32.const 10)
-                                        )
+                                        (get_local $5)
                                         (i32.const -1)
                                       )
-                                      (i32.const 0)
                                     )
-                                    (block
-                                      (set_local $5
-                                        (i32.const 10)
-                                      )
-                                      (set_local $6
-                                        (i32.const 0)
-                                      )
-                                    )
-                                    (block
-                                      (set_local $6
-                                        (i32.const 0)
-                                      )
-                                      (br $do-once$100)
-                                    )
-                                  )
-                                  (loop $while-out$102 $while-in$103
-                                    (set_local $6
-                                      (i32.add
-                                        (get_local $6)
-                                        (i32.const 1)
-                                      )
-                                    )
-                                    (if
-                                      (i32.ne
-                                        (i32.and
-                                          (call_import $i32u-rem
-                                            (get_local $1)
-                                            (set_local $5
-                                              (i32.mul
-                                                (get_local $5)
-                                                (i32.const 10)
-                                              )
-                                            )
-                                          )
-                                          (i32.const -1)
-                                        )
-                                        (i32.const 0)
-                                      )
-                                      (br $while-out$102)
-                                    )
-                                    (br $while-in$103)
-                                  )
-                                )
-                                (set_local $6
-                                  (i32.const 9)
-                                )
-                              )
-                            )
-                            (set_local $1
-                              (i32.add
-                                (i32.mul
-                                  (i32.shr_s
-                                    (i32.sub
-                                      (get_local $23)
-                                      (get_local $62)
-                                    )
-                                    (i32.const 2)
-                                  )
-                                  (i32.const 9)
-                                )
-                                (i32.const -9)
-                              )
-                            )
-                            (if
-                              (i32.eq
-                                (i32.or
-                                  (get_local $10)
-                                  (i32.const 32)
-                                )
-                                (i32.const 102)
-                              )
-                              (block
-                                (set_local $1
-                                  (i32.lt_s
-                                    (set_local $5
-                                      (i32.sub
-                                        (get_local $1)
-                                        (get_local $6)
-                                      )
-                                    )
-                                    (i32.const 0)
-                                  )
-                                )
-                                (set_local $5
-                                  (i32.lt_s
-                                    (get_local $8)
-                                    (set_local $1
-                                      (select
-                                        (i32.const 0)
-                                        (get_local $5)
-                                        (get_local $1)
-                                      )
-                                    )
-                                  )
-                                )
-                                (set_local $14
-                                  (select
-                                    (get_local $8)
-                                    (get_local $1)
-                                    (get_local $5)
-                                  )
-                                )
-                                (set_local $26
-                                  (get_local $10)
-                                )
-                                (i32.const 0)
-                              )
-                              (block
-                                (set_local $1
-                                  (i32.lt_s
-                                    (set_local $5
-                                      (i32.sub
-                                        (i32.add
-                                          (get_local $1)
-                                          (get_local $13)
-                                        )
-                                        (get_local $6)
-                                      )
-                                    )
-                                    (i32.const 0)
-                                  )
-                                )
-                                (set_local $5
-                                  (i32.lt_s
-                                    (get_local $8)
-                                    (set_local $1
-                                      (select
-                                        (i32.const 0)
-                                        (get_local $5)
-                                        (get_local $1)
-                                      )
-                                    )
-                                  )
-                                )
-                                (set_local $14
-                                  (select
-                                    (get_local $8)
-                                    (get_local $1)
-                                    (get_local $5)
-                                  )
-                                )
-                                (set_local $26
-                                  (get_local $10)
-                                )
-                                (i32.const 0)
-                              )
-                            )
-                          )
-                          (block
-                            (set_local $14
-                              (get_local $1)
-                            )
-                            (i32.and
-                              (get_local $18)
-                              (i32.const 8)
-                            )
-                          )
-                        )
-                      )
-                    )
-                    (set_local $17
-                      (i32.and
-                        (i32.ne
-                          (set_local $1
-                            (i32.or
-                              (get_local $14)
-                              (get_local $8)
-                            )
-                          )
-                          (i32.const 0)
-                        )
-                        (i32.const 1)
-                      )
-                    )
-                    (set_local $13
-                      (if
-                        (set_local $10
-                          (i32.eq
-                            (i32.or
-                              (get_local $26)
-                              (i32.const 32)
-                            )
-                            (i32.const 102)
-                          )
-                        )
-                        (block
-                          (set_local $6
-                            (select
-                              (get_local $13)
-                              (i32.const 0)
-                              (i32.gt_s
-                                (get_local $13)
-                                (i32.const 0)
-                              )
-                            )
-                          )
-                          (i32.const 0)
-                        )
-                        (block
-                          (set_local $5
-                            (i32.shr_s
-                              (i32.shl
-                                (i32.lt_s
-                                  (set_local $6
-                                    (select
-                                      (get_local $27)
-                                      (get_local $13)
-                                      (i32.lt_s
-                                        (get_local $13)
-                                        (i32.const 0)
-                                      )
-                                    )
-                                  )
-                                  (i32.const 0)
-                                )
-                                (i32.const 31)
-                              )
-                              (i32.const 31)
-                            )
-                          )
-                          (if
-                            (i32.lt_s
-                              (i32.sub
-                                (get_local $40)
-                                (set_local $5
-                                  (call $_fmt_u
-                                    (get_local $6)
-                                    (get_local $5)
-                                    (get_local $52)
-                                  )
-                                )
-                              )
-                              (i32.const 2)
-                            )
-                            (loop $while-out$104 $while-in$105
-                              (i32.store8
-                                (set_local $5
-                                  (i32.add
-                                    (get_local $5)
-                                    (i32.const -1)
-                                  )
-                                )
-                                (i32.const 48)
-                              )
-                              (if
-                                (i32.lt_s
-                                  (i32.sub
-                                    (get_local $40)
-                                    (get_local $5)
-                                  )
-                                  (i32.const 2)
-                                )
-                                (get_local $5)
-                                (br $while-out$104)
-                              )
-                              (br $while-in$105)
-                            )
-                            (get_local $5)
-                          )
-                          (i32.store8
-                            (i32.add
-                              (get_local $5)
-                              (i32.const -1)
-                            )
-                            (i32.and
-                              (i32.add
-                                (i32.and
-                                  (i32.shr_s
-                                    (get_local $13)
-                                    (i32.const 31)
-                                  )
-                                  (i32.const 2)
-                                )
-                                (i32.const 43)
-                              )
-                              (i32.const 255)
-                            )
-                          )
-                          (i32.store8
-                            (set_local $5
-                              (i32.add
-                                (get_local $5)
-                                (i32.const -2)
-                              )
-                            )
-                            (i32.and
-                              (get_local $26)
-                              (i32.const 255)
-                            )
-                          )
-                          (set_local $6
-                            (i32.sub
-                              (get_local $40)
-                              (get_local $5)
-                            )
-                          )
-                          (get_local $5)
-                        )
-                      )
-                    )
-                    (call $_pad
-                      (get_local $0)
-                      (i32.const 32)
-                      (get_local $16)
-                      (set_local $6
-                        (i32.add
-                          (i32.add
-                            (i32.add
-                              (i32.add
-                                (get_local $51)
-                                (i32.const 1)
-                              )
-                              (get_local $14)
-                            )
-                            (get_local $17)
-                          )
-                          (get_local $6)
-                        )
-                      )
-                      (get_local $18)
-                    )
-                    (if
-                      (i32.eq
-                        (i32.and
-                          (i32.load
-                            (get_local $0)
-                          )
-                          (i32.const 32)
-                        )
-                        (i32.const 0)
-                      )
-                      (call $___fwritex
-                        (get_local $39)
-                        (get_local $51)
-                        (get_local $0)
-                      )
-                    )
-                    (call $_pad
-                      (get_local $0)
-                      (i32.const 48)
-                      (get_local $16)
-                      (get_local $6)
-                      (i32.xor
-                        (get_local $18)
-                        (i32.const 65536)
-                      )
-                    )
-                    (block $do-once$106
-                      (if
-                        (get_local $10)
-                        (block
-                          (set_local $7
-                            (set_local $8
-                              (select
-                                (get_local $9)
-                                (get_local $7)
-                                (i32.gt_u
-                                  (get_local $7)
-                                  (get_local $9)
-                                )
-                              )
-                            )
-                          )
-                          (loop $while-out$108 $while-in$109
-                            (set_local $5
-                              (call $_fmt_u
-                                (i32.load
-                                  (get_local $7)
-                                )
-                                (i32.const 0)
-                                (get_local $45)
-                              )
-                            )
-                            (block $do-once$110
-                              (if
-                                (i32.eq
-                                  (get_local $7)
-                                  (get_local $8)
-                                )
-                                (block
-                                  (if
-                                    (i32.ne
-                                      (get_local $5)
-                                      (get_local $45)
-                                    )
-                                    (br $do-once$110)
-                                  )
-                                  (i32.store8
-                                    (get_local $53)
                                     (i32.const 48)
                                   )
-                                  (set_local $5
-                                    (get_local $53)
-                                  )
-                                )
-                                (block
                                   (if
                                     (i32.gt_u
                                       (get_local $5)
                                       (get_local $29)
                                     )
                                     (get_local $5)
-                                    (br $do-once$110)
+                                    (br $while-out$112)
                                   )
-                                  (loop $while-out$112 $while-in$113
-                                    (i32.store8
-                                      (set_local $5
-                                        (i32.add
-                                          (get_local $5)
-                                          (i32.const -1)
-                                        )
-                                      )
-                                      (i32.const 48)
-                                    )
-                                    (if
-                                      (i32.gt_u
-                                        (get_local $5)
-                                        (get_local $29)
-                                      )
-                                      (get_local $5)
-                                      (br $while-out$112)
-                                    )
-                                    (br $while-in$113)
-                                  )
+                                  (br $while-in$113)
                                 )
                               )
+                            )
+                          )
+                          (if
+                            (i32.eq
+                              (i32.and
+                                (i32.load
+                                  (get_local $0)
+                                )
+                                (i32.const 32)
+                              )
+                              (i32.const 0)
+                            )
+                            (call $___fwritex
+                              (get_local $5)
+                              (i32.sub
+                                (get_local $75)
+                                (get_local $5)
+                              )
+                              (get_local $0)
+                            )
+                          )
+                          (if
+                            (i32.gt_u
+                              (set_local $7
+                                (i32.add
+                                  (get_local $7)
+                                  (i32.const 4)
+                                )
+                              )
+                              (get_local $9)
+                            )
+                            (block
+                              (set_local $5
+                                (get_local $7)
+                              )
+                              (br $while-out$108)
+                            )
+                            (get_local $7)
+                          )
+                          (br $while-in$109)
+                        )
+                        (block $do-once$114
+                          (if
+                            (i32.ne
+                              (get_local $1)
+                              (i32.const 0)
+                            )
+                            (block
+                              (br_if $do-once$114
+                                (i32.ne
+                                  (i32.and
+                                    (i32.load
+                                      (get_local $0)
+                                    )
+                                    (i32.const 32)
+                                  )
+                                  (i32.const 0)
+                                )
+                              )
+                              (call $___fwritex
+                                (i32.const 4143)
+                                (i32.const 1)
+                                (get_local $0)
+                              )
+                            )
+                          )
+                        )
+                        (if
+                          (i32.and
+                            (i32.gt_s
+                              (get_local $14)
+                              (i32.const 0)
+                            )
+                            (i32.lt_u
+                              (get_local $5)
+                              (get_local $23)
+                            )
+                          )
+                          (loop $while-out$116 $while-in$117
+                            (if
+                              (i32.gt_u
+                                (set_local $1
+                                  (call $_fmt_u
+                                    (i32.load
+                                      (get_local $5)
+                                    )
+                                    (i32.const 0)
+                                    (get_local $45)
+                                  )
+                                )
+                                (get_local $29)
+                              )
+                              (loop $while-out$118 $while-in$119
+                                (i32.store8
+                                  (set_local $1
+                                    (i32.add
+                                      (get_local $1)
+                                      (i32.const -1)
+                                    )
+                                  )
+                                  (i32.const 48)
+                                )
+                                (if
+                                  (i32.gt_u
+                                    (get_local $1)
+                                    (get_local $29)
+                                  )
+                                  (get_local $1)
+                                  (br $while-out$118)
+                                )
+                                (br $while-in$119)
+                              )
+                              (get_local $1)
                             )
                             (if
                               (i32.eq
@@ -7277,106 +7370,217 @@
                                 (i32.const 0)
                               )
                               (call $___fwritex
-                                (get_local $5)
-                                (i32.sub
-                                  (get_local $75)
-                                  (get_local $5)
+                                (get_local $1)
+                                (select
+                                  (i32.const 9)
+                                  (get_local $14)
+                                  (i32.gt_s
+                                    (get_local $14)
+                                    (i32.const 9)
+                                  )
                                 )
                                 (get_local $0)
                               )
                             )
+                            (set_local $1
+                              (i32.add
+                                (get_local $14)
+                                (i32.const -9)
+                              )
+                            )
                             (if
-                              (i32.gt_u
-                                (set_local $7
-                                  (i32.add
-                                    (get_local $7)
-                                    (i32.const 4)
-                                  )
+                              (i32.and
+                                (i32.gt_s
+                                  (get_local $14)
+                                  (i32.const 9)
                                 )
-                                (get_local $9)
+                                (i32.lt_u
+                                  (set_local $5
+                                    (i32.add
+                                      (get_local $5)
+                                      (i32.const 4)
+                                    )
+                                  )
+                                  (get_local $23)
+                                )
+                              )
+                              (set_local $14
+                                (get_local $1)
                               )
                               (block
-                                (set_local $5
-                                  (get_local $7)
+                                (set_local $14
+                                  (get_local $1)
                                 )
-                                (br $while-out$108)
+                                (br $while-out$116)
                               )
+                            )
+                            (br $while-in$117)
+                          )
+                          (get_local $14)
+                        )
+                        (call $_pad
+                          (get_local $0)
+                          (i32.const 48)
+                          (i32.add
+                            (get_local $14)
+                            (i32.const 9)
+                          )
+                          (i32.const 9)
+                          (i32.const 0)
+                        )
+                      )
+                      (block
+                        (set_local $11
+                          (select
+                            (get_local $23)
+                            (i32.add
+                              (get_local $7)
+                              (i32.const 4)
+                            )
+                            (get_local $11)
+                          )
+                        )
+                        (if
+                          (i32.gt_s
+                            (get_local $14)
+                            (i32.const -1)
+                          )
+                          (block
+                            (set_local $9
+                              (i32.eq
+                                (get_local $8)
+                                (i32.const 0)
+                              )
+                            )
+                            (set_local $5
                               (get_local $7)
                             )
-                            (br $while-in$109)
-                          )
-                          (block $do-once$114
-                            (if
-                              (i32.ne
-                                (get_local $1)
-                                (i32.const 0)
-                              )
-                              (block
-                                (br_if $do-once$114
-                                  (i32.ne
-                                    (i32.and
-                                      (i32.load
-                                        (get_local $0)
+                            (loop $while-out$120 $while-in$121
+                              (set_local $8
+                                (if
+                                  (i32.eq
+                                    (set_local $1
+                                      (call $_fmt_u
+                                        (i32.load
+                                          (get_local $5)
+                                        )
+                                        (i32.const 0)
+                                        (get_local $45)
                                       )
-                                      (i32.const 32)
                                     )
-                                    (i32.const 0)
+                                    (get_local $45)
                                   )
-                                )
-                                (call $___fwritex
-                                  (i32.const 4143)
-                                  (i32.const 1)
-                                  (get_local $0)
-                                )
-                              )
-                            )
-                          )
-                          (if
-                            (i32.and
-                              (i32.gt_s
-                                (get_local $14)
-                                (i32.const 0)
-                              )
-                              (i32.lt_u
-                                (get_local $5)
-                                (get_local $23)
-                              )
-                            )
-                            (loop $while-out$116 $while-in$117
-                              (if
-                                (i32.gt_u
-                                  (set_local $1
-                                    (call $_fmt_u
-                                      (i32.load
-                                        (get_local $5)
-                                      )
-                                      (i32.const 0)
-                                      (get_local $45)
+                                  (block
+                                    (i32.store8
+                                      (get_local $53)
+                                      (i32.const 48)
                                     )
+                                    (get_local $53)
                                   )
-                                  (get_local $29)
+                                  (get_local $1)
                                 )
-                                (loop $while-out$118 $while-in$119
-                                  (i32.store8
+                              )
+                              (block $do-once$122
+                                (if
+                                  (i32.eq
+                                    (get_local $5)
+                                    (get_local $7)
+                                  )
+                                  (block
                                     (set_local $1
                                       (i32.add
-                                        (get_local $1)
-                                        (i32.const -1)
+                                        (get_local $8)
+                                        (i32.const 1)
                                       )
                                     )
-                                    (i32.const 48)
-                                  )
-                                  (if
-                                    (i32.gt_u
-                                      (get_local $1)
-                                      (get_local $29)
+                                    (if
+                                      (i32.eq
+                                        (i32.and
+                                          (i32.load
+                                            (get_local $0)
+                                          )
+                                          (i32.const 32)
+                                        )
+                                        (i32.const 0)
+                                      )
+                                      (call $___fwritex
+                                        (get_local $8)
+                                        (i32.const 1)
+                                        (get_local $0)
+                                      )
                                     )
-                                    (get_local $1)
-                                    (br $while-out$118)
+                                    (if
+                                      (i32.and
+                                        (get_local $9)
+                                        (i32.lt_s
+                                          (get_local $14)
+                                          (i32.const 1)
+                                        )
+                                      )
+                                      (br $do-once$122)
+                                    )
+                                    (if
+                                      (i32.ne
+                                        (i32.and
+                                          (i32.load
+                                            (get_local $0)
+                                          )
+                                          (i32.const 32)
+                                        )
+                                        (i32.const 0)
+                                      )
+                                      (br $do-once$122)
+                                    )
+                                    (call $___fwritex
+                                      (i32.const 4143)
+                                      (i32.const 1)
+                                      (get_local $0)
+                                    )
                                   )
-                                  (br $while-in$119)
+                                  (block
+                                    (if
+                                      (i32.gt_u
+                                        (get_local $8)
+                                        (get_local $29)
+                                      )
+                                      (set_local $1
+                                        (get_local $8)
+                                      )
+                                      (block
+                                        (set_local $1
+                                          (get_local $8)
+                                        )
+                                        (br $do-once$122)
+                                      )
+                                    )
+                                    (loop $while-out$124 $while-in$125
+                                      (i32.store8
+                                        (set_local $1
+                                          (i32.add
+                                            (get_local $1)
+                                            (i32.const -1)
+                                          )
+                                        )
+                                        (i32.const 48)
+                                      )
+                                      (if
+                                        (i32.gt_u
+                                          (get_local $1)
+                                          (get_local $29)
+                                        )
+                                        (get_local $1)
+                                        (br $while-out$124)
+                                      )
+                                      (br $while-in$125)
+                                    )
+                                  )
                                 )
-                                (get_local $1)
+                              )
+                              (set_local $8
+                                (i32.sub
+                                  (get_local $75)
+                                  (get_local $1)
+                                )
                               )
                               (if
                                 (i32.eq
@@ -7391,456 +7595,232 @@
                                 (call $___fwritex
                                   (get_local $1)
                                   (select
-                                    (i32.const 9)
+                                    (get_local $8)
                                     (get_local $14)
                                     (i32.gt_s
                                       (get_local $14)
-                                      (i32.const 9)
+                                      (get_local $8)
                                     )
                                   )
                                   (get_local $0)
-                                )
-                              )
-                              (set_local $1
-                                (i32.add
-                                  (get_local $14)
-                                  (i32.const -9)
                                 )
                               )
                               (if
-                                (i32.and
-                                  (i32.gt_s
-                                    (get_local $14)
-                                    (i32.const 9)
-                                  )
-                                  (i32.lt_u
-                                    (set_local $5
-                                      (i32.add
-                                        (get_local $5)
-                                        (i32.const 4)
-                                      )
-                                    )
-                                    (get_local $23)
-                                  )
-                                )
-                                (set_local $14
-                                  (get_local $1)
-                                )
-                                (block
-                                  (set_local $14
-                                    (get_local $1)
-                                  )
-                                  (br $while-out$116)
-                                )
-                              )
-                              (br $while-in$117)
-                            )
-                            (get_local $14)
-                          )
-                          (call $_pad
-                            (get_local $0)
-                            (i32.const 48)
-                            (i32.add
-                              (get_local $14)
-                              (i32.const 9)
-                            )
-                            (i32.const 9)
-                            (i32.const 0)
-                          )
-                        )
-                        (block
-                          (set_local $11
-                            (select
-                              (get_local $23)
-                              (i32.add
-                                (get_local $7)
-                                (i32.const 4)
-                              )
-                              (get_local $11)
-                            )
-                          )
-                          (if
-                            (i32.gt_s
-                              (get_local $14)
-                              (i32.const -1)
-                            )
-                            (block
-                              (set_local $9
-                                (i32.eq
-                                  (get_local $8)
-                                  (i32.const 0)
-                                )
-                              )
-                              (set_local $5
-                                (get_local $7)
-                              )
-                              (loop $while-out$120 $while-in$121
-                                (set_local $8
-                                  (if
-                                    (i32.eq
-                                      (set_local $1
-                                        (call $_fmt_u
-                                          (i32.load
-                                            (get_local $5)
-                                          )
-                                          (i32.const 0)
-                                          (get_local $45)
-                                        )
-                                      )
-                                      (get_local $45)
-                                    )
-                                    (block
-                                      (i32.store8
-                                        (get_local $53)
-                                        (i32.const 48)
-                                      )
-                                      (get_local $53)
-                                    )
-                                    (get_local $1)
-                                  )
-                                )
-                                (block $do-once$122
-                                  (if
-                                    (i32.eq
-                                      (get_local $5)
-                                      (get_local $7)
-                                    )
-                                    (block
-                                      (set_local $1
+                                (i32.eqz
+                                  (i32.and
+                                    (i32.lt_u
+                                      (set_local $5
                                         (i32.add
-                                          (get_local $8)
-                                          (i32.const 1)
+                                          (get_local $5)
+                                          (i32.const 4)
                                         )
                                       )
-                                      (if
-                                        (i32.eq
-                                          (i32.and
-                                            (i32.load
-                                              (get_local $0)
-                                            )
-                                            (i32.const 32)
-                                          )
-                                          (i32.const 0)
-                                        )
-                                        (call $___fwritex
-                                          (get_local $8)
-                                          (i32.const 1)
-                                          (get_local $0)
-                                        )
-                                      )
-                                      (if
-                                        (i32.and
-                                          (get_local $9)
-                                          (i32.lt_s
-                                            (get_local $14)
-                                            (i32.const 1)
-                                          )
-                                        )
-                                        (br $do-once$122)
-                                      )
-                                      (if
-                                        (i32.ne
-                                          (i32.and
-                                            (i32.load
-                                              (get_local $0)
-                                            )
-                                            (i32.const 32)
-                                          )
-                                          (i32.const 0)
-                                        )
-                                        (br $do-once$122)
-                                      )
-                                      (call $___fwritex
-                                        (i32.const 4143)
-                                        (i32.const 1)
-                                        (get_local $0)
-                                      )
+                                      (get_local $11)
                                     )
-                                    (block
-                                      (if
-                                        (i32.gt_u
-                                          (get_local $8)
-                                          (get_local $29)
-                                        )
-                                        (set_local $1
+                                    (i32.gt_s
+                                      (set_local $14
+                                        (i32.sub
+                                          (get_local $14)
                                           (get_local $8)
                                         )
-                                        (block
-                                          (set_local $1
-                                            (get_local $8)
-                                          )
-                                          (br $do-once$122)
-                                        )
                                       )
-                                      (loop $while-out$124 $while-in$125
-                                        (i32.store8
-                                          (set_local $1
-                                            (i32.add
-                                              (get_local $1)
-                                              (i32.const -1)
-                                            )
-                                          )
-                                          (i32.const 48)
-                                        )
-                                        (if
-                                          (i32.gt_u
-                                            (get_local $1)
-                                            (get_local $29)
-                                          )
-                                          (get_local $1)
-                                          (br $while-out$124)
-                                        )
-                                        (br $while-in$125)
-                                      )
+                                      (i32.const -1)
                                     )
                                   )
                                 )
-                                (set_local $8
-                                  (i32.sub
-                                    (get_local $75)
-                                    (get_local $1)
-                                  )
-                                )
-                                (if
-                                  (i32.eq
-                                    (i32.and
-                                      (i32.load
-                                        (get_local $0)
-                                      )
-                                      (i32.const 32)
-                                    )
-                                    (i32.const 0)
-                                  )
-                                  (call $___fwritex
-                                    (get_local $1)
-                                    (select
-                                      (get_local $8)
-                                      (get_local $14)
-                                      (i32.gt_s
-                                        (get_local $14)
-                                        (get_local $8)
-                                      )
-                                    )
-                                    (get_local $0)
-                                  )
-                                )
-                                (if
-                                  (i32.eqz
-                                    (i32.and
-                                      (i32.lt_u
-                                        (set_local $5
-                                          (i32.add
-                                            (get_local $5)
-                                            (i32.const 4)
-                                          )
-                                        )
-                                        (get_local $11)
-                                      )
-                                      (i32.gt_s
-                                        (set_local $14
-                                          (i32.sub
-                                            (get_local $14)
-                                            (get_local $8)
-                                          )
-                                        )
-                                        (i32.const -1)
-                                      )
-                                    )
-                                  )
-                                  (br $while-out$120)
-                                )
-                                (br $while-in$121)
+                                (br $while-out$120)
                               )
-                            )
-                            (get_local $14)
-                          )
-                          (call $_pad
-                            (get_local $0)
-                            (i32.const 48)
-                            (i32.add
-                              (get_local $14)
-                              (i32.const 18)
-                            )
-                            (i32.const 18)
-                            (i32.const 0)
-                          )
-                          (br_if $do-once$106
-                            (i32.ne
-                              (i32.and
-                                (i32.load
-                                  (get_local $0)
-                                )
-                                (i32.const 32)
-                              )
-                              (i32.const 0)
+                              (br $while-in$121)
                             )
                           )
-                          (call $___fwritex
-                            (get_local $13)
-                            (i32.sub
-                              (get_local $40)
-                              (get_local $13)
-                            )
-                            (get_local $0)
-                          )
+                          (get_local $14)
                         )
-                      )
-                    )
-                    (call $_pad
-                      (get_local $0)
-                      (i32.const 32)
-                      (get_local $16)
-                      (get_local $6)
-                      (i32.xor
-                        (get_local $18)
-                        (i32.const 8192)
-                      )
-                    )
-                    (select
-                      (get_local $16)
-                      (get_local $6)
-                      (i32.lt_s
-                        (get_local $6)
-                        (get_local $16)
-                      )
-                    )
-                  )
-                  (block
-                    (set_local $5
-                      (select
-                        (i32.const 4127)
-                        (i32.const 4131)
-                        (set_local $8
+                        (call $_pad
+                          (get_local $0)
+                          (i32.const 48)
+                          (i32.add
+                            (get_local $14)
+                            (i32.const 18)
+                          )
+                          (i32.const 18)
+                          (i32.const 0)
+                        )
+                        (br_if $do-once$106
                           (i32.ne
                             (i32.and
-                              (get_local $26)
+                              (i32.load
+                                (get_local $0)
+                              )
                               (i32.const 32)
                             )
                             (i32.const 0)
                           )
                         )
+                        (call $___fwritex
+                          (get_local $13)
+                          (i32.sub
+                            (get_local $40)
+                            (get_local $13)
+                          )
+                          (get_local $0)
+                        )
                       )
                     )
-                    (set_local $6
+                  )
+                  (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $16)
+                    (get_local $6)
+                    (i32.xor
+                      (get_local $18)
+                      (i32.const 8192)
+                    )
+                  )
+                  (select
+                    (get_local $16)
+                    (get_local $6)
+                    (i32.lt_s
+                      (get_local $6)
+                      (get_local $16)
+                    )
+                  )
+                )
+                (block
+                  (set_local $5
+                    (select
+                      (i32.const 4127)
+                      (i32.const 4131)
+                      (set_local $8
+                        (i32.ne
+                          (i32.and
+                            (get_local $26)
+                            (i32.const 32)
+                          )
+                          (i32.const 0)
+                        )
+                      )
+                    )
+                  )
+                  (set_local $6
+                    (select
+                      (i32.const 0)
+                      (get_local $51)
+                      (set_local $1
+                        (i32.or
+                          (f64.ne
+                            (get_local $15)
+                            (get_local $15)
+                          )
+                          (i32.const 0)
+                        )
+                      )
+                    )
+                  )
+                  (set_local $8
+                    (select
                       (select
-                        (i32.const 0)
-                        (get_local $51)
-                        (set_local $1
-                          (i32.or
-                            (f64.ne
-                              (get_local $15)
-                              (get_local $15)
+                        (i32.const 4135)
+                        (i32.const 4139)
+                        (get_local $8)
+                      )
+                      (get_local $5)
+                      (get_local $1)
+                    )
+                  )
+                  (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $16)
+                    (set_local $5
+                      (i32.add
+                        (get_local $6)
+                        (i32.const 3)
+                      )
+                    )
+                    (get_local $7)
+                  )
+                  (if
+                    (i32.eq
+                      (i32.and
+                        (if
+                          (i32.eq
+                            (i32.and
+                              (set_local $1
+                                (i32.load
+                                  (get_local $0)
+                                )
+                              )
+                              (i32.const 32)
                             )
                             (i32.const 0)
                           )
-                        )
-                      )
-                    )
-                    (set_local $8
-                      (select
-                        (select
-                          (i32.const 4135)
-                          (i32.const 4139)
-                          (get_local $8)
-                        )
-                        (get_local $5)
-                        (get_local $1)
-                      )
-                    )
-                    (call $_pad
-                      (get_local $0)
-                      (i32.const 32)
-                      (get_local $16)
-                      (set_local $5
-                        (i32.add
-                          (get_local $6)
-                          (i32.const 3)
-                        )
-                      )
-                      (get_local $7)
-                    )
-                    (if
-                      (i32.eq
-                        (i32.and
-                          (if
-                            (i32.eq
-                              (i32.and
-                                (set_local $1
-                                  (i32.load
-                                    (get_local $0)
-                                  )
-                                )
-                                (i32.const 32)
-                              )
-                              (i32.const 0)
+                          (block
+                            (call $___fwritex
+                              (get_local $39)
+                              (get_local $6)
+                              (get_local $0)
                             )
-                            (block
-                              (call $___fwritex
-                                (get_local $39)
-                                (get_local $6)
-                                (get_local $0)
-                              )
-                              (i32.load
-                                (get_local $0)
-                              )
+                            (i32.load
+                              (get_local $0)
                             )
-                            (get_local $1)
                           )
-                          (i32.const 32)
+                          (get_local $1)
                         )
-                        (i32.const 0)
+                        (i32.const 32)
                       )
-                      (call $___fwritex
-                        (get_local $8)
-                        (i32.const 3)
-                        (get_local $0)
-                      )
+                      (i32.const 0)
                     )
-                    (call $_pad
+                    (call $___fwritex
+                      (get_local $8)
+                      (i32.const 3)
                       (get_local $0)
-                      (i32.const 32)
-                      (get_local $16)
-                      (get_local $5)
-                      (i32.xor
-                        (get_local $18)
-                        (i32.const 8192)
-                      )
                     )
-                    (select
-                      (get_local $16)
+                  )
+                  (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $16)
+                    (get_local $5)
+                    (i32.xor
+                      (get_local $18)
+                      (i32.const 8192)
+                    )
+                  )
+                  (select
+                    (get_local $16)
+                    (get_local $5)
+                    (i32.lt_s
                       (get_local $5)
-                      (i32.lt_s
-                        (get_local $5)
-                        (get_local $16)
-                      )
+                      (get_local $16)
                     )
                   )
                 )
               )
             )
-            (set_local $8
-              (get_local $21)
-            )
-            (br $label$continue$L1)
           )
-          (set_local $47
-            (get_local $20)
+          (set_local $8
+            (get_local $21)
           )
-          (set_local $37
-            (get_local $18)
-          )
-          (set_local $42
-            (get_local $10)
-          )
-          (set_local $43
-            (i32.const 0)
-          )
-          (set_local $48
-            (i32.const 4091)
-          )
-          (set_local $49
-            (get_local $28)
-          )
+          (br $label$continue$L1)
+        )
+        (set_local $47
+          (get_local $20)
+        )
+        (set_local $37
+          (get_local $18)
+        )
+        (set_local $42
+          (get_local $10)
+        )
+        (set_local $43
+          (i32.const 0)
+        )
+        (set_local $48
+          (i32.const 4091)
+        )
+        (set_local $49
+          (get_local $28)
         )
       )
       (block $label$break$L308

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -4383,960 +4383,2648 @@
           )
         )
       )
-      (block $label$break$L75
-        (block $switch$24
-          (block $switch-default$127
-            (block $switch-case$126
-              (block $switch-case$55
-                (block $switch-case$54
-                  (block $switch-case$53
-                    (block $switch-case$52
-                      (block $switch-case$51
-                        (block $switch-case$50
-                          (block $switch-case$49
-                            (block $switch-case$48
-                              (block $switch-case$47
-                                (block $switch-case$46
-                                  (block $switch-case$45
-                                    (block $switch-case$44
-                                      (block $switch-case$43
-                                        (block $switch-case$42
-                                          (block $switch-case$41
-                                            (block $switch-case$40
-                                              (block $switch-case$37
-                                                (block $switch-case$36
-                                                  (block $switch-case$35
-                                                    (block $switch-case$34
-                                                      (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$52 $switch-case$51 $switch-case$50 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$53 $switch-default$127 $switch-case$44 $switch-case$42 $switch-case$126 $switch-case$55 $switch-case$54 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$37 $switch-default$127
-                                                        (i32.sub
-                                                          (set_local $26
-                                                            (select
-                                                              (i32.and
-                                                                (get_local $1)
-                                                                (i32.const -33)
-                                                              )
-                                                              (get_local $1)
-                                                              (get_local $5)
-                                                            )
-                                                          )
-                                                          (i32.const 65)
-                                                        )
-                                                      )
-                                                    )
-                                                    (block $switch-default$33
-                                                      (block $switch-case$32
-                                                        (block $switch-case$31
-                                                          (block $switch-case$30
-                                                            (block $switch-case$29
-                                                              (block $switch-case$28
-                                                                (block $switch-case$27
-                                                                  (block $switch-case$26
-                                                                    (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
-                                                                      (i32.sub
-                                                                        (get_local $13)
-                                                                        (i32.const 0)
-                                                                      )
-                                                                    )
-                                                                  )
-                                                                  (i32.store
-                                                                    (i32.load
-                                                                      (get_local $19)
-                                                                    )
-                                                                    (get_local $22)
-                                                                  )
-                                                                  (set_local $20
-                                                                    (get_local $9)
-                                                                  )
-                                                                  (set_local $1
-                                                                    (get_local $17)
-                                                                  )
-                                                                  (set_local $8
-                                                                    (get_local $21)
-                                                                  )
-                                                                  (br $label$continue$L1)
-                                                                )
-                                                                (i32.store
-                                                                  (i32.load
-                                                                    (get_local $19)
-                                                                  )
-                                                                  (get_local $22)
-                                                                )
-                                                                (set_local $20
-                                                                  (get_local $9)
-                                                                )
-                                                                (set_local $1
-                                                                  (get_local $17)
-                                                                )
-                                                                (set_local $8
-                                                                  (get_local $21)
-                                                                )
-                                                                (br $label$continue$L1)
-                                                              )
-                                                              (i32.store
-                                                                (set_local $1
-                                                                  (i32.load
-                                                                    (get_local $19)
-                                                                  )
-                                                                )
-                                                                (get_local $22)
-                                                              )
-                                                              (i32.store offset=4
-                                                                (get_local $1)
-                                                                (i32.shr_s
-                                                                  (i32.shl
-                                                                    (i32.lt_s
-                                                                      (get_local $22)
-                                                                      (i32.const 0)
-                                                                    )
-                                                                    (i32.const 31)
-                                                                  )
-                                                                  (i32.const 31)
-                                                                )
-                                                              )
-                                                              (set_local $20
-                                                                (get_local $9)
-                                                              )
-                                                              (set_local $1
-                                                                (get_local $17)
-                                                              )
-                                                              (set_local $8
-                                                                (get_local $21)
-                                                              )
-                                                              (br $label$continue$L1)
-                                                            )
-                                                            (i32.store16
-                                                              (i32.load
-                                                                (get_local $19)
-                                                              )
-                                                              (i32.and
-                                                                (get_local $22)
-                                                                (i32.const 65535)
-                                                              )
-                                                            )
-                                                            (set_local $20
-                                                              (get_local $9)
-                                                            )
-                                                            (set_local $1
-                                                              (get_local $17)
-                                                            )
-                                                            (set_local $8
-                                                              (get_local $21)
-                                                            )
-                                                            (br $label$continue$L1)
-                                                          )
-                                                          (i32.store8
-                                                            (i32.load
-                                                              (get_local $19)
-                                                            )
-                                                            (i32.and
-                                                              (get_local $22)
-                                                              (i32.const 255)
-                                                            )
-                                                          )
-                                                          (set_local $20
-                                                            (get_local $9)
-                                                          )
-                                                          (set_local $1
-                                                            (get_local $17)
-                                                          )
-                                                          (set_local $8
-                                                            (get_local $21)
-                                                          )
-                                                          (br $label$continue$L1)
-                                                        )
-                                                        (i32.store
-                                                          (i32.load
-                                                            (get_local $19)
-                                                          )
-                                                          (get_local $22)
-                                                        )
-                                                        (set_local $20
-                                                          (get_local $9)
-                                                        )
-                                                        (set_local $1
-                                                          (get_local $17)
-                                                        )
-                                                        (set_local $8
-                                                          (get_local $21)
-                                                        )
-                                                        (br $label$continue$L1)
-                                                      )
-                                                      (i32.store
-                                                        (set_local $1
-                                                          (i32.load
-                                                            (get_local $19)
-                                                          )
-                                                        )
-                                                        (get_local $22)
-                                                      )
-                                                      (i32.store offset=4
-                                                        (get_local $1)
-                                                        (i32.shr_s
-                                                          (i32.shl
-                                                            (i32.lt_s
-                                                              (get_local $22)
-                                                              (i32.const 0)
-                                                            )
-                                                            (i32.const 31)
-                                                          )
-                                                          (i32.const 31)
-                                                        )
-                                                      )
-                                                      (set_local $20
-                                                        (get_local $9)
-                                                      )
-                                                      (set_local $1
-                                                        (get_local $17)
-                                                      )
-                                                      (set_local $8
-                                                        (get_local $21)
-                                                      )
-                                                      (br $label$continue$L1)
-                                                    )
-                                                    (set_local $20
-                                                      (get_local $9)
-                                                    )
-                                                    (set_local $1
-                                                      (get_local $17)
-                                                    )
-                                                    (set_local $8
-                                                      (get_local $21)
-                                                    )
-                                                    (br $label$continue$L1)
-                                                  )
-                                                  (set_local $46
-                                                    (i32.or
-                                                      (get_local $18)
-                                                      (i32.const 8)
-                                                    )
-                                                  )
-                                                  (set_local $57
-                                                    (select
-                                                      (get_local $10)
-                                                      (i32.const 8)
-                                                      (i32.gt_u
-                                                        (get_local $10)
-                                                        (i32.const 8)
-                                                      )
-                                                    )
-                                                  )
-                                                  (set_local $68
-                                                    (i32.const 120)
-                                                  )
-                                                  (set_local $12
-                                                    (i32.const 64)
-                                                  )
-                                                  (br $switch$24)
-                                                )
-                                              )
-                                              (set_local $46
-                                                (get_local $18)
-                                              )
-                                              (set_local $57
-                                                (get_local $10)
-                                              )
-                                              (set_local $68
-                                                (get_local $26)
-                                              )
-                                              (set_local $12
-                                                (i32.const 64)
-                                              )
-                                              (br $switch$24)
-                                            )
-                                            (if
-                                              (i32.and
-                                                (i32.eq
-                                                  (set_local $5
-                                                    (i32.load
-                                                      (set_local $1
-                                                        (get_local $19)
-                                                      )
-                                                    )
-                                                  )
-                                                  (i32.const 0)
-                                                )
-                                                (i32.eq
-                                                  (set_local $1
-                                                    (i32.load offset=4
-                                                      (get_local $1)
-                                                    )
-                                                  )
-                                                  (i32.const 0)
-                                                )
-                                              )
-                                              (set_local $6
-                                                (get_local $28)
-                                              )
-                                              (block
-                                                (set_local $6
-                                                  (get_local $28)
-                                                )
-                                                (loop $while-out$38 $while-in$39
-                                                  (i32.store8
-                                                    (set_local $6
-                                                      (i32.add
-                                                        (get_local $6)
-                                                        (i32.const -1)
-                                                      )
-                                                    )
-                                                    (i32.and
-                                                      (i32.or
-                                                        (i32.and
-                                                          (get_local $5)
-                                                          (i32.const 7)
-                                                        )
-                                                        (i32.const 48)
-                                                      )
-                                                      (i32.const 255)
-                                                    )
-                                                  )
-                                                  (if
-                                                    (i32.and
-                                                      (i32.eq
-                                                        (set_local $5
-                                                          (call $_bitshift64Lshr
-                                                            (get_local $5)
-                                                            (get_local $1)
-                                                            (i32.const 3)
-                                                          )
-                                                        )
-                                                        (i32.const 0)
-                                                      )
-                                                      (i32.eq
-                                                        (set_local $1
-                                                          (i32.load
-                                                            (i32.const 168)
-                                                          )
-                                                        )
-                                                        (i32.const 0)
-                                                      )
-                                                    )
-                                                    (br $while-out$38)
-                                                  )
-                                                  (br $while-in$39)
-                                                )
-                                              )
-                                            )
-                                            (set_local $58
-                                              (if
-                                                (i32.eq
-                                                  (i32.and
-                                                    (get_local $18)
-                                                    (i32.const 8)
-                                                  )
-                                                  (i32.const 0)
-                                                )
-                                                (block
-                                                  (set_local $34
-                                                    (get_local $18)
-                                                  )
-                                                  (set_local $32
-                                                    (get_local $10)
-                                                  )
-                                                  (set_local $35
+      (block $switch$24
+        (block $switch-default$127
+          (block $switch-case$49
+            (block $switch-case$48
+              (block $switch-case$47
+                (block $switch-case$46
+                  (block $switch-case$45
+                    (block $switch-case$44
+                      (block $switch-case$43
+                        (block $switch-case$41
+                          (block $switch-case$40
+                            (block $switch-case$36
+                              (block $switch-case$35
+                                (block $switch-case$34
+                                  (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$49 $switch-case$49 $switch-case$49 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$49 $switch-default$127 $switch-case$44 $switch-case$41 $switch-case$49 $switch-case$49 $switch-case$49 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127
+                                    (i32.sub
+                                      (set_local $26
+                                        (select
+                                          (i32.and
+                                            (get_local $1)
+                                            (i32.const -33)
+                                          )
+                                          (get_local $1)
+                                          (get_local $5)
+                                        )
+                                      )
+                                      (i32.const 65)
+                                    )
+                                  )
+                                )
+                                (block $switch-default$33
+                                  (block $switch-case$32
+                                    (block $switch-case$31
+                                      (block $switch-case$30
+                                        (block $switch-case$29
+                                          (block $switch-case$28
+                                            (block $switch-case$27
+                                              (block $switch-case$26
+                                                (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
+                                                  (i32.sub
+                                                    (get_local $13)
                                                     (i32.const 0)
                                                   )
-                                                  (set_local $36
-                                                    (i32.const 4091)
-                                                  )
-                                                  (set_local $12
-                                                    (i32.const 77)
-                                                  )
-                                                  (get_local $6)
-                                                )
-                                                (block
-                                                  (set_local $5
-                                                    (i32.lt_s
-                                                      (get_local $10)
-                                                      (set_local $1
-                                                        (i32.add
-                                                          (i32.sub
-                                                            (get_local $71)
-                                                            (get_local $6)
-                                                          )
-                                                          (i32.const 1)
-                                                        )
-                                                      )
-                                                    )
-                                                  )
-                                                  (set_local $34
-                                                    (get_local $18)
-                                                  )
-                                                  (set_local $32
-                                                    (select
-                                                      (get_local $1)
-                                                      (get_local $10)
-                                                      (get_local $5)
-                                                    )
-                                                  )
-                                                  (set_local $35
-                                                    (i32.const 0)
-                                                  )
-                                                  (set_local $36
-                                                    (i32.const 4091)
-                                                  )
-                                                  (set_local $12
-                                                    (i32.const 77)
-                                                  )
-                                                  (get_local $6)
                                                 )
                                               )
-                                            )
-                                            (br $switch$24)
-                                          )
-                                        )
-                                        (set_local $5
-                                          (i32.load
-                                            (set_local $1
-                                              (get_local $19)
-                                            )
-                                          )
-                                        )
-                                        (if
-                                          (i32.lt_s
-                                            (set_local $33
-                                              (i32.load offset=4
-                                                (get_local $1)
+                                              (i32.store
+                                                (i32.load
+                                                  (get_local $19)
+                                                )
+                                                (get_local $22)
                                               )
-                                            )
-                                            (i32.const 0)
-                                          )
-                                          (block
-                                            (set_local $1
-                                              (call $_i64Subtract
-                                                (i32.const 0)
-                                                (i32.const 0)
-                                                (get_local $5)
-                                                (get_local $33)
+                                              (set_local $20
+                                                (get_local $9)
                                               )
-                                            )
-                                            (set_local $5
-                                              (i32.load
-                                                (i32.const 168)
+                                              (set_local $1
+                                                (get_local $17)
                                               )
+                                              (set_local $8
+                                                (get_local $21)
+                                              )
+                                              (br $label$continue$L1)
                                             )
                                             (i32.store
-                                              (set_local $33
+                                              (i32.load
                                                 (get_local $19)
                                               )
-                                              (get_local $1)
+                                              (get_local $22)
                                             )
-                                            (i32.store offset=4
-                                              (get_local $33)
-                                              (get_local $5)
+                                            (set_local $20
+                                              (get_local $9)
                                             )
-                                            (set_local $33
-                                              (get_local $1)
+                                            (set_local $1
+                                              (get_local $17)
                                             )
-                                            (set_local $59
-                                              (get_local $5)
+                                            (set_local $8
+                                              (get_local $21)
                                             )
-                                            (set_local $60
-                                              (i32.const 1)
-                                            )
-                                            (set_local $61
-                                              (i32.const 4091)
-                                            )
-                                            (set_local $12
-                                              (i32.const 76)
-                                            )
-                                            (br $label$break$L75)
+                                            (br $label$continue$L1)
                                           )
-                                        )
-                                        (set_local $33
-                                          (if
-                                            (i32.eq
-                                              (i32.and
-                                                (get_local $18)
-                                                (i32.const 2048)
+                                          (i32.store
+                                            (set_local $1
+                                              (i32.load
+                                                (get_local $19)
                                               )
-                                              (i32.const 0)
                                             )
-                                            (block
-                                              (set_local $1
-                                                (select
-                                                  (i32.const 4091)
-                                                  (i32.const 4093)
-                                                  (i32.eq
-                                                    (set_local $6
-                                                      (i32.and
-                                                        (get_local $18)
-                                                        (i32.const 1)
-                                                      )
-                                                    )
-                                                    (i32.const 0)
-                                                  )
+                                            (get_local $22)
+                                          )
+                                          (i32.store offset=4
+                                            (get_local $1)
+                                            (i32.shr_s
+                                              (i32.shl
+                                                (i32.lt_s
+                                                  (get_local $22)
+                                                  (i32.const 0)
                                                 )
+                                                (i32.const 31)
                                               )
-                                              (set_local $59
-                                                (get_local $33)
-                                              )
-                                              (set_local $60
-                                                (get_local $6)
-                                              )
-                                              (set_local $61
-                                                (get_local $1)
-                                              )
-                                              (set_local $12
-                                                (i32.const 76)
-                                              )
-                                              (get_local $5)
-                                            )
-                                            (block
-                                              (set_local $59
-                                                (get_local $33)
-                                              )
-                                              (set_local $60
-                                                (i32.const 1)
-                                              )
-                                              (set_local $61
-                                                (i32.const 4092)
-                                              )
-                                              (set_local $12
-                                                (i32.const 76)
-                                              )
-                                              (get_local $5)
+                                              (i32.const 31)
                                             )
                                           )
-                                        )
-                                        (br $switch$24)
-                                      )
-                                      (set_local $33
-                                        (i32.load
+                                          (set_local $20
+                                            (get_local $9)
+                                          )
                                           (set_local $1
+                                            (get_local $17)
+                                          )
+                                          (set_local $8
+                                            (get_local $21)
+                                          )
+                                          (br $label$continue$L1)
+                                        )
+                                        (i32.store16
+                                          (i32.load
                                             (get_local $19)
                                           )
+                                          (i32.and
+                                            (get_local $22)
+                                            (i32.const 65535)
+                                          )
                                         )
-                                      )
-                                      (set_local $59
-                                        (i32.load offset=4
-                                          (get_local $1)
+                                        (set_local $20
+                                          (get_local $9)
                                         )
-                                      )
-                                      (set_local $60
-                                        (i32.const 0)
-                                      )
-                                      (set_local $61
-                                        (i32.const 4091)
-                                      )
-                                      (set_local $12
-                                        (i32.const 76)
-                                      )
-                                      (br $switch$24)
-                                    )
-                                    (set_local $5
-                                      (i32.load
                                         (set_local $1
+                                          (get_local $17)
+                                        )
+                                        (set_local $8
+                                          (get_local $21)
+                                        )
+                                        (br $label$continue$L1)
+                                      )
+                                      (i32.store8
+                                        (i32.load
                                           (get_local $19)
                                         )
+                                        (i32.and
+                                          (get_local $22)
+                                          (i32.const 255)
+                                        )
                                       )
-                                    )
-                                    (i32.load offset=4
-                                      (get_local $1)
-                                    )
-                                    (i32.store8
-                                      (get_local $72)
-                                      (i32.and
-                                        (get_local $5)
-                                        (i32.const 255)
+                                      (set_local $20
+                                        (get_local $9)
                                       )
+                                      (set_local $1
+                                        (get_local $17)
+                                      )
+                                      (set_local $8
+                                        (get_local $21)
+                                      )
+                                      (br $label$continue$L1)
                                     )
-                                    (set_local $47
-                                      (get_local $72)
-                                    )
-                                    (set_local $37
-                                      (get_local $7)
-                                    )
-                                    (set_local $42
-                                      (i32.const 1)
-                                    )
-                                    (set_local $43
-                                      (i32.const 0)
-                                    )
-                                    (set_local $48
-                                      (i32.const 4091)
-                                    )
-                                    (set_local $49
-                                      (get_local $28)
-                                    )
-                                    (br $switch$24)
-                                  )
-                                  (set_local $50
-                                    (call $_strerror
+                                    (i32.store
                                       (i32.load
-                                        (call $___errno_location)
+                                        (get_local $19)
                                       )
+                                      (get_local $22)
                                     )
+                                    (set_local $20
+                                      (get_local $9)
+                                    )
+                                    (set_local $1
+                                      (get_local $17)
+                                    )
+                                    (set_local $8
+                                      (get_local $21)
+                                    )
+                                    (br $label$continue$L1)
                                   )
-                                  (set_local $12
-                                    (i32.const 82)
-                                  )
-                                  (br $switch$24)
-                                )
-                                (set_local $5
-                                  (i32.ne
+                                  (i32.store
                                     (set_local $1
                                       (i32.load
                                         (get_local $19)
                                       )
                                     )
-                                    (i32.const 0)
+                                    (get_local $22)
                                   )
-                                )
-                                (set_local $50
-                                  (select
+                                  (i32.store offset=4
                                     (get_local $1)
-                                    (i32.const 4101)
-                                    (get_local $5)
+                                    (i32.shr_s
+                                      (i32.shl
+                                        (i32.lt_s
+                                          (get_local $22)
+                                          (i32.const 0)
+                                        )
+                                        (i32.const 31)
+                                      )
+                                      (i32.const 31)
+                                    )
                                   )
-                                )
-                                (set_local $12
-                                  (i32.const 82)
-                                )
-                                (br $switch$24)
-                              )
-                              (set_local $5
-                                (i32.load
+                                  (set_local $20
+                                    (get_local $9)
+                                  )
                                   (set_local $1
-                                    (get_local $19)
+                                    (get_local $17)
+                                  )
+                                  (set_local $8
+                                    (get_local $21)
+                                  )
+                                  (br $label$continue$L1)
+                                )
+                                (set_local $20
+                                  (get_local $9)
+                                )
+                                (set_local $1
+                                  (get_local $17)
+                                )
+                                (set_local $8
+                                  (get_local $21)
+                                )
+                                (br $label$continue$L1)
+                              )
+                              (set_local $46
+                                (i32.or
+                                  (get_local $18)
+                                  (i32.const 8)
+                                )
+                              )
+                              (set_local $57
+                                (select
+                                  (get_local $10)
+                                  (i32.const 8)
+                                  (i32.gt_u
+                                    (get_local $10)
+                                    (i32.const 8)
                                   )
                                 )
                               )
-                              (i32.load offset=4
-                                (get_local $1)
-                              )
-                              (i32.store
-                                (get_local $73)
-                                (get_local $5)
-                              )
-                              (i32.store
-                                (get_local $76)
-                                (i32.const 0)
-                              )
-                              (i32.store
-                                (get_local $19)
-                                (get_local $73)
-                              )
-                              (set_local $69
-                                (i32.const -1)
+                              (set_local $68
+                                (i32.const 120)
                               )
                               (set_local $12
-                                (i32.const 86)
+                                (i32.const 64)
                               )
                               (br $switch$24)
                             )
+                            (set_local $46
+                              (get_local $18)
+                            )
+                            (set_local $57
+                              (get_local $10)
+                            )
+                            (set_local $68
+                              (get_local $26)
+                            )
                             (set_local $12
-                              (if
-                                (i32.eq
+                              (i32.const 64)
+                            )
+                            (br $switch$24)
+                          )
+                          (if
+                            (i32.and
+                              (i32.eq
+                                (set_local $5
+                                  (i32.load
+                                    (set_local $1
+                                      (get_local $19)
+                                    )
+                                  )
+                                )
+                                (i32.const 0)
+                              )
+                              (i32.eq
+                                (set_local $1
+                                  (i32.load offset=4
+                                    (get_local $1)
+                                  )
+                                )
+                                (i32.const 0)
+                              )
+                            )
+                            (set_local $6
+                              (get_local $28)
+                            )
+                            (block
+                              (set_local $6
+                                (get_local $28)
+                              )
+                              (loop $while-out$38 $while-in$39
+                                (i32.store8
+                                  (set_local $6
+                                    (i32.add
+                                      (get_local $6)
+                                      (i32.const -1)
+                                    )
+                                  )
+                                  (i32.and
+                                    (i32.or
+                                      (i32.and
+                                        (get_local $5)
+                                        (i32.const 7)
+                                      )
+                                      (i32.const 48)
+                                    )
+                                    (i32.const 255)
+                                  )
+                                )
+                                (if
+                                  (i32.and
+                                    (i32.eq
+                                      (set_local $5
+                                        (call $_bitshift64Lshr
+                                          (get_local $5)
+                                          (get_local $1)
+                                          (i32.const 3)
+                                        )
+                                      )
+                                      (i32.const 0)
+                                    )
+                                    (i32.eq
+                                      (set_local $1
+                                        (i32.load
+                                          (i32.const 168)
+                                        )
+                                      )
+                                      (i32.const 0)
+                                    )
+                                  )
+                                  (br $while-out$38)
+                                )
+                                (br $while-in$39)
+                              )
+                            )
+                          )
+                          (set_local $58
+                            (if
+                              (i32.eq
+                                (i32.and
+                                  (get_local $18)
+                                  (i32.const 8)
+                                )
+                                (i32.const 0)
+                              )
+                              (block
+                                (set_local $34
+                                  (get_local $18)
+                                )
+                                (set_local $32
                                   (get_local $10)
+                                )
+                                (set_local $35
                                   (i32.const 0)
                                 )
-                                (block
-                                  (call $_pad
-                                    (get_local $0)
-                                    (i32.const 32)
-                                    (get_local $16)
-                                    (i32.const 0)
-                                    (get_local $18)
-                                  )
-                                  (set_local $38
-                                    (i32.const 0)
-                                  )
-                                  (i32.const 98)
+                                (set_local $36
+                                  (i32.const 4091)
                                 )
-                                (block
-                                  (set_local $69
-                                    (get_local $10)
-                                  )
-                                  (i32.const 86)
+                                (set_local $12
+                                  (i32.const 77)
                                 )
+                                (get_local $6)
                               )
+                              (block
+                                (set_local $5
+                                  (i32.lt_s
+                                    (get_local $10)
+                                    (set_local $1
+                                      (i32.add
+                                        (i32.sub
+                                          (get_local $71)
+                                          (get_local $6)
+                                        )
+                                        (i32.const 1)
+                                      )
+                                    )
+                                  )
+                                )
+                                (set_local $34
+                                  (get_local $18)
+                                )
+                                (set_local $32
+                                  (select
+                                    (get_local $1)
+                                    (get_local $10)
+                                    (get_local $5)
+                                  )
+                                )
+                                (set_local $35
+                                  (i32.const 0)
+                                )
+                                (set_local $36
+                                  (i32.const 4091)
+                                )
+                                (set_local $12
+                                  (i32.const 77)
+                                )
+                                (get_local $6)
+                              )
+                            )
+                          )
+                          (br $switch$24)
+                        )
+                        (set_local $5
+                          (i32.load
+                            (set_local $1
+                              (get_local $19)
+                            )
+                          )
+                        )
+                        (if
+                          (i32.lt_s
+                            (set_local $33
+                              (i32.load offset=4
+                                (get_local $1)
+                              )
+                            )
+                            (i32.const 0)
+                          )
+                          (block
+                            (set_local $1
+                              (call $_i64Subtract
+                                (i32.const 0)
+                                (i32.const 0)
+                                (get_local $5)
+                                (get_local $33)
+                              )
+                            )
+                            (set_local $5
+                              (i32.load
+                                (i32.const 168)
+                              )
+                            )
+                            (i32.store
+                              (set_local $33
+                                (get_local $19)
+                              )
+                              (get_local $1)
+                            )
+                            (i32.store offset=4
+                              (get_local $33)
+                              (get_local $5)
+                            )
+                            (set_local $33
+                              (get_local $1)
+                            )
+                            (set_local $59
+                              (get_local $5)
+                            )
+                            (set_local $60
+                              (i32.const 1)
+                            )
+                            (set_local $61
+                              (i32.const 4091)
+                            )
+                            (set_local $12
+                              (i32.const 76)
                             )
                             (br $switch$24)
                           )
                         )
+                        (set_local $33
+                          (if
+                            (i32.eq
+                              (i32.and
+                                (get_local $18)
+                                (i32.const 2048)
+                              )
+                              (i32.const 0)
+                            )
+                            (block
+                              (set_local $1
+                                (select
+                                  (i32.const 4091)
+                                  (i32.const 4093)
+                                  (i32.eq
+                                    (set_local $6
+                                      (i32.and
+                                        (get_local $18)
+                                        (i32.const 1)
+                                      )
+                                    )
+                                    (i32.const 0)
+                                  )
+                                )
+                              )
+                              (set_local $59
+                                (get_local $33)
+                              )
+                              (set_local $60
+                                (get_local $6)
+                              )
+                              (set_local $61
+                                (get_local $1)
+                              )
+                              (set_local $12
+                                (i32.const 76)
+                              )
+                              (get_local $5)
+                            )
+                            (block
+                              (set_local $59
+                                (get_local $33)
+                              )
+                              (set_local $60
+                                (i32.const 1)
+                              )
+                              (set_local $61
+                                (i32.const 4092)
+                              )
+                              (set_local $12
+                                (i32.const 76)
+                              )
+                              (get_local $5)
+                            )
+                          )
+                        )
+                        (br $switch$24)
+                      )
+                      (set_local $33
+                        (i32.load
+                          (set_local $1
+                            (get_local $19)
+                          )
+                        )
+                      )
+                      (set_local $59
+                        (i32.load offset=4
+                          (get_local $1)
+                        )
+                      )
+                      (set_local $60
+                        (i32.const 0)
+                      )
+                      (set_local $61
+                        (i32.const 4091)
+                      )
+                      (set_local $12
+                        (i32.const 76)
+                      )
+                      (br $switch$24)
+                    )
+                    (set_local $5
+                      (i32.load
+                        (set_local $1
+                          (get_local $19)
+                        )
+                      )
+                    )
+                    (i32.load offset=4
+                      (get_local $1)
+                    )
+                    (i32.store8
+                      (get_local $72)
+                      (i32.and
+                        (get_local $5)
+                        (i32.const 255)
+                      )
+                    )
+                    (set_local $47
+                      (get_local $72)
+                    )
+                    (set_local $37
+                      (get_local $7)
+                    )
+                    (set_local $42
+                      (i32.const 1)
+                    )
+                    (set_local $43
+                      (i32.const 0)
+                    )
+                    (set_local $48
+                      (i32.const 4091)
+                    )
+                    (set_local $49
+                      (get_local $28)
+                    )
+                    (br $switch$24)
+                  )
+                  (set_local $50
+                    (call $_strerror
+                      (i32.load
+                        (call $___errno_location)
                       )
                     )
                   )
+                  (set_local $12
+                    (i32.const 82)
+                  )
+                  (br $switch$24)
+                )
+                (set_local $5
+                  (i32.ne
+                    (set_local $1
+                      (i32.load
+                        (get_local $19)
+                      )
+                    )
+                    (i32.const 0)
+                  )
+                )
+                (set_local $50
+                  (select
+                    (get_local $1)
+                    (i32.const 4101)
+                    (get_local $5)
+                  )
+                )
+                (set_local $12
+                  (i32.const 82)
+                )
+                (br $switch$24)
+              )
+              (set_local $5
+                (i32.load
+                  (set_local $1
+                    (get_local $19)
+                  )
+                )
+              )
+              (i32.load offset=4
+                (get_local $1)
+              )
+              (i32.store
+                (get_local $73)
+                (get_local $5)
+              )
+              (i32.store
+                (get_local $76)
+                (i32.const 0)
+              )
+              (i32.store
+                (get_local $19)
+                (get_local $73)
+              )
+              (set_local $69
+                (i32.const -1)
+              )
+              (set_local $12
+                (i32.const 86)
+              )
+              (br $switch$24)
+            )
+            (set_local $12
+              (if
+                (i32.eq
+                  (get_local $10)
+                  (i32.const 0)
+                )
+                (block
+                  (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $16)
+                    (i32.const 0)
+                    (get_local $18)
+                  )
+                  (set_local $38
+                    (i32.const 0)
+                  )
+                  (i32.const 98)
+                )
+                (block
+                  (set_local $69
+                    (get_local $10)
+                  )
+                  (i32.const 86)
                 )
               )
             )
-            (set_local $15
-              (f64.load
-                (get_local $19)
-              )
+            (br $switch$24)
+          )
+          (set_local $15
+            (f64.load
+              (get_local $19)
             )
-            (i32.store
-              (get_local $25)
-              (i32.const 0)
-            )
-            (f64.store
-              (i32.load
-                (i32.const 24)
-              )
-              (get_local $15)
-            )
+          )
+          (i32.store
+            (get_local $25)
+            (i32.const 0)
+          )
+          (f64.store
             (i32.load
-              (i32.load
-                (i32.const 24)
-              )
+              (i32.const 24)
             )
-            (set_local $51
+            (get_local $15)
+          )
+          (i32.load
+            (i32.load
+              (i32.const 24)
+            )
+          )
+          (set_local $51
+            (if
+              (i32.lt_s
+                (i32.load offset=4
+                  (i32.load
+                    (i32.const 24)
+                  )
+                )
+                (i32.const 0)
+              )
+              (block
+                (set_local $39
+                  (i32.const 4108)
+                )
+                (set_local $15
+                  (f64.neg
+                    (get_local $15)
+                  )
+                )
+                (i32.const 1)
+              )
               (if
-                (i32.lt_s
-                  (i32.load offset=4
-                    (i32.load
-                      (i32.const 24)
-                    )
+                (i32.eq
+                  (i32.and
+                    (get_local $18)
+                    (i32.const 2048)
                   )
                   (i32.const 0)
                 )
                 (block
                   (set_local $39
-                    (i32.const 4108)
-                  )
-                  (set_local $15
-                    (f64.neg
-                      (get_local $15)
+                    (select
+                      (i32.const 4109)
+                      (i32.const 4114)
+                      (i32.eq
+                        (set_local $1
+                          (i32.and
+                            (get_local $18)
+                            (i32.const 1)
+                          )
+                        )
+                        (i32.const 0)
+                      )
                     )
+                  )
+                  (get_local $1)
+                )
+                (block
+                  (set_local $39
+                    (i32.const 4111)
                   )
                   (i32.const 1)
                 )
-                (if
-                  (i32.eq
-                    (i32.and
-                      (get_local $18)
-                      (i32.const 2048)
+              )
+            )
+          )
+          (f64.store
+            (i32.load
+              (i32.const 24)
+            )
+            (get_local $15)
+          )
+          (i32.load
+            (i32.load
+              (i32.const 24)
+            )
+          )
+          (set_local $20
+            (get_local $9)
+          )
+          (set_local $1
+            (block $do-once$56
+              (if
+                (i32.or
+                  (i32.lt_u
+                    (set_local $1
+                      (i32.and
+                        (i32.load offset=4
+                          (i32.load
+                            (i32.const 24)
+                          )
+                        )
+                        (i32.const 2146435072)
+                      )
+                    )
+                    (i32.const 2146435072)
+                  )
+                  (i32.and
+                    (i32.eq
+                      (get_local $1)
+                      (i32.const 2146435072)
                     )
                     (i32.const 0)
                   )
-                  (block
-                    (set_local $39
-                      (select
-                        (i32.const 4109)
-                        (i32.const 4114)
-                        (i32.eq
+                )
+                (block
+                  (if
+                    (set_local $5
+                      (f64.ne
+                        (set_local $15
+                          (f64.mul
+                            (call $_frexpl
+                              (get_local $15)
+                              (get_local $25)
+                            )
+                            (f64.const 2)
+                          )
+                        )
+                        (f64.const 0)
+                      )
+                    )
+                    (i32.store
+                      (get_local $25)
+                      (i32.add
+                        (i32.load
+                          (get_local $25)
+                        )
+                        (i32.const -1)
+                      )
+                    )
+                  )
+                  (if
+                    (i32.eq
+                      (set_local $14
+                        (i32.or
+                          (get_local $26)
+                          (i32.const 32)
+                        )
+                      )
+                      (i32.const 97)
+                    )
+                    (block
+                      (set_local $9
+                        (select
+                          (get_local $39)
+                          (i32.add
+                            (get_local $39)
+                            (i32.const 9)
+                          )
+                          (i32.eq
+                            (set_local $6
+                              (i32.and
+                                (get_local $26)
+                                (i32.const 32)
+                              )
+                            )
+                            (i32.const 0)
+                          )
+                        )
+                      )
+                      (set_local $7
+                        (i32.or
+                          (get_local $51)
+                          (i32.const 2)
+                        )
+                      )
+                      (set_local $15
+                        (if
+                          (i32.or
+                            (i32.gt_u
+                              (get_local $10)
+                              (i32.const 11)
+                            )
+                            (i32.eq
+                              (set_local $1
+                                (i32.sub
+                                  (i32.const 12)
+                                  (get_local $10)
+                                )
+                              )
+                              (i32.const 0)
+                            )
+                          )
+                          (get_local $15)
+                          (block
+                            (set_local $30
+                              (f64.const 8)
+                            )
+                            (loop $while-out$60 $while-in$61
+                              (set_local $30
+                                (f64.mul
+                                  (get_local $30)
+                                  (f64.const 16)
+                                )
+                              )
+                              (if
+                                (i32.eq
+                                  (set_local $1
+                                    (i32.add
+                                      (get_local $1)
+                                      (i32.const -1)
+                                    )
+                                  )
+                                  (i32.const 0)
+                                )
+                                (br $while-out$60)
+                              )
+                              (br $while-in$61)
+                            )
+                            (select
+                              (f64.neg
+                                (f64.add
+                                  (get_local $30)
+                                  (f64.sub
+                                    (f64.neg
+                                      (get_local $15)
+                                    )
+                                    (get_local $30)
+                                  )
+                                )
+                              )
+                              (f64.sub
+                                (f64.add
+                                  (get_local $15)
+                                  (get_local $30)
+                                )
+                                (get_local $30)
+                              )
+                              (i32.eq
+                                (i32.shr_s
+                                  (i32.shl
+                                    (i32.load8_s
+                                      (get_local $9)
+                                    )
+                                    (i32.const 24)
+                                  )
+                                  (i32.const 24)
+                                )
+                                (i32.const 45)
+                              )
+                            )
+                          )
+                        )
+                      )
+                      (set_local $5
+                        (i32.lt_s
                           (set_local $1
+                            (i32.load
+                              (get_local $25)
+                            )
+                          )
+                          (i32.const 0)
+                        )
+                      )
+                      (set_local $5
+                        (i32.shr_s
+                          (i32.shl
+                            (i32.lt_s
+                              (set_local $8
+                                (select
+                                  (i32.sub
+                                    (i32.const 0)
+                                    (get_local $1)
+                                  )
+                                  (get_local $1)
+                                  (get_local $5)
+                                )
+                              )
+                              (i32.const 0)
+                            )
+                            (i32.const 31)
+                          )
+                          (i32.const 31)
+                        )
+                      )
+                      (i32.store8
+                        (i32.add
+                          (set_local $5
+                            (if
+                              (i32.eq
+                                (set_local $5
+                                  (call $_fmt_u
+                                    (get_local $8)
+                                    (get_local $5)
+                                    (get_local $52)
+                                  )
+                                )
+                                (get_local $52)
+                              )
+                              (block
+                                (i32.store8
+                                  (get_local $74)
+                                  (i32.const 48)
+                                )
+                                (get_local $74)
+                              )
+                              (get_local $5)
+                            )
+                          )
+                          (i32.const -1)
+                        )
+                        (i32.and
+                          (i32.add
                             (i32.and
-                              (get_local $18)
-                              (i32.const 1)
+                              (i32.shr_s
+                                (get_local $1)
+                                (i32.const 31)
+                              )
+                              (i32.const 2)
+                            )
+                            (i32.const 43)
+                          )
+                          (i32.const 255)
+                        )
+                      )
+                      (i32.store8
+                        (set_local $8
+                          (i32.add
+                            (get_local $5)
+                            (i32.const -2)
+                          )
+                        )
+                        (i32.and
+                          (i32.add
+                            (get_local $26)
+                            (i32.const 15)
+                          )
+                          (i32.const 255)
+                        )
+                      )
+                      (set_local $5
+                        (i32.lt_s
+                          (get_local $10)
+                          (i32.const 1)
+                        )
+                      )
+                      (set_local $13
+                        (i32.eq
+                          (i32.and
+                            (get_local $18)
+                            (i32.const 8)
+                          )
+                          (i32.const 0)
+                        )
+                      )
+                      (set_local $11
+                        (get_local $29)
+                      )
+                      (loop $while-out$62 $while-in$63
+                        (i32.store8
+                          (get_local $11)
+                          (i32.and
+                            (i32.or
+                              (i32.and
+                                (i32.load8_s
+                                  (i32.add
+                                    (set_local $1
+                                      (i32.trunc_s/f64
+                                        (get_local $15)
+                                      )
+                                    )
+                                    (i32.const 4075)
+                                  )
+                                )
+                                (i32.const 255)
+                              )
+                              (get_local $6)
+                            )
+                            (i32.const 255)
+                          )
+                        )
+                        (set_local $15
+                          (f64.mul
+                            (f64.sub
+                              (get_local $15)
+                              (f64.convert_s/i32
+                                (get_local $1)
+                              )
+                            )
+                            (f64.const 16)
+                          )
+                        )
+                        (set_local $11
+                          (block $do-once$64
+                            (if
+                              (i32.eq
+                                (i32.sub
+                                  (set_local $1
+                                    (i32.add
+                                      (get_local $11)
+                                      (i32.const 1)
+                                    )
+                                  )
+                                  (get_local $64)
+                                )
+                                (i32.const 1)
+                              )
+                              (block
+                                (br_if $do-once$64
+                                  (get_local $1)
+                                  (i32.and
+                                    (get_local $13)
+                                    (i32.and
+                                      (get_local $5)
+                                      (f64.eq
+                                        (get_local $15)
+                                        (f64.const 0)
+                                      )
+                                    )
+                                  )
+                                )
+                                (i32.store8
+                                  (get_local $1)
+                                  (i32.const 46)
+                                )
+                                (i32.add
+                                  (get_local $11)
+                                  (i32.const 2)
+                                )
+                              )
+                              (get_local $1)
+                            )
+                          )
+                        )
+                        (if
+                          (f64.eq
+                            (get_local $15)
+                            (f64.const 0)
+                          )
+                          (block
+                            (set_local $1
+                              (get_local $11)
+                            )
+                            (br $while-out$62)
+                          )
+                        )
+                        (br $while-in$63)
+                      )
+                      (set_local $5
+                        (i32.and
+                          (i32.ne
+                            (get_local $10)
+                            (i32.const 0)
+                          )
+                          (i32.lt_s
+                            (i32.add
+                              (get_local $78)
+                              (get_local $1)
+                            )
+                            (get_local $10)
+                          )
+                        )
+                      )
+                      (call $_pad
+                        (get_local $0)
+                        (i32.const 32)
+                        (get_local $16)
+                        (set_local $5
+                          (i32.add
+                            (set_local $6
+                              (select
+                                (i32.sub
+                                  (i32.add
+                                    (get_local $79)
+                                    (get_local $10)
+                                  )
+                                  (get_local $8)
+                                )
+                                (i32.add
+                                  (i32.sub
+                                    (get_local $77)
+                                    (get_local $8)
+                                  )
+                                  (get_local $1)
+                                )
+                                (get_local $5)
+                              )
+                            )
+                            (get_local $7)
+                          )
+                        )
+                        (get_local $18)
+                      )
+                      (if
+                        (i32.eq
+                          (i32.and
+                            (i32.load
+                              (get_local $0)
+                            )
+                            (i32.const 32)
+                          )
+                          (i32.const 0)
+                        )
+                        (call $___fwritex
+                          (get_local $9)
+                          (get_local $7)
+                          (get_local $0)
+                        )
+                      )
+                      (call $_pad
+                        (get_local $0)
+                        (i32.const 48)
+                        (get_local $16)
+                        (get_local $5)
+                        (i32.xor
+                          (get_local $18)
+                          (i32.const 65536)
+                        )
+                      )
+                      (set_local $1
+                        (i32.sub
+                          (get_local $1)
+                          (get_local $64)
+                        )
+                      )
+                      (if
+                        (i32.eq
+                          (i32.and
+                            (i32.load
+                              (get_local $0)
+                            )
+                            (i32.const 32)
+                          )
+                          (i32.const 0)
+                        )
+                        (call $___fwritex
+                          (get_local $29)
+                          (get_local $1)
+                          (get_local $0)
+                        )
+                      )
+                      (call $_pad
+                        (get_local $0)
+                        (i32.const 48)
+                        (i32.sub
+                          (get_local $6)
+                          (i32.add
+                            (get_local $1)
+                            (set_local $1
+                              (i32.sub
+                                (get_local $40)
+                                (get_local $8)
+                              )
+                            )
+                          )
+                        )
+                        (i32.const 0)
+                        (i32.const 0)
+                      )
+                      (if
+                        (i32.eq
+                          (i32.and
+                            (i32.load
+                              (get_local $0)
+                            )
+                            (i32.const 32)
+                          )
+                          (i32.const 0)
+                        )
+                        (call $___fwritex
+                          (get_local $8)
+                          (get_local $1)
+                          (get_local $0)
+                        )
+                      )
+                      (call $_pad
+                        (get_local $0)
+                        (i32.const 32)
+                        (get_local $16)
+                        (get_local $5)
+                        (i32.xor
+                          (get_local $18)
+                          (i32.const 8192)
+                        )
+                      )
+                      (br $do-once$56
+                        (select
+                          (get_local $16)
+                          (get_local $5)
+                          (i32.lt_s
+                            (get_local $5)
+                            (get_local $16)
+                          )
+                        )
+                      )
+                    )
+                  )
+                  (set_local $1
+                    (select
+                      (i32.const 6)
+                      (get_local $10)
+                      (i32.lt_s
+                        (get_local $10)
+                        (i32.const 0)
+                      )
+                    )
+                  )
+                  (set_local $62
+                    (set_local $9
+                      (select
+                        (get_local $80)
+                        (get_local $81)
+                        (i32.lt_s
+                          (if
+                            (get_local $5)
+                            (block
+                              (i32.store
+                                (get_local $25)
+                                (set_local $5
+                                  (i32.add
+                                    (i32.load
+                                      (get_local $25)
+                                    )
+                                    (i32.const -28)
+                                  )
+                                )
+                              )
+                              (set_local $15
+                                (f64.mul
+                                  (get_local $15)
+                                  (f64.const 268435456)
+                                )
+                              )
+                              (get_local $5)
+                            )
+                            (i32.load
+                              (get_local $25)
                             )
                           )
                           (i32.const 0)
                         )
                       )
                     )
-                    (get_local $1)
                   )
-                  (block
-                    (set_local $39
-                      (i32.const 4111)
-                    )
-                    (i32.const 1)
+                  (set_local $7
+                    (get_local $9)
                   )
-                )
-              )
-            )
-            (f64.store
-              (i32.load
-                (i32.const 24)
-              )
-              (get_local $15)
-            )
-            (i32.load
-              (i32.load
-                (i32.const 24)
-              )
-            )
-            (set_local $20
-              (get_local $9)
-            )
-            (set_local $1
-              (block $do-once$56
-                (if
-                  (i32.or
-                    (i32.lt_u
-                      (set_local $1
-                        (i32.and
-                          (i32.load offset=4
-                            (i32.load
-                              (i32.const 24)
-                            )
-                          )
-                          (i32.const 2146435072)
+                  (loop $while-out$66 $while-in$67
+                    (i32.store
+                      (get_local $7)
+                      (set_local $5
+                        (i32.trunc_s/f64
+                          (get_local $15)
                         )
                       )
-                      (i32.const 2146435072)
                     )
-                    (i32.and
-                      (i32.eq
-                        (get_local $1)
-                        (i32.const 2146435072)
+                    (set_local $7
+                      (i32.add
+                        (get_local $7)
+                        (i32.const 4)
+                      )
+                    )
+                    (if
+                      (f64.eq
+                        (set_local $15
+                          (f64.mul
+                            (f64.sub
+                              (get_local $15)
+                              (f64.convert_u/i32
+                                (get_local $5)
+                              )
+                            )
+                            (f64.const 1e9)
+                          )
+                        )
+                        (f64.const 0)
+                      )
+                      (block
+                        (set_local $6
+                          (get_local $7)
+                        )
+                        (br $while-out$66)
+                      )
+                    )
+                    (br $while-in$67)
+                  )
+                  (if
+                    (i32.gt_s
+                      (set_local $5
+                        (i32.load
+                          (get_local $25)
+                        )
                       )
                       (i32.const 0)
                     )
-                  )
-                  (block
-                    (if
-                      (set_local $5
-                        (f64.ne
-                          (set_local $15
-                            (f64.mul
-                              (call $_frexpl
-                                (get_local $15)
-                                (get_local $25)
-                              )
-                              (f64.const 2)
+                    (block
+                      (set_local $8
+                        (get_local $9)
+                      )
+                      (set_local $13
+                        (get_local $6)
+                      )
+                      (loop $while-out$68 $while-in$69
+                        (set_local $11
+                          (select
+                            (i32.const 29)
+                            (get_local $5)
+                            (i32.gt_s
+                              (get_local $5)
+                              (i32.const 29)
                             )
                           )
-                          (f64.const 0)
+                        )
+                        (set_local $7
+                          (block $do-once$70
+                            (if
+                              (i32.lt_u
+                                (set_local $7
+                                  (i32.add
+                                    (get_local $13)
+                                    (i32.const -4)
+                                  )
+                                )
+                                (get_local $8)
+                              )
+                              (get_local $8)
+                              (block
+                                (set_local $5
+                                  (i32.const 0)
+                                )
+                                (set_local $10
+                                  (get_local $7)
+                                )
+                                (loop $while-out$72 $while-in$73
+                                  (set_local $6
+                                    (call $___uremdi3
+                                      (set_local $5
+                                        (call $_i64Add
+                                          (call $_bitshift64Shl
+                                            (i32.load
+                                              (get_local $10)
+                                            )
+                                            (i32.const 0)
+                                            (get_local $11)
+                                          )
+                                          (i32.load
+                                            (i32.const 168)
+                                          )
+                                          (get_local $5)
+                                          (i32.const 0)
+                                        )
+                                      )
+                                      (set_local $7
+                                        (i32.load
+                                          (i32.const 168)
+                                        )
+                                      )
+                                      (i32.const 1000000000)
+                                      (i32.const 0)
+                                    )
+                                  )
+                                  (i32.load
+                                    (i32.const 168)
+                                  )
+                                  (i32.store
+                                    (get_local $10)
+                                    (get_local $6)
+                                  )
+                                  (set_local $5
+                                    (call $___udivdi3
+                                      (get_local $5)
+                                      (get_local $7)
+                                      (i32.const 1000000000)
+                                      (i32.const 0)
+                                    )
+                                  )
+                                  (i32.load
+                                    (i32.const 168)
+                                  )
+                                  (if
+                                    (i32.lt_u
+                                      (set_local $7
+                                        (i32.add
+                                          (get_local $10)
+                                          (i32.const -4)
+                                        )
+                                      )
+                                      (get_local $8)
+                                    )
+                                    (br $while-out$72)
+                                    (set_local $10
+                                      (get_local $7)
+                                    )
+                                  )
+                                  (br $while-in$73)
+                                )
+                                (br_if $do-once$70
+                                  (get_local $8)
+                                  (i32.eq
+                                    (get_local $5)
+                                    (i32.const 0)
+                                  )
+                                )
+                                (i32.store
+                                  (set_local $7
+                                    (i32.add
+                                      (get_local $8)
+                                      (i32.const -4)
+                                    )
+                                  )
+                                  (get_local $5)
+                                )
+                                (get_local $7)
+                              )
+                            )
+                          )
+                        )
+                        (loop $while-out$74 $while-in$75
+                          (if
+                            (i32.le_u
+                              (get_local $13)
+                              (get_local $7)
+                            )
+                            (br $while-out$74)
+                          )
+                          (if
+                            (i32.eq
+                              (i32.load
+                                (set_local $5
+                                  (i32.add
+                                    (get_local $13)
+                                    (i32.const -4)
+                                  )
+                                )
+                              )
+                              (i32.const 0)
+                            )
+                            (set_local $13
+                              (get_local $5)
+                            )
+                            (br $while-out$74)
+                          )
+                          (br $while-in$75)
+                        )
+                        (i32.store
+                          (get_local $25)
+                          (set_local $5
+                            (i32.sub
+                              (i32.load
+                                (get_local $25)
+                              )
+                              (get_local $11)
+                            )
+                          )
+                        )
+                        (if
+                          (i32.gt_s
+                            (get_local $5)
+                            (i32.const 0)
+                          )
+                          (set_local $8
+                            (get_local $7)
+                          )
+                          (block
+                            (set_local $6
+                              (get_local $13)
+                            )
+                            (br $while-out$68)
+                          )
+                        )
+                        (br $while-in$69)
+                      )
+                    )
+                    (set_local $7
+                      (get_local $9)
+                    )
+                  )
+                  (if
+                    (i32.lt_s
+                      (get_local $5)
+                      (i32.const 0)
+                    )
+                    (block
+                      (set_local $8
+                        (i32.add
+                          (i32.and
+                            (i32.div_s
+                              (i32.add
+                                (get_local $1)
+                                (i32.const 25)
+                              )
+                              (i32.const 9)
+                            )
+                            (i32.const -1)
+                          )
+                          (i32.const 1)
                         )
                       )
-                      (i32.store
-                        (get_local $25)
-                        (i32.add
-                          (i32.load
-                            (get_local $25)
-                          )
-                          (i32.const -1)
+                      (set_local $10
+                        (i32.eq
+                          (get_local $14)
+                          (i32.const 102)
                         )
+                      )
+                      (set_local $23
+                        (get_local $6)
+                      )
+                      (loop $while-out$76 $while-in$77
+                        (set_local $5
+                          (i32.gt_s
+                            (set_local $6
+                              (i32.sub
+                                (i32.const 0)
+                                (get_local $5)
+                              )
+                            )
+                            (i32.const 9)
+                          )
+                        )
+                        (set_local $13
+                          (select
+                            (i32.const 9)
+                            (get_local $6)
+                            (get_local $5)
+                          )
+                        )
+                        (set_local $11
+                          (block $do-once$78
+                            (if
+                              (i32.lt_u
+                                (get_local $7)
+                                (get_local $23)
+                              )
+                              (block
+                                (set_local $70
+                                  (i32.add
+                                    (i32.shl
+                                      (i32.const 1)
+                                      (get_local $13)
+                                    )
+                                    (i32.const -1)
+                                  )
+                                )
+                                (set_local $27
+                                  (i32.shr_u
+                                    (i32.const 1000000000)
+                                    (get_local $13)
+                                  )
+                                )
+                                (set_local $11
+                                  (i32.const 0)
+                                )
+                                (set_local $17
+                                  (get_local $7)
+                                )
+                                (loop $while-out$80 $while-in$81
+                                  (set_local $6
+                                    (i32.and
+                                      (set_local $5
+                                        (i32.load
+                                          (get_local $17)
+                                        )
+                                      )
+                                      (get_local $70)
+                                    )
+                                  )
+                                  (i32.store
+                                    (get_local $17)
+                                    (i32.add
+                                      (i32.shr_u
+                                        (get_local $5)
+                                        (get_local $13)
+                                      )
+                                      (get_local $11)
+                                    )
+                                  )
+                                  (set_local $11
+                                    (i32.mul
+                                      (get_local $6)
+                                      (get_local $27)
+                                    )
+                                  )
+                                  (if
+                                    (i32.ge_u
+                                      (set_local $17
+                                        (i32.add
+                                          (get_local $17)
+                                          (i32.const 4)
+                                        )
+                                      )
+                                      (get_local $23)
+                                    )
+                                    (br $while-out$80)
+                                  )
+                                  (br $while-in$81)
+                                )
+                                (set_local $5
+                                  (select
+                                    (i32.add
+                                      (get_local $7)
+                                      (i32.const 4)
+                                    )
+                                    (get_local $7)
+                                    (i32.eq
+                                      (i32.load
+                                        (get_local $7)
+                                      )
+                                      (i32.const 0)
+                                    )
+                                  )
+                                )
+                                (if
+                                  (i32.eq
+                                    (get_local $11)
+                                    (i32.const 0)
+                                  )
+                                  (br $do-once$78
+                                    (get_local $5)
+                                  )
+                                )
+                                (i32.store
+                                  (get_local $23)
+                                  (get_local $11)
+                                )
+                                (set_local $23
+                                  (i32.add
+                                    (get_local $23)
+                                    (i32.const 4)
+                                  )
+                                )
+                                (get_local $5)
+                              )
+                              (select
+                                (i32.add
+                                  (get_local $7)
+                                  (i32.const 4)
+                                )
+                                (get_local $7)
+                                (i32.eq
+                                  (i32.load
+                                    (get_local $7)
+                                  )
+                                  (i32.const 0)
+                                )
+                              )
+                            )
+                          )
+                        )
+                        (set_local $5
+                          (i32.gt_s
+                            (i32.shr_s
+                              (i32.sub
+                                (get_local $23)
+                                (set_local $7
+                                  (select
+                                    (get_local $9)
+                                    (get_local $11)
+                                    (get_local $10)
+                                  )
+                                )
+                              )
+                              (i32.const 2)
+                            )
+                            (get_local $8)
+                          )
+                        )
+                        (set_local $6
+                          (select
+                            (i32.add
+                              (get_local $7)
+                              (i32.shl
+                                (get_local $8)
+                                (i32.const 2)
+                              )
+                            )
+                            (get_local $23)
+                            (get_local $5)
+                          )
+                        )
+                        (i32.store
+                          (get_local $25)
+                          (set_local $5
+                            (i32.add
+                              (i32.load
+                                (get_local $25)
+                              )
+                              (get_local $13)
+                            )
+                          )
+                        )
+                        (if
+                          (i32.lt_s
+                            (get_local $5)
+                            (i32.const 0)
+                          )
+                          (block
+                            (set_local $7
+                              (get_local $11)
+                            )
+                            (set_local $23
+                              (get_local $6)
+                            )
+                          )
+                          (block
+                            (set_local $7
+                              (get_local $11)
+                            )
+                            (set_local $27
+                              (get_local $6)
+                            )
+                            (br $while-out$76)
+                          )
+                        )
+                        (br $while-in$77)
+                      )
+                    )
+                    (set_local $27
+                      (get_local $6)
+                    )
+                  )
+                  (block $do-once$82
+                    (if
+                      (i32.lt_u
+                        (get_local $7)
+                        (get_local $27)
+                      )
+                      (block
+                        (set_local $6
+                          (i32.mul
+                            (i32.shr_s
+                              (i32.sub
+                                (get_local $62)
+                                (get_local $7)
+                              )
+                              (i32.const 2)
+                            )
+                            (i32.const 9)
+                          )
+                        )
+                        (if
+                          (i32.lt_u
+                            (set_local $5
+                              (i32.load
+                                (get_local $7)
+                              )
+                            )
+                            (i32.const 10)
+                          )
+                          (block
+                            (set_local $13
+                              (get_local $6)
+                            )
+                            (br $do-once$82)
+                          )
+                          (set_local $8
+                            (i32.const 10)
+                          )
+                        )
+                        (loop $while-out$84 $while-in$85
+                          (set_local $6
+                            (i32.add
+                              (get_local $6)
+                              (i32.const 1)
+                            )
+                          )
+                          (if
+                            (i32.lt_u
+                              (get_local $5)
+                              (set_local $8
+                                (i32.mul
+                                  (get_local $8)
+                                  (i32.const 10)
+                                )
+                              )
+                            )
+                            (block
+                              (set_local $13
+                                (get_local $6)
+                              )
+                              (br $while-out$84)
+                            )
+                          )
+                          (br $while-in$85)
+                        )
+                      )
+                      (set_local $13
+                        (i32.const 0)
+                      )
+                    )
+                  )
+                  (set_local $7
+                    (if
+                      (i32.lt_s
+                        (set_local $5
+                          (i32.add
+                            (i32.sub
+                              (get_local $1)
+                              (select
+                                (get_local $13)
+                                (i32.const 0)
+                                (i32.ne
+                                  (get_local $14)
+                                  (i32.const 102)
+                                )
+                              )
+                            )
+                            (i32.shr_s
+                              (i32.shl
+                                (i32.and
+                                  (set_local $70
+                                    (i32.ne
+                                      (get_local $1)
+                                      (i32.const 0)
+                                    )
+                                  )
+                                  (set_local $8
+                                    (i32.eq
+                                      (get_local $14)
+                                      (i32.const 103)
+                                    )
+                                  )
+                                )
+                                (i32.const 31)
+                              )
+                              (i32.const 31)
+                            )
+                          )
+                        )
+                        (i32.add
+                          (i32.mul
+                            (i32.shr_s
+                              (i32.sub
+                                (get_local $27)
+                                (get_local $62)
+                              )
+                              (i32.const 2)
+                            )
+                            (i32.const 9)
+                          )
+                          (i32.const -9)
+                        )
+                      )
+                      (block
+                        (set_local $6
+                          (i32.add
+                            (i32.add
+                              (get_local $9)
+                              (i32.const 4)
+                            )
+                            (i32.shl
+                              (i32.add
+                                (i32.and
+                                  (i32.div_s
+                                    (set_local $5
+                                      (i32.add
+                                        (get_local $5)
+                                        (i32.const 9216)
+                                      )
+                                    )
+                                    (i32.const 9)
+                                  )
+                                  (i32.const -1)
+                                )
+                                (i32.const -1024)
+                              )
+                              (i32.const 2)
+                            )
+                          )
+                        )
+                        (if
+                          (i32.lt_s
+                            (set_local $11
+                              (i32.add
+                                (i32.and
+                                  (i32.rem_s
+                                    (get_local $5)
+                                    (i32.const 9)
+                                  )
+                                  (i32.const -1)
+                                )
+                                (i32.const 1)
+                              )
+                            )
+                            (i32.const 9)
+                          )
+                          (block
+                            (set_local $5
+                              (i32.const 10)
+                            )
+                            (loop $while-out$86 $while-in$87
+                              (set_local $5
+                                (i32.mul
+                                  (get_local $5)
+                                  (i32.const 10)
+                                )
+                              )
+                              (if
+                                (i32.eq
+                                  (set_local $11
+                                    (i32.add
+                                      (get_local $11)
+                                      (i32.const 1)
+                                    )
+                                  )
+                                  (i32.const 9)
+                                )
+                                (block
+                                  (set_local $17
+                                    (get_local $5)
+                                  )
+                                  (br $while-out$86)
+                                )
+                              )
+                              (br $while-in$87)
+                            )
+                          )
+                          (set_local $17
+                            (i32.const 10)
+                          )
+                        )
+                        (block $do-once$88
+                          (if
+                            (i32.eqz
+                              (i32.and
+                                (set_local $11
+                                  (i32.eq
+                                    (i32.add
+                                      (get_local $6)
+                                      (i32.const 4)
+                                    )
+                                    (get_local $27)
+                                  )
+                                )
+                                (i32.eq
+                                  (set_local $14
+                                    (i32.and
+                                      (i32.rem_u
+                                        (set_local $5
+                                          (i32.load
+                                            (get_local $6)
+                                          )
+                                        )
+                                        (get_local $17)
+                                      )
+                                      (i32.const -1)
+                                    )
+                                  )
+                                  (i32.const 0)
+                                )
+                              )
+                            )
+                            (block
+                              (set_local $15
+                                (select
+                                  (f64.const 9007199254740992)
+                                  (f64.const 9007199254740994)
+                                  (i32.eq
+                                    (i32.and
+                                      (i32.and
+                                        (i32.div_u
+                                          (get_local $5)
+                                          (get_local $17)
+                                        )
+                                        (i32.const -1)
+                                      )
+                                      (i32.const 1)
+                                    )
+                                    (i32.const 0)
+                                  )
+                                )
+                              )
+                              (set_local $30
+                                (if
+                                  (i32.lt_u
+                                    (get_local $14)
+                                    (set_local $10
+                                      (i32.and
+                                        (i32.div_s
+                                          (get_local $17)
+                                          (i32.const 2)
+                                        )
+                                        (i32.const -1)
+                                      )
+                                    )
+                                  )
+                                  (f64.const 0.5)
+                                  (select
+                                    (f64.const 1)
+                                    (f64.const 1.5)
+                                    (i32.and
+                                      (get_local $11)
+                                      (i32.eq
+                                        (get_local $14)
+                                        (get_local $10)
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                              (set_local $15
+                                (block $do-once$90
+                                  (if
+                                    (i32.eq
+                                      (get_local $51)
+                                      (i32.const 0)
+                                    )
+                                    (get_local $15)
+                                    (block
+                                      (if
+                                        (i32.ne
+                                          (i32.shr_s
+                                            (i32.shl
+                                              (i32.load8_s
+                                                (get_local $39)
+                                              )
+                                              (i32.const 24)
+                                            )
+                                            (i32.const 24)
+                                          )
+                                          (i32.const 45)
+                                        )
+                                        (br $do-once$90
+                                          (get_local $15)
+                                        )
+                                      )
+                                      (set_local $30
+                                        (f64.neg
+                                          (get_local $30)
+                                        )
+                                      )
+                                      (f64.neg
+                                        (get_local $15)
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                              (i32.store
+                                (get_local $6)
+                                (set_local $5
+                                  (i32.sub
+                                    (get_local $5)
+                                    (get_local $14)
+                                  )
+                                )
+                              )
+                              (if
+                                (f64.eq
+                                  (f64.add
+                                    (get_local $15)
+                                    (get_local $30)
+                                  )
+                                  (get_local $15)
+                                )
+                                (br $do-once$88)
+                              )
+                              (i32.store
+                                (get_local $6)
+                                (set_local $5
+                                  (i32.add
+                                    (get_local $5)
+                                    (get_local $17)
+                                  )
+                                )
+                              )
+                              (if
+                                (i32.gt_u
+                                  (get_local $5)
+                                  (i32.const 999999999)
+                                )
+                                (loop $while-out$92 $while-in$93
+                                  (i32.store
+                                    (get_local $6)
+                                    (i32.const 0)
+                                  )
+                                  (set_local $7
+                                    (if
+                                      (i32.lt_u
+                                        (set_local $6
+                                          (i32.add
+                                            (get_local $6)
+                                            (i32.const -4)
+                                          )
+                                        )
+                                        (get_local $7)
+                                      )
+                                      (block
+                                        (i32.store
+                                          (set_local $5
+                                            (i32.add
+                                              (get_local $7)
+                                              (i32.const -4)
+                                            )
+                                          )
+                                          (i32.const 0)
+                                        )
+                                        (get_local $5)
+                                      )
+                                      (get_local $7)
+                                    )
+                                  )
+                                  (i32.store
+                                    (get_local $6)
+                                    (set_local $5
+                                      (i32.add
+                                        (i32.load
+                                          (get_local $6)
+                                        )
+                                        (i32.const 1)
+                                      )
+                                    )
+                                  )
+                                  (if
+                                    (i32.le_u
+                                      (get_local $5)
+                                      (i32.const 999999999)
+                                    )
+                                    (br $while-out$92)
+                                  )
+                                  (br $while-in$93)
+                                )
+                              )
+                              (set_local $11
+                                (i32.mul
+                                  (i32.shr_s
+                                    (i32.sub
+                                      (get_local $62)
+                                      (get_local $7)
+                                    )
+                                    (i32.const 2)
+                                  )
+                                  (i32.const 9)
+                                )
+                              )
+                              (if
+                                (i32.lt_u
+                                  (set_local $5
+                                    (i32.load
+                                      (get_local $7)
+                                    )
+                                  )
+                                  (i32.const 10)
+                                )
+                                (block
+                                  (set_local $13
+                                    (get_local $11)
+                                  )
+                                  (br $do-once$88)
+                                )
+                                (set_local $10
+                                  (i32.const 10)
+                                )
+                              )
+                              (loop $while-out$94 $while-in$95
+                                (set_local $11
+                                  (i32.add
+                                    (get_local $11)
+                                    (i32.const 1)
+                                  )
+                                )
+                                (if
+                                  (i32.lt_u
+                                    (get_local $5)
+                                    (set_local $10
+                                      (i32.mul
+                                        (get_local $10)
+                                        (i32.const 10)
+                                      )
+                                    )
+                                  )
+                                  (block
+                                    (set_local $13
+                                      (get_local $11)
+                                    )
+                                    (br $while-out$94)
+                                  )
+                                )
+                                (br $while-in$95)
+                              )
+                            )
+                          )
+                        )
+                        (set_local $6
+                          (i32.gt_u
+                            (get_local $27)
+                            (set_local $5
+                              (i32.add
+                                (get_local $6)
+                                (i32.const 4)
+                              )
+                            )
+                          )
+                        )
+                        (set_local $6
+                          (select
+                            (get_local $5)
+                            (get_local $27)
+                            (get_local $6)
+                          )
+                        )
+                        (get_local $7)
+                      )
+                      (block
+                        (set_local $6
+                          (get_local $27)
+                        )
+                        (get_local $7)
+                      )
+                    )
+                  )
+                  (set_local $27
+                    (i32.sub
+                      (i32.const 0)
+                      (get_local $13)
+                    )
+                  )
+                  (loop $while-out$96 $while-in$97
+                    (if
+                      (i32.le_u
+                        (get_local $6)
+                        (get_local $7)
+                      )
+                      (block
+                        (set_local $11
+                          (i32.const 0)
+                        )
+                        (set_local $23
+                          (get_local $6)
+                        )
+                        (br $while-out$96)
                       )
                     )
                     (if
                       (i32.eq
-                        (set_local $14
-                          (i32.or
-                            (get_local $26)
-                            (i32.const 32)
+                        (i32.load
+                          (set_local $5
+                            (i32.add
+                              (get_local $6)
+                              (i32.const -4)
+                            )
                           )
                         )
-                        (i32.const 97)
+                        (i32.const 0)
+                      )
+                      (set_local $6
+                        (get_local $5)
                       )
                       (block
-                        (set_local $9
-                          (select
-                            (get_local $39)
-                            (i32.add
-                              (get_local $39)
-                              (i32.const 9)
-                            )
-                            (i32.eq
-                              (set_local $6
-                                (i32.and
-                                  (get_local $26)
-                                  (i32.const 32)
+                        (set_local $11
+                          (i32.const 1)
+                        )
+                        (set_local $23
+                          (get_local $6)
+                        )
+                        (br $while-out$96)
+                      )
+                    )
+                    (br $while-in$97)
+                  )
+                  (set_local $8
+                    (block $do-once$98
+                      (if
+                        (get_local $8)
+                        (block
+                          (set_local $8
+                            (if
+                              (i32.and
+                                (i32.gt_s
+                                  (set_local $1
+                                    (i32.add
+                                      (i32.xor
+                                        (i32.and
+                                          (get_local $70)
+                                          (i32.const 1)
+                                        )
+                                        (i32.const 1)
+                                      )
+                                      (get_local $1)
+                                    )
+                                  )
+                                  (get_local $13)
                                 )
+                                (i32.gt_s
+                                  (get_local $13)
+                                  (i32.const -5)
+                                )
+                              )
+                              (block
+                                (set_local $10
+                                  (i32.add
+                                    (get_local $26)
+                                    (i32.const -1)
+                                  )
+                                )
+                                (i32.sub
+                                  (i32.add
+                                    (get_local $1)
+                                    (i32.const -1)
+                                  )
+                                  (get_local $13)
+                                )
+                              )
+                              (block
+                                (set_local $10
+                                  (i32.add
+                                    (get_local $26)
+                                    (i32.const -2)
+                                  )
+                                )
+                                (i32.add
+                                  (get_local $1)
+                                  (i32.const -1)
+                                )
+                              )
+                            )
+                          )
+                          (if
+                            (i32.ne
+                              (set_local $1
+                                (i32.and
+                                  (get_local $18)
+                                  (i32.const 8)
+                                )
+                              )
+                              (i32.const 0)
+                            )
+                            (block
+                              (set_local $14
+                                (get_local $8)
+                              )
+                              (set_local $26
+                                (get_local $10)
+                              )
+                              (br $do-once$98
+                                (get_local $1)
+                              )
+                            )
+                          )
+                          (block $do-once$100
+                            (if
+                              (get_local $11)
+                              (block
+                                (if
+                                  (i32.eq
+                                    (set_local $1
+                                      (i32.load
+                                        (i32.add
+                                          (get_local $23)
+                                          (i32.const -4)
+                                        )
+                                      )
+                                    )
+                                    (i32.const 0)
+                                  )
+                                  (block
+                                    (set_local $6
+                                      (i32.const 9)
+                                    )
+                                    (br $do-once$100)
+                                  )
+                                )
+                                (if
+                                  (i32.eq
+                                    (i32.and
+                                      (i32.rem_u
+                                        (get_local $1)
+                                        (i32.const 10)
+                                      )
+                                      (i32.const -1)
+                                    )
+                                    (i32.const 0)
+                                  )
+                                  (block
+                                    (set_local $5
+                                      (i32.const 10)
+                                    )
+                                    (set_local $6
+                                      (i32.const 0)
+                                    )
+                                  )
+                                  (block
+                                    (set_local $6
+                                      (i32.const 0)
+                                    )
+                                    (br $do-once$100)
+                                  )
+                                )
+                                (loop $while-out$102 $while-in$103
+                                  (set_local $6
+                                    (i32.add
+                                      (get_local $6)
+                                      (i32.const 1)
+                                    )
+                                  )
+                                  (if
+                                    (i32.ne
+                                      (i32.and
+                                        (i32.rem_u
+                                          (get_local $1)
+                                          (set_local $5
+                                            (i32.mul
+                                              (get_local $5)
+                                              (i32.const 10)
+                                            )
+                                          )
+                                        )
+                                        (i32.const -1)
+                                      )
+                                      (i32.const 0)
+                                    )
+                                    (br $while-out$102)
+                                  )
+                                  (br $while-in$103)
+                                )
+                              )
+                              (set_local $6
+                                (i32.const 9)
+                              )
+                            )
+                          )
+                          (set_local $1
+                            (i32.add
+                              (i32.mul
+                                (i32.shr_s
+                                  (i32.sub
+                                    (get_local $23)
+                                    (get_local $62)
+                                  )
+                                  (i32.const 2)
+                                )
+                                (i32.const 9)
+                              )
+                              (i32.const -9)
+                            )
+                          )
+                          (if
+                            (i32.eq
+                              (i32.or
+                                (get_local $10)
+                                (i32.const 32)
+                              )
+                              (i32.const 102)
+                            )
+                            (block
+                              (set_local $1
+                                (i32.lt_s
+                                  (set_local $5
+                                    (i32.sub
+                                      (get_local $1)
+                                      (get_local $6)
+                                    )
+                                  )
+                                  (i32.const 0)
+                                )
+                              )
+                              (set_local $5
+                                (i32.lt_s
+                                  (get_local $8)
+                                  (set_local $1
+                                    (select
+                                      (i32.const 0)
+                                      (get_local $5)
+                                      (get_local $1)
+                                    )
+                                  )
+                                )
+                              )
+                              (set_local $14
+                                (select
+                                  (get_local $8)
+                                  (get_local $1)
+                                  (get_local $5)
+                                )
+                              )
+                              (set_local $26
+                                (get_local $10)
+                              )
+                              (i32.const 0)
+                            )
+                            (block
+                              (set_local $1
+                                (i32.lt_s
+                                  (set_local $5
+                                    (i32.sub
+                                      (i32.add
+                                        (get_local $1)
+                                        (get_local $13)
+                                      )
+                                      (get_local $6)
+                                    )
+                                  )
+                                  (i32.const 0)
+                                )
+                              )
+                              (set_local $5
+                                (i32.lt_s
+                                  (get_local $8)
+                                  (set_local $1
+                                    (select
+                                      (i32.const 0)
+                                      (get_local $5)
+                                      (get_local $1)
+                                    )
+                                  )
+                                )
+                              )
+                              (set_local $14
+                                (select
+                                  (get_local $8)
+                                  (get_local $1)
+                                  (get_local $5)
+                                )
+                              )
+                              (set_local $26
+                                (get_local $10)
                               )
                               (i32.const 0)
                             )
                           )
                         )
-                        (set_local $7
+                        (block
+                          (set_local $14
+                            (get_local $1)
+                          )
+                          (i32.and
+                            (get_local $18)
+                            (i32.const 8)
+                          )
+                        )
+                      )
+                    )
+                  )
+                  (set_local $17
+                    (i32.and
+                      (i32.ne
+                        (set_local $1
                           (i32.or
-                            (get_local $51)
-                            (i32.const 2)
+                            (get_local $14)
+                            (get_local $8)
                           )
                         )
-                        (set_local $15
-                          (if
-                            (i32.or
-                              (i32.gt_u
-                                (get_local $10)
-                                (i32.const 11)
-                              )
-                              (i32.eq
-                                (set_local $1
-                                  (i32.sub
-                                    (i32.const 12)
-                                    (get_local $10)
-                                  )
-                                )
-                                (i32.const 0)
-                              )
-                            )
-                            (get_local $15)
-                            (block
-                              (set_local $30
-                                (f64.const 8)
-                              )
-                              (loop $while-out$60 $while-in$61
-                                (set_local $30
-                                  (f64.mul
-                                    (get_local $30)
-                                    (f64.const 16)
-                                  )
-                                )
-                                (if
-                                  (i32.eq
-                                    (set_local $1
-                                      (i32.add
-                                        (get_local $1)
-                                        (i32.const -1)
-                                      )
-                                    )
-                                    (i32.const 0)
-                                  )
-                                  (br $while-out$60)
-                                )
-                                (br $while-in$61)
-                              )
-                              (select
-                                (f64.neg
-                                  (f64.add
-                                    (get_local $30)
-                                    (f64.sub
-                                      (f64.neg
-                                        (get_local $15)
-                                      )
-                                      (get_local $30)
-                                    )
-                                  )
-                                )
-                                (f64.sub
-                                  (f64.add
-                                    (get_local $15)
-                                    (get_local $30)
-                                  )
-                                  (get_local $30)
-                                )
-                                (i32.eq
-                                  (i32.shr_s
-                                    (i32.shl
-                                      (i32.load8_s
-                                        (get_local $9)
-                                      )
-                                      (i32.const 24)
-                                    )
-                                    (i32.const 24)
-                                  )
-                                  (i32.const 45)
-                                )
-                              )
-                            )
+                        (i32.const 0)
+                      )
+                      (i32.const 1)
+                    )
+                  )
+                  (set_local $13
+                    (if
+                      (set_local $10
+                        (i32.eq
+                          (i32.or
+                            (get_local $26)
+                            (i32.const 32)
                           )
+                          (i32.const 102)
                         )
-                        (set_local $5
-                          (i32.lt_s
-                            (set_local $1
-                              (i32.load
-                                (get_local $25)
-                              )
-                            )
+                      )
+                      (block
+                        (set_local $6
+                          (select
+                            (get_local $13)
                             (i32.const 0)
+                            (i32.gt_s
+                              (get_local $13)
+                              (i32.const 0)
+                            )
                           )
                         )
+                        (i32.const 0)
+                      )
+                      (block
                         (set_local $5
                           (i32.shr_s
                             (i32.shl
                               (i32.lt_s
-                                (set_local $8
+                                (set_local $6
                                   (select
-                                    (i32.sub
+                                    (get_local $27)
+                                    (get_local $13)
+                                    (i32.lt_s
+                                      (get_local $13)
                                       (i32.const 0)
-                                      (get_local $1)
                                     )
-                                    (get_local $1)
-                                    (get_local $5)
                                   )
                                 )
                                 (i32.const 0)
@@ -5346,37 +7034,55 @@
                             (i32.const 31)
                           )
                         )
-                        (i32.store8
-                          (i32.add
-                            (set_local $5
-                              (if
-                                (i32.eq
-                                  (set_local $5
-                                    (call $_fmt_u
-                                      (get_local $8)
-                                      (get_local $5)
-                                      (get_local $52)
-                                    )
-                                  )
+                        (if
+                          (i32.lt_s
+                            (i32.sub
+                              (get_local $40)
+                              (set_local $5
+                                (call $_fmt_u
+                                  (get_local $6)
+                                  (get_local $5)
                                   (get_local $52)
                                 )
-                                (block
-                                  (i32.store8
-                                    (get_local $74)
-                                    (i32.const 48)
-                                  )
-                                  (get_local $74)
-                                )
-                                (get_local $5)
                               )
                             )
+                            (i32.const 2)
+                          )
+                          (loop $while-out$104 $while-in$105
+                            (i32.store8
+                              (set_local $5
+                                (i32.add
+                                  (get_local $5)
+                                  (i32.const -1)
+                                )
+                              )
+                              (i32.const 48)
+                            )
+                            (if
+                              (i32.lt_s
+                                (i32.sub
+                                  (get_local $40)
+                                  (get_local $5)
+                                )
+                                (i32.const 2)
+                              )
+                              (get_local $5)
+                              (br $while-out$104)
+                            )
+                            (br $while-in$105)
+                          )
+                          (get_local $5)
+                        )
+                        (i32.store8
+                          (i32.add
+                            (get_local $5)
                             (i32.const -1)
                           )
                           (i32.and
                             (i32.add
                               (i32.and
                                 (i32.shr_s
-                                  (get_local $1)
+                                  (get_local $13)
                                   (i32.const 31)
                                 )
                                 (i32.const 2)
@@ -5387,1878 +7093,265 @@
                           )
                         )
                         (i32.store8
-                          (set_local $8
+                          (set_local $5
                             (i32.add
                               (get_local $5)
                               (i32.const -2)
                             )
                           )
                           (i32.and
-                            (i32.add
-                              (get_local $26)
-                              (i32.const 15)
-                            )
+                            (get_local $26)
                             (i32.const 255)
                           )
                         )
-                        (set_local $5
-                          (i32.lt_s
-                            (get_local $10)
-                            (i32.const 1)
-                          )
-                        )
-                        (set_local $13
-                          (i32.eq
-                            (i32.and
-                              (get_local $18)
-                              (i32.const 8)
-                            )
-                            (i32.const 0)
-                          )
-                        )
-                        (set_local $11
-                          (get_local $29)
-                        )
-                        (loop $while-out$62 $while-in$63
-                          (i32.store8
-                            (get_local $11)
-                            (i32.and
-                              (i32.or
-                                (i32.and
-                                  (i32.load8_s
-                                    (i32.add
-                                      (set_local $1
-                                        (i32.trunc_s/f64
-                                          (get_local $15)
-                                        )
-                                      )
-                                      (i32.const 4075)
-                                    )
-                                  )
-                                  (i32.const 255)
-                                )
-                                (get_local $6)
-                              )
-                              (i32.const 255)
-                            )
-                          )
-                          (set_local $15
-                            (f64.mul
-                              (f64.sub
-                                (get_local $15)
-                                (f64.convert_s/i32
-                                  (get_local $1)
-                                )
-                              )
-                              (f64.const 16)
-                            )
-                          )
-                          (set_local $11
-                            (block $do-once$64
-                              (if
-                                (i32.eq
-                                  (i32.sub
-                                    (set_local $1
-                                      (i32.add
-                                        (get_local $11)
-                                        (i32.const 1)
-                                      )
-                                    )
-                                    (get_local $64)
-                                  )
-                                  (i32.const 1)
-                                )
-                                (block
-                                  (br_if $do-once$64
-                                    (get_local $1)
-                                    (i32.and
-                                      (get_local $13)
-                                      (i32.and
-                                        (get_local $5)
-                                        (f64.eq
-                                          (get_local $15)
-                                          (f64.const 0)
-                                        )
-                                      )
-                                    )
-                                  )
-                                  (i32.store8
-                                    (get_local $1)
-                                    (i32.const 46)
-                                  )
-                                  (i32.add
-                                    (get_local $11)
-                                    (i32.const 2)
-                                  )
-                                )
-                                (get_local $1)
-                              )
-                            )
-                          )
-                          (if
-                            (f64.eq
-                              (get_local $15)
-                              (f64.const 0)
-                            )
-                            (block
-                              (set_local $1
-                                (get_local $11)
-                              )
-                              (br $while-out$62)
-                            )
-                          )
-                          (br $while-in$63)
-                        )
-                        (set_local $5
-                          (i32.and
-                            (i32.ne
-                              (get_local $10)
-                              (i32.const 0)
-                            )
-                            (i32.lt_s
-                              (i32.add
-                                (get_local $78)
-                                (get_local $1)
-                              )
-                              (get_local $10)
-                            )
-                          )
-                        )
-                        (call $_pad
-                          (get_local $0)
-                          (i32.const 32)
-                          (get_local $16)
-                          (set_local $5
-                            (i32.add
-                              (set_local $6
-                                (select
-                                  (i32.sub
-                                    (i32.add
-                                      (get_local $79)
-                                      (get_local $10)
-                                    )
-                                    (get_local $8)
-                                  )
-                                  (i32.add
-                                    (i32.sub
-                                      (get_local $77)
-                                      (get_local $8)
-                                    )
-                                    (get_local $1)
-                                  )
-                                  (get_local $5)
-                                )
-                              )
-                              (get_local $7)
-                            )
-                          )
-                          (get_local $18)
-                        )
-                        (if
-                          (i32.eq
-                            (i32.and
-                              (i32.load
-                                (get_local $0)
-                              )
-                              (i32.const 32)
-                            )
-                            (i32.const 0)
-                          )
-                          (call $___fwritex
-                            (get_local $9)
-                            (get_local $7)
-                            (get_local $0)
-                          )
-                        )
-                        (call $_pad
-                          (get_local $0)
-                          (i32.const 48)
-                          (get_local $16)
-                          (get_local $5)
-                          (i32.xor
-                            (get_local $18)
-                            (i32.const 65536)
-                          )
-                        )
-                        (set_local $1
+                        (set_local $6
                           (i32.sub
-                            (get_local $1)
-                            (get_local $64)
-                          )
-                        )
-                        (if
-                          (i32.eq
-                            (i32.and
-                              (i32.load
-                                (get_local $0)
-                              )
-                              (i32.const 32)
-                            )
-                            (i32.const 0)
-                          )
-                          (call $___fwritex
-                            (get_local $29)
-                            (get_local $1)
-                            (get_local $0)
-                          )
-                        )
-                        (call $_pad
-                          (get_local $0)
-                          (i32.const 48)
-                          (i32.sub
-                            (get_local $6)
-                            (i32.add
-                              (get_local $1)
-                              (set_local $1
-                                (i32.sub
-                                  (get_local $40)
-                                  (get_local $8)
-                                )
-                              )
-                            )
-                          )
-                          (i32.const 0)
-                          (i32.const 0)
-                        )
-                        (if
-                          (i32.eq
-                            (i32.and
-                              (i32.load
-                                (get_local $0)
-                              )
-                              (i32.const 32)
-                            )
-                            (i32.const 0)
-                          )
-                          (call $___fwritex
-                            (get_local $8)
-                            (get_local $1)
-                            (get_local $0)
-                          )
-                        )
-                        (call $_pad
-                          (get_local $0)
-                          (i32.const 32)
-                          (get_local $16)
-                          (get_local $5)
-                          (i32.xor
-                            (get_local $18)
-                            (i32.const 8192)
-                          )
-                        )
-                        (br $do-once$56
-                          (select
-                            (get_local $16)
+                            (get_local $40)
                             (get_local $5)
-                            (i32.lt_s
-                              (get_local $5)
-                              (get_local $16)
-                            )
                           )
                         )
-                      )
-                    )
-                    (set_local $1
-                      (select
-                        (i32.const 6)
-                        (get_local $10)
-                        (i32.lt_s
-                          (get_local $10)
-                          (i32.const 0)
-                        )
-                      )
-                    )
-                    (set_local $62
-                      (set_local $9
-                        (select
-                          (get_local $80)
-                          (get_local $81)
-                          (i32.lt_s
-                            (if
-                              (get_local $5)
-                              (block
-                                (i32.store
-                                  (get_local $25)
-                                  (set_local $5
-                                    (i32.add
-                                      (i32.load
-                                        (get_local $25)
-                                      )
-                                      (i32.const -28)
-                                    )
-                                  )
-                                )
-                                (set_local $15
-                                  (f64.mul
-                                    (get_local $15)
-                                    (f64.const 268435456)
-                                  )
-                                )
-                                (get_local $5)
-                              )
-                              (i32.load
-                                (get_local $25)
-                              )
-                            )
-                            (i32.const 0)
-                          )
-                        )
-                      )
-                    )
-                    (set_local $7
-                      (get_local $9)
-                    )
-                    (loop $while-out$66 $while-in$67
-                      (i32.store
-                        (get_local $7)
-                        (set_local $5
-                          (i32.trunc_s/f64
-                            (get_local $15)
-                          )
-                        )
-                      )
-                      (set_local $7
-                        (i32.add
-                          (get_local $7)
-                          (i32.const 4)
-                        )
-                      )
-                      (if
-                        (f64.eq
-                          (set_local $15
-                            (f64.mul
-                              (f64.sub
-                                (get_local $15)
-                                (f64.convert_u/i32
-                                  (get_local $5)
-                                )
-                              )
-                              (f64.const 1e9)
-                            )
-                          )
-                          (f64.const 0)
-                        )
-                        (block
-                          (set_local $6
-                            (get_local $7)
-                          )
-                          (br $while-out$66)
-                        )
-                      )
-                      (br $while-in$67)
-                    )
-                    (if
-                      (i32.gt_s
-                        (set_local $5
-                          (i32.load
-                            (get_local $25)
-                          )
-                        )
-                        (i32.const 0)
-                      )
-                      (block
-                        (set_local $8
-                          (get_local $9)
-                        )
-                        (set_local $13
-                          (get_local $6)
-                        )
-                        (loop $while-out$68 $while-in$69
-                          (set_local $11
-                            (select
-                              (i32.const 29)
-                              (get_local $5)
-                              (i32.gt_s
-                                (get_local $5)
-                                (i32.const 29)
-                              )
-                            )
-                          )
-                          (set_local $7
-                            (block $do-once$70
-                              (if
-                                (i32.lt_u
-                                  (set_local $7
-                                    (i32.add
-                                      (get_local $13)
-                                      (i32.const -4)
-                                    )
-                                  )
-                                  (get_local $8)
-                                )
-                                (get_local $8)
-                                (block
-                                  (set_local $5
-                                    (i32.const 0)
-                                  )
-                                  (set_local $10
-                                    (get_local $7)
-                                  )
-                                  (loop $while-out$72 $while-in$73
-                                    (set_local $6
-                                      (call $___uremdi3
-                                        (set_local $5
-                                          (call $_i64Add
-                                            (call $_bitshift64Shl
-                                              (i32.load
-                                                (get_local $10)
-                                              )
-                                              (i32.const 0)
-                                              (get_local $11)
-                                            )
-                                            (i32.load
-                                              (i32.const 168)
-                                            )
-                                            (get_local $5)
-                                            (i32.const 0)
-                                          )
-                                        )
-                                        (set_local $7
-                                          (i32.load
-                                            (i32.const 168)
-                                          )
-                                        )
-                                        (i32.const 1000000000)
-                                        (i32.const 0)
-                                      )
-                                    )
-                                    (i32.load
-                                      (i32.const 168)
-                                    )
-                                    (i32.store
-                                      (get_local $10)
-                                      (get_local $6)
-                                    )
-                                    (set_local $5
-                                      (call $___udivdi3
-                                        (get_local $5)
-                                        (get_local $7)
-                                        (i32.const 1000000000)
-                                        (i32.const 0)
-                                      )
-                                    )
-                                    (i32.load
-                                      (i32.const 168)
-                                    )
-                                    (if
-                                      (i32.lt_u
-                                        (set_local $7
-                                          (i32.add
-                                            (get_local $10)
-                                            (i32.const -4)
-                                          )
-                                        )
-                                        (get_local $8)
-                                      )
-                                      (br $while-out$72)
-                                      (set_local $10
-                                        (get_local $7)
-                                      )
-                                    )
-                                    (br $while-in$73)
-                                  )
-                                  (br_if $do-once$70
-                                    (get_local $8)
-                                    (i32.eq
-                                      (get_local $5)
-                                      (i32.const 0)
-                                    )
-                                  )
-                                  (i32.store
-                                    (set_local $7
-                                      (i32.add
-                                        (get_local $8)
-                                        (i32.const -4)
-                                      )
-                                    )
-                                    (get_local $5)
-                                  )
-                                  (get_local $7)
-                                )
-                              )
-                            )
-                          )
-                          (loop $while-out$74 $while-in$75
-                            (if
-                              (i32.le_u
-                                (get_local $13)
-                                (get_local $7)
-                              )
-                              (br $while-out$74)
-                            )
-                            (if
-                              (i32.eq
-                                (i32.load
-                                  (set_local $5
-                                    (i32.add
-                                      (get_local $13)
-                                      (i32.const -4)
-                                    )
-                                  )
-                                )
-                                (i32.const 0)
-                              )
-                              (set_local $13
-                                (get_local $5)
-                              )
-                              (br $while-out$74)
-                            )
-                            (br $while-in$75)
-                          )
-                          (i32.store
-                            (get_local $25)
-                            (set_local $5
-                              (i32.sub
-                                (i32.load
-                                  (get_local $25)
-                                )
-                                (get_local $11)
-                              )
-                            )
-                          )
-                          (if
-                            (i32.gt_s
-                              (get_local $5)
-                              (i32.const 0)
-                            )
-                            (set_local $8
-                              (get_local $7)
-                            )
-                            (block
-                              (set_local $6
-                                (get_local $13)
-                              )
-                              (br $while-out$68)
-                            )
-                          )
-                          (br $while-in$69)
-                        )
-                      )
-                      (set_local $7
-                        (get_local $9)
-                      )
-                    )
-                    (if
-                      (i32.lt_s
                         (get_local $5)
-                        (i32.const 0)
                       )
-                      (block
-                        (set_local $8
+                    )
+                  )
+                  (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $16)
+                    (set_local $6
+                      (i32.add
+                        (i32.add
                           (i32.add
-                            (i32.and
-                              (i32.div_s
-                                (i32.add
-                                  (get_local $1)
-                                  (i32.const 25)
-                                )
-                                (i32.const 9)
-                              )
-                              (i32.const -1)
+                            (i32.add
+                              (get_local $51)
+                              (i32.const 1)
                             )
-                            (i32.const 1)
-                          )
-                        )
-                        (set_local $10
-                          (i32.eq
                             (get_local $14)
-                            (i32.const 102)
                           )
+                          (get_local $17)
                         )
-                        (set_local $23
-                          (get_local $6)
-                        )
-                        (loop $while-out$76 $while-in$77
-                          (set_local $5
-                            (i32.gt_s
-                              (set_local $6
-                                (i32.sub
-                                  (i32.const 0)
-                                  (get_local $5)
-                                )
-                              )
-                              (i32.const 9)
-                            )
-                          )
-                          (set_local $13
-                            (select
-                              (i32.const 9)
-                              (get_local $6)
-                              (get_local $5)
-                            )
-                          )
-                          (set_local $11
-                            (block $do-once$78
-                              (if
-                                (i32.lt_u
-                                  (get_local $7)
-                                  (get_local $23)
-                                )
-                                (block
-                                  (set_local $70
-                                    (i32.add
-                                      (i32.shl
-                                        (i32.const 1)
-                                        (get_local $13)
-                                      )
-                                      (i32.const -1)
-                                    )
-                                  )
-                                  (set_local $27
-                                    (i32.shr_u
-                                      (i32.const 1000000000)
-                                      (get_local $13)
-                                    )
-                                  )
-                                  (set_local $11
-                                    (i32.const 0)
-                                  )
-                                  (set_local $17
-                                    (get_local $7)
-                                  )
-                                  (loop $while-out$80 $while-in$81
-                                    (set_local $6
-                                      (i32.and
-                                        (set_local $5
-                                          (i32.load
-                                            (get_local $17)
-                                          )
-                                        )
-                                        (get_local $70)
-                                      )
-                                    )
-                                    (i32.store
-                                      (get_local $17)
-                                      (i32.add
-                                        (i32.shr_u
-                                          (get_local $5)
-                                          (get_local $13)
-                                        )
-                                        (get_local $11)
-                                      )
-                                    )
-                                    (set_local $11
-                                      (i32.mul
-                                        (get_local $6)
-                                        (get_local $27)
-                                      )
-                                    )
-                                    (if
-                                      (i32.ge_u
-                                        (set_local $17
-                                          (i32.add
-                                            (get_local $17)
-                                            (i32.const 4)
-                                          )
-                                        )
-                                        (get_local $23)
-                                      )
-                                      (br $while-out$80)
-                                    )
-                                    (br $while-in$81)
-                                  )
-                                  (set_local $5
-                                    (select
-                                      (i32.add
-                                        (get_local $7)
-                                        (i32.const 4)
-                                      )
-                                      (get_local $7)
-                                      (i32.eq
-                                        (i32.load
-                                          (get_local $7)
-                                        )
-                                        (i32.const 0)
-                                      )
-                                    )
-                                  )
-                                  (if
-                                    (i32.eq
-                                      (get_local $11)
-                                      (i32.const 0)
-                                    )
-                                    (br $do-once$78
-                                      (get_local $5)
-                                    )
-                                  )
-                                  (i32.store
-                                    (get_local $23)
-                                    (get_local $11)
-                                  )
-                                  (set_local $23
-                                    (i32.add
-                                      (get_local $23)
-                                      (i32.const 4)
-                                    )
-                                  )
-                                  (get_local $5)
-                                )
-                                (select
-                                  (i32.add
-                                    (get_local $7)
-                                    (i32.const 4)
-                                  )
-                                  (get_local $7)
-                                  (i32.eq
-                                    (i32.load
-                                      (get_local $7)
-                                    )
-                                    (i32.const 0)
-                                  )
-                                )
-                              )
-                            )
-                          )
-                          (set_local $5
-                            (i32.gt_s
-                              (i32.shr_s
-                                (i32.sub
-                                  (get_local $23)
-                                  (set_local $7
-                                    (select
-                                      (get_local $9)
-                                      (get_local $11)
-                                      (get_local $10)
-                                    )
-                                  )
-                                )
-                                (i32.const 2)
-                              )
-                              (get_local $8)
-                            )
-                          )
-                          (set_local $6
-                            (select
-                              (i32.add
-                                (get_local $7)
-                                (i32.shl
-                                  (get_local $8)
-                                  (i32.const 2)
-                                )
-                              )
-                              (get_local $23)
-                              (get_local $5)
-                            )
-                          )
-                          (i32.store
-                            (get_local $25)
-                            (set_local $5
-                              (i32.add
-                                (i32.load
-                                  (get_local $25)
-                                )
-                                (get_local $13)
-                              )
-                            )
-                          )
-                          (if
-                            (i32.lt_s
-                              (get_local $5)
-                              (i32.const 0)
-                            )
-                            (block
-                              (set_local $7
-                                (get_local $11)
-                              )
-                              (set_local $23
-                                (get_local $6)
-                              )
-                            )
-                            (block
-                              (set_local $7
-                                (get_local $11)
-                              )
-                              (set_local $27
-                                (get_local $6)
-                              )
-                              (br $while-out$76)
-                            )
-                          )
-                          (br $while-in$77)
-                        )
-                      )
-                      (set_local $27
                         (get_local $6)
                       )
                     )
-                    (block $do-once$82
-                      (if
-                        (i32.lt_u
-                          (get_local $7)
-                          (get_local $27)
+                    (get_local $18)
+                  )
+                  (if
+                    (i32.eq
+                      (i32.and
+                        (i32.load
+                          (get_local $0)
                         )
-                        (block
-                          (set_local $6
-                            (i32.mul
-                              (i32.shr_s
-                                (i32.sub
-                                  (get_local $62)
-                                  (get_local $7)
-                                )
-                                (i32.const 2)
-                              )
-                              (i32.const 9)
-                            )
-                          )
-                          (if
-                            (i32.lt_u
-                              (set_local $5
-                                (i32.load
-                                  (get_local $7)
-                                )
-                              )
-                              (i32.const 10)
-                            )
-                            (block
-                              (set_local $13
-                                (get_local $6)
-                              )
-                              (br $do-once$82)
-                            )
-                            (set_local $8
-                              (i32.const 10)
-                            )
-                          )
-                          (loop $while-out$84 $while-in$85
-                            (set_local $6
-                              (i32.add
-                                (get_local $6)
-                                (i32.const 1)
-                              )
-                            )
-                            (if
-                              (i32.lt_u
-                                (get_local $5)
-                                (set_local $8
-                                  (i32.mul
-                                    (get_local $8)
-                                    (i32.const 10)
-                                  )
-                                )
-                              )
-                              (block
-                                (set_local $13
-                                  (get_local $6)
-                                )
-                                (br $while-out$84)
-                              )
-                            )
-                            (br $while-in$85)
-                          )
-                        )
-                        (set_local $13
-                          (i32.const 0)
-                        )
+                        (i32.const 32)
                       )
+                      (i32.const 0)
                     )
-                    (set_local $7
-                      (if
-                        (i32.lt_s
-                          (set_local $5
-                            (i32.add
-                              (i32.sub
-                                (get_local $1)
-                                (select
-                                  (get_local $13)
-                                  (i32.const 0)
-                                  (i32.ne
-                                    (get_local $14)
-                                    (i32.const 102)
-                                  )
-                                )
-                              )
-                              (i32.shr_s
-                                (i32.shl
-                                  (i32.and
-                                    (set_local $70
-                                      (i32.ne
-                                        (get_local $1)
-                                        (i32.const 0)
-                                      )
-                                    )
-                                    (set_local $8
-                                      (i32.eq
-                                        (get_local $14)
-                                        (i32.const 103)
-                                      )
-                                    )
-                                  )
-                                  (i32.const 31)
-                                )
-                                (i32.const 31)
+                    (call $___fwritex
+                      (get_local $39)
+                      (get_local $51)
+                      (get_local $0)
+                    )
+                  )
+                  (call $_pad
+                    (get_local $0)
+                    (i32.const 48)
+                    (get_local $16)
+                    (get_local $6)
+                    (i32.xor
+                      (get_local $18)
+                      (i32.const 65536)
+                    )
+                  )
+                  (block $do-once$106
+                    (if
+                      (get_local $10)
+                      (block
+                        (set_local $7
+                          (set_local $8
+                            (select
+                              (get_local $9)
+                              (get_local $7)
+                              (i32.gt_u
+                                (get_local $7)
+                                (get_local $9)
                               )
                             )
-                          )
-                          (i32.add
-                            (i32.mul
-                              (i32.shr_s
-                                (i32.sub
-                                  (get_local $27)
-                                  (get_local $62)
-                                )
-                                (i32.const 2)
-                              )
-                              (i32.const 9)
-                            )
-                            (i32.const -9)
                           )
                         )
-                        (block
-                          (set_local $6
-                            (i32.add
-                              (i32.add
-                                (get_local $9)
-                                (i32.const 4)
+                        (loop $while-out$108 $while-in$109
+                          (set_local $5
+                            (call $_fmt_u
+                              (i32.load
+                                (get_local $7)
                               )
-                              (i32.shl
-                                (i32.add
-                                  (i32.and
-                                    (i32.div_s
-                                      (set_local $5
-                                        (i32.add
-                                          (get_local $5)
-                                          (i32.const 9216)
-                                        )
-                                      )
-                                      (i32.const 9)
-                                    )
-                                    (i32.const -1)
-                                  )
-                                  (i32.const -1024)
-                                )
-                                (i32.const 2)
-                              )
+                              (i32.const 0)
+                              (get_local $45)
                             )
                           )
-                          (if
-                            (i32.lt_s
-                              (set_local $11
-                                (i32.add
-                                  (i32.and
-                                    (i32.rem_s
-                                      (get_local $5)
-                                      (i32.const 9)
-                                    )
-                                    (i32.const -1)
-                                  )
-                                  (i32.const 1)
-                                )
-                              )
-                              (i32.const 9)
-                            )
-                            (block
-                              (set_local $5
-                                (i32.const 10)
-                              )
-                              (loop $while-out$86 $while-in$87
-                                (set_local $5
-                                  (i32.mul
-                                    (get_local $5)
-                                    (i32.const 10)
-                                  )
-                                )
-                                (if
-                                  (i32.eq
-                                    (set_local $11
-                                      (i32.add
-                                        (get_local $11)
-                                        (i32.const 1)
-                                      )
-                                    )
-                                    (i32.const 9)
-                                  )
-                                  (block
-                                    (set_local $17
-                                      (get_local $5)
-                                    )
-                                    (br $while-out$86)
-                                  )
-                                )
-                                (br $while-in$87)
-                              )
-                            )
-                            (set_local $17
-                              (i32.const 10)
-                            )
-                          )
-                          (block $do-once$88
+                          (block $do-once$110
                             (if
-                              (i32.eqz
-                                (i32.and
-                                  (set_local $11
-                                    (i32.eq
-                                      (i32.add
-                                        (get_local $6)
-                                        (i32.const 4)
-                                      )
-                                      (get_local $27)
-                                    )
+                              (i32.eq
+                                (get_local $7)
+                                (get_local $8)
+                              )
+                              (block
+                                (if
+                                  (i32.ne
+                                    (get_local $5)
+                                    (get_local $45)
                                   )
-                                  (i32.eq
-                                    (set_local $14
-                                      (i32.and
-                                        (i32.rem_u
-                                          (set_local $5
-                                            (i32.load
-                                              (get_local $6)
-                                            )
-                                          )
-                                          (get_local $17)
-                                        )
-                                        (i32.const -1)
-                                      )
-                                    )
-                                    (i32.const 0)
-                                  )
+                                  (br $do-once$110)
+                                )
+                                (i32.store8
+                                  (get_local $53)
+                                  (i32.const 48)
+                                )
+                                (set_local $5
+                                  (get_local $53)
                                 )
                               )
                               (block
-                                (set_local $15
-                                  (select
-                                    (f64.const 9007199254740992)
-                                    (f64.const 9007199254740994)
-                                    (i32.eq
-                                      (i32.and
-                                        (i32.and
-                                          (i32.div_u
-                                            (get_local $5)
-                                            (get_local $17)
-                                          )
-                                          (i32.const -1)
-                                        )
-                                        (i32.const 1)
-                                      )
-                                      (i32.const 0)
-                                    )
-                                  )
-                                )
-                                (set_local $30
-                                  (if
-                                    (i32.lt_u
-                                      (get_local $14)
-                                      (set_local $10
-                                        (i32.and
-                                          (i32.div_s
-                                            (get_local $17)
-                                            (i32.const 2)
-                                          )
-                                          (i32.const -1)
-                                        )
-                                      )
-                                    )
-                                    (f64.const 0.5)
-                                    (select
-                                      (f64.const 1)
-                                      (f64.const 1.5)
-                                      (i32.and
-                                        (get_local $11)
-                                        (i32.eq
-                                          (get_local $14)
-                                          (get_local $10)
-                                        )
-                                      )
-                                    )
-                                  )
-                                )
-                                (set_local $15
-                                  (block $do-once$90
-                                    (if
-                                      (i32.eq
-                                        (get_local $51)
-                                        (i32.const 0)
-                                      )
-                                      (get_local $15)
-                                      (block
-                                        (if
-                                          (i32.ne
-                                            (i32.shr_s
-                                              (i32.shl
-                                                (i32.load8_s
-                                                  (get_local $39)
-                                                )
-                                                (i32.const 24)
-                                              )
-                                              (i32.const 24)
-                                            )
-                                            (i32.const 45)
-                                          )
-                                          (br $do-once$90
-                                            (get_local $15)
-                                          )
-                                        )
-                                        (set_local $30
-                                          (f64.neg
-                                            (get_local $30)
-                                          )
-                                        )
-                                        (f64.neg
-                                          (get_local $15)
-                                        )
-                                      )
-                                    )
-                                  )
-                                )
-                                (i32.store
-                                  (get_local $6)
-                                  (set_local $5
-                                    (i32.sub
-                                      (get_local $5)
-                                      (get_local $14)
-                                    )
-                                  )
-                                )
-                                (if
-                                  (f64.eq
-                                    (f64.add
-                                      (get_local $15)
-                                      (get_local $30)
-                                    )
-                                    (get_local $15)
-                                  )
-                                  (br $do-once$88)
-                                )
-                                (i32.store
-                                  (get_local $6)
-                                  (set_local $5
-                                    (i32.add
-                                      (get_local $5)
-                                      (get_local $17)
-                                    )
-                                  )
-                                )
                                 (if
                                   (i32.gt_u
                                     (get_local $5)
-                                    (i32.const 999999999)
+                                    (get_local $29)
                                   )
-                                  (loop $while-out$92 $while-in$93
-                                    (i32.store
-                                      (get_local $6)
-                                      (i32.const 0)
-                                    )
-                                    (set_local $7
-                                      (if
-                                        (i32.lt_u
-                                          (set_local $6
-                                            (i32.add
-                                              (get_local $6)
-                                              (i32.const -4)
-                                            )
-                                          )
-                                          (get_local $7)
-                                        )
-                                        (block
-                                          (i32.store
-                                            (set_local $5
-                                              (i32.add
-                                                (get_local $7)
-                                                (i32.const -4)
-                                              )
-                                            )
-                                            (i32.const 0)
-                                          )
-                                          (get_local $5)
-                                        )
-                                        (get_local $7)
-                                      )
-                                    )
-                                    (i32.store
-                                      (get_local $6)
-                                      (set_local $5
-                                        (i32.add
-                                          (i32.load
-                                            (get_local $6)
-                                          )
-                                          (i32.const 1)
-                                        )
-                                      )
-                                    )
-                                    (if
-                                      (i32.le_u
-                                        (get_local $5)
-                                        (i32.const 999999999)
-                                      )
-                                      (br $while-out$92)
-                                    )
-                                    (br $while-in$93)
-                                  )
+                                  (get_local $5)
+                                  (br $do-once$110)
                                 )
-                                (set_local $11
-                                  (i32.mul
-                                    (i32.shr_s
-                                      (i32.sub
-                                        (get_local $62)
-                                        (get_local $7)
-                                      )
-                                      (i32.const 2)
-                                    )
-                                    (i32.const 9)
-                                  )
-                                )
-                                (if
-                                  (i32.lt_u
+                                (loop $while-out$112 $while-in$113
+                                  (i32.store8
                                     (set_local $5
-                                      (i32.load
-                                        (get_local $7)
-                                      )
-                                    )
-                                    (i32.const 10)
-                                  )
-                                  (block
-                                    (set_local $13
-                                      (get_local $11)
-                                    )
-                                    (br $do-once$88)
-                                  )
-                                  (set_local $10
-                                    (i32.const 10)
-                                  )
-                                )
-                                (loop $while-out$94 $while-in$95
-                                  (set_local $11
-                                    (i32.add
-                                      (get_local $11)
-                                      (i32.const 1)
-                                    )
-                                  )
-                                  (if
-                                    (i32.lt_u
-                                      (get_local $5)
-                                      (set_local $10
-                                        (i32.mul
-                                          (get_local $10)
-                                          (i32.const 10)
-                                        )
-                                      )
-                                    )
-                                    (block
-                                      (set_local $13
-                                        (get_local $11)
-                                      )
-                                      (br $while-out$94)
-                                    )
-                                  )
-                                  (br $while-in$95)
-                                )
-                              )
-                            )
-                          )
-                          (set_local $6
-                            (i32.gt_u
-                              (get_local $27)
-                              (set_local $5
-                                (i32.add
-                                  (get_local $6)
-                                  (i32.const 4)
-                                )
-                              )
-                            )
-                          )
-                          (set_local $6
-                            (select
-                              (get_local $5)
-                              (get_local $27)
-                              (get_local $6)
-                            )
-                          )
-                          (get_local $7)
-                        )
-                        (block
-                          (set_local $6
-                            (get_local $27)
-                          )
-                          (get_local $7)
-                        )
-                      )
-                    )
-                    (set_local $27
-                      (i32.sub
-                        (i32.const 0)
-                        (get_local $13)
-                      )
-                    )
-                    (loop $while-out$96 $while-in$97
-                      (if
-                        (i32.le_u
-                          (get_local $6)
-                          (get_local $7)
-                        )
-                        (block
-                          (set_local $11
-                            (i32.const 0)
-                          )
-                          (set_local $23
-                            (get_local $6)
-                          )
-                          (br $while-out$96)
-                        )
-                      )
-                      (if
-                        (i32.eq
-                          (i32.load
-                            (set_local $5
-                              (i32.add
-                                (get_local $6)
-                                (i32.const -4)
-                              )
-                            )
-                          )
-                          (i32.const 0)
-                        )
-                        (set_local $6
-                          (get_local $5)
-                        )
-                        (block
-                          (set_local $11
-                            (i32.const 1)
-                          )
-                          (set_local $23
-                            (get_local $6)
-                          )
-                          (br $while-out$96)
-                        )
-                      )
-                      (br $while-in$97)
-                    )
-                    (set_local $8
-                      (block $do-once$98
-                        (if
-                          (get_local $8)
-                          (block
-                            (set_local $8
-                              (if
-                                (i32.and
-                                  (i32.gt_s
-                                    (set_local $1
                                       (i32.add
-                                        (i32.xor
-                                          (i32.and
-                                            (get_local $70)
-                                            (i32.const 1)
-                                          )
-                                          (i32.const 1)
-                                        )
-                                        (get_local $1)
-                                      )
-                                    )
-                                    (get_local $13)
-                                  )
-                                  (i32.gt_s
-                                    (get_local $13)
-                                    (i32.const -5)
-                                  )
-                                )
-                                (block
-                                  (set_local $10
-                                    (i32.add
-                                      (get_local $26)
-                                      (i32.const -1)
-                                    )
-                                  )
-                                  (i32.sub
-                                    (i32.add
-                                      (get_local $1)
-                                      (i32.const -1)
-                                    )
-                                    (get_local $13)
-                                  )
-                                )
-                                (block
-                                  (set_local $10
-                                    (i32.add
-                                      (get_local $26)
-                                      (i32.const -2)
-                                    )
-                                  )
-                                  (i32.add
-                                    (get_local $1)
-                                    (i32.const -1)
-                                  )
-                                )
-                              )
-                            )
-                            (if
-                              (i32.ne
-                                (set_local $1
-                                  (i32.and
-                                    (get_local $18)
-                                    (i32.const 8)
-                                  )
-                                )
-                                (i32.const 0)
-                              )
-                              (block
-                                (set_local $14
-                                  (get_local $8)
-                                )
-                                (set_local $26
-                                  (get_local $10)
-                                )
-                                (br $do-once$98
-                                  (get_local $1)
-                                )
-                              )
-                            )
-                            (block $do-once$100
-                              (if
-                                (get_local $11)
-                                (block
-                                  (if
-                                    (i32.eq
-                                      (set_local $1
-                                        (i32.load
-                                          (i32.add
-                                            (get_local $23)
-                                            (i32.const -4)
-                                          )
-                                        )
-                                      )
-                                      (i32.const 0)
-                                    )
-                                    (block
-                                      (set_local $6
-                                        (i32.const 9)
-                                      )
-                                      (br $do-once$100)
-                                    )
-                                  )
-                                  (if
-                                    (i32.eq
-                                      (i32.and
-                                        (i32.rem_u
-                                          (get_local $1)
-                                          (i32.const 10)
-                                        )
+                                        (get_local $5)
                                         (i32.const -1)
                                       )
-                                      (i32.const 0)
                                     )
-                                    (block
-                                      (set_local $5
-                                        (i32.const 10)
-                                      )
-                                      (set_local $6
-                                        (i32.const 0)
-                                      )
-                                    )
-                                    (block
-                                      (set_local $6
-                                        (i32.const 0)
-                                      )
-                                      (br $do-once$100)
-                                    )
-                                  )
-                                  (loop $while-out$102 $while-in$103
-                                    (set_local $6
-                                      (i32.add
-                                        (get_local $6)
-                                        (i32.const 1)
-                                      )
-                                    )
-                                    (if
-                                      (i32.ne
-                                        (i32.and
-                                          (i32.rem_u
-                                            (get_local $1)
-                                            (set_local $5
-                                              (i32.mul
-                                                (get_local $5)
-                                                (i32.const 10)
-                                              )
-                                            )
-                                          )
-                                          (i32.const -1)
-                                        )
-                                        (i32.const 0)
-                                      )
-                                      (br $while-out$102)
-                                    )
-                                    (br $while-in$103)
-                                  )
-                                )
-                                (set_local $6
-                                  (i32.const 9)
-                                )
-                              )
-                            )
-                            (set_local $1
-                              (i32.add
-                                (i32.mul
-                                  (i32.shr_s
-                                    (i32.sub
-                                      (get_local $23)
-                                      (get_local $62)
-                                    )
-                                    (i32.const 2)
-                                  )
-                                  (i32.const 9)
-                                )
-                                (i32.const -9)
-                              )
-                            )
-                            (if
-                              (i32.eq
-                                (i32.or
-                                  (get_local $10)
-                                  (i32.const 32)
-                                )
-                                (i32.const 102)
-                              )
-                              (block
-                                (set_local $1
-                                  (i32.lt_s
-                                    (set_local $5
-                                      (i32.sub
-                                        (get_local $1)
-                                        (get_local $6)
-                                      )
-                                    )
-                                    (i32.const 0)
-                                  )
-                                )
-                                (set_local $5
-                                  (i32.lt_s
-                                    (get_local $8)
-                                    (set_local $1
-                                      (select
-                                        (i32.const 0)
-                                        (get_local $5)
-                                        (get_local $1)
-                                      )
-                                    )
-                                  )
-                                )
-                                (set_local $14
-                                  (select
-                                    (get_local $8)
-                                    (get_local $1)
-                                    (get_local $5)
-                                  )
-                                )
-                                (set_local $26
-                                  (get_local $10)
-                                )
-                                (i32.const 0)
-                              )
-                              (block
-                                (set_local $1
-                                  (i32.lt_s
-                                    (set_local $5
-                                      (i32.sub
-                                        (i32.add
-                                          (get_local $1)
-                                          (get_local $13)
-                                        )
-                                        (get_local $6)
-                                      )
-                                    )
-                                    (i32.const 0)
-                                  )
-                                )
-                                (set_local $5
-                                  (i32.lt_s
-                                    (get_local $8)
-                                    (set_local $1
-                                      (select
-                                        (i32.const 0)
-                                        (get_local $5)
-                                        (get_local $1)
-                                      )
-                                    )
-                                  )
-                                )
-                                (set_local $14
-                                  (select
-                                    (get_local $8)
-                                    (get_local $1)
-                                    (get_local $5)
-                                  )
-                                )
-                                (set_local $26
-                                  (get_local $10)
-                                )
-                                (i32.const 0)
-                              )
-                            )
-                          )
-                          (block
-                            (set_local $14
-                              (get_local $1)
-                            )
-                            (i32.and
-                              (get_local $18)
-                              (i32.const 8)
-                            )
-                          )
-                        )
-                      )
-                    )
-                    (set_local $17
-                      (i32.and
-                        (i32.ne
-                          (set_local $1
-                            (i32.or
-                              (get_local $14)
-                              (get_local $8)
-                            )
-                          )
-                          (i32.const 0)
-                        )
-                        (i32.const 1)
-                      )
-                    )
-                    (set_local $13
-                      (if
-                        (set_local $10
-                          (i32.eq
-                            (i32.or
-                              (get_local $26)
-                              (i32.const 32)
-                            )
-                            (i32.const 102)
-                          )
-                        )
-                        (block
-                          (set_local $6
-                            (select
-                              (get_local $13)
-                              (i32.const 0)
-                              (i32.gt_s
-                                (get_local $13)
-                                (i32.const 0)
-                              )
-                            )
-                          )
-                          (i32.const 0)
-                        )
-                        (block
-                          (set_local $5
-                            (i32.shr_s
-                              (i32.shl
-                                (i32.lt_s
-                                  (set_local $6
-                                    (select
-                                      (get_local $27)
-                                      (get_local $13)
-                                      (i32.lt_s
-                                        (get_local $13)
-                                        (i32.const 0)
-                                      )
-                                    )
-                                  )
-                                  (i32.const 0)
-                                )
-                                (i32.const 31)
-                              )
-                              (i32.const 31)
-                            )
-                          )
-                          (if
-                            (i32.lt_s
-                              (i32.sub
-                                (get_local $40)
-                                (set_local $5
-                                  (call $_fmt_u
-                                    (get_local $6)
-                                    (get_local $5)
-                                    (get_local $52)
-                                  )
-                                )
-                              )
-                              (i32.const 2)
-                            )
-                            (loop $while-out$104 $while-in$105
-                              (i32.store8
-                                (set_local $5
-                                  (i32.add
-                                    (get_local $5)
-                                    (i32.const -1)
-                                  )
-                                )
-                                (i32.const 48)
-                              )
-                              (if
-                                (i32.lt_s
-                                  (i32.sub
-                                    (get_local $40)
-                                    (get_local $5)
-                                  )
-                                  (i32.const 2)
-                                )
-                                (get_local $5)
-                                (br $while-out$104)
-                              )
-                              (br $while-in$105)
-                            )
-                            (get_local $5)
-                          )
-                          (i32.store8
-                            (i32.add
-                              (get_local $5)
-                              (i32.const -1)
-                            )
-                            (i32.and
-                              (i32.add
-                                (i32.and
-                                  (i32.shr_s
-                                    (get_local $13)
-                                    (i32.const 31)
-                                  )
-                                  (i32.const 2)
-                                )
-                                (i32.const 43)
-                              )
-                              (i32.const 255)
-                            )
-                          )
-                          (i32.store8
-                            (set_local $5
-                              (i32.add
-                                (get_local $5)
-                                (i32.const -2)
-                              )
-                            )
-                            (i32.and
-                              (get_local $26)
-                              (i32.const 255)
-                            )
-                          )
-                          (set_local $6
-                            (i32.sub
-                              (get_local $40)
-                              (get_local $5)
-                            )
-                          )
-                          (get_local $5)
-                        )
-                      )
-                    )
-                    (call $_pad
-                      (get_local $0)
-                      (i32.const 32)
-                      (get_local $16)
-                      (set_local $6
-                        (i32.add
-                          (i32.add
-                            (i32.add
-                              (i32.add
-                                (get_local $51)
-                                (i32.const 1)
-                              )
-                              (get_local $14)
-                            )
-                            (get_local $17)
-                          )
-                          (get_local $6)
-                        )
-                      )
-                      (get_local $18)
-                    )
-                    (if
-                      (i32.eq
-                        (i32.and
-                          (i32.load
-                            (get_local $0)
-                          )
-                          (i32.const 32)
-                        )
-                        (i32.const 0)
-                      )
-                      (call $___fwritex
-                        (get_local $39)
-                        (get_local $51)
-                        (get_local $0)
-                      )
-                    )
-                    (call $_pad
-                      (get_local $0)
-                      (i32.const 48)
-                      (get_local $16)
-                      (get_local $6)
-                      (i32.xor
-                        (get_local $18)
-                        (i32.const 65536)
-                      )
-                    )
-                    (block $do-once$106
-                      (if
-                        (get_local $10)
-                        (block
-                          (set_local $7
-                            (set_local $8
-                              (select
-                                (get_local $9)
-                                (get_local $7)
-                                (i32.gt_u
-                                  (get_local $7)
-                                  (get_local $9)
-                                )
-                              )
-                            )
-                          )
-                          (loop $while-out$108 $while-in$109
-                            (set_local $5
-                              (call $_fmt_u
-                                (i32.load
-                                  (get_local $7)
-                                )
-                                (i32.const 0)
-                                (get_local $45)
-                              )
-                            )
-                            (block $do-once$110
-                              (if
-                                (i32.eq
-                                  (get_local $7)
-                                  (get_local $8)
-                                )
-                                (block
-                                  (if
-                                    (i32.ne
-                                      (get_local $5)
-                                      (get_local $45)
-                                    )
-                                    (br $do-once$110)
-                                  )
-                                  (i32.store8
-                                    (get_local $53)
                                     (i32.const 48)
                                   )
-                                  (set_local $5
-                                    (get_local $53)
-                                  )
-                                )
-                                (block
                                   (if
                                     (i32.gt_u
                                       (get_local $5)
                                       (get_local $29)
                                     )
                                     (get_local $5)
-                                    (br $do-once$110)
+                                    (br $while-out$112)
                                   )
-                                  (loop $while-out$112 $while-in$113
-                                    (i32.store8
-                                      (set_local $5
-                                        (i32.add
-                                          (get_local $5)
-                                          (i32.const -1)
-                                        )
-                                      )
-                                      (i32.const 48)
-                                    )
-                                    (if
-                                      (i32.gt_u
-                                        (get_local $5)
-                                        (get_local $29)
-                                      )
-                                      (get_local $5)
-                                      (br $while-out$112)
-                                    )
-                                    (br $while-in$113)
-                                  )
+                                  (br $while-in$113)
                                 )
                               )
+                            )
+                          )
+                          (if
+                            (i32.eq
+                              (i32.and
+                                (i32.load
+                                  (get_local $0)
+                                )
+                                (i32.const 32)
+                              )
+                              (i32.const 0)
+                            )
+                            (call $___fwritex
+                              (get_local $5)
+                              (i32.sub
+                                (get_local $75)
+                                (get_local $5)
+                              )
+                              (get_local $0)
+                            )
+                          )
+                          (if
+                            (i32.gt_u
+                              (set_local $7
+                                (i32.add
+                                  (get_local $7)
+                                  (i32.const 4)
+                                )
+                              )
+                              (get_local $9)
+                            )
+                            (block
+                              (set_local $5
+                                (get_local $7)
+                              )
+                              (br $while-out$108)
+                            )
+                            (get_local $7)
+                          )
+                          (br $while-in$109)
+                        )
+                        (block $do-once$114
+                          (if
+                            (i32.ne
+                              (get_local $1)
+                              (i32.const 0)
+                            )
+                            (block
+                              (br_if $do-once$114
+                                (i32.ne
+                                  (i32.and
+                                    (i32.load
+                                      (get_local $0)
+                                    )
+                                    (i32.const 32)
+                                  )
+                                  (i32.const 0)
+                                )
+                              )
+                              (call $___fwritex
+                                (i32.const 4143)
+                                (i32.const 1)
+                                (get_local $0)
+                              )
+                            )
+                          )
+                        )
+                        (if
+                          (i32.and
+                            (i32.gt_s
+                              (get_local $14)
+                              (i32.const 0)
+                            )
+                            (i32.lt_u
+                              (get_local $5)
+                              (get_local $23)
+                            )
+                          )
+                          (loop $while-out$116 $while-in$117
+                            (if
+                              (i32.gt_u
+                                (set_local $1
+                                  (call $_fmt_u
+                                    (i32.load
+                                      (get_local $5)
+                                    )
+                                    (i32.const 0)
+                                    (get_local $45)
+                                  )
+                                )
+                                (get_local $29)
+                              )
+                              (loop $while-out$118 $while-in$119
+                                (i32.store8
+                                  (set_local $1
+                                    (i32.add
+                                      (get_local $1)
+                                      (i32.const -1)
+                                    )
+                                  )
+                                  (i32.const 48)
+                                )
+                                (if
+                                  (i32.gt_u
+                                    (get_local $1)
+                                    (get_local $29)
+                                  )
+                                  (get_local $1)
+                                  (br $while-out$118)
+                                )
+                                (br $while-in$119)
+                              )
+                              (get_local $1)
                             )
                             (if
                               (i32.eq
@@ -7271,106 +7364,217 @@
                                 (i32.const 0)
                               )
                               (call $___fwritex
-                                (get_local $5)
-                                (i32.sub
-                                  (get_local $75)
-                                  (get_local $5)
+                                (get_local $1)
+                                (select
+                                  (i32.const 9)
+                                  (get_local $14)
+                                  (i32.gt_s
+                                    (get_local $14)
+                                    (i32.const 9)
+                                  )
                                 )
                                 (get_local $0)
                               )
                             )
+                            (set_local $1
+                              (i32.add
+                                (get_local $14)
+                                (i32.const -9)
+                              )
+                            )
                             (if
-                              (i32.gt_u
-                                (set_local $7
-                                  (i32.add
-                                    (get_local $7)
-                                    (i32.const 4)
-                                  )
+                              (i32.and
+                                (i32.gt_s
+                                  (get_local $14)
+                                  (i32.const 9)
                                 )
-                                (get_local $9)
+                                (i32.lt_u
+                                  (set_local $5
+                                    (i32.add
+                                      (get_local $5)
+                                      (i32.const 4)
+                                    )
+                                  )
+                                  (get_local $23)
+                                )
+                              )
+                              (set_local $14
+                                (get_local $1)
                               )
                               (block
-                                (set_local $5
-                                  (get_local $7)
+                                (set_local $14
+                                  (get_local $1)
                                 )
-                                (br $while-out$108)
+                                (br $while-out$116)
                               )
+                            )
+                            (br $while-in$117)
+                          )
+                          (get_local $14)
+                        )
+                        (call $_pad
+                          (get_local $0)
+                          (i32.const 48)
+                          (i32.add
+                            (get_local $14)
+                            (i32.const 9)
+                          )
+                          (i32.const 9)
+                          (i32.const 0)
+                        )
+                      )
+                      (block
+                        (set_local $11
+                          (select
+                            (get_local $23)
+                            (i32.add
+                              (get_local $7)
+                              (i32.const 4)
+                            )
+                            (get_local $11)
+                          )
+                        )
+                        (if
+                          (i32.gt_s
+                            (get_local $14)
+                            (i32.const -1)
+                          )
+                          (block
+                            (set_local $9
+                              (i32.eq
+                                (get_local $8)
+                                (i32.const 0)
+                              )
+                            )
+                            (set_local $5
                               (get_local $7)
                             )
-                            (br $while-in$109)
-                          )
-                          (block $do-once$114
-                            (if
-                              (i32.ne
-                                (get_local $1)
-                                (i32.const 0)
-                              )
-                              (block
-                                (br_if $do-once$114
-                                  (i32.ne
-                                    (i32.and
-                                      (i32.load
-                                        (get_local $0)
+                            (loop $while-out$120 $while-in$121
+                              (set_local $8
+                                (if
+                                  (i32.eq
+                                    (set_local $1
+                                      (call $_fmt_u
+                                        (i32.load
+                                          (get_local $5)
+                                        )
+                                        (i32.const 0)
+                                        (get_local $45)
                                       )
-                                      (i32.const 32)
                                     )
-                                    (i32.const 0)
+                                    (get_local $45)
                                   )
-                                )
-                                (call $___fwritex
-                                  (i32.const 4143)
-                                  (i32.const 1)
-                                  (get_local $0)
-                                )
-                              )
-                            )
-                          )
-                          (if
-                            (i32.and
-                              (i32.gt_s
-                                (get_local $14)
-                                (i32.const 0)
-                              )
-                              (i32.lt_u
-                                (get_local $5)
-                                (get_local $23)
-                              )
-                            )
-                            (loop $while-out$116 $while-in$117
-                              (if
-                                (i32.gt_u
-                                  (set_local $1
-                                    (call $_fmt_u
-                                      (i32.load
-                                        (get_local $5)
-                                      )
-                                      (i32.const 0)
-                                      (get_local $45)
+                                  (block
+                                    (i32.store8
+                                      (get_local $53)
+                                      (i32.const 48)
                                     )
+                                    (get_local $53)
                                   )
-                                  (get_local $29)
+                                  (get_local $1)
                                 )
-                                (loop $while-out$118 $while-in$119
-                                  (i32.store8
+                              )
+                              (block $do-once$122
+                                (if
+                                  (i32.eq
+                                    (get_local $5)
+                                    (get_local $7)
+                                  )
+                                  (block
                                     (set_local $1
                                       (i32.add
-                                        (get_local $1)
-                                        (i32.const -1)
+                                        (get_local $8)
+                                        (i32.const 1)
                                       )
                                     )
-                                    (i32.const 48)
-                                  )
-                                  (if
-                                    (i32.gt_u
-                                      (get_local $1)
-                                      (get_local $29)
+                                    (if
+                                      (i32.eq
+                                        (i32.and
+                                          (i32.load
+                                            (get_local $0)
+                                          )
+                                          (i32.const 32)
+                                        )
+                                        (i32.const 0)
+                                      )
+                                      (call $___fwritex
+                                        (get_local $8)
+                                        (i32.const 1)
+                                        (get_local $0)
+                                      )
                                     )
-                                    (get_local $1)
-                                    (br $while-out$118)
+                                    (if
+                                      (i32.and
+                                        (get_local $9)
+                                        (i32.lt_s
+                                          (get_local $14)
+                                          (i32.const 1)
+                                        )
+                                      )
+                                      (br $do-once$122)
+                                    )
+                                    (if
+                                      (i32.ne
+                                        (i32.and
+                                          (i32.load
+                                            (get_local $0)
+                                          )
+                                          (i32.const 32)
+                                        )
+                                        (i32.const 0)
+                                      )
+                                      (br $do-once$122)
+                                    )
+                                    (call $___fwritex
+                                      (i32.const 4143)
+                                      (i32.const 1)
+                                      (get_local $0)
+                                    )
                                   )
-                                  (br $while-in$119)
+                                  (block
+                                    (if
+                                      (i32.gt_u
+                                        (get_local $8)
+                                        (get_local $29)
+                                      )
+                                      (set_local $1
+                                        (get_local $8)
+                                      )
+                                      (block
+                                        (set_local $1
+                                          (get_local $8)
+                                        )
+                                        (br $do-once$122)
+                                      )
+                                    )
+                                    (loop $while-out$124 $while-in$125
+                                      (i32.store8
+                                        (set_local $1
+                                          (i32.add
+                                            (get_local $1)
+                                            (i32.const -1)
+                                          )
+                                        )
+                                        (i32.const 48)
+                                      )
+                                      (if
+                                        (i32.gt_u
+                                          (get_local $1)
+                                          (get_local $29)
+                                        )
+                                        (get_local $1)
+                                        (br $while-out$124)
+                                      )
+                                      (br $while-in$125)
+                                    )
+                                  )
                                 )
-                                (get_local $1)
+                              )
+                              (set_local $8
+                                (i32.sub
+                                  (get_local $75)
+                                  (get_local $1)
+                                )
                               )
                               (if
                                 (i32.eq
@@ -7385,456 +7589,232 @@
                                 (call $___fwritex
                                   (get_local $1)
                                   (select
-                                    (i32.const 9)
+                                    (get_local $8)
                                     (get_local $14)
                                     (i32.gt_s
                                       (get_local $14)
-                                      (i32.const 9)
+                                      (get_local $8)
                                     )
                                   )
                                   (get_local $0)
-                                )
-                              )
-                              (set_local $1
-                                (i32.add
-                                  (get_local $14)
-                                  (i32.const -9)
                                 )
                               )
                               (if
-                                (i32.and
-                                  (i32.gt_s
-                                    (get_local $14)
-                                    (i32.const 9)
-                                  )
-                                  (i32.lt_u
-                                    (set_local $5
-                                      (i32.add
-                                        (get_local $5)
-                                        (i32.const 4)
-                                      )
-                                    )
-                                    (get_local $23)
-                                  )
-                                )
-                                (set_local $14
-                                  (get_local $1)
-                                )
-                                (block
-                                  (set_local $14
-                                    (get_local $1)
-                                  )
-                                  (br $while-out$116)
-                                )
-                              )
-                              (br $while-in$117)
-                            )
-                            (get_local $14)
-                          )
-                          (call $_pad
-                            (get_local $0)
-                            (i32.const 48)
-                            (i32.add
-                              (get_local $14)
-                              (i32.const 9)
-                            )
-                            (i32.const 9)
-                            (i32.const 0)
-                          )
-                        )
-                        (block
-                          (set_local $11
-                            (select
-                              (get_local $23)
-                              (i32.add
-                                (get_local $7)
-                                (i32.const 4)
-                              )
-                              (get_local $11)
-                            )
-                          )
-                          (if
-                            (i32.gt_s
-                              (get_local $14)
-                              (i32.const -1)
-                            )
-                            (block
-                              (set_local $9
-                                (i32.eq
-                                  (get_local $8)
-                                  (i32.const 0)
-                                )
-                              )
-                              (set_local $5
-                                (get_local $7)
-                              )
-                              (loop $while-out$120 $while-in$121
-                                (set_local $8
-                                  (if
-                                    (i32.eq
-                                      (set_local $1
-                                        (call $_fmt_u
-                                          (i32.load
-                                            (get_local $5)
-                                          )
-                                          (i32.const 0)
-                                          (get_local $45)
-                                        )
-                                      )
-                                      (get_local $45)
-                                    )
-                                    (block
-                                      (i32.store8
-                                        (get_local $53)
-                                        (i32.const 48)
-                                      )
-                                      (get_local $53)
-                                    )
-                                    (get_local $1)
-                                  )
-                                )
-                                (block $do-once$122
-                                  (if
-                                    (i32.eq
-                                      (get_local $5)
-                                      (get_local $7)
-                                    )
-                                    (block
-                                      (set_local $1
+                                (i32.eqz
+                                  (i32.and
+                                    (i32.lt_u
+                                      (set_local $5
                                         (i32.add
-                                          (get_local $8)
-                                          (i32.const 1)
+                                          (get_local $5)
+                                          (i32.const 4)
                                         )
                                       )
-                                      (if
-                                        (i32.eq
-                                          (i32.and
-                                            (i32.load
-                                              (get_local $0)
-                                            )
-                                            (i32.const 32)
-                                          )
-                                          (i32.const 0)
-                                        )
-                                        (call $___fwritex
-                                          (get_local $8)
-                                          (i32.const 1)
-                                          (get_local $0)
-                                        )
-                                      )
-                                      (if
-                                        (i32.and
-                                          (get_local $9)
-                                          (i32.lt_s
-                                            (get_local $14)
-                                            (i32.const 1)
-                                          )
-                                        )
-                                        (br $do-once$122)
-                                      )
-                                      (if
-                                        (i32.ne
-                                          (i32.and
-                                            (i32.load
-                                              (get_local $0)
-                                            )
-                                            (i32.const 32)
-                                          )
-                                          (i32.const 0)
-                                        )
-                                        (br $do-once$122)
-                                      )
-                                      (call $___fwritex
-                                        (i32.const 4143)
-                                        (i32.const 1)
-                                        (get_local $0)
-                                      )
+                                      (get_local $11)
                                     )
-                                    (block
-                                      (if
-                                        (i32.gt_u
-                                          (get_local $8)
-                                          (get_local $29)
-                                        )
-                                        (set_local $1
+                                    (i32.gt_s
+                                      (set_local $14
+                                        (i32.sub
+                                          (get_local $14)
                                           (get_local $8)
                                         )
-                                        (block
-                                          (set_local $1
-                                            (get_local $8)
-                                          )
-                                          (br $do-once$122)
-                                        )
                                       )
-                                      (loop $while-out$124 $while-in$125
-                                        (i32.store8
-                                          (set_local $1
-                                            (i32.add
-                                              (get_local $1)
-                                              (i32.const -1)
-                                            )
-                                          )
-                                          (i32.const 48)
-                                        )
-                                        (if
-                                          (i32.gt_u
-                                            (get_local $1)
-                                            (get_local $29)
-                                          )
-                                          (get_local $1)
-                                          (br $while-out$124)
-                                        )
-                                        (br $while-in$125)
-                                      )
+                                      (i32.const -1)
                                     )
                                   )
                                 )
-                                (set_local $8
-                                  (i32.sub
-                                    (get_local $75)
-                                    (get_local $1)
-                                  )
-                                )
-                                (if
-                                  (i32.eq
-                                    (i32.and
-                                      (i32.load
-                                        (get_local $0)
-                                      )
-                                      (i32.const 32)
-                                    )
-                                    (i32.const 0)
-                                  )
-                                  (call $___fwritex
-                                    (get_local $1)
-                                    (select
-                                      (get_local $8)
-                                      (get_local $14)
-                                      (i32.gt_s
-                                        (get_local $14)
-                                        (get_local $8)
-                                      )
-                                    )
-                                    (get_local $0)
-                                  )
-                                )
-                                (if
-                                  (i32.eqz
-                                    (i32.and
-                                      (i32.lt_u
-                                        (set_local $5
-                                          (i32.add
-                                            (get_local $5)
-                                            (i32.const 4)
-                                          )
-                                        )
-                                        (get_local $11)
-                                      )
-                                      (i32.gt_s
-                                        (set_local $14
-                                          (i32.sub
-                                            (get_local $14)
-                                            (get_local $8)
-                                          )
-                                        )
-                                        (i32.const -1)
-                                      )
-                                    )
-                                  )
-                                  (br $while-out$120)
-                                )
-                                (br $while-in$121)
+                                (br $while-out$120)
                               )
-                            )
-                            (get_local $14)
-                          )
-                          (call $_pad
-                            (get_local $0)
-                            (i32.const 48)
-                            (i32.add
-                              (get_local $14)
-                              (i32.const 18)
-                            )
-                            (i32.const 18)
-                            (i32.const 0)
-                          )
-                          (br_if $do-once$106
-                            (i32.ne
-                              (i32.and
-                                (i32.load
-                                  (get_local $0)
-                                )
-                                (i32.const 32)
-                              )
-                              (i32.const 0)
+                              (br $while-in$121)
                             )
                           )
-                          (call $___fwritex
-                            (get_local $13)
-                            (i32.sub
-                              (get_local $40)
-                              (get_local $13)
-                            )
-                            (get_local $0)
-                          )
+                          (get_local $14)
                         )
-                      )
-                    )
-                    (call $_pad
-                      (get_local $0)
-                      (i32.const 32)
-                      (get_local $16)
-                      (get_local $6)
-                      (i32.xor
-                        (get_local $18)
-                        (i32.const 8192)
-                      )
-                    )
-                    (select
-                      (get_local $16)
-                      (get_local $6)
-                      (i32.lt_s
-                        (get_local $6)
-                        (get_local $16)
-                      )
-                    )
-                  )
-                  (block
-                    (set_local $5
-                      (select
-                        (i32.const 4127)
-                        (i32.const 4131)
-                        (set_local $8
+                        (call $_pad
+                          (get_local $0)
+                          (i32.const 48)
+                          (i32.add
+                            (get_local $14)
+                            (i32.const 18)
+                          )
+                          (i32.const 18)
+                          (i32.const 0)
+                        )
+                        (br_if $do-once$106
                           (i32.ne
                             (i32.and
-                              (get_local $26)
+                              (i32.load
+                                (get_local $0)
+                              )
                               (i32.const 32)
                             )
                             (i32.const 0)
                           )
                         )
+                        (call $___fwritex
+                          (get_local $13)
+                          (i32.sub
+                            (get_local $40)
+                            (get_local $13)
+                          )
+                          (get_local $0)
+                        )
                       )
                     )
-                    (set_local $6
+                  )
+                  (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $16)
+                    (get_local $6)
+                    (i32.xor
+                      (get_local $18)
+                      (i32.const 8192)
+                    )
+                  )
+                  (select
+                    (get_local $16)
+                    (get_local $6)
+                    (i32.lt_s
+                      (get_local $6)
+                      (get_local $16)
+                    )
+                  )
+                )
+                (block
+                  (set_local $5
+                    (select
+                      (i32.const 4127)
+                      (i32.const 4131)
+                      (set_local $8
+                        (i32.ne
+                          (i32.and
+                            (get_local $26)
+                            (i32.const 32)
+                          )
+                          (i32.const 0)
+                        )
+                      )
+                    )
+                  )
+                  (set_local $6
+                    (select
+                      (i32.const 0)
+                      (get_local $51)
+                      (set_local $1
+                        (i32.or
+                          (f64.ne
+                            (get_local $15)
+                            (get_local $15)
+                          )
+                          (i32.const 0)
+                        )
+                      )
+                    )
+                  )
+                  (set_local $8
+                    (select
                       (select
-                        (i32.const 0)
-                        (get_local $51)
-                        (set_local $1
-                          (i32.or
-                            (f64.ne
-                              (get_local $15)
-                              (get_local $15)
+                        (i32.const 4135)
+                        (i32.const 4139)
+                        (get_local $8)
+                      )
+                      (get_local $5)
+                      (get_local $1)
+                    )
+                  )
+                  (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $16)
+                    (set_local $5
+                      (i32.add
+                        (get_local $6)
+                        (i32.const 3)
+                      )
+                    )
+                    (get_local $7)
+                  )
+                  (if
+                    (i32.eq
+                      (i32.and
+                        (if
+                          (i32.eq
+                            (i32.and
+                              (set_local $1
+                                (i32.load
+                                  (get_local $0)
+                                )
+                              )
+                              (i32.const 32)
                             )
                             (i32.const 0)
                           )
-                        )
-                      )
-                    )
-                    (set_local $8
-                      (select
-                        (select
-                          (i32.const 4135)
-                          (i32.const 4139)
-                          (get_local $8)
-                        )
-                        (get_local $5)
-                        (get_local $1)
-                      )
-                    )
-                    (call $_pad
-                      (get_local $0)
-                      (i32.const 32)
-                      (get_local $16)
-                      (set_local $5
-                        (i32.add
-                          (get_local $6)
-                          (i32.const 3)
-                        )
-                      )
-                      (get_local $7)
-                    )
-                    (if
-                      (i32.eq
-                        (i32.and
-                          (if
-                            (i32.eq
-                              (i32.and
-                                (set_local $1
-                                  (i32.load
-                                    (get_local $0)
-                                  )
-                                )
-                                (i32.const 32)
-                              )
-                              (i32.const 0)
+                          (block
+                            (call $___fwritex
+                              (get_local $39)
+                              (get_local $6)
+                              (get_local $0)
                             )
-                            (block
-                              (call $___fwritex
-                                (get_local $39)
-                                (get_local $6)
-                                (get_local $0)
-                              )
-                              (i32.load
-                                (get_local $0)
-                              )
+                            (i32.load
+                              (get_local $0)
                             )
-                            (get_local $1)
                           )
-                          (i32.const 32)
+                          (get_local $1)
                         )
-                        (i32.const 0)
+                        (i32.const 32)
                       )
-                      (call $___fwritex
-                        (get_local $8)
-                        (i32.const 3)
-                        (get_local $0)
-                      )
+                      (i32.const 0)
                     )
-                    (call $_pad
+                    (call $___fwritex
+                      (get_local $8)
+                      (i32.const 3)
                       (get_local $0)
-                      (i32.const 32)
-                      (get_local $16)
-                      (get_local $5)
-                      (i32.xor
-                        (get_local $18)
-                        (i32.const 8192)
-                      )
                     )
-                    (select
-                      (get_local $16)
+                  )
+                  (call $_pad
+                    (get_local $0)
+                    (i32.const 32)
+                    (get_local $16)
+                    (get_local $5)
+                    (i32.xor
+                      (get_local $18)
+                      (i32.const 8192)
+                    )
+                  )
+                  (select
+                    (get_local $16)
+                    (get_local $5)
+                    (i32.lt_s
                       (get_local $5)
-                      (i32.lt_s
-                        (get_local $5)
-                        (get_local $16)
-                      )
+                      (get_local $16)
                     )
                   )
                 )
               )
             )
-            (set_local $8
-              (get_local $21)
-            )
-            (br $label$continue$L1)
           )
-          (set_local $47
-            (get_local $20)
+          (set_local $8
+            (get_local $21)
           )
-          (set_local $37
-            (get_local $18)
-          )
-          (set_local $42
-            (get_local $10)
-          )
-          (set_local $43
-            (i32.const 0)
-          )
-          (set_local $48
-            (i32.const 4091)
-          )
-          (set_local $49
-            (get_local $28)
-          )
+          (br $label$continue$L1)
+        )
+        (set_local $47
+          (get_local $20)
+        )
+        (set_local $37
+          (get_local $18)
+        )
+        (set_local $42
+          (get_local $10)
+        )
+        (set_local $43
+          (i32.const 0)
+        )
+        (set_local $48
+          (i32.const 4091)
+        )
+        (set_local $49
+          (get_local $28)
         )
       )
       (block $label$break$L308

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -317,80 +317,78 @@
     )
     (block $switch$0
       (block $switch-default$3
-        (block $switch-default$3
-          (block $switch-case$2
-            (block $switch-case$1
-              (br_table $switch-case$1 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-case$2 $switch-default$3
-                (i32.sub
-                  (set_local $2
-                    (i32.and
-                      (get_local $2)
-                      (i32.const 2047)
-                    )
-                  )
-                  (i32.const 0)
-                )
-              )
-            )
-            (i32.store
-              (get_local $1)
-              (if
-                (f64.ne
-                  (get_local $0)
-                  (f64.const 0)
-                )
-                (block
-                  (set_local $0
-                    (call $_frexp
-                      (f64.mul
-                        (get_local $0)
-                        (f64.const 18446744073709551615)
-                      )
-                      (get_local $1)
-                    )
-                  )
-                  (i32.add
-                    (i32.load
-                      (get_local $1)
-                    )
-                    (i32.const -64)
+        (block $switch-case$2
+          (block $switch-case$1
+            (br_table $switch-case$1 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-case$2 $switch-default$3
+              (i32.sub
+                (set_local $2
+                  (i32.and
+                    (get_local $2)
+                    (i32.const 2047)
                   )
                 )
                 (i32.const 0)
               )
             )
-            (br $switch$0
-              (get_local $0)
+          )
+          (i32.store
+            (get_local $1)
+            (if
+              (f64.ne
+                (get_local $0)
+                (f64.const 0)
+              )
+              (block
+                (set_local $0
+                  (call $_frexp
+                    (f64.mul
+                      (get_local $0)
+                      (f64.const 18446744073709551615)
+                    )
+                    (get_local $1)
+                  )
+                )
+                (i32.add
+                  (i32.load
+                    (get_local $1)
+                  )
+                  (i32.const -64)
+                )
+              )
+              (i32.const 0)
             )
           )
           (br $switch$0
             (get_local $0)
           )
         )
-        (i32.store
-          (get_local $1)
-          (i32.add
-            (get_local $2)
-            (i32.const -1022)
-          )
+        (br $switch$0
+          (get_local $0)
         )
-        (i32.store
-          (i32.load
-            (i32.const 24)
-          )
-          (get_local $3)
+      )
+      (i32.store
+        (get_local $1)
+        (i32.add
+          (get_local $2)
+          (i32.const -1022)
         )
-        (i32.store offset=4
-          (i32.load
-            (i32.const 24)
+      )
+      (i32.store
+        (i32.load
+          (i32.const 24)
+        )
+        (get_local $3)
+      )
+      (i32.store offset=4
+        (i32.load
+          (i32.const 24)
+        )
+        (i32.or
+          (i32.and
+            (get_local $4)
+            (i32.const -2146435073)
           )
-          (i32.or
-            (i32.and
-              (get_local $4)
-              (i32.const -2146435073)
-            )
-            (i32.const 1071644672)
-          )
+          (i32.const 1071644672)
         )
       )
       (f64.load
@@ -1488,7 +1486,7 @@
         (i32.const 40)
       )
     )
-    (loop $do-out$0 $do-in$1
+    (loop $do-in$1
       (i32.store
         (get_local $4)
         (i32.const 0)
@@ -3202,41 +3200,39 @@
       )
       (loop $label$break$L9 $label$continue$L9
         (block $switch-default$5
-          (block $switch-default$5
-            (block $switch-case$4
-              (block $switch-case$3
-                (br_table $switch-case$4 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-case$3 $switch-default$5
-                  (i32.sub
-                    (i32.shr_s
-                      (i32.shl
-                        (get_local $1)
-                        (i32.const 24)
-                      )
+          (block $switch-case$4
+            (block $switch-case$3
+              (br_table $switch-case$4 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-case$3 $switch-default$5
+                (i32.sub
+                  (i32.shr_s
+                    (i32.shl
+                      (get_local $1)
                       (i32.const 24)
                     )
-                    (i32.const 0)
+                    (i32.const 24)
                   )
+                  (i32.const 0)
                 )
               )
-              (set_local $54
-                (get_local $5)
-              )
-              (set_local $65
-                (get_local $5)
-              )
-              (set_local $12
-                (i32.const 9)
-              )
-              (br $label$break$L9)
             )
-            (set_local $41
+            (set_local $54
               (get_local $5)
             )
-            (set_local $55
+            (set_local $65
               (get_local $5)
+            )
+            (set_local $12
+              (i32.const 9)
             )
             (br $label$break$L9)
           )
+          (set_local $41
+            (get_local $5)
+          )
+          (set_local $55
+            (get_local $5)
+          )
+          (br $label$break$L9)
         )
         (set_local $1
           (i32.load8_s
@@ -3932,7 +3928,7 @@
                       )
                     )
                   )
-                  (loop $while-out$17 $while-in$18
+                  (loop $while-in$18
                     (set_local $5
                       (i32.add
                         (i32.mul
@@ -4390,114 +4386,63 @@
       (block $label$break$L75
         (block $switch$24
           (block $switch-default$127
-            (block $switch-default$127
-              (block $switch-case$126
-                (block $switch-case$55
-                  (block $switch-case$54
-                    (block $switch-case$53
-                      (block $switch-case$52
-                        (block $switch-case$51
-                          (block $switch-case$50
-                            (block $switch-case$49
-                              (block $switch-case$48
-                                (block $switch-case$47
-                                  (block $switch-case$46
-                                    (block $switch-case$45
-                                      (block $switch-case$44
-                                        (block $switch-case$43
-                                          (block $switch-case$42
-                                            (block $switch-case$41
-                                              (block $switch-case$40
-                                                (block $switch-case$37
-                                                  (block $switch-case$36
-                                                    (block $switch-case$35
-                                                      (block $switch-case$34
-                                                        (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$52 $switch-case$51 $switch-case$50 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$53 $switch-default$127 $switch-case$44 $switch-case$42 $switch-case$126 $switch-case$55 $switch-case$54 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$37 $switch-default$127
-                                                          (i32.sub
-                                                            (set_local $26
-                                                              (select
-                                                                (i32.and
-                                                                  (get_local $1)
-                                                                  (i32.const -33)
-                                                                )
+            (block $switch-case$126
+              (block $switch-case$55
+                (block $switch-case$54
+                  (block $switch-case$53
+                    (block $switch-case$52
+                      (block $switch-case$51
+                        (block $switch-case$50
+                          (block $switch-case$49
+                            (block $switch-case$48
+                              (block $switch-case$47
+                                (block $switch-case$46
+                                  (block $switch-case$45
+                                    (block $switch-case$44
+                                      (block $switch-case$43
+                                        (block $switch-case$42
+                                          (block $switch-case$41
+                                            (block $switch-case$40
+                                              (block $switch-case$37
+                                                (block $switch-case$36
+                                                  (block $switch-case$35
+                                                    (block $switch-case$34
+                                                      (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$52 $switch-case$51 $switch-case$50 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$53 $switch-default$127 $switch-case$44 $switch-case$42 $switch-case$126 $switch-case$55 $switch-case$54 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$37 $switch-default$127
+                                                        (i32.sub
+                                                          (set_local $26
+                                                            (select
+                                                              (i32.and
                                                                 (get_local $1)
-                                                                (get_local $5)
+                                                                (i32.const -33)
                                                               )
+                                                              (get_local $1)
+                                                              (get_local $5)
                                                             )
-                                                            (i32.const 65)
                                                           )
+                                                          (i32.const 65)
                                                         )
                                                       )
-                                                      (block $switch-default$33
-                                                        (block $switch-default$33
-                                                          (block $switch-case$32
-                                                            (block $switch-case$31
-                                                              (block $switch-case$30
-                                                                (block $switch-case$29
-                                                                  (block $switch-case$28
-                                                                    (block $switch-case$27
-                                                                      (block $switch-case$26
-                                                                        (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
-                                                                          (i32.sub
-                                                                            (get_local $13)
-                                                                            (i32.const 0)
-                                                                          )
-                                                                        )
+                                                    )
+                                                    (block $switch-default$33
+                                                      (block $switch-case$32
+                                                        (block $switch-case$31
+                                                          (block $switch-case$30
+                                                            (block $switch-case$29
+                                                              (block $switch-case$28
+                                                                (block $switch-case$27
+                                                                  (block $switch-case$26
+                                                                    (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
+                                                                      (i32.sub
+                                                                        (get_local $13)
+                                                                        (i32.const 0)
                                                                       )
-                                                                      (i32.store
-                                                                        (i32.load
-                                                                          (get_local $19)
-                                                                        )
-                                                                        (get_local $22)
-                                                                      )
-                                                                      (set_local $20
-                                                                        (get_local $9)
-                                                                      )
-                                                                      (set_local $1
-                                                                        (get_local $17)
-                                                                      )
-                                                                      (set_local $8
-                                                                        (get_local $21)
-                                                                      )
-                                                                      (br $label$continue$L1)
                                                                     )
-                                                                    (i32.store
-                                                                      (i32.load
-                                                                        (get_local $19)
-                                                                      )
-                                                                      (get_local $22)
-                                                                    )
-                                                                    (set_local $20
-                                                                      (get_local $9)
-                                                                    )
-                                                                    (set_local $1
-                                                                      (get_local $17)
-                                                                    )
-                                                                    (set_local $8
-                                                                      (get_local $21)
-                                                                    )
-                                                                    (br $label$continue$L1)
                                                                   )
                                                                   (i32.store
-                                                                    (set_local $1
-                                                                      (i32.load
-                                                                        (get_local $19)
-                                                                      )
+                                                                    (i32.load
+                                                                      (get_local $19)
                                                                     )
                                                                     (get_local $22)
-                                                                  )
-                                                                  (i32.store offset=4
-                                                                    (get_local $1)
-                                                                    (i32.shr_s
-                                                                      (i32.shl
-                                                                        (i32.lt_s
-                                                                          (get_local $22)
-                                                                          (i32.const 0)
-                                                                        )
-                                                                        (i32.const 31)
-                                                                      )
-                                                                      (i32.const 31)
-                                                                    )
                                                                   )
                                                                   (set_local $20
                                                                     (get_local $9)
@@ -4510,14 +4455,11 @@
                                                                   )
                                                                   (br $label$continue$L1)
                                                                 )
-                                                                (i32.store16
+                                                                (i32.store
                                                                   (i32.load
                                                                     (get_local $19)
                                                                   )
-                                                                  (i32.and
-                                                                    (get_local $22)
-                                                                    (i32.const 65535)
-                                                                  )
+                                                                  (get_local $22)
                                                                 )
                                                                 (set_local $20
                                                                   (get_local $9)
@@ -4530,13 +4472,25 @@
                                                                 )
                                                                 (br $label$continue$L1)
                                                               )
-                                                              (i32.store8
-                                                                (i32.load
-                                                                  (get_local $19)
+                                                              (i32.store
+                                                                (set_local $1
+                                                                  (i32.load
+                                                                    (get_local $19)
+                                                                  )
                                                                 )
-                                                                (i32.and
-                                                                  (get_local $22)
-                                                                  (i32.const 255)
+                                                                (get_local $22)
+                                                              )
+                                                              (i32.store offset=4
+                                                                (get_local $1)
+                                                                (i32.shr_s
+                                                                  (i32.shl
+                                                                    (i32.lt_s
+                                                                      (get_local $22)
+                                                                      (i32.const 0)
+                                                                    )
+                                                                    (i32.const 31)
+                                                                  )
+                                                                  (i32.const 31)
                                                                 )
                                                               )
                                                               (set_local $20
@@ -4550,11 +4504,14 @@
                                                               )
                                                               (br $label$continue$L1)
                                                             )
-                                                            (i32.store
+                                                            (i32.store16
                                                               (i32.load
                                                                 (get_local $19)
                                                               )
-                                                              (get_local $22)
+                                                              (i32.and
+                                                                (get_local $22)
+                                                                (i32.const 65535)
+                                                              )
                                                             )
                                                             (set_local $20
                                                               (get_local $9)
@@ -4567,25 +4524,13 @@
                                                             )
                                                             (br $label$continue$L1)
                                                           )
-                                                          (i32.store
-                                                            (set_local $1
-                                                              (i32.load
-                                                                (get_local $19)
-                                                              )
+                                                          (i32.store8
+                                                            (i32.load
+                                                              (get_local $19)
                                                             )
-                                                            (get_local $22)
-                                                          )
-                                                          (i32.store offset=4
-                                                            (get_local $1)
-                                                            (i32.shr_s
-                                                              (i32.shl
-                                                                (i32.lt_s
-                                                                  (get_local $22)
-                                                                  (i32.const 0)
-                                                                )
-                                                                (i32.const 31)
-                                                              )
-                                                              (i32.const 31)
+                                                            (i32.and
+                                                              (get_local $22)
+                                                              (i32.const 255)
                                                             )
                                                           )
                                                           (set_local $20
@@ -4599,6 +4544,12 @@
                                                           )
                                                           (br $label$continue$L1)
                                                         )
+                                                        (i32.store
+                                                          (i32.load
+                                                            (get_local $19)
+                                                          )
+                                                          (get_local $22)
+                                                        )
                                                         (set_local $20
                                                           (get_local $9)
                                                         )
@@ -4610,391 +4561,411 @@
                                                         )
                                                         (br $label$continue$L1)
                                                       )
-                                                    )
-                                                    (set_local $46
-                                                      (i32.or
-                                                        (get_local $18)
-                                                        (i32.const 8)
-                                                      )
-                                                    )
-                                                    (set_local $57
-                                                      (select
-                                                        (get_local $10)
-                                                        (i32.const 8)
-                                                        (i32.gt_u
-                                                          (get_local $10)
-                                                          (i32.const 8)
-                                                        )
-                                                      )
-                                                    )
-                                                    (set_local $68
-                                                      (i32.const 120)
-                                                    )
-                                                    (set_local $12
-                                                      (i32.const 64)
-                                                    )
-                                                    (br $switch$24)
-                                                  )
-                                                )
-                                                (set_local $46
-                                                  (get_local $18)
-                                                )
-                                                (set_local $57
-                                                  (get_local $10)
-                                                )
-                                                (set_local $68
-                                                  (get_local $26)
-                                                )
-                                                (set_local $12
-                                                  (i32.const 64)
-                                                )
-                                                (br $switch$24)
-                                              )
-                                              (if
-                                                (i32.and
-                                                  (i32.eq
-                                                    (set_local $5
-                                                      (i32.load
+                                                      (i32.store
                                                         (set_local $1
-                                                          (get_local $19)
+                                                          (i32.load
+                                                            (get_local $19)
+                                                          )
                                                         )
+                                                        (get_local $22)
                                                       )
-                                                    )
-                                                    (i32.const 0)
-                                                  )
-                                                  (i32.eq
-                                                    (set_local $1
-                                                      (i32.load offset=4
+                                                      (i32.store offset=4
                                                         (get_local $1)
-                                                      )
-                                                    )
-                                                    (i32.const 0)
-                                                  )
-                                                )
-                                                (set_local $6
-                                                  (get_local $28)
-                                                )
-                                                (block
-                                                  (set_local $6
-                                                    (get_local $28)
-                                                  )
-                                                  (loop $while-out$38 $while-in$39
-                                                    (i32.store8
-                                                      (set_local $6
-                                                        (i32.add
-                                                          (get_local $6)
-                                                          (i32.const -1)
-                                                        )
-                                                      )
-                                                      (i32.and
-                                                        (i32.or
-                                                          (i32.and
-                                                            (get_local $5)
-                                                            (i32.const 7)
-                                                          )
-                                                          (i32.const 48)
-                                                        )
-                                                        (i32.const 255)
-                                                      )
-                                                    )
-                                                    (if
-                                                      (i32.and
-                                                        (i32.eq
-                                                          (set_local $5
-                                                            (call $_bitshift64Lshr
-                                                              (get_local $5)
-                                                              (get_local $1)
-                                                              (i32.const 3)
+                                                        (i32.shr_s
+                                                          (i32.shl
+                                                            (i32.lt_s
+                                                              (get_local $22)
+                                                              (i32.const 0)
                                                             )
+                                                            (i32.const 31)
                                                           )
-                                                          (i32.const 0)
-                                                        )
-                                                        (i32.eq
-                                                          (set_local $1
-                                                            (i32.load
-                                                              (i32.const 168)
-                                                            )
-                                                          )
-                                                          (i32.const 0)
+                                                          (i32.const 31)
                                                         )
                                                       )
-                                                      (br $while-out$38)
+                                                      (set_local $20
+                                                        (get_local $9)
+                                                      )
+                                                      (set_local $1
+                                                        (get_local $17)
+                                                      )
+                                                      (set_local $8
+                                                        (get_local $21)
+                                                      )
+                                                      (br $label$continue$L1)
                                                     )
-                                                    (br $while-in$39)
+                                                    (set_local $20
+                                                      (get_local $9)
+                                                    )
+                                                    (set_local $1
+                                                      (get_local $17)
+                                                    )
+                                                    (set_local $8
+                                                      (get_local $21)
+                                                    )
+                                                    (br $label$continue$L1)
                                                   )
-                                                )
-                                              )
-                                              (set_local $58
-                                                (if
-                                                  (i32.eq
-                                                    (i32.and
+                                                  (set_local $46
+                                                    (i32.or
                                                       (get_local $18)
                                                       (i32.const 8)
                                                     )
-                                                    (i32.const 0)
                                                   )
-                                                  (block
-                                                    (set_local $34
-                                                      (get_local $18)
-                                                    )
-                                                    (set_local $32
+                                                  (set_local $57
+                                                    (select
                                                       (get_local $10)
-                                                    )
-                                                    (set_local $35
-                                                      (i32.const 0)
-                                                    )
-                                                    (set_local $36
-                                                      (i32.const 4091)
-                                                    )
-                                                    (set_local $12
-                                                      (i32.const 77)
-                                                    )
-                                                    (get_local $6)
-                                                  )
-                                                  (block
-                                                    (set_local $5
-                                                      (i32.lt_s
+                                                      (i32.const 8)
+                                                      (i32.gt_u
                                                         (get_local $10)
-                                                        (set_local $1
-                                                          (i32.add
-                                                            (i32.sub
-                                                              (get_local $71)
-                                                              (get_local $6)
-                                                            )
-                                                            (i32.const 1)
-                                                          )
-                                                        )
+                                                        (i32.const 8)
                                                       )
                                                     )
-                                                    (set_local $34
-                                                      (get_local $18)
-                                                    )
-                                                    (set_local $32
-                                                      (select
-                                                        (get_local $1)
-                                                        (get_local $10)
-                                                        (get_local $5)
-                                                      )
-                                                    )
-                                                    (set_local $35
-                                                      (i32.const 0)
-                                                    )
-                                                    (set_local $36
-                                                      (i32.const 4091)
-                                                    )
-                                                    (set_local $12
-                                                      (i32.const 77)
-                                                    )
-                                                    (get_local $6)
                                                   )
+                                                  (set_local $68
+                                                    (i32.const 120)
+                                                  )
+                                                  (set_local $12
+                                                    (i32.const 64)
+                                                  )
+                                                  (br $switch$24)
                                                 )
+                                              )
+                                              (set_local $46
+                                                (get_local $18)
+                                              )
+                                              (set_local $57
+                                                (get_local $10)
+                                              )
+                                              (set_local $68
+                                                (get_local $26)
+                                              )
+                                              (set_local $12
+                                                (i32.const 64)
                                               )
                                               (br $switch$24)
                                             )
-                                          )
-                                          (set_local $5
-                                            (i32.load
-                                              (set_local $1
-                                                (get_local $19)
-                                              )
-                                            )
-                                          )
-                                          (if
-                                            (i32.lt_s
-                                              (set_local $33
-                                                (i32.load offset=4
-                                                  (get_local $1)
-                                                )
-                                              )
-                                              (i32.const 0)
-                                            )
-                                            (block
-                                              (set_local $1
-                                                (call $_i64Subtract
-                                                  (i32.const 0)
-                                                  (i32.const 0)
-                                                  (get_local $5)
-                                                  (get_local $33)
-                                                )
-                                              )
-                                              (set_local $5
-                                                (i32.load
-                                                  (i32.const 168)
-                                                )
-                                              )
-                                              (i32.store
-                                                (set_local $33
-                                                  (get_local $19)
-                                                )
-                                                (get_local $1)
-                                              )
-                                              (i32.store offset=4
-                                                (get_local $33)
-                                                (get_local $5)
-                                              )
-                                              (set_local $33
-                                                (get_local $1)
-                                              )
-                                              (set_local $59
-                                                (get_local $5)
-                                              )
-                                              (set_local $60
-                                                (i32.const 1)
-                                              )
-                                              (set_local $61
-                                                (i32.const 4091)
-                                              )
-                                              (set_local $12
-                                                (i32.const 76)
-                                              )
-                                              (br $label$break$L75)
-                                            )
-                                          )
-                                          (set_local $33
                                             (if
-                                              (i32.eq
-                                                (i32.and
-                                                  (get_local $18)
-                                                  (i32.const 2048)
+                                              (i32.and
+                                                (i32.eq
+                                                  (set_local $5
+                                                    (i32.load
+                                                      (set_local $1
+                                                        (get_local $19)
+                                                      )
+                                                    )
+                                                  )
+                                                  (i32.const 0)
                                                 )
-                                                (i32.const 0)
+                                                (i32.eq
+                                                  (set_local $1
+                                                    (i32.load offset=4
+                                                      (get_local $1)
+                                                    )
+                                                  )
+                                                  (i32.const 0)
+                                                )
+                                              )
+                                              (set_local $6
+                                                (get_local $28)
                                               )
                                               (block
-                                                (set_local $1
-                                                  (select
-                                                    (i32.const 4091)
-                                                    (i32.const 4093)
-                                                    (i32.eq
-                                                      (set_local $6
+                                                (set_local $6
+                                                  (get_local $28)
+                                                )
+                                                (loop $while-out$38 $while-in$39
+                                                  (i32.store8
+                                                    (set_local $6
+                                                      (i32.add
+                                                        (get_local $6)
+                                                        (i32.const -1)
+                                                      )
+                                                    )
+                                                    (i32.and
+                                                      (i32.or
                                                         (i32.and
-                                                          (get_local $18)
+                                                          (get_local $5)
+                                                          (i32.const 7)
+                                                        )
+                                                        (i32.const 48)
+                                                      )
+                                                      (i32.const 255)
+                                                    )
+                                                  )
+                                                  (if
+                                                    (i32.and
+                                                      (i32.eq
+                                                        (set_local $5
+                                                          (call $_bitshift64Lshr
+                                                            (get_local $5)
+                                                            (get_local $1)
+                                                            (i32.const 3)
+                                                          )
+                                                        )
+                                                        (i32.const 0)
+                                                      )
+                                                      (i32.eq
+                                                        (set_local $1
+                                                          (i32.load
+                                                            (i32.const 168)
+                                                          )
+                                                        )
+                                                        (i32.const 0)
+                                                      )
+                                                    )
+                                                    (br $while-out$38)
+                                                  )
+                                                  (br $while-in$39)
+                                                )
+                                              )
+                                            )
+                                            (set_local $58
+                                              (if
+                                                (i32.eq
+                                                  (i32.and
+                                                    (get_local $18)
+                                                    (i32.const 8)
+                                                  )
+                                                  (i32.const 0)
+                                                )
+                                                (block
+                                                  (set_local $34
+                                                    (get_local $18)
+                                                  )
+                                                  (set_local $32
+                                                    (get_local $10)
+                                                  )
+                                                  (set_local $35
+                                                    (i32.const 0)
+                                                  )
+                                                  (set_local $36
+                                                    (i32.const 4091)
+                                                  )
+                                                  (set_local $12
+                                                    (i32.const 77)
+                                                  )
+                                                  (get_local $6)
+                                                )
+                                                (block
+                                                  (set_local $5
+                                                    (i32.lt_s
+                                                      (get_local $10)
+                                                      (set_local $1
+                                                        (i32.add
+                                                          (i32.sub
+                                                            (get_local $71)
+                                                            (get_local $6)
+                                                          )
                                                           (i32.const 1)
                                                         )
                                                       )
-                                                      (i32.const 0)
                                                     )
                                                   )
-                                                )
-                                                (set_local $59
-                                                  (get_local $33)
-                                                )
-                                                (set_local $60
+                                                  (set_local $34
+                                                    (get_local $18)
+                                                  )
+                                                  (set_local $32
+                                                    (select
+                                                      (get_local $1)
+                                                      (get_local $10)
+                                                      (get_local $5)
+                                                    )
+                                                  )
+                                                  (set_local $35
+                                                    (i32.const 0)
+                                                  )
+                                                  (set_local $36
+                                                    (i32.const 4091)
+                                                  )
+                                                  (set_local $12
+                                                    (i32.const 77)
+                                                  )
                                                   (get_local $6)
                                                 )
-                                                (set_local $61
-                                                  (get_local $1)
-                                                )
-                                                (set_local $12
-                                                  (i32.const 76)
-                                                )
-                                                (get_local $5)
-                                              )
-                                              (block
-                                                (set_local $59
-                                                  (get_local $33)
-                                                )
-                                                (set_local $60
-                                                  (i32.const 1)
-                                                )
-                                                (set_local $61
-                                                  (i32.const 4092)
-                                                )
-                                                (set_local $12
-                                                  (i32.const 76)
-                                                )
-                                                (get_local $5)
                                               )
                                             )
+                                            (br $switch$24)
                                           )
-                                          (br $switch$24)
                                         )
-                                        (set_local $33
+                                        (set_local $5
                                           (i32.load
                                             (set_local $1
                                               (get_local $19)
                                             )
                                           )
                                         )
-                                        (set_local $59
-                                          (i32.load offset=4
-                                            (get_local $1)
+                                        (if
+                                          (i32.lt_s
+                                            (set_local $33
+                                              (i32.load offset=4
+                                                (get_local $1)
+                                              )
+                                            )
+                                            (i32.const 0)
+                                          )
+                                          (block
+                                            (set_local $1
+                                              (call $_i64Subtract
+                                                (i32.const 0)
+                                                (i32.const 0)
+                                                (get_local $5)
+                                                (get_local $33)
+                                              )
+                                            )
+                                            (set_local $5
+                                              (i32.load
+                                                (i32.const 168)
+                                              )
+                                            )
+                                            (i32.store
+                                              (set_local $33
+                                                (get_local $19)
+                                              )
+                                              (get_local $1)
+                                            )
+                                            (i32.store offset=4
+                                              (get_local $33)
+                                              (get_local $5)
+                                            )
+                                            (set_local $33
+                                              (get_local $1)
+                                            )
+                                            (set_local $59
+                                              (get_local $5)
+                                            )
+                                            (set_local $60
+                                              (i32.const 1)
+                                            )
+                                            (set_local $61
+                                              (i32.const 4091)
+                                            )
+                                            (set_local $12
+                                              (i32.const 76)
+                                            )
+                                            (br $label$break$L75)
                                           )
                                         )
-                                        (set_local $60
-                                          (i32.const 0)
-                                        )
-                                        (set_local $61
-                                          (i32.const 4091)
-                                        )
-                                        (set_local $12
-                                          (i32.const 76)
+                                        (set_local $33
+                                          (if
+                                            (i32.eq
+                                              (i32.and
+                                                (get_local $18)
+                                                (i32.const 2048)
+                                              )
+                                              (i32.const 0)
+                                            )
+                                            (block
+                                              (set_local $1
+                                                (select
+                                                  (i32.const 4091)
+                                                  (i32.const 4093)
+                                                  (i32.eq
+                                                    (set_local $6
+                                                      (i32.and
+                                                        (get_local $18)
+                                                        (i32.const 1)
+                                                      )
+                                                    )
+                                                    (i32.const 0)
+                                                  )
+                                                )
+                                              )
+                                              (set_local $59
+                                                (get_local $33)
+                                              )
+                                              (set_local $60
+                                                (get_local $6)
+                                              )
+                                              (set_local $61
+                                                (get_local $1)
+                                              )
+                                              (set_local $12
+                                                (i32.const 76)
+                                              )
+                                              (get_local $5)
+                                            )
+                                            (block
+                                              (set_local $59
+                                                (get_local $33)
+                                              )
+                                              (set_local $60
+                                                (i32.const 1)
+                                              )
+                                              (set_local $61
+                                                (i32.const 4092)
+                                              )
+                                              (set_local $12
+                                                (i32.const 76)
+                                              )
+                                              (get_local $5)
+                                            )
+                                          )
                                         )
                                         (br $switch$24)
                                       )
-                                      (set_local $5
+                                      (set_local $33
                                         (i32.load
                                           (set_local $1
                                             (get_local $19)
                                           )
                                         )
                                       )
-                                      (i32.load offset=4
-                                        (get_local $1)
-                                      )
-                                      (i32.store8
-                                        (get_local $72)
-                                        (i32.and
-                                          (get_local $5)
-                                          (i32.const 255)
+                                      (set_local $59
+                                        (i32.load offset=4
+                                          (get_local $1)
                                         )
                                       )
-                                      (set_local $47
-                                        (get_local $72)
-                                      )
-                                      (set_local $37
-                                        (get_local $7)
-                                      )
-                                      (set_local $42
-                                        (i32.const 1)
-                                      )
-                                      (set_local $43
+                                      (set_local $60
                                         (i32.const 0)
                                       )
-                                      (set_local $48
+                                      (set_local $61
                                         (i32.const 4091)
                                       )
-                                      (set_local $49
-                                        (get_local $28)
+                                      (set_local $12
+                                        (i32.const 76)
                                       )
                                       (br $switch$24)
                                     )
-                                    (set_local $50
-                                      (call $_strerror
-                                        (i32.load
-                                          (call $___errno_location)
-                                        )
-                                      )
-                                    )
-                                    (set_local $12
-                                      (i32.const 82)
-                                    )
-                                    (br $switch$24)
-                                  )
-                                  (set_local $5
-                                    (i32.ne
-                                      (set_local $1
-                                        (i32.load
+                                    (set_local $5
+                                      (i32.load
+                                        (set_local $1
                                           (get_local $19)
                                         )
                                       )
+                                    )
+                                    (i32.load offset=4
+                                      (get_local $1)
+                                    )
+                                    (i32.store8
+                                      (get_local $72)
+                                      (i32.and
+                                        (get_local $5)
+                                        (i32.const 255)
+                                      )
+                                    )
+                                    (set_local $47
+                                      (get_local $72)
+                                    )
+                                    (set_local $37
+                                      (get_local $7)
+                                    )
+                                    (set_local $42
+                                      (i32.const 1)
+                                    )
+                                    (set_local $43
                                       (i32.const 0)
                                     )
+                                    (set_local $48
+                                      (i32.const 4091)
+                                    )
+                                    (set_local $49
+                                      (get_local $28)
+                                    )
+                                    (br $switch$24)
                                   )
                                   (set_local $50
-                                    (select
-                                      (get_local $1)
-                                      (i32.const 4101)
-                                      (get_local $5)
+                                    (call $_strerror
+                                      (i32.load
+                                        (call $___errno_location)
+                                      )
                                     )
                                   )
                                   (set_local $12
@@ -5003,64 +4974,85 @@
                                   (br $switch$24)
                                 )
                                 (set_local $5
-                                  (i32.load
+                                  (i32.ne
                                     (set_local $1
-                                      (get_local $19)
+                                      (i32.load
+                                        (get_local $19)
+                                      )
                                     )
+                                    (i32.const 0)
                                   )
                                 )
-                                (i32.load offset=4
-                                  (get_local $1)
-                                )
-                                (i32.store
-                                  (get_local $73)
-                                  (get_local $5)
-                                )
-                                (i32.store
-                                  (get_local $76)
-                                  (i32.const 0)
-                                )
-                                (i32.store
-                                  (get_local $19)
-                                  (get_local $73)
-                                )
-                                (set_local $69
-                                  (i32.const -1)
+                                (set_local $50
+                                  (select
+                                    (get_local $1)
+                                    (i32.const 4101)
+                                    (get_local $5)
+                                  )
                                 )
                                 (set_local $12
-                                  (i32.const 86)
+                                  (i32.const 82)
                                 )
                                 (br $switch$24)
                               )
-                              (set_local $12
-                                (if
-                                  (i32.eq
-                                    (get_local $10)
-                                    (i32.const 0)
-                                  )
-                                  (block
-                                    (call $_pad
-                                      (get_local $0)
-                                      (i32.const 32)
-                                      (get_local $16)
-                                      (i32.const 0)
-                                      (get_local $18)
-                                    )
-                                    (set_local $38
-                                      (i32.const 0)
-                                    )
-                                    (i32.const 98)
-                                  )
-                                  (block
-                                    (set_local $69
-                                      (get_local $10)
-                                    )
-                                    (i32.const 86)
+                              (set_local $5
+                                (i32.load
+                                  (set_local $1
+                                    (get_local $19)
                                   )
                                 )
                               )
+                              (i32.load offset=4
+                                (get_local $1)
+                              )
+                              (i32.store
+                                (get_local $73)
+                                (get_local $5)
+                              )
+                              (i32.store
+                                (get_local $76)
+                                (i32.const 0)
+                              )
+                              (i32.store
+                                (get_local $19)
+                                (get_local $73)
+                              )
+                              (set_local $69
+                                (i32.const -1)
+                              )
+                              (set_local $12
+                                (i32.const 86)
+                              )
                               (br $switch$24)
                             )
+                            (set_local $12
+                              (if
+                                (i32.eq
+                                  (get_local $10)
+                                  (i32.const 0)
+                                )
+                                (block
+                                  (call $_pad
+                                    (get_local $0)
+                                    (i32.const 32)
+                                    (get_local $16)
+                                    (i32.const 0)
+                                    (get_local $18)
+                                  )
+                                  (set_local $38
+                                    (i32.const 0)
+                                  )
+                                  (i32.const 98)
+                                )
+                                (block
+                                  (set_local $69
+                                    (get_local $10)
+                                  )
+                                  (i32.const 86)
+                                )
+                              )
+                            )
+                            (br $switch$24)
                           )
                         )
                       )
@@ -5068,282 +5060,1990 @@
                   )
                 )
               )
-              (set_local $15
-                (f64.load
-                  (get_local $19)
-                )
+            )
+            (set_local $15
+              (f64.load
+                (get_local $19)
               )
-              (i32.store
-                (get_local $25)
-                (i32.const 0)
-              )
-              (f64.store
-                (i32.load
-                  (i32.const 24)
-                )
-                (get_local $15)
-              )
+            )
+            (i32.store
+              (get_local $25)
+              (i32.const 0)
+            )
+            (f64.store
               (i32.load
-                (i32.load
-                  (i32.const 24)
-                )
+                (i32.const 24)
               )
-              (set_local $51
+              (get_local $15)
+            )
+            (i32.load
+              (i32.load
+                (i32.const 24)
+              )
+            )
+            (set_local $51
+              (if
+                (i32.lt_s
+                  (i32.load offset=4
+                    (i32.load
+                      (i32.const 24)
+                    )
+                  )
+                  (i32.const 0)
+                )
+                (block
+                  (set_local $39
+                    (i32.const 4108)
+                  )
+                  (set_local $15
+                    (f64.neg
+                      (get_local $15)
+                    )
+                  )
+                  (i32.const 1)
+                )
                 (if
-                  (i32.lt_s
-                    (i32.load offset=4
-                      (i32.load
-                        (i32.const 24)
-                      )
+                  (i32.eq
+                    (i32.and
+                      (get_local $18)
+                      (i32.const 2048)
                     )
                     (i32.const 0)
                   )
                   (block
                     (set_local $39
-                      (i32.const 4108)
-                    )
-                    (set_local $15
-                      (f64.neg
-                        (get_local $15)
+                      (select
+                        (i32.const 4109)
+                        (i32.const 4114)
+                        (i32.eq
+                          (set_local $1
+                            (i32.and
+                              (get_local $18)
+                              (i32.const 1)
+                            )
+                          )
+                          (i32.const 0)
+                        )
                       )
+                    )
+                    (get_local $1)
+                  )
+                  (block
+                    (set_local $39
+                      (i32.const 4111)
                     )
                     (i32.const 1)
                   )
-                  (if
-                    (i32.eq
-                      (i32.and
-                        (get_local $18)
-                        (i32.const 2048)
+                )
+              )
+            )
+            (f64.store
+              (i32.load
+                (i32.const 24)
+              )
+              (get_local $15)
+            )
+            (i32.load
+              (i32.load
+                (i32.const 24)
+              )
+            )
+            (set_local $20
+              (get_local $9)
+            )
+            (set_local $1
+              (block $do-once$56
+                (if
+                  (i32.or
+                    (i32.lt_u
+                      (set_local $1
+                        (i32.and
+                          (i32.load offset=4
+                            (i32.load
+                              (i32.const 24)
+                            )
+                          )
+                          (i32.const 2146435072)
+                        )
+                      )
+                      (i32.const 2146435072)
+                    )
+                    (i32.and
+                      (i32.eq
+                        (get_local $1)
+                        (i32.const 2146435072)
                       )
                       (i32.const 0)
                     )
-                    (block
-                      (set_local $39
-                        (select
-                          (i32.const 4109)
-                          (i32.const 4114)
-                          (i32.eq
+                  )
+                  (block
+                    (if
+                      (set_local $5
+                        (f64.ne
+                          (set_local $15
+                            (f64.mul
+                              (call $_frexpl
+                                (get_local $15)
+                                (get_local $25)
+                              )
+                              (f64.const 2)
+                            )
+                          )
+                          (f64.const 0)
+                        )
+                      )
+                      (i32.store
+                        (get_local $25)
+                        (i32.add
+                          (i32.load
+                            (get_local $25)
+                          )
+                          (i32.const -1)
+                        )
+                      )
+                    )
+                    (if
+                      (i32.eq
+                        (set_local $14
+                          (i32.or
+                            (get_local $26)
+                            (i32.const 32)
+                          )
+                        )
+                        (i32.const 97)
+                      )
+                      (block
+                        (set_local $9
+                          (select
+                            (get_local $39)
+                            (i32.add
+                              (get_local $39)
+                              (i32.const 9)
+                            )
+                            (i32.eq
+                              (set_local $6
+                                (i32.and
+                                  (get_local $26)
+                                  (i32.const 32)
+                                )
+                              )
+                              (i32.const 0)
+                            )
+                          )
+                        )
+                        (set_local $7
+                          (i32.or
+                            (get_local $51)
+                            (i32.const 2)
+                          )
+                        )
+                        (set_local $15
+                          (if
+                            (i32.or
+                              (i32.gt_u
+                                (get_local $10)
+                                (i32.const 11)
+                              )
+                              (i32.eq
+                                (set_local $1
+                                  (i32.sub
+                                    (i32.const 12)
+                                    (get_local $10)
+                                  )
+                                )
+                                (i32.const 0)
+                              )
+                            )
+                            (get_local $15)
+                            (block
+                              (set_local $30
+                                (f64.const 8)
+                              )
+                              (loop $while-out$60 $while-in$61
+                                (set_local $30
+                                  (f64.mul
+                                    (get_local $30)
+                                    (f64.const 16)
+                                  )
+                                )
+                                (if
+                                  (i32.eq
+                                    (set_local $1
+                                      (i32.add
+                                        (get_local $1)
+                                        (i32.const -1)
+                                      )
+                                    )
+                                    (i32.const 0)
+                                  )
+                                  (br $while-out$60)
+                                )
+                                (br $while-in$61)
+                              )
+                              (select
+                                (f64.neg
+                                  (f64.add
+                                    (get_local $30)
+                                    (f64.sub
+                                      (f64.neg
+                                        (get_local $15)
+                                      )
+                                      (get_local $30)
+                                    )
+                                  )
+                                )
+                                (f64.sub
+                                  (f64.add
+                                    (get_local $15)
+                                    (get_local $30)
+                                  )
+                                  (get_local $30)
+                                )
+                                (i32.eq
+                                  (i32.shr_s
+                                    (i32.shl
+                                      (i32.load8_s
+                                        (get_local $9)
+                                      )
+                                      (i32.const 24)
+                                    )
+                                    (i32.const 24)
+                                  )
+                                  (i32.const 45)
+                                )
+                              )
+                            )
+                          )
+                        )
+                        (set_local $5
+                          (i32.lt_s
                             (set_local $1
+                              (i32.load
+                                (get_local $25)
+                              )
+                            )
+                            (i32.const 0)
+                          )
+                        )
+                        (set_local $5
+                          (i32.shr_s
+                            (i32.shl
+                              (i32.lt_s
+                                (set_local $8
+                                  (select
+                                    (i32.sub
+                                      (i32.const 0)
+                                      (get_local $1)
+                                    )
+                                    (get_local $1)
+                                    (get_local $5)
+                                  )
+                                )
+                                (i32.const 0)
+                              )
+                              (i32.const 31)
+                            )
+                            (i32.const 31)
+                          )
+                        )
+                        (i32.store8
+                          (i32.add
+                            (set_local $5
+                              (if
+                                (i32.eq
+                                  (set_local $5
+                                    (call $_fmt_u
+                                      (get_local $8)
+                                      (get_local $5)
+                                      (get_local $52)
+                                    )
+                                  )
+                                  (get_local $52)
+                                )
+                                (block
+                                  (i32.store8
+                                    (get_local $74)
+                                    (i32.const 48)
+                                  )
+                                  (get_local $74)
+                                )
+                                (get_local $5)
+                              )
+                            )
+                            (i32.const -1)
+                          )
+                          (i32.and
+                            (i32.add
                               (i32.and
-                                (get_local $18)
-                                (i32.const 1)
+                                (i32.shr_s
+                                  (get_local $1)
+                                  (i32.const 31)
+                                )
+                                (i32.const 2)
+                              )
+                              (i32.const 43)
+                            )
+                            (i32.const 255)
+                          )
+                        )
+                        (i32.store8
+                          (set_local $8
+                            (i32.add
+                              (get_local $5)
+                              (i32.const -2)
+                            )
+                          )
+                          (i32.and
+                            (i32.add
+                              (get_local $26)
+                              (i32.const 15)
+                            )
+                            (i32.const 255)
+                          )
+                        )
+                        (set_local $5
+                          (i32.lt_s
+                            (get_local $10)
+                            (i32.const 1)
+                          )
+                        )
+                        (set_local $13
+                          (i32.eq
+                            (i32.and
+                              (get_local $18)
+                              (i32.const 8)
+                            )
+                            (i32.const 0)
+                          )
+                        )
+                        (set_local $11
+                          (get_local $29)
+                        )
+                        (loop $while-out$62 $while-in$63
+                          (i32.store8
+                            (get_local $11)
+                            (i32.and
+                              (i32.or
+                                (i32.and
+                                  (i32.load8_s
+                                    (i32.add
+                                      (set_local $1
+                                        (i32.trunc_s/f64
+                                          (get_local $15)
+                                        )
+                                      )
+                                      (i32.const 4075)
+                                    )
+                                  )
+                                  (i32.const 255)
+                                )
+                                (get_local $6)
+                              )
+                              (i32.const 255)
+                            )
+                          )
+                          (set_local $15
+                            (f64.mul
+                              (f64.sub
+                                (get_local $15)
+                                (f64.convert_s/i32
+                                  (get_local $1)
+                                )
+                              )
+                              (f64.const 16)
+                            )
+                          )
+                          (set_local $11
+                            (block $do-once$64
+                              (if
+                                (i32.eq
+                                  (i32.sub
+                                    (set_local $1
+                                      (i32.add
+                                        (get_local $11)
+                                        (i32.const 1)
+                                      )
+                                    )
+                                    (get_local $64)
+                                  )
+                                  (i32.const 1)
+                                )
+                                (block
+                                  (br_if $do-once$64
+                                    (get_local $1)
+                                    (i32.and
+                                      (get_local $13)
+                                      (i32.and
+                                        (get_local $5)
+                                        (f64.eq
+                                          (get_local $15)
+                                          (f64.const 0)
+                                        )
+                                      )
+                                    )
+                                  )
+                                  (i32.store8
+                                    (get_local $1)
+                                    (i32.const 46)
+                                  )
+                                  (i32.add
+                                    (get_local $11)
+                                    (i32.const 2)
+                                  )
+                                )
+                                (get_local $1)
+                              )
+                            )
+                          )
+                          (if
+                            (f64.eq
+                              (get_local $15)
+                              (f64.const 0)
+                            )
+                            (block
+                              (set_local $1
+                                (get_local $11)
+                              )
+                              (br $while-out$62)
+                            )
+                          )
+                          (br $while-in$63)
+                        )
+                        (set_local $5
+                          (i32.and
+                            (i32.ne
+                              (get_local $10)
+                              (i32.const 0)
+                            )
+                            (i32.lt_s
+                              (i32.add
+                                (get_local $78)
+                                (get_local $1)
+                              )
+                              (get_local $10)
+                            )
+                          )
+                        )
+                        (call $_pad
+                          (get_local $0)
+                          (i32.const 32)
+                          (get_local $16)
+                          (set_local $5
+                            (i32.add
+                              (set_local $6
+                                (select
+                                  (i32.sub
+                                    (i32.add
+                                      (get_local $79)
+                                      (get_local $10)
+                                    )
+                                    (get_local $8)
+                                  )
+                                  (i32.add
+                                    (i32.sub
+                                      (get_local $77)
+                                      (get_local $8)
+                                    )
+                                    (get_local $1)
+                                  )
+                                  (get_local $5)
+                                )
+                              )
+                              (get_local $7)
+                            )
+                          )
+                          (get_local $18)
+                        )
+                        (if
+                          (i32.eq
+                            (i32.and
+                              (i32.load
+                                (get_local $0)
+                              )
+                              (i32.const 32)
+                            )
+                            (i32.const 0)
+                          )
+                          (call $___fwritex
+                            (get_local $9)
+                            (get_local $7)
+                            (get_local $0)
+                          )
+                        )
+                        (call $_pad
+                          (get_local $0)
+                          (i32.const 48)
+                          (get_local $16)
+                          (get_local $5)
+                          (i32.xor
+                            (get_local $18)
+                            (i32.const 65536)
+                          )
+                        )
+                        (set_local $1
+                          (i32.sub
+                            (get_local $1)
+                            (get_local $64)
+                          )
+                        )
+                        (if
+                          (i32.eq
+                            (i32.and
+                              (i32.load
+                                (get_local $0)
+                              )
+                              (i32.const 32)
+                            )
+                            (i32.const 0)
+                          )
+                          (call $___fwritex
+                            (get_local $29)
+                            (get_local $1)
+                            (get_local $0)
+                          )
+                        )
+                        (call $_pad
+                          (get_local $0)
+                          (i32.const 48)
+                          (i32.sub
+                            (get_local $6)
+                            (i32.add
+                              (get_local $1)
+                              (set_local $1
+                                (i32.sub
+                                  (get_local $40)
+                                  (get_local $8)
+                                )
+                              )
+                            )
+                          )
+                          (i32.const 0)
+                          (i32.const 0)
+                        )
+                        (if
+                          (i32.eq
+                            (i32.and
+                              (i32.load
+                                (get_local $0)
+                              )
+                              (i32.const 32)
+                            )
+                            (i32.const 0)
+                          )
+                          (call $___fwritex
+                            (get_local $8)
+                            (get_local $1)
+                            (get_local $0)
+                          )
+                        )
+                        (call $_pad
+                          (get_local $0)
+                          (i32.const 32)
+                          (get_local $16)
+                          (get_local $5)
+                          (i32.xor
+                            (get_local $18)
+                            (i32.const 8192)
+                          )
+                        )
+                        (br $do-once$56
+                          (select
+                            (get_local $16)
+                            (get_local $5)
+                            (i32.lt_s
+                              (get_local $5)
+                              (get_local $16)
+                            )
+                          )
+                        )
+                      )
+                    )
+                    (set_local $1
+                      (select
+                        (i32.const 6)
+                        (get_local $10)
+                        (i32.lt_s
+                          (get_local $10)
+                          (i32.const 0)
+                        )
+                      )
+                    )
+                    (set_local $62
+                      (set_local $9
+                        (select
+                          (get_local $80)
+                          (get_local $81)
+                          (i32.lt_s
+                            (if
+                              (get_local $5)
+                              (block
+                                (i32.store
+                                  (get_local $25)
+                                  (set_local $5
+                                    (i32.add
+                                      (i32.load
+                                        (get_local $25)
+                                      )
+                                      (i32.const -28)
+                                    )
+                                  )
+                                )
+                                (set_local $15
+                                  (f64.mul
+                                    (get_local $15)
+                                    (f64.const 268435456)
+                                  )
+                                )
+                                (get_local $5)
+                              )
+                              (i32.load
+                                (get_local $25)
                               )
                             )
                             (i32.const 0)
                           )
                         )
                       )
-                      (get_local $1)
                     )
-                    (block
-                      (set_local $39
-                        (i32.const 4111)
-                      )
-                      (i32.const 1)
+                    (set_local $7
+                      (get_local $9)
                     )
-                  )
-                )
-              )
-              (f64.store
-                (i32.load
-                  (i32.const 24)
-                )
-                (get_local $15)
-              )
-              (i32.load
-                (i32.load
-                  (i32.const 24)
-                )
-              )
-              (set_local $20
-                (get_local $9)
-              )
-              (set_local $1
-                (block $do-once$56
-                  (if
-                    (i32.or
-                      (i32.lt_u
-                        (set_local $1
-                          (i32.and
-                            (i32.load offset=4
-                              (i32.load
-                                (i32.const 24)
-                              )
-                            )
-                            (i32.const 2146435072)
+                    (loop $while-out$66 $while-in$67
+                      (i32.store
+                        (get_local $7)
+                        (set_local $5
+                          (i32.trunc_s/f64
+                            (get_local $15)
                           )
                         )
-                        (i32.const 2146435072)
                       )
-                      (i32.and
-                        (i32.eq
-                          (get_local $1)
-                          (i32.const 2146435072)
+                      (set_local $7
+                        (i32.add
+                          (get_local $7)
+                          (i32.const 4)
+                        )
+                      )
+                      (if
+                        (f64.eq
+                          (set_local $15
+                            (f64.mul
+                              (f64.sub
+                                (get_local $15)
+                                (f64.convert_u/i32
+                                  (get_local $5)
+                                )
+                              )
+                              (f64.const 1e9)
+                            )
+                          )
+                          (f64.const 0)
+                        )
+                        (block
+                          (set_local $6
+                            (get_local $7)
+                          )
+                          (br $while-out$66)
+                        )
+                      )
+                      (br $while-in$67)
+                    )
+                    (if
+                      (i32.gt_s
+                        (set_local $5
+                          (i32.load
+                            (get_local $25)
+                          )
                         )
                         (i32.const 0)
                       )
-                    )
-                    (block
-                      (if
-                        (set_local $5
-                          (f64.ne
-                            (set_local $15
-                              (f64.mul
-                                (call $_frexpl
-                                  (get_local $15)
-                                  (get_local $25)
-                                )
-                                (f64.const 2)
+                      (block
+                        (set_local $8
+                          (get_local $9)
+                        )
+                        (set_local $13
+                          (get_local $6)
+                        )
+                        (loop $while-out$68 $while-in$69
+                          (set_local $11
+                            (select
+                              (i32.const 29)
+                              (get_local $5)
+                              (i32.gt_s
+                                (get_local $5)
+                                (i32.const 29)
                               )
                             )
-                            (f64.const 0)
+                          )
+                          (set_local $7
+                            (block $do-once$70
+                              (if
+                                (i32.lt_u
+                                  (set_local $7
+                                    (i32.add
+                                      (get_local $13)
+                                      (i32.const -4)
+                                    )
+                                  )
+                                  (get_local $8)
+                                )
+                                (get_local $8)
+                                (block
+                                  (set_local $5
+                                    (i32.const 0)
+                                  )
+                                  (set_local $10
+                                    (get_local $7)
+                                  )
+                                  (loop $while-out$72 $while-in$73
+                                    (set_local $6
+                                      (call $___uremdi3
+                                        (set_local $5
+                                          (call $_i64Add
+                                            (call $_bitshift64Shl
+                                              (i32.load
+                                                (get_local $10)
+                                              )
+                                              (i32.const 0)
+                                              (get_local $11)
+                                            )
+                                            (i32.load
+                                              (i32.const 168)
+                                            )
+                                            (get_local $5)
+                                            (i32.const 0)
+                                          )
+                                        )
+                                        (set_local $7
+                                          (i32.load
+                                            (i32.const 168)
+                                          )
+                                        )
+                                        (i32.const 1000000000)
+                                        (i32.const 0)
+                                      )
+                                    )
+                                    (i32.load
+                                      (i32.const 168)
+                                    )
+                                    (i32.store
+                                      (get_local $10)
+                                      (get_local $6)
+                                    )
+                                    (set_local $5
+                                      (call $___udivdi3
+                                        (get_local $5)
+                                        (get_local $7)
+                                        (i32.const 1000000000)
+                                        (i32.const 0)
+                                      )
+                                    )
+                                    (i32.load
+                                      (i32.const 168)
+                                    )
+                                    (if
+                                      (i32.lt_u
+                                        (set_local $7
+                                          (i32.add
+                                            (get_local $10)
+                                            (i32.const -4)
+                                          )
+                                        )
+                                        (get_local $8)
+                                      )
+                                      (br $while-out$72)
+                                      (set_local $10
+                                        (get_local $7)
+                                      )
+                                    )
+                                    (br $while-in$73)
+                                  )
+                                  (br_if $do-once$70
+                                    (get_local $8)
+                                    (i32.eq
+                                      (get_local $5)
+                                      (i32.const 0)
+                                    )
+                                  )
+                                  (i32.store
+                                    (set_local $7
+                                      (i32.add
+                                        (get_local $8)
+                                        (i32.const -4)
+                                      )
+                                    )
+                                    (get_local $5)
+                                  )
+                                  (get_local $7)
+                                )
+                              )
+                            )
+                          )
+                          (loop $while-out$74 $while-in$75
+                            (if
+                              (i32.le_u
+                                (get_local $13)
+                                (get_local $7)
+                              )
+                              (br $while-out$74)
+                            )
+                            (if
+                              (i32.eq
+                                (i32.load
+                                  (set_local $5
+                                    (i32.add
+                                      (get_local $13)
+                                      (i32.const -4)
+                                    )
+                                  )
+                                )
+                                (i32.const 0)
+                              )
+                              (set_local $13
+                                (get_local $5)
+                              )
+                              (br $while-out$74)
+                            )
+                            (br $while-in$75)
+                          )
+                          (i32.store
+                            (get_local $25)
+                            (set_local $5
+                              (i32.sub
+                                (i32.load
+                                  (get_local $25)
+                                )
+                                (get_local $11)
+                              )
+                            )
+                          )
+                          (if
+                            (i32.gt_s
+                              (get_local $5)
+                              (i32.const 0)
+                            )
+                            (set_local $8
+                              (get_local $7)
+                            )
+                            (block
+                              (set_local $6
+                                (get_local $13)
+                              )
+                              (br $while-out$68)
+                            )
+                          )
+                          (br $while-in$69)
+                        )
+                      )
+                      (set_local $7
+                        (get_local $9)
+                      )
+                    )
+                    (if
+                      (i32.lt_s
+                        (get_local $5)
+                        (i32.const 0)
+                      )
+                      (block
+                        (set_local $8
+                          (i32.add
+                            (i32.and
+                              (i32.div_s
+                                (i32.add
+                                  (get_local $1)
+                                  (i32.const 25)
+                                )
+                                (i32.const 9)
+                              )
+                              (i32.const -1)
+                            )
+                            (i32.const 1)
                           )
                         )
-                        (i32.store
-                          (get_local $25)
-                          (i32.add
-                            (i32.load
-                              (get_local $25)
-                            )
-                            (i32.const -1)
+                        (set_local $10
+                          (i32.eq
+                            (get_local $14)
+                            (i32.const 102)
                           )
+                        )
+                        (set_local $23
+                          (get_local $6)
+                        )
+                        (loop $while-out$76 $while-in$77
+                          (set_local $5
+                            (i32.gt_s
+                              (set_local $6
+                                (i32.sub
+                                  (i32.const 0)
+                                  (get_local $5)
+                                )
+                              )
+                              (i32.const 9)
+                            )
+                          )
+                          (set_local $13
+                            (select
+                              (i32.const 9)
+                              (get_local $6)
+                              (get_local $5)
+                            )
+                          )
+                          (set_local $11
+                            (block $do-once$78
+                              (if
+                                (i32.lt_u
+                                  (get_local $7)
+                                  (get_local $23)
+                                )
+                                (block
+                                  (set_local $70
+                                    (i32.add
+                                      (i32.shl
+                                        (i32.const 1)
+                                        (get_local $13)
+                                      )
+                                      (i32.const -1)
+                                    )
+                                  )
+                                  (set_local $27
+                                    (i32.shr_u
+                                      (i32.const 1000000000)
+                                      (get_local $13)
+                                    )
+                                  )
+                                  (set_local $11
+                                    (i32.const 0)
+                                  )
+                                  (set_local $17
+                                    (get_local $7)
+                                  )
+                                  (loop $while-out$80 $while-in$81
+                                    (set_local $6
+                                      (i32.and
+                                        (set_local $5
+                                          (i32.load
+                                            (get_local $17)
+                                          )
+                                        )
+                                        (get_local $70)
+                                      )
+                                    )
+                                    (i32.store
+                                      (get_local $17)
+                                      (i32.add
+                                        (i32.shr_u
+                                          (get_local $5)
+                                          (get_local $13)
+                                        )
+                                        (get_local $11)
+                                      )
+                                    )
+                                    (set_local $11
+                                      (i32.mul
+                                        (get_local $6)
+                                        (get_local $27)
+                                      )
+                                    )
+                                    (if
+                                      (i32.ge_u
+                                        (set_local $17
+                                          (i32.add
+                                            (get_local $17)
+                                            (i32.const 4)
+                                          )
+                                        )
+                                        (get_local $23)
+                                      )
+                                      (br $while-out$80)
+                                    )
+                                    (br $while-in$81)
+                                  )
+                                  (set_local $5
+                                    (select
+                                      (i32.add
+                                        (get_local $7)
+                                        (i32.const 4)
+                                      )
+                                      (get_local $7)
+                                      (i32.eq
+                                        (i32.load
+                                          (get_local $7)
+                                        )
+                                        (i32.const 0)
+                                      )
+                                    )
+                                  )
+                                  (if
+                                    (i32.eq
+                                      (get_local $11)
+                                      (i32.const 0)
+                                    )
+                                    (br $do-once$78
+                                      (get_local $5)
+                                    )
+                                  )
+                                  (i32.store
+                                    (get_local $23)
+                                    (get_local $11)
+                                  )
+                                  (set_local $23
+                                    (i32.add
+                                      (get_local $23)
+                                      (i32.const 4)
+                                    )
+                                  )
+                                  (get_local $5)
+                                )
+                                (select
+                                  (i32.add
+                                    (get_local $7)
+                                    (i32.const 4)
+                                  )
+                                  (get_local $7)
+                                  (i32.eq
+                                    (i32.load
+                                      (get_local $7)
+                                    )
+                                    (i32.const 0)
+                                  )
+                                )
+                              )
+                            )
+                          )
+                          (set_local $5
+                            (i32.gt_s
+                              (i32.shr_s
+                                (i32.sub
+                                  (get_local $23)
+                                  (set_local $7
+                                    (select
+                                      (get_local $9)
+                                      (get_local $11)
+                                      (get_local $10)
+                                    )
+                                  )
+                                )
+                                (i32.const 2)
+                              )
+                              (get_local $8)
+                            )
+                          )
+                          (set_local $6
+                            (select
+                              (i32.add
+                                (get_local $7)
+                                (i32.shl
+                                  (get_local $8)
+                                  (i32.const 2)
+                                )
+                              )
+                              (get_local $23)
+                              (get_local $5)
+                            )
+                          )
+                          (i32.store
+                            (get_local $25)
+                            (set_local $5
+                              (i32.add
+                                (i32.load
+                                  (get_local $25)
+                                )
+                                (get_local $13)
+                              )
+                            )
+                          )
+                          (if
+                            (i32.lt_s
+                              (get_local $5)
+                              (i32.const 0)
+                            )
+                            (block
+                              (set_local $7
+                                (get_local $11)
+                              )
+                              (set_local $23
+                                (get_local $6)
+                              )
+                            )
+                            (block
+                              (set_local $7
+                                (get_local $11)
+                              )
+                              (set_local $27
+                                (get_local $6)
+                              )
+                              (br $while-out$76)
+                            )
+                          )
+                          (br $while-in$77)
+                        )
+                      )
+                      (set_local $27
+                        (get_local $6)
+                      )
+                    )
+                    (block $do-once$82
+                      (if
+                        (i32.lt_u
+                          (get_local $7)
+                          (get_local $27)
+                        )
+                        (block
+                          (set_local $6
+                            (i32.mul
+                              (i32.shr_s
+                                (i32.sub
+                                  (get_local $62)
+                                  (get_local $7)
+                                )
+                                (i32.const 2)
+                              )
+                              (i32.const 9)
+                            )
+                          )
+                          (if
+                            (i32.lt_u
+                              (set_local $5
+                                (i32.load
+                                  (get_local $7)
+                                )
+                              )
+                              (i32.const 10)
+                            )
+                            (block
+                              (set_local $13
+                                (get_local $6)
+                              )
+                              (br $do-once$82)
+                            )
+                            (set_local $8
+                              (i32.const 10)
+                            )
+                          )
+                          (loop $while-out$84 $while-in$85
+                            (set_local $6
+                              (i32.add
+                                (get_local $6)
+                                (i32.const 1)
+                              )
+                            )
+                            (if
+                              (i32.lt_u
+                                (get_local $5)
+                                (set_local $8
+                                  (i32.mul
+                                    (get_local $8)
+                                    (i32.const 10)
+                                  )
+                                )
+                              )
+                              (block
+                                (set_local $13
+                                  (get_local $6)
+                                )
+                                (br $while-out$84)
+                              )
+                            )
+                            (br $while-in$85)
+                          )
+                        )
+                        (set_local $13
+                          (i32.const 0)
+                        )
+                      )
+                    )
+                    (set_local $7
+                      (if
+                        (i32.lt_s
+                          (set_local $5
+                            (i32.add
+                              (i32.sub
+                                (get_local $1)
+                                (select
+                                  (get_local $13)
+                                  (i32.const 0)
+                                  (i32.ne
+                                    (get_local $14)
+                                    (i32.const 102)
+                                  )
+                                )
+                              )
+                              (i32.shr_s
+                                (i32.shl
+                                  (i32.and
+                                    (set_local $70
+                                      (i32.ne
+                                        (get_local $1)
+                                        (i32.const 0)
+                                      )
+                                    )
+                                    (set_local $8
+                                      (i32.eq
+                                        (get_local $14)
+                                        (i32.const 103)
+                                      )
+                                    )
+                                  )
+                                  (i32.const 31)
+                                )
+                                (i32.const 31)
+                              )
+                            )
+                          )
+                          (i32.add
+                            (i32.mul
+                              (i32.shr_s
+                                (i32.sub
+                                  (get_local $27)
+                                  (get_local $62)
+                                )
+                                (i32.const 2)
+                              )
+                              (i32.const 9)
+                            )
+                            (i32.const -9)
+                          )
+                        )
+                        (block
+                          (set_local $6
+                            (i32.add
+                              (i32.add
+                                (get_local $9)
+                                (i32.const 4)
+                              )
+                              (i32.shl
+                                (i32.add
+                                  (i32.and
+                                    (i32.div_s
+                                      (set_local $5
+                                        (i32.add
+                                          (get_local $5)
+                                          (i32.const 9216)
+                                        )
+                                      )
+                                      (i32.const 9)
+                                    )
+                                    (i32.const -1)
+                                  )
+                                  (i32.const -1024)
+                                )
+                                (i32.const 2)
+                              )
+                            )
+                          )
+                          (if
+                            (i32.lt_s
+                              (set_local $11
+                                (i32.add
+                                  (i32.and
+                                    (i32.rem_s
+                                      (get_local $5)
+                                      (i32.const 9)
+                                    )
+                                    (i32.const -1)
+                                  )
+                                  (i32.const 1)
+                                )
+                              )
+                              (i32.const 9)
+                            )
+                            (block
+                              (set_local $5
+                                (i32.const 10)
+                              )
+                              (loop $while-out$86 $while-in$87
+                                (set_local $5
+                                  (i32.mul
+                                    (get_local $5)
+                                    (i32.const 10)
+                                  )
+                                )
+                                (if
+                                  (i32.eq
+                                    (set_local $11
+                                      (i32.add
+                                        (get_local $11)
+                                        (i32.const 1)
+                                      )
+                                    )
+                                    (i32.const 9)
+                                  )
+                                  (block
+                                    (set_local $17
+                                      (get_local $5)
+                                    )
+                                    (br $while-out$86)
+                                  )
+                                )
+                                (br $while-in$87)
+                              )
+                            )
+                            (set_local $17
+                              (i32.const 10)
+                            )
+                          )
+                          (block $do-once$88
+                            (if
+                              (i32.eqz
+                                (i32.and
+                                  (set_local $11
+                                    (i32.eq
+                                      (i32.add
+                                        (get_local $6)
+                                        (i32.const 4)
+                                      )
+                                      (get_local $27)
+                                    )
+                                  )
+                                  (i32.eq
+                                    (set_local $14
+                                      (i32.and
+                                        (i32.rem_u
+                                          (set_local $5
+                                            (i32.load
+                                              (get_local $6)
+                                            )
+                                          )
+                                          (get_local $17)
+                                        )
+                                        (i32.const -1)
+                                      )
+                                    )
+                                    (i32.const 0)
+                                  )
+                                )
+                              )
+                              (block
+                                (set_local $15
+                                  (select
+                                    (f64.const 9007199254740992)
+                                    (f64.const 9007199254740994)
+                                    (i32.eq
+                                      (i32.and
+                                        (i32.and
+                                          (i32.div_u
+                                            (get_local $5)
+                                            (get_local $17)
+                                          )
+                                          (i32.const -1)
+                                        )
+                                        (i32.const 1)
+                                      )
+                                      (i32.const 0)
+                                    )
+                                  )
+                                )
+                                (set_local $30
+                                  (if
+                                    (i32.lt_u
+                                      (get_local $14)
+                                      (set_local $10
+                                        (i32.and
+                                          (i32.div_s
+                                            (get_local $17)
+                                            (i32.const 2)
+                                          )
+                                          (i32.const -1)
+                                        )
+                                      )
+                                    )
+                                    (f64.const 0.5)
+                                    (select
+                                      (f64.const 1)
+                                      (f64.const 1.5)
+                                      (i32.and
+                                        (get_local $11)
+                                        (i32.eq
+                                          (get_local $14)
+                                          (get_local $10)
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                                (set_local $15
+                                  (block $do-once$90
+                                    (if
+                                      (i32.eq
+                                        (get_local $51)
+                                        (i32.const 0)
+                                      )
+                                      (get_local $15)
+                                      (block
+                                        (if
+                                          (i32.ne
+                                            (i32.shr_s
+                                              (i32.shl
+                                                (i32.load8_s
+                                                  (get_local $39)
+                                                )
+                                                (i32.const 24)
+                                              )
+                                              (i32.const 24)
+                                            )
+                                            (i32.const 45)
+                                          )
+                                          (br $do-once$90
+                                            (get_local $15)
+                                          )
+                                        )
+                                        (set_local $30
+                                          (f64.neg
+                                            (get_local $30)
+                                          )
+                                        )
+                                        (f64.neg
+                                          (get_local $15)
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                                (i32.store
+                                  (get_local $6)
+                                  (set_local $5
+                                    (i32.sub
+                                      (get_local $5)
+                                      (get_local $14)
+                                    )
+                                  )
+                                )
+                                (if
+                                  (f64.eq
+                                    (f64.add
+                                      (get_local $15)
+                                      (get_local $30)
+                                    )
+                                    (get_local $15)
+                                  )
+                                  (br $do-once$88)
+                                )
+                                (i32.store
+                                  (get_local $6)
+                                  (set_local $5
+                                    (i32.add
+                                      (get_local $5)
+                                      (get_local $17)
+                                    )
+                                  )
+                                )
+                                (if
+                                  (i32.gt_u
+                                    (get_local $5)
+                                    (i32.const 999999999)
+                                  )
+                                  (loop $while-out$92 $while-in$93
+                                    (i32.store
+                                      (get_local $6)
+                                      (i32.const 0)
+                                    )
+                                    (set_local $7
+                                      (if
+                                        (i32.lt_u
+                                          (set_local $6
+                                            (i32.add
+                                              (get_local $6)
+                                              (i32.const -4)
+                                            )
+                                          )
+                                          (get_local $7)
+                                        )
+                                        (block
+                                          (i32.store
+                                            (set_local $5
+                                              (i32.add
+                                                (get_local $7)
+                                                (i32.const -4)
+                                              )
+                                            )
+                                            (i32.const 0)
+                                          )
+                                          (get_local $5)
+                                        )
+                                        (get_local $7)
+                                      )
+                                    )
+                                    (i32.store
+                                      (get_local $6)
+                                      (set_local $5
+                                        (i32.add
+                                          (i32.load
+                                            (get_local $6)
+                                          )
+                                          (i32.const 1)
+                                        )
+                                      )
+                                    )
+                                    (if
+                                      (i32.le_u
+                                        (get_local $5)
+                                        (i32.const 999999999)
+                                      )
+                                      (br $while-out$92)
+                                    )
+                                    (br $while-in$93)
+                                  )
+                                )
+                                (set_local $11
+                                  (i32.mul
+                                    (i32.shr_s
+                                      (i32.sub
+                                        (get_local $62)
+                                        (get_local $7)
+                                      )
+                                      (i32.const 2)
+                                    )
+                                    (i32.const 9)
+                                  )
+                                )
+                                (if
+                                  (i32.lt_u
+                                    (set_local $5
+                                      (i32.load
+                                        (get_local $7)
+                                      )
+                                    )
+                                    (i32.const 10)
+                                  )
+                                  (block
+                                    (set_local $13
+                                      (get_local $11)
+                                    )
+                                    (br $do-once$88)
+                                  )
+                                  (set_local $10
+                                    (i32.const 10)
+                                  )
+                                )
+                                (loop $while-out$94 $while-in$95
+                                  (set_local $11
+                                    (i32.add
+                                      (get_local $11)
+                                      (i32.const 1)
+                                    )
+                                  )
+                                  (if
+                                    (i32.lt_u
+                                      (get_local $5)
+                                      (set_local $10
+                                        (i32.mul
+                                          (get_local $10)
+                                          (i32.const 10)
+                                        )
+                                      )
+                                    )
+                                    (block
+                                      (set_local $13
+                                        (get_local $11)
+                                      )
+                                      (br $while-out$94)
+                                    )
+                                  )
+                                  (br $while-in$95)
+                                )
+                              )
+                            )
+                          )
+                          (set_local $6
+                            (i32.gt_u
+                              (get_local $27)
+                              (set_local $5
+                                (i32.add
+                                  (get_local $6)
+                                  (i32.const 4)
+                                )
+                              )
+                            )
+                          )
+                          (set_local $6
+                            (select
+                              (get_local $5)
+                              (get_local $27)
+                              (get_local $6)
+                            )
+                          )
+                          (get_local $7)
+                        )
+                        (block
+                          (set_local $6
+                            (get_local $27)
+                          )
+                          (get_local $7)
+                        )
+                      )
+                    )
+                    (set_local $27
+                      (i32.sub
+                        (i32.const 0)
+                        (get_local $13)
+                      )
+                    )
+                    (loop $while-out$96 $while-in$97
+                      (if
+                        (i32.le_u
+                          (get_local $6)
+                          (get_local $7)
+                        )
+                        (block
+                          (set_local $11
+                            (i32.const 0)
+                          )
+                          (set_local $23
+                            (get_local $6)
+                          )
+                          (br $while-out$96)
                         )
                       )
                       (if
                         (i32.eq
-                          (set_local $14
-                            (i32.or
-                              (get_local $26)
-                              (i32.const 32)
+                          (i32.load
+                            (set_local $5
+                              (i32.add
+                                (get_local $6)
+                                (i32.const -4)
+                              )
                             )
                           )
-                          (i32.const 97)
+                          (i32.const 0)
+                        )
+                        (set_local $6
+                          (get_local $5)
                         )
                         (block
-                          (set_local $9
-                            (select
-                              (get_local $39)
-                              (i32.add
-                                (get_local $39)
-                                (i32.const 9)
-                              )
-                              (i32.eq
-                                (set_local $6
-                                  (i32.and
-                                    (get_local $26)
-                                    (i32.const 32)
+                          (set_local $11
+                            (i32.const 1)
+                          )
+                          (set_local $23
+                            (get_local $6)
+                          )
+                          (br $while-out$96)
+                        )
+                      )
+                      (br $while-in$97)
+                    )
+                    (set_local $8
+                      (block $do-once$98
+                        (if
+                          (get_local $8)
+                          (block
+                            (set_local $8
+                              (if
+                                (i32.and
+                                  (i32.gt_s
+                                    (set_local $1
+                                      (i32.add
+                                        (i32.xor
+                                          (i32.and
+                                            (get_local $70)
+                                            (i32.const 1)
+                                          )
+                                          (i32.const 1)
+                                        )
+                                        (get_local $1)
+                                      )
+                                    )
+                                    (get_local $13)
                                   )
+                                  (i32.gt_s
+                                    (get_local $13)
+                                    (i32.const -5)
+                                  )
+                                )
+                                (block
+                                  (set_local $10
+                                    (i32.add
+                                      (get_local $26)
+                                      (i32.const -1)
+                                    )
+                                  )
+                                  (i32.sub
+                                    (i32.add
+                                      (get_local $1)
+                                      (i32.const -1)
+                                    )
+                                    (get_local $13)
+                                  )
+                                )
+                                (block
+                                  (set_local $10
+                                    (i32.add
+                                      (get_local $26)
+                                      (i32.const -2)
+                                    )
+                                  )
+                                  (i32.add
+                                    (get_local $1)
+                                    (i32.const -1)
+                                  )
+                                )
+                              )
+                            )
+                            (if
+                              (i32.ne
+                                (set_local $1
+                                  (i32.and
+                                    (get_local $18)
+                                    (i32.const 8)
+                                  )
+                                )
+                                (i32.const 0)
+                              )
+                              (block
+                                (set_local $14
+                                  (get_local $8)
+                                )
+                                (set_local $26
+                                  (get_local $10)
+                                )
+                                (br $do-once$98
+                                  (get_local $1)
+                                )
+                              )
+                            )
+                            (block $do-once$100
+                              (if
+                                (get_local $11)
+                                (block
+                                  (if
+                                    (i32.eq
+                                      (set_local $1
+                                        (i32.load
+                                          (i32.add
+                                            (get_local $23)
+                                            (i32.const -4)
+                                          )
+                                        )
+                                      )
+                                      (i32.const 0)
+                                    )
+                                    (block
+                                      (set_local $6
+                                        (i32.const 9)
+                                      )
+                                      (br $do-once$100)
+                                    )
+                                  )
+                                  (if
+                                    (i32.eq
+                                      (i32.and
+                                        (i32.rem_u
+                                          (get_local $1)
+                                          (i32.const 10)
+                                        )
+                                        (i32.const -1)
+                                      )
+                                      (i32.const 0)
+                                    )
+                                    (block
+                                      (set_local $5
+                                        (i32.const 10)
+                                      )
+                                      (set_local $6
+                                        (i32.const 0)
+                                      )
+                                    )
+                                    (block
+                                      (set_local $6
+                                        (i32.const 0)
+                                      )
+                                      (br $do-once$100)
+                                    )
+                                  )
+                                  (loop $while-out$102 $while-in$103
+                                    (set_local $6
+                                      (i32.add
+                                        (get_local $6)
+                                        (i32.const 1)
+                                      )
+                                    )
+                                    (if
+                                      (i32.ne
+                                        (i32.and
+                                          (i32.rem_u
+                                            (get_local $1)
+                                            (set_local $5
+                                              (i32.mul
+                                                (get_local $5)
+                                                (i32.const 10)
+                                              )
+                                            )
+                                          )
+                                          (i32.const -1)
+                                        )
+                                        (i32.const 0)
+                                      )
+                                      (br $while-out$102)
+                                    )
+                                    (br $while-in$103)
+                                  )
+                                )
+                                (set_local $6
+                                  (i32.const 9)
+                                )
+                              )
+                            )
+                            (set_local $1
+                              (i32.add
+                                (i32.mul
+                                  (i32.shr_s
+                                    (i32.sub
+                                      (get_local $23)
+                                      (get_local $62)
+                                    )
+                                    (i32.const 2)
+                                  )
+                                  (i32.const 9)
+                                )
+                                (i32.const -9)
+                              )
+                            )
+                            (if
+                              (i32.eq
+                                (i32.or
+                                  (get_local $10)
+                                  (i32.const 32)
+                                )
+                                (i32.const 102)
+                              )
+                              (block
+                                (set_local $1
+                                  (i32.lt_s
+                                    (set_local $5
+                                      (i32.sub
+                                        (get_local $1)
+                                        (get_local $6)
+                                      )
+                                    )
+                                    (i32.const 0)
+                                  )
+                                )
+                                (set_local $5
+                                  (i32.lt_s
+                                    (get_local $8)
+                                    (set_local $1
+                                      (select
+                                        (i32.const 0)
+                                        (get_local $5)
+                                        (get_local $1)
+                                      )
+                                    )
+                                  )
+                                )
+                                (set_local $14
+                                  (select
+                                    (get_local $8)
+                                    (get_local $1)
+                                    (get_local $5)
+                                  )
+                                )
+                                (set_local $26
+                                  (get_local $10)
+                                )
+                                (i32.const 0)
+                              )
+                              (block
+                                (set_local $1
+                                  (i32.lt_s
+                                    (set_local $5
+                                      (i32.sub
+                                        (i32.add
+                                          (get_local $1)
+                                          (get_local $13)
+                                        )
+                                        (get_local $6)
+                                      )
+                                    )
+                                    (i32.const 0)
+                                  )
+                                )
+                                (set_local $5
+                                  (i32.lt_s
+                                    (get_local $8)
+                                    (set_local $1
+                                      (select
+                                        (i32.const 0)
+                                        (get_local $5)
+                                        (get_local $1)
+                                      )
+                                    )
+                                  )
+                                )
+                                (set_local $14
+                                  (select
+                                    (get_local $8)
+                                    (get_local $1)
+                                    (get_local $5)
+                                  )
+                                )
+                                (set_local $26
+                                  (get_local $10)
                                 )
                                 (i32.const 0)
                               )
                             )
                           )
-                          (set_local $7
+                          (block
+                            (set_local $14
+                              (get_local $1)
+                            )
+                            (i32.and
+                              (get_local $18)
+                              (i32.const 8)
+                            )
+                          )
+                        )
+                      )
+                    )
+                    (set_local $17
+                      (i32.and
+                        (i32.ne
+                          (set_local $1
                             (i32.or
-                              (get_local $51)
-                              (i32.const 2)
+                              (get_local $14)
+                              (get_local $8)
                             )
                           )
-                          (set_local $15
-                            (if
-                              (i32.or
-                                (i32.gt_u
-                                  (get_local $10)
-                                  (i32.const 11)
-                                )
-                                (i32.eq
-                                  (set_local $1
-                                    (i32.sub
-                                      (i32.const 12)
-                                      (get_local $10)
-                                    )
-                                  )
-                                  (i32.const 0)
-                                )
-                              )
-                              (get_local $15)
-                              (block
-                                (set_local $30
-                                  (f64.const 8)
-                                )
-                                (loop $while-out$60 $while-in$61
-                                  (set_local $30
-                                    (f64.mul
-                                      (get_local $30)
-                                      (f64.const 16)
-                                    )
-                                  )
-                                  (if
-                                    (i32.eq
-                                      (set_local $1
-                                        (i32.add
-                                          (get_local $1)
-                                          (i32.const -1)
-                                        )
-                                      )
-                                      (i32.const 0)
-                                    )
-                                    (br $while-out$60)
-                                  )
-                                  (br $while-in$61)
-                                )
-                                (select
-                                  (f64.neg
-                                    (f64.add
-                                      (get_local $30)
-                                      (f64.sub
-                                        (f64.neg
-                                          (get_local $15)
-                                        )
-                                        (get_local $30)
-                                      )
-                                    )
-                                  )
-                                  (f64.sub
-                                    (f64.add
-                                      (get_local $15)
-                                      (get_local $30)
-                                    )
-                                    (get_local $30)
-                                  )
-                                  (i32.eq
-                                    (i32.shr_s
-                                      (i32.shl
-                                        (i32.load8_s
-                                          (get_local $9)
-                                        )
-                                        (i32.const 24)
-                                      )
-                                      (i32.const 24)
-                                    )
-                                    (i32.const 45)
-                                  )
-                                )
-                              )
+                          (i32.const 0)
+                        )
+                        (i32.const 1)
+                      )
+                    )
+                    (set_local $13
+                      (if
+                        (set_local $10
+                          (i32.eq
+                            (i32.or
+                              (get_local $26)
+                              (i32.const 32)
                             )
+                            (i32.const 102)
                           )
-                          (set_local $5
-                            (i32.lt_s
-                              (set_local $1
-                                (i32.load
-                                  (get_local $25)
-                                )
-                              )
+                        )
+                        (block
+                          (set_local $6
+                            (select
+                              (get_local $13)
                               (i32.const 0)
+                              (i32.gt_s
+                                (get_local $13)
+                                (i32.const 0)
+                              )
                             )
                           )
+                          (i32.const 0)
+                        )
+                        (block
                           (set_local $5
                             (i32.shr_s
                               (i32.shl
                                 (i32.lt_s
-                                  (set_local $8
+                                  (set_local $6
                                     (select
-                                      (i32.sub
+                                      (get_local $27)
+                                      (get_local $13)
+                                      (i32.lt_s
+                                        (get_local $13)
                                         (i32.const 0)
-                                        (get_local $1)
                                       )
-                                      (get_local $1)
-                                      (get_local $5)
                                     )
                                   )
                                   (i32.const 0)
@@ -5353,37 +7053,55 @@
                               (i32.const 31)
                             )
                           )
-                          (i32.store8
-                            (i32.add
-                              (set_local $5
-                                (if
-                                  (i32.eq
-                                    (set_local $5
-                                      (call $_fmt_u
-                                        (get_local $8)
-                                        (get_local $5)
-                                        (get_local $52)
-                                      )
-                                    )
+                          (if
+                            (i32.lt_s
+                              (i32.sub
+                                (get_local $40)
+                                (set_local $5
+                                  (call $_fmt_u
+                                    (get_local $6)
+                                    (get_local $5)
                                     (get_local $52)
                                   )
-                                  (block
-                                    (i32.store8
-                                      (get_local $74)
-                                      (i32.const 48)
-                                    )
-                                    (get_local $74)
-                                  )
-                                  (get_local $5)
                                 )
                               )
+                              (i32.const 2)
+                            )
+                            (loop $while-out$104 $while-in$105
+                              (i32.store8
+                                (set_local $5
+                                  (i32.add
+                                    (get_local $5)
+                                    (i32.const -1)
+                                  )
+                                )
+                                (i32.const 48)
+                              )
+                              (if
+                                (i32.lt_s
+                                  (i32.sub
+                                    (get_local $40)
+                                    (get_local $5)
+                                  )
+                                  (i32.const 2)
+                                )
+                                (get_local $5)
+                                (br $while-out$104)
+                              )
+                              (br $while-in$105)
+                            )
+                            (get_local $5)
+                          )
+                          (i32.store8
+                            (i32.add
+                              (get_local $5)
                               (i32.const -1)
                             )
                             (i32.and
                               (i32.add
                                 (i32.and
                                   (i32.shr_s
-                                    (get_local $1)
+                                    (get_local $13)
                                     (i32.const 31)
                                   )
                                   (i32.const 2)
@@ -5394,1878 +7112,265 @@
                             )
                           )
                           (i32.store8
-                            (set_local $8
+                            (set_local $5
                               (i32.add
                                 (get_local $5)
                                 (i32.const -2)
                               )
                             )
                             (i32.and
-                              (i32.add
-                                (get_local $26)
-                                (i32.const 15)
-                              )
+                              (get_local $26)
                               (i32.const 255)
                             )
                           )
-                          (set_local $5
-                            (i32.lt_s
-                              (get_local $10)
-                              (i32.const 1)
-                            )
-                          )
-                          (set_local $13
-                            (i32.eq
-                              (i32.and
-                                (get_local $18)
-                                (i32.const 8)
-                              )
-                              (i32.const 0)
-                            )
-                          )
-                          (set_local $11
-                            (get_local $29)
-                          )
-                          (loop $while-out$62 $while-in$63
-                            (i32.store8
-                              (get_local $11)
-                              (i32.and
-                                (i32.or
-                                  (i32.and
-                                    (i32.load8_s
-                                      (i32.add
-                                        (set_local $1
-                                          (i32.trunc_s/f64
-                                            (get_local $15)
-                                          )
-                                        )
-                                        (i32.const 4075)
-                                      )
-                                    )
-                                    (i32.const 255)
-                                  )
-                                  (get_local $6)
-                                )
-                                (i32.const 255)
-                              )
-                            )
-                            (set_local $15
-                              (f64.mul
-                                (f64.sub
-                                  (get_local $15)
-                                  (f64.convert_s/i32
-                                    (get_local $1)
-                                  )
-                                )
-                                (f64.const 16)
-                              )
-                            )
-                            (set_local $11
-                              (block $do-once$64
-                                (if
-                                  (i32.eq
-                                    (i32.sub
-                                      (set_local $1
-                                        (i32.add
-                                          (get_local $11)
-                                          (i32.const 1)
-                                        )
-                                      )
-                                      (get_local $64)
-                                    )
-                                    (i32.const 1)
-                                  )
-                                  (block
-                                    (br_if $do-once$64
-                                      (get_local $1)
-                                      (i32.and
-                                        (get_local $13)
-                                        (i32.and
-                                          (get_local $5)
-                                          (f64.eq
-                                            (get_local $15)
-                                            (f64.const 0)
-                                          )
-                                        )
-                                      )
-                                    )
-                                    (i32.store8
-                                      (get_local $1)
-                                      (i32.const 46)
-                                    )
-                                    (i32.add
-                                      (get_local $11)
-                                      (i32.const 2)
-                                    )
-                                  )
-                                  (get_local $1)
-                                )
-                              )
-                            )
-                            (if
-                              (f64.eq
-                                (get_local $15)
-                                (f64.const 0)
-                              )
-                              (block
-                                (set_local $1
-                                  (get_local $11)
-                                )
-                                (br $while-out$62)
-                              )
-                            )
-                            (br $while-in$63)
-                          )
-                          (set_local $5
-                            (i32.and
-                              (i32.ne
-                                (get_local $10)
-                                (i32.const 0)
-                              )
-                              (i32.lt_s
-                                (i32.add
-                                  (get_local $78)
-                                  (get_local $1)
-                                )
-                                (get_local $10)
-                              )
-                            )
-                          )
-                          (call $_pad
-                            (get_local $0)
-                            (i32.const 32)
-                            (get_local $16)
-                            (set_local $5
-                              (i32.add
-                                (set_local $6
-                                  (select
-                                    (i32.sub
-                                      (i32.add
-                                        (get_local $79)
-                                        (get_local $10)
-                                      )
-                                      (get_local $8)
-                                    )
-                                    (i32.add
-                                      (i32.sub
-                                        (get_local $77)
-                                        (get_local $8)
-                                      )
-                                      (get_local $1)
-                                    )
-                                    (get_local $5)
-                                  )
-                                )
-                                (get_local $7)
-                              )
-                            )
-                            (get_local $18)
-                          )
-                          (if
-                            (i32.eq
-                              (i32.and
-                                (i32.load
-                                  (get_local $0)
-                                )
-                                (i32.const 32)
-                              )
-                              (i32.const 0)
-                            )
-                            (call $___fwritex
-                              (get_local $9)
-                              (get_local $7)
-                              (get_local $0)
-                            )
-                          )
-                          (call $_pad
-                            (get_local $0)
-                            (i32.const 48)
-                            (get_local $16)
-                            (get_local $5)
-                            (i32.xor
-                              (get_local $18)
-                              (i32.const 65536)
-                            )
-                          )
-                          (set_local $1
+                          (set_local $6
                             (i32.sub
-                              (get_local $1)
-                              (get_local $64)
-                            )
-                          )
-                          (if
-                            (i32.eq
-                              (i32.and
-                                (i32.load
-                                  (get_local $0)
-                                )
-                                (i32.const 32)
-                              )
-                              (i32.const 0)
-                            )
-                            (call $___fwritex
-                              (get_local $29)
-                              (get_local $1)
-                              (get_local $0)
-                            )
-                          )
-                          (call $_pad
-                            (get_local $0)
-                            (i32.const 48)
-                            (i32.sub
-                              (get_local $6)
-                              (i32.add
-                                (get_local $1)
-                                (set_local $1
-                                  (i32.sub
-                                    (get_local $40)
-                                    (get_local $8)
-                                  )
-                                )
-                              )
-                            )
-                            (i32.const 0)
-                            (i32.const 0)
-                          )
-                          (if
-                            (i32.eq
-                              (i32.and
-                                (i32.load
-                                  (get_local $0)
-                                )
-                                (i32.const 32)
-                              )
-                              (i32.const 0)
-                            )
-                            (call $___fwritex
-                              (get_local $8)
-                              (get_local $1)
-                              (get_local $0)
-                            )
-                          )
-                          (call $_pad
-                            (get_local $0)
-                            (i32.const 32)
-                            (get_local $16)
-                            (get_local $5)
-                            (i32.xor
-                              (get_local $18)
-                              (i32.const 8192)
-                            )
-                          )
-                          (br $do-once$56
-                            (select
-                              (get_local $16)
+                              (get_local $40)
                               (get_local $5)
-                              (i32.lt_s
-                                (get_local $5)
-                                (get_local $16)
-                              )
                             )
                           )
-                        )
-                      )
-                      (set_local $1
-                        (select
-                          (i32.const 6)
-                          (get_local $10)
-                          (i32.lt_s
-                            (get_local $10)
-                            (i32.const 0)
-                          )
-                        )
-                      )
-                      (set_local $62
-                        (set_local $9
-                          (select
-                            (get_local $80)
-                            (get_local $81)
-                            (i32.lt_s
-                              (if
-                                (get_local $5)
-                                (block
-                                  (i32.store
-                                    (get_local $25)
-                                    (set_local $5
-                                      (i32.add
-                                        (i32.load
-                                          (get_local $25)
-                                        )
-                                        (i32.const -28)
-                                      )
-                                    )
-                                  )
-                                  (set_local $15
-                                    (f64.mul
-                                      (get_local $15)
-                                      (f64.const 268435456)
-                                    )
-                                  )
-                                  (get_local $5)
-                                )
-                                (i32.load
-                                  (get_local $25)
-                                )
-                              )
-                              (i32.const 0)
-                            )
-                          )
-                        )
-                      )
-                      (set_local $7
-                        (get_local $9)
-                      )
-                      (loop $while-out$66 $while-in$67
-                        (i32.store
-                          (get_local $7)
-                          (set_local $5
-                            (i32.trunc_s/f64
-                              (get_local $15)
-                            )
-                          )
-                        )
-                        (set_local $7
-                          (i32.add
-                            (get_local $7)
-                            (i32.const 4)
-                          )
-                        )
-                        (if
-                          (f64.eq
-                            (set_local $15
-                              (f64.mul
-                                (f64.sub
-                                  (get_local $15)
-                                  (f64.convert_u/i32
-                                    (get_local $5)
-                                  )
-                                )
-                                (f64.const 1e9)
-                              )
-                            )
-                            (f64.const 0)
-                          )
-                          (block
-                            (set_local $6
-                              (get_local $7)
-                            )
-                            (br $while-out$66)
-                          )
-                        )
-                        (br $while-in$67)
-                      )
-                      (if
-                        (i32.gt_s
-                          (set_local $5
-                            (i32.load
-                              (get_local $25)
-                            )
-                          )
-                          (i32.const 0)
-                        )
-                        (block
-                          (set_local $8
-                            (get_local $9)
-                          )
-                          (set_local $13
-                            (get_local $6)
-                          )
-                          (loop $while-out$68 $while-in$69
-                            (set_local $11
-                              (select
-                                (i32.const 29)
-                                (get_local $5)
-                                (i32.gt_s
-                                  (get_local $5)
-                                  (i32.const 29)
-                                )
-                              )
-                            )
-                            (set_local $7
-                              (block $do-once$70
-                                (if
-                                  (i32.lt_u
-                                    (set_local $7
-                                      (i32.add
-                                        (get_local $13)
-                                        (i32.const -4)
-                                      )
-                                    )
-                                    (get_local $8)
-                                  )
-                                  (get_local $8)
-                                  (block
-                                    (set_local $5
-                                      (i32.const 0)
-                                    )
-                                    (set_local $10
-                                      (get_local $7)
-                                    )
-                                    (loop $while-out$72 $while-in$73
-                                      (set_local $6
-                                        (call $___uremdi3
-                                          (set_local $5
-                                            (call $_i64Add
-                                              (call $_bitshift64Shl
-                                                (i32.load
-                                                  (get_local $10)
-                                                )
-                                                (i32.const 0)
-                                                (get_local $11)
-                                              )
-                                              (i32.load
-                                                (i32.const 168)
-                                              )
-                                              (get_local $5)
-                                              (i32.const 0)
-                                            )
-                                          )
-                                          (set_local $7
-                                            (i32.load
-                                              (i32.const 168)
-                                            )
-                                          )
-                                          (i32.const 1000000000)
-                                          (i32.const 0)
-                                        )
-                                      )
-                                      (i32.load
-                                        (i32.const 168)
-                                      )
-                                      (i32.store
-                                        (get_local $10)
-                                        (get_local $6)
-                                      )
-                                      (set_local $5
-                                        (call $___udivdi3
-                                          (get_local $5)
-                                          (get_local $7)
-                                          (i32.const 1000000000)
-                                          (i32.const 0)
-                                        )
-                                      )
-                                      (i32.load
-                                        (i32.const 168)
-                                      )
-                                      (if
-                                        (i32.lt_u
-                                          (set_local $7
-                                            (i32.add
-                                              (get_local $10)
-                                              (i32.const -4)
-                                            )
-                                          )
-                                          (get_local $8)
-                                        )
-                                        (br $while-out$72)
-                                        (set_local $10
-                                          (get_local $7)
-                                        )
-                                      )
-                                      (br $while-in$73)
-                                    )
-                                    (br_if $do-once$70
-                                      (get_local $8)
-                                      (i32.eq
-                                        (get_local $5)
-                                        (i32.const 0)
-                                      )
-                                    )
-                                    (i32.store
-                                      (set_local $7
-                                        (i32.add
-                                          (get_local $8)
-                                          (i32.const -4)
-                                        )
-                                      )
-                                      (get_local $5)
-                                    )
-                                    (get_local $7)
-                                  )
-                                )
-                              )
-                            )
-                            (loop $while-out$74 $while-in$75
-                              (if
-                                (i32.le_u
-                                  (get_local $13)
-                                  (get_local $7)
-                                )
-                                (br $while-out$74)
-                              )
-                              (if
-                                (i32.eq
-                                  (i32.load
-                                    (set_local $5
-                                      (i32.add
-                                        (get_local $13)
-                                        (i32.const -4)
-                                      )
-                                    )
-                                  )
-                                  (i32.const 0)
-                                )
-                                (set_local $13
-                                  (get_local $5)
-                                )
-                                (br $while-out$74)
-                              )
-                              (br $while-in$75)
-                            )
-                            (i32.store
-                              (get_local $25)
-                              (set_local $5
-                                (i32.sub
-                                  (i32.load
-                                    (get_local $25)
-                                  )
-                                  (get_local $11)
-                                )
-                              )
-                            )
-                            (if
-                              (i32.gt_s
-                                (get_local $5)
-                                (i32.const 0)
-                              )
-                              (set_local $8
-                                (get_local $7)
-                              )
-                              (block
-                                (set_local $6
-                                  (get_local $13)
-                                )
-                                (br $while-out$68)
-                              )
-                            )
-                            (br $while-in$69)
-                          )
-                        )
-                        (set_local $7
-                          (get_local $9)
-                        )
-                      )
-                      (if
-                        (i32.lt_s
                           (get_local $5)
-                          (i32.const 0)
                         )
-                        (block
-                          (set_local $8
+                      )
+                    )
+                    (call $_pad
+                      (get_local $0)
+                      (i32.const 32)
+                      (get_local $16)
+                      (set_local $6
+                        (i32.add
+                          (i32.add
                             (i32.add
-                              (i32.and
-                                (i32.div_s
-                                  (i32.add
-                                    (get_local $1)
-                                    (i32.const 25)
-                                  )
-                                  (i32.const 9)
-                                )
-                                (i32.const -1)
+                              (i32.add
+                                (get_local $51)
+                                (i32.const 1)
                               )
-                              (i32.const 1)
-                            )
-                          )
-                          (set_local $10
-                            (i32.eq
                               (get_local $14)
-                              (i32.const 102)
                             )
+                            (get_local $17)
                           )
-                          (set_local $23
-                            (get_local $6)
-                          )
-                          (loop $while-out$76 $while-in$77
-                            (set_local $5
-                              (i32.gt_s
-                                (set_local $6
-                                  (i32.sub
-                                    (i32.const 0)
-                                    (get_local $5)
-                                  )
-                                )
-                                (i32.const 9)
-                              )
-                            )
-                            (set_local $13
-                              (select
-                                (i32.const 9)
-                                (get_local $6)
-                                (get_local $5)
-                              )
-                            )
-                            (set_local $11
-                              (block $do-once$78
-                                (if
-                                  (i32.lt_u
-                                    (get_local $7)
-                                    (get_local $23)
-                                  )
-                                  (block
-                                    (set_local $70
-                                      (i32.add
-                                        (i32.shl
-                                          (i32.const 1)
-                                          (get_local $13)
-                                        )
-                                        (i32.const -1)
-                                      )
-                                    )
-                                    (set_local $27
-                                      (i32.shr_u
-                                        (i32.const 1000000000)
-                                        (get_local $13)
-                                      )
-                                    )
-                                    (set_local $11
-                                      (i32.const 0)
-                                    )
-                                    (set_local $17
-                                      (get_local $7)
-                                    )
-                                    (loop $while-out$80 $while-in$81
-                                      (set_local $6
-                                        (i32.and
-                                          (set_local $5
-                                            (i32.load
-                                              (get_local $17)
-                                            )
-                                          )
-                                          (get_local $70)
-                                        )
-                                      )
-                                      (i32.store
-                                        (get_local $17)
-                                        (i32.add
-                                          (i32.shr_u
-                                            (get_local $5)
-                                            (get_local $13)
-                                          )
-                                          (get_local $11)
-                                        )
-                                      )
-                                      (set_local $11
-                                        (i32.mul
-                                          (get_local $6)
-                                          (get_local $27)
-                                        )
-                                      )
-                                      (if
-                                        (i32.ge_u
-                                          (set_local $17
-                                            (i32.add
-                                              (get_local $17)
-                                              (i32.const 4)
-                                            )
-                                          )
-                                          (get_local $23)
-                                        )
-                                        (br $while-out$80)
-                                      )
-                                      (br $while-in$81)
-                                    )
-                                    (set_local $5
-                                      (select
-                                        (i32.add
-                                          (get_local $7)
-                                          (i32.const 4)
-                                        )
-                                        (get_local $7)
-                                        (i32.eq
-                                          (i32.load
-                                            (get_local $7)
-                                          )
-                                          (i32.const 0)
-                                        )
-                                      )
-                                    )
-                                    (if
-                                      (i32.eq
-                                        (get_local $11)
-                                        (i32.const 0)
-                                      )
-                                      (br $do-once$78
-                                        (get_local $5)
-                                      )
-                                    )
-                                    (i32.store
-                                      (get_local $23)
-                                      (get_local $11)
-                                    )
-                                    (set_local $23
-                                      (i32.add
-                                        (get_local $23)
-                                        (i32.const 4)
-                                      )
-                                    )
-                                    (get_local $5)
-                                  )
-                                  (select
-                                    (i32.add
-                                      (get_local $7)
-                                      (i32.const 4)
-                                    )
-                                    (get_local $7)
-                                    (i32.eq
-                                      (i32.load
-                                        (get_local $7)
-                                      )
-                                      (i32.const 0)
-                                    )
-                                  )
-                                )
-                              )
-                            )
-                            (set_local $5
-                              (i32.gt_s
-                                (i32.shr_s
-                                  (i32.sub
-                                    (get_local $23)
-                                    (set_local $7
-                                      (select
-                                        (get_local $9)
-                                        (get_local $11)
-                                        (get_local $10)
-                                      )
-                                    )
-                                  )
-                                  (i32.const 2)
-                                )
-                                (get_local $8)
-                              )
-                            )
-                            (set_local $6
-                              (select
-                                (i32.add
-                                  (get_local $7)
-                                  (i32.shl
-                                    (get_local $8)
-                                    (i32.const 2)
-                                  )
-                                )
-                                (get_local $23)
-                                (get_local $5)
-                              )
-                            )
-                            (i32.store
-                              (get_local $25)
-                              (set_local $5
-                                (i32.add
-                                  (i32.load
-                                    (get_local $25)
-                                  )
-                                  (get_local $13)
-                                )
-                              )
-                            )
-                            (if
-                              (i32.lt_s
-                                (get_local $5)
-                                (i32.const 0)
-                              )
-                              (block
-                                (set_local $7
-                                  (get_local $11)
-                                )
-                                (set_local $23
-                                  (get_local $6)
-                                )
-                              )
-                              (block
-                                (set_local $7
-                                  (get_local $11)
-                                )
-                                (set_local $27
-                                  (get_local $6)
-                                )
-                                (br $while-out$76)
-                              )
-                            )
-                            (br $while-in$77)
-                          )
-                        )
-                        (set_local $27
                           (get_local $6)
                         )
                       )
-                      (block $do-once$82
-                        (if
-                          (i32.lt_u
-                            (get_local $7)
-                            (get_local $27)
+                      (get_local $18)
+                    )
+                    (if
+                      (i32.eq
+                        (i32.and
+                          (i32.load
+                            (get_local $0)
                           )
-                          (block
-                            (set_local $6
-                              (i32.mul
-                                (i32.shr_s
-                                  (i32.sub
-                                    (get_local $62)
-                                    (get_local $7)
-                                  )
-                                  (i32.const 2)
-                                )
-                                (i32.const 9)
-                              )
-                            )
-                            (if
-                              (i32.lt_u
-                                (set_local $5
-                                  (i32.load
-                                    (get_local $7)
-                                  )
-                                )
-                                (i32.const 10)
-                              )
-                              (block
-                                (set_local $13
-                                  (get_local $6)
-                                )
-                                (br $do-once$82)
-                              )
-                              (set_local $8
-                                (i32.const 10)
-                              )
-                            )
-                            (loop $while-out$84 $while-in$85
-                              (set_local $6
-                                (i32.add
-                                  (get_local $6)
-                                  (i32.const 1)
-                                )
-                              )
-                              (if
-                                (i32.lt_u
-                                  (get_local $5)
-                                  (set_local $8
-                                    (i32.mul
-                                      (get_local $8)
-                                      (i32.const 10)
-                                    )
-                                  )
-                                )
-                                (block
-                                  (set_local $13
-                                    (get_local $6)
-                                  )
-                                  (br $while-out$84)
-                                )
-                              )
-                              (br $while-in$85)
-                            )
-                          )
-                          (set_local $13
-                            (i32.const 0)
-                          )
+                          (i32.const 32)
                         )
+                        (i32.const 0)
                       )
-                      (set_local $7
-                        (if
-                          (i32.lt_s
-                            (set_local $5
-                              (i32.add
-                                (i32.sub
-                                  (get_local $1)
-                                  (select
-                                    (get_local $13)
-                                    (i32.const 0)
-                                    (i32.ne
-                                      (get_local $14)
-                                      (i32.const 102)
-                                    )
-                                  )
-                                )
-                                (i32.shr_s
-                                  (i32.shl
-                                    (i32.and
-                                      (set_local $70
-                                        (i32.ne
-                                          (get_local $1)
-                                          (i32.const 0)
-                                        )
-                                      )
-                                      (set_local $8
-                                        (i32.eq
-                                          (get_local $14)
-                                          (i32.const 103)
-                                        )
-                                      )
-                                    )
-                                    (i32.const 31)
-                                  )
-                                  (i32.const 31)
+                      (call $___fwritex
+                        (get_local $39)
+                        (get_local $51)
+                        (get_local $0)
+                      )
+                    )
+                    (call $_pad
+                      (get_local $0)
+                      (i32.const 48)
+                      (get_local $16)
+                      (get_local $6)
+                      (i32.xor
+                        (get_local $18)
+                        (i32.const 65536)
+                      )
+                    )
+                    (block $do-once$106
+                      (if
+                        (get_local $10)
+                        (block
+                          (set_local $7
+                            (set_local $8
+                              (select
+                                (get_local $9)
+                                (get_local $7)
+                                (i32.gt_u
+                                  (get_local $7)
+                                  (get_local $9)
                                 )
                               )
-                            )
-                            (i32.add
-                              (i32.mul
-                                (i32.shr_s
-                                  (i32.sub
-                                    (get_local $27)
-                                    (get_local $62)
-                                  )
-                                  (i32.const 2)
-                                )
-                                (i32.const 9)
-                              )
-                              (i32.const -9)
                             )
                           )
-                          (block
-                            (set_local $6
-                              (i32.add
-                                (i32.add
-                                  (get_local $9)
-                                  (i32.const 4)
+                          (loop $while-out$108 $while-in$109
+                            (set_local $5
+                              (call $_fmt_u
+                                (i32.load
+                                  (get_local $7)
                                 )
-                                (i32.shl
-                                  (i32.add
-                                    (i32.and
-                                      (i32.div_s
-                                        (set_local $5
-                                          (i32.add
-                                            (get_local $5)
-                                            (i32.const 9216)
-                                          )
-                                        )
-                                        (i32.const 9)
-                                      )
-                                      (i32.const -1)
-                                    )
-                                    (i32.const -1024)
-                                  )
-                                  (i32.const 2)
-                                )
+                                (i32.const 0)
+                                (get_local $45)
                               )
                             )
-                            (if
-                              (i32.lt_s
-                                (set_local $11
-                                  (i32.add
-                                    (i32.and
-                                      (i32.rem_s
-                                        (get_local $5)
-                                        (i32.const 9)
-                                      )
-                                      (i32.const -1)
-                                    )
-                                    (i32.const 1)
-                                  )
-                                )
-                                (i32.const 9)
-                              )
-                              (block
-                                (set_local $5
-                                  (i32.const 10)
-                                )
-                                (loop $while-out$86 $while-in$87
-                                  (set_local $5
-                                    (i32.mul
-                                      (get_local $5)
-                                      (i32.const 10)
-                                    )
-                                  )
-                                  (if
-                                    (i32.eq
-                                      (set_local $11
-                                        (i32.add
-                                          (get_local $11)
-                                          (i32.const 1)
-                                        )
-                                      )
-                                      (i32.const 9)
-                                    )
-                                    (block
-                                      (set_local $17
-                                        (get_local $5)
-                                      )
-                                      (br $while-out$86)
-                                    )
-                                  )
-                                  (br $while-in$87)
-                                )
-                              )
-                              (set_local $17
-                                (i32.const 10)
-                              )
-                            )
-                            (block $do-once$88
+                            (block $do-once$110
                               (if
-                                (i32.eqz
-                                  (i32.and
-                                    (set_local $11
-                                      (i32.eq
-                                        (i32.add
-                                          (get_local $6)
-                                          (i32.const 4)
-                                        )
-                                        (get_local $27)
-                                      )
+                                (i32.eq
+                                  (get_local $7)
+                                  (get_local $8)
+                                )
+                                (block
+                                  (if
+                                    (i32.ne
+                                      (get_local $5)
+                                      (get_local $45)
                                     )
-                                    (i32.eq
-                                      (set_local $14
-                                        (i32.and
-                                          (i32.rem_u
-                                            (set_local $5
-                                              (i32.load
-                                                (get_local $6)
-                                              )
-                                            )
-                                            (get_local $17)
-                                          )
-                                          (i32.const -1)
-                                        )
-                                      )
-                                      (i32.const 0)
-                                    )
+                                    (br $do-once$110)
+                                  )
+                                  (i32.store8
+                                    (get_local $53)
+                                    (i32.const 48)
+                                  )
+                                  (set_local $5
+                                    (get_local $53)
                                   )
                                 )
                                 (block
-                                  (set_local $15
-                                    (select
-                                      (f64.const 9007199254740992)
-                                      (f64.const 9007199254740994)
-                                      (i32.eq
-                                        (i32.and
-                                          (i32.and
-                                            (i32.div_u
-                                              (get_local $5)
-                                              (get_local $17)
-                                            )
-                                            (i32.const -1)
-                                          )
-                                          (i32.const 1)
-                                        )
-                                        (i32.const 0)
-                                      )
-                                    )
-                                  )
-                                  (set_local $30
-                                    (if
-                                      (i32.lt_u
-                                        (get_local $14)
-                                        (set_local $10
-                                          (i32.and
-                                            (i32.div_s
-                                              (get_local $17)
-                                              (i32.const 2)
-                                            )
-                                            (i32.const -1)
-                                          )
-                                        )
-                                      )
-                                      (f64.const 0.5)
-                                      (select
-                                        (f64.const 1)
-                                        (f64.const 1.5)
-                                        (i32.and
-                                          (get_local $11)
-                                          (i32.eq
-                                            (get_local $14)
-                                            (get_local $10)
-                                          )
-                                        )
-                                      )
-                                    )
-                                  )
-                                  (set_local $15
-                                    (block $do-once$90
-                                      (if
-                                        (i32.eq
-                                          (get_local $51)
-                                          (i32.const 0)
-                                        )
-                                        (get_local $15)
-                                        (block
-                                          (if
-                                            (i32.ne
-                                              (i32.shr_s
-                                                (i32.shl
-                                                  (i32.load8_s
-                                                    (get_local $39)
-                                                  )
-                                                  (i32.const 24)
-                                                )
-                                                (i32.const 24)
-                                              )
-                                              (i32.const 45)
-                                            )
-                                            (br $do-once$90
-                                              (get_local $15)
-                                            )
-                                          )
-                                          (set_local $30
-                                            (f64.neg
-                                              (get_local $30)
-                                            )
-                                          )
-                                          (f64.neg
-                                            (get_local $15)
-                                          )
-                                        )
-                                      )
-                                    )
-                                  )
-                                  (i32.store
-                                    (get_local $6)
-                                    (set_local $5
-                                      (i32.sub
-                                        (get_local $5)
-                                        (get_local $14)
-                                      )
-                                    )
-                                  )
-                                  (if
-                                    (f64.eq
-                                      (f64.add
-                                        (get_local $15)
-                                        (get_local $30)
-                                      )
-                                      (get_local $15)
-                                    )
-                                    (br $do-once$88)
-                                  )
-                                  (i32.store
-                                    (get_local $6)
-                                    (set_local $5
-                                      (i32.add
-                                        (get_local $5)
-                                        (get_local $17)
-                                      )
-                                    )
-                                  )
                                   (if
                                     (i32.gt_u
                                       (get_local $5)
-                                      (i32.const 999999999)
+                                      (get_local $29)
                                     )
-                                    (loop $while-out$92 $while-in$93
-                                      (i32.store
-                                        (get_local $6)
-                                        (i32.const 0)
-                                      )
-                                      (set_local $7
-                                        (if
-                                          (i32.lt_u
-                                            (set_local $6
-                                              (i32.add
-                                                (get_local $6)
-                                                (i32.const -4)
-                                              )
-                                            )
-                                            (get_local $7)
-                                          )
-                                          (block
-                                            (i32.store
-                                              (set_local $5
-                                                (i32.add
-                                                  (get_local $7)
-                                                  (i32.const -4)
-                                                )
-                                              )
-                                              (i32.const 0)
-                                            )
-                                            (get_local $5)
-                                          )
-                                          (get_local $7)
-                                        )
-                                      )
-                                      (i32.store
-                                        (get_local $6)
-                                        (set_local $5
-                                          (i32.add
-                                            (i32.load
-                                              (get_local $6)
-                                            )
-                                            (i32.const 1)
-                                          )
-                                        )
-                                      )
-                                      (if
-                                        (i32.le_u
-                                          (get_local $5)
-                                          (i32.const 999999999)
-                                        )
-                                        (br $while-out$92)
-                                      )
-                                      (br $while-in$93)
-                                    )
+                                    (get_local $5)
+                                    (br $do-once$110)
                                   )
-                                  (set_local $11
-                                    (i32.mul
-                                      (i32.shr_s
-                                        (i32.sub
-                                          (get_local $62)
-                                          (get_local $7)
-                                        )
-                                        (i32.const 2)
-                                      )
-                                      (i32.const 9)
-                                    )
-                                  )
-                                  (if
-                                    (i32.lt_u
+                                  (loop $while-out$112 $while-in$113
+                                    (i32.store8
                                       (set_local $5
-                                        (i32.load
-                                          (get_local $7)
-                                        )
-                                      )
-                                      (i32.const 10)
-                                    )
-                                    (block
-                                      (set_local $13
-                                        (get_local $11)
-                                      )
-                                      (br $do-once$88)
-                                    )
-                                    (set_local $10
-                                      (i32.const 10)
-                                    )
-                                  )
-                                  (loop $while-out$94 $while-in$95
-                                    (set_local $11
-                                      (i32.add
-                                        (get_local $11)
-                                        (i32.const 1)
-                                      )
-                                    )
-                                    (if
-                                      (i32.lt_u
-                                        (get_local $5)
-                                        (set_local $10
-                                          (i32.mul
-                                            (get_local $10)
-                                            (i32.const 10)
-                                          )
-                                        )
-                                      )
-                                      (block
-                                        (set_local $13
-                                          (get_local $11)
-                                        )
-                                        (br $while-out$94)
-                                      )
-                                    )
-                                    (br $while-in$95)
-                                  )
-                                )
-                              )
-                            )
-                            (set_local $6
-                              (i32.gt_u
-                                (get_local $27)
-                                (set_local $5
-                                  (i32.add
-                                    (get_local $6)
-                                    (i32.const 4)
-                                  )
-                                )
-                              )
-                            )
-                            (set_local $6
-                              (select
-                                (get_local $5)
-                                (get_local $27)
-                                (get_local $6)
-                              )
-                            )
-                            (get_local $7)
-                          )
-                          (block
-                            (set_local $6
-                              (get_local $27)
-                            )
-                            (get_local $7)
-                          )
-                        )
-                      )
-                      (set_local $27
-                        (i32.sub
-                          (i32.const 0)
-                          (get_local $13)
-                        )
-                      )
-                      (loop $while-out$96 $while-in$97
-                        (if
-                          (i32.le_u
-                            (get_local $6)
-                            (get_local $7)
-                          )
-                          (block
-                            (set_local $11
-                              (i32.const 0)
-                            )
-                            (set_local $23
-                              (get_local $6)
-                            )
-                            (br $while-out$96)
-                          )
-                        )
-                        (if
-                          (i32.eq
-                            (i32.load
-                              (set_local $5
-                                (i32.add
-                                  (get_local $6)
-                                  (i32.const -4)
-                                )
-                              )
-                            )
-                            (i32.const 0)
-                          )
-                          (set_local $6
-                            (get_local $5)
-                          )
-                          (block
-                            (set_local $11
-                              (i32.const 1)
-                            )
-                            (set_local $23
-                              (get_local $6)
-                            )
-                            (br $while-out$96)
-                          )
-                        )
-                        (br $while-in$97)
-                      )
-                      (set_local $8
-                        (block $do-once$98
-                          (if
-                            (get_local $8)
-                            (block
-                              (set_local $8
-                                (if
-                                  (i32.and
-                                    (i32.gt_s
-                                      (set_local $1
                                         (i32.add
-                                          (i32.xor
-                                            (i32.and
-                                              (get_local $70)
-                                              (i32.const 1)
-                                            )
-                                            (i32.const 1)
-                                          )
-                                          (get_local $1)
-                                        )
-                                      )
-                                      (get_local $13)
-                                    )
-                                    (i32.gt_s
-                                      (get_local $13)
-                                      (i32.const -5)
-                                    )
-                                  )
-                                  (block
-                                    (set_local $10
-                                      (i32.add
-                                        (get_local $26)
-                                        (i32.const -1)
-                                      )
-                                    )
-                                    (i32.sub
-                                      (i32.add
-                                        (get_local $1)
-                                        (i32.const -1)
-                                      )
-                                      (get_local $13)
-                                    )
-                                  )
-                                  (block
-                                    (set_local $10
-                                      (i32.add
-                                        (get_local $26)
-                                        (i32.const -2)
-                                      )
-                                    )
-                                    (i32.add
-                                      (get_local $1)
-                                      (i32.const -1)
-                                    )
-                                  )
-                                )
-                              )
-                              (if
-                                (i32.ne
-                                  (set_local $1
-                                    (i32.and
-                                      (get_local $18)
-                                      (i32.const 8)
-                                    )
-                                  )
-                                  (i32.const 0)
-                                )
-                                (block
-                                  (set_local $14
-                                    (get_local $8)
-                                  )
-                                  (set_local $26
-                                    (get_local $10)
-                                  )
-                                  (br $do-once$98
-                                    (get_local $1)
-                                  )
-                                )
-                              )
-                              (block $do-once$100
-                                (if
-                                  (get_local $11)
-                                  (block
-                                    (if
-                                      (i32.eq
-                                        (set_local $1
-                                          (i32.load
-                                            (i32.add
-                                              (get_local $23)
-                                              (i32.const -4)
-                                            )
-                                          )
-                                        )
-                                        (i32.const 0)
-                                      )
-                                      (block
-                                        (set_local $6
-                                          (i32.const 9)
-                                        )
-                                        (br $do-once$100)
-                                      )
-                                    )
-                                    (if
-                                      (i32.eq
-                                        (i32.and
-                                          (i32.rem_u
-                                            (get_local $1)
-                                            (i32.const 10)
-                                          )
+                                          (get_local $5)
                                           (i32.const -1)
                                         )
-                                        (i32.const 0)
                                       )
-                                      (block
-                                        (set_local $5
-                                          (i32.const 10)
-                                        )
-                                        (set_local $6
-                                          (i32.const 0)
-                                        )
-                                      )
-                                      (block
-                                        (set_local $6
-                                          (i32.const 0)
-                                        )
-                                        (br $do-once$100)
-                                      )
-                                    )
-                                    (loop $while-out$102 $while-in$103
-                                      (set_local $6
-                                        (i32.add
-                                          (get_local $6)
-                                          (i32.const 1)
-                                        )
-                                      )
-                                      (if
-                                        (i32.ne
-                                          (i32.and
-                                            (i32.rem_u
-                                              (get_local $1)
-                                              (set_local $5
-                                                (i32.mul
-                                                  (get_local $5)
-                                                  (i32.const 10)
-                                                )
-                                              )
-                                            )
-                                            (i32.const -1)
-                                          )
-                                          (i32.const 0)
-                                        )
-                                        (br $while-out$102)
-                                      )
-                                      (br $while-in$103)
-                                    )
-                                  )
-                                  (set_local $6
-                                    (i32.const 9)
-                                  )
-                                )
-                              )
-                              (set_local $1
-                                (i32.add
-                                  (i32.mul
-                                    (i32.shr_s
-                                      (i32.sub
-                                        (get_local $23)
-                                        (get_local $62)
-                                      )
-                                      (i32.const 2)
-                                    )
-                                    (i32.const 9)
-                                  )
-                                  (i32.const -9)
-                                )
-                              )
-                              (if
-                                (i32.eq
-                                  (i32.or
-                                    (get_local $10)
-                                    (i32.const 32)
-                                  )
-                                  (i32.const 102)
-                                )
-                                (block
-                                  (set_local $1
-                                    (i32.lt_s
-                                      (set_local $5
-                                        (i32.sub
-                                          (get_local $1)
-                                          (get_local $6)
-                                        )
-                                      )
-                                      (i32.const 0)
-                                    )
-                                  )
-                                  (set_local $5
-                                    (i32.lt_s
-                                      (get_local $8)
-                                      (set_local $1
-                                        (select
-                                          (i32.const 0)
-                                          (get_local $5)
-                                          (get_local $1)
-                                        )
-                                      )
-                                    )
-                                  )
-                                  (set_local $14
-                                    (select
-                                      (get_local $8)
-                                      (get_local $1)
-                                      (get_local $5)
-                                    )
-                                  )
-                                  (set_local $26
-                                    (get_local $10)
-                                  )
-                                  (i32.const 0)
-                                )
-                                (block
-                                  (set_local $1
-                                    (i32.lt_s
-                                      (set_local $5
-                                        (i32.sub
-                                          (i32.add
-                                            (get_local $1)
-                                            (get_local $13)
-                                          )
-                                          (get_local $6)
-                                        )
-                                      )
-                                      (i32.const 0)
-                                    )
-                                  )
-                                  (set_local $5
-                                    (i32.lt_s
-                                      (get_local $8)
-                                      (set_local $1
-                                        (select
-                                          (i32.const 0)
-                                          (get_local $5)
-                                          (get_local $1)
-                                        )
-                                      )
-                                    )
-                                  )
-                                  (set_local $14
-                                    (select
-                                      (get_local $8)
-                                      (get_local $1)
-                                      (get_local $5)
-                                    )
-                                  )
-                                  (set_local $26
-                                    (get_local $10)
-                                  )
-                                  (i32.const 0)
-                                )
-                              )
-                            )
-                            (block
-                              (set_local $14
-                                (get_local $1)
-                              )
-                              (i32.and
-                                (get_local $18)
-                                (i32.const 8)
-                              )
-                            )
-                          )
-                        )
-                      )
-                      (set_local $17
-                        (i32.and
-                          (i32.ne
-                            (set_local $1
-                              (i32.or
-                                (get_local $14)
-                                (get_local $8)
-                              )
-                            )
-                            (i32.const 0)
-                          )
-                          (i32.const 1)
-                        )
-                      )
-                      (set_local $13
-                        (if
-                          (set_local $10
-                            (i32.eq
-                              (i32.or
-                                (get_local $26)
-                                (i32.const 32)
-                              )
-                              (i32.const 102)
-                            )
-                          )
-                          (block
-                            (set_local $6
-                              (select
-                                (get_local $13)
-                                (i32.const 0)
-                                (i32.gt_s
-                                  (get_local $13)
-                                  (i32.const 0)
-                                )
-                              )
-                            )
-                            (i32.const 0)
-                          )
-                          (block
-                            (set_local $5
-                              (i32.shr_s
-                                (i32.shl
-                                  (i32.lt_s
-                                    (set_local $6
-                                      (select
-                                        (get_local $27)
-                                        (get_local $13)
-                                        (i32.lt_s
-                                          (get_local $13)
-                                          (i32.const 0)
-                                        )
-                                      )
-                                    )
-                                    (i32.const 0)
-                                  )
-                                  (i32.const 31)
-                                )
-                                (i32.const 31)
-                              )
-                            )
-                            (if
-                              (i32.lt_s
-                                (i32.sub
-                                  (get_local $40)
-                                  (set_local $5
-                                    (call $_fmt_u
-                                      (get_local $6)
-                                      (get_local $5)
-                                      (get_local $52)
-                                    )
-                                  )
-                                )
-                                (i32.const 2)
-                              )
-                              (loop $while-out$104 $while-in$105
-                                (i32.store8
-                                  (set_local $5
-                                    (i32.add
-                                      (get_local $5)
-                                      (i32.const -1)
-                                    )
-                                  )
-                                  (i32.const 48)
-                                )
-                                (if
-                                  (i32.lt_s
-                                    (i32.sub
-                                      (get_local $40)
-                                      (get_local $5)
-                                    )
-                                    (i32.const 2)
-                                  )
-                                  (get_local $5)
-                                  (br $while-out$104)
-                                )
-                                (br $while-in$105)
-                              )
-                              (get_local $5)
-                            )
-                            (i32.store8
-                              (i32.add
-                                (get_local $5)
-                                (i32.const -1)
-                              )
-                              (i32.and
-                                (i32.add
-                                  (i32.and
-                                    (i32.shr_s
-                                      (get_local $13)
-                                      (i32.const 31)
-                                    )
-                                    (i32.const 2)
-                                  )
-                                  (i32.const 43)
-                                )
-                                (i32.const 255)
-                              )
-                            )
-                            (i32.store8
-                              (set_local $5
-                                (i32.add
-                                  (get_local $5)
-                                  (i32.const -2)
-                                )
-                              )
-                              (i32.and
-                                (get_local $26)
-                                (i32.const 255)
-                              )
-                            )
-                            (set_local $6
-                              (i32.sub
-                                (get_local $40)
-                                (get_local $5)
-                              )
-                            )
-                            (get_local $5)
-                          )
-                        )
-                      )
-                      (call $_pad
-                        (get_local $0)
-                        (i32.const 32)
-                        (get_local $16)
-                        (set_local $6
-                          (i32.add
-                            (i32.add
-                              (i32.add
-                                (i32.add
-                                  (get_local $51)
-                                  (i32.const 1)
-                                )
-                                (get_local $14)
-                              )
-                              (get_local $17)
-                            )
-                            (get_local $6)
-                          )
-                        )
-                        (get_local $18)
-                      )
-                      (if
-                        (i32.eq
-                          (i32.and
-                            (i32.load
-                              (get_local $0)
-                            )
-                            (i32.const 32)
-                          )
-                          (i32.const 0)
-                        )
-                        (call $___fwritex
-                          (get_local $39)
-                          (get_local $51)
-                          (get_local $0)
-                        )
-                      )
-                      (call $_pad
-                        (get_local $0)
-                        (i32.const 48)
-                        (get_local $16)
-                        (get_local $6)
-                        (i32.xor
-                          (get_local $18)
-                          (i32.const 65536)
-                        )
-                      )
-                      (block $do-once$106
-                        (if
-                          (get_local $10)
-                          (block
-                            (set_local $7
-                              (set_local $8
-                                (select
-                                  (get_local $9)
-                                  (get_local $7)
-                                  (i32.gt_u
-                                    (get_local $7)
-                                    (get_local $9)
-                                  )
-                                )
-                              )
-                            )
-                            (loop $while-out$108 $while-in$109
-                              (set_local $5
-                                (call $_fmt_u
-                                  (i32.load
-                                    (get_local $7)
-                                  )
-                                  (i32.const 0)
-                                  (get_local $45)
-                                )
-                              )
-                              (block $do-once$110
-                                (if
-                                  (i32.eq
-                                    (get_local $7)
-                                    (get_local $8)
-                                  )
-                                  (block
-                                    (if
-                                      (i32.ne
-                                        (get_local $5)
-                                        (get_local $45)
-                                      )
-                                      (br $do-once$110)
-                                    )
-                                    (i32.store8
-                                      (get_local $53)
                                       (i32.const 48)
                                     )
-                                    (set_local $5
-                                      (get_local $53)
-                                    )
-                                  )
-                                  (block
                                     (if
                                       (i32.gt_u
                                         (get_local $5)
                                         (get_local $29)
                                       )
                                       (get_local $5)
-                                      (br $do-once$110)
+                                      (br $while-out$112)
                                     )
-                                    (loop $while-out$112 $while-in$113
-                                      (i32.store8
-                                        (set_local $5
-                                          (i32.add
-                                            (get_local $5)
-                                            (i32.const -1)
-                                          )
-                                        )
-                                        (i32.const 48)
-                                      )
-                                      (if
-                                        (i32.gt_u
-                                          (get_local $5)
-                                          (get_local $29)
-                                        )
-                                        (get_local $5)
-                                        (br $while-out$112)
-                                      )
-                                      (br $while-in$113)
-                                    )
+                                    (br $while-in$113)
                                   )
                                 )
+                              )
+                            )
+                            (if
+                              (i32.eq
+                                (i32.and
+                                  (i32.load
+                                    (get_local $0)
+                                  )
+                                  (i32.const 32)
+                                )
+                                (i32.const 0)
+                              )
+                              (call $___fwritex
+                                (get_local $5)
+                                (i32.sub
+                                  (get_local $75)
+                                  (get_local $5)
+                                )
+                                (get_local $0)
+                              )
+                            )
+                            (if
+                              (i32.gt_u
+                                (set_local $7
+                                  (i32.add
+                                    (get_local $7)
+                                    (i32.const 4)
+                                  )
+                                )
+                                (get_local $9)
+                              )
+                              (block
+                                (set_local $5
+                                  (get_local $7)
+                                )
+                                (br $while-out$108)
+                              )
+                              (get_local $7)
+                            )
+                            (br $while-in$109)
+                          )
+                          (block $do-once$114
+                            (if
+                              (i32.ne
+                                (get_local $1)
+                                (i32.const 0)
+                              )
+                              (block
+                                (br_if $do-once$114
+                                  (i32.ne
+                                    (i32.and
+                                      (i32.load
+                                        (get_local $0)
+                                      )
+                                      (i32.const 32)
+                                    )
+                                    (i32.const 0)
+                                  )
+                                )
+                                (call $___fwritex
+                                  (i32.const 4143)
+                                  (i32.const 1)
+                                  (get_local $0)
+                                )
+                              )
+                            )
+                          )
+                          (if
+                            (i32.and
+                              (i32.gt_s
+                                (get_local $14)
+                                (i32.const 0)
+                              )
+                              (i32.lt_u
+                                (get_local $5)
+                                (get_local $23)
+                              )
+                            )
+                            (loop $while-out$116 $while-in$117
+                              (if
+                                (i32.gt_u
+                                  (set_local $1
+                                    (call $_fmt_u
+                                      (i32.load
+                                        (get_local $5)
+                                      )
+                                      (i32.const 0)
+                                      (get_local $45)
+                                    )
+                                  )
+                                  (get_local $29)
+                                )
+                                (loop $while-out$118 $while-in$119
+                                  (i32.store8
+                                    (set_local $1
+                                      (i32.add
+                                        (get_local $1)
+                                        (i32.const -1)
+                                      )
+                                    )
+                                    (i32.const 48)
+                                  )
+                                  (if
+                                    (i32.gt_u
+                                      (get_local $1)
+                                      (get_local $29)
+                                    )
+                                    (get_local $1)
+                                    (br $while-out$118)
+                                  )
+                                  (br $while-in$119)
+                                )
+                                (get_local $1)
                               )
                               (if
                                 (i32.eq
@@ -7278,106 +7383,217 @@
                                   (i32.const 0)
                                 )
                                 (call $___fwritex
-                                  (get_local $5)
-                                  (i32.sub
-                                    (get_local $75)
-                                    (get_local $5)
+                                  (get_local $1)
+                                  (select
+                                    (i32.const 9)
+                                    (get_local $14)
+                                    (i32.gt_s
+                                      (get_local $14)
+                                      (i32.const 9)
+                                    )
                                   )
                                   (get_local $0)
                                 )
                               )
+                              (set_local $1
+                                (i32.add
+                                  (get_local $14)
+                                  (i32.const -9)
+                                )
+                              )
                               (if
-                                (i32.gt_u
-                                  (set_local $7
-                                    (i32.add
-                                      (get_local $7)
-                                      (i32.const 4)
-                                    )
+                                (i32.and
+                                  (i32.gt_s
+                                    (get_local $14)
+                                    (i32.const 9)
                                   )
-                                  (get_local $9)
+                                  (i32.lt_u
+                                    (set_local $5
+                                      (i32.add
+                                        (get_local $5)
+                                        (i32.const 4)
+                                      )
+                                    )
+                                    (get_local $23)
+                                  )
+                                )
+                                (set_local $14
+                                  (get_local $1)
                                 )
                                 (block
-                                  (set_local $5
-                                    (get_local $7)
+                                  (set_local $14
+                                    (get_local $1)
                                   )
-                                  (br $while-out$108)
+                                  (br $while-out$116)
                                 )
+                              )
+                              (br $while-in$117)
+                            )
+                            (get_local $14)
+                          )
+                          (call $_pad
+                            (get_local $0)
+                            (i32.const 48)
+                            (i32.add
+                              (get_local $14)
+                              (i32.const 9)
+                            )
+                            (i32.const 9)
+                            (i32.const 0)
+                          )
+                        )
+                        (block
+                          (set_local $11
+                            (select
+                              (get_local $23)
+                              (i32.add
+                                (get_local $7)
+                                (i32.const 4)
+                              )
+                              (get_local $11)
+                            )
+                          )
+                          (if
+                            (i32.gt_s
+                              (get_local $14)
+                              (i32.const -1)
+                            )
+                            (block
+                              (set_local $9
+                                (i32.eq
+                                  (get_local $8)
+                                  (i32.const 0)
+                                )
+                              )
+                              (set_local $5
                                 (get_local $7)
                               )
-                              (br $while-in$109)
-                            )
-                            (block $do-once$114
-                              (if
-                                (i32.ne
-                                  (get_local $1)
-                                  (i32.const 0)
-                                )
-                                (block
-                                  (br_if $do-once$114
-                                    (i32.ne
-                                      (i32.and
-                                        (i32.load
-                                          (get_local $0)
+                              (loop $while-out$120 $while-in$121
+                                (set_local $8
+                                  (if
+                                    (i32.eq
+                                      (set_local $1
+                                        (call $_fmt_u
+                                          (i32.load
+                                            (get_local $5)
+                                          )
+                                          (i32.const 0)
+                                          (get_local $45)
                                         )
-                                        (i32.const 32)
                                       )
-                                      (i32.const 0)
+                                      (get_local $45)
                                     )
-                                  )
-                                  (call $___fwritex
-                                    (i32.const 4143)
-                                    (i32.const 1)
-                                    (get_local $0)
-                                  )
-                                )
-                              )
-                            )
-                            (if
-                              (i32.and
-                                (i32.gt_s
-                                  (get_local $14)
-                                  (i32.const 0)
-                                )
-                                (i32.lt_u
-                                  (get_local $5)
-                                  (get_local $23)
-                                )
-                              )
-                              (loop $while-out$116 $while-in$117
-                                (if
-                                  (i32.gt_u
-                                    (set_local $1
-                                      (call $_fmt_u
-                                        (i32.load
-                                          (get_local $5)
-                                        )
-                                        (i32.const 0)
-                                        (get_local $45)
+                                    (block
+                                      (i32.store8
+                                        (get_local $53)
+                                        (i32.const 48)
                                       )
+                                      (get_local $53)
                                     )
-                                    (get_local $29)
+                                    (get_local $1)
                                   )
-                                  (loop $while-out$118 $while-in$119
-                                    (i32.store8
+                                )
+                                (block $do-once$122
+                                  (if
+                                    (i32.eq
+                                      (get_local $5)
+                                      (get_local $7)
+                                    )
+                                    (block
                                       (set_local $1
                                         (i32.add
-                                          (get_local $1)
-                                          (i32.const -1)
+                                          (get_local $8)
+                                          (i32.const 1)
                                         )
                                       )
-                                      (i32.const 48)
-                                    )
-                                    (if
-                                      (i32.gt_u
-                                        (get_local $1)
-                                        (get_local $29)
+                                      (if
+                                        (i32.eq
+                                          (i32.and
+                                            (i32.load
+                                              (get_local $0)
+                                            )
+                                            (i32.const 32)
+                                          )
+                                          (i32.const 0)
+                                        )
+                                        (call $___fwritex
+                                          (get_local $8)
+                                          (i32.const 1)
+                                          (get_local $0)
+                                        )
                                       )
-                                      (get_local $1)
-                                      (br $while-out$118)
+                                      (if
+                                        (i32.and
+                                          (get_local $9)
+                                          (i32.lt_s
+                                            (get_local $14)
+                                            (i32.const 1)
+                                          )
+                                        )
+                                        (br $do-once$122)
+                                      )
+                                      (if
+                                        (i32.ne
+                                          (i32.and
+                                            (i32.load
+                                              (get_local $0)
+                                            )
+                                            (i32.const 32)
+                                          )
+                                          (i32.const 0)
+                                        )
+                                        (br $do-once$122)
+                                      )
+                                      (call $___fwritex
+                                        (i32.const 4143)
+                                        (i32.const 1)
+                                        (get_local $0)
+                                      )
                                     )
-                                    (br $while-in$119)
+                                    (block
+                                      (if
+                                        (i32.gt_u
+                                          (get_local $8)
+                                          (get_local $29)
+                                        )
+                                        (set_local $1
+                                          (get_local $8)
+                                        )
+                                        (block
+                                          (set_local $1
+                                            (get_local $8)
+                                          )
+                                          (br $do-once$122)
+                                        )
+                                      )
+                                      (loop $while-out$124 $while-in$125
+                                        (i32.store8
+                                          (set_local $1
+                                            (i32.add
+                                              (get_local $1)
+                                              (i32.const -1)
+                                            )
+                                          )
+                                          (i32.const 48)
+                                        )
+                                        (if
+                                          (i32.gt_u
+                                            (get_local $1)
+                                            (get_local $29)
+                                          )
+                                          (get_local $1)
+                                          (br $while-out$124)
+                                        )
+                                        (br $while-in$125)
+                                      )
+                                    )
                                   )
-                                  (get_local $1)
+                                )
+                                (set_local $8
+                                  (i32.sub
+                                    (get_local $75)
+                                    (get_local $1)
+                                  )
                                 )
                                 (if
                                   (i32.eq
@@ -7392,456 +7608,232 @@
                                   (call $___fwritex
                                     (get_local $1)
                                     (select
-                                      (i32.const 9)
+                                      (get_local $8)
                                       (get_local $14)
                                       (i32.gt_s
                                         (get_local $14)
-                                        (i32.const 9)
+                                        (get_local $8)
                                       )
                                     )
                                     (get_local $0)
-                                  )
-                                )
-                                (set_local $1
-                                  (i32.add
-                                    (get_local $14)
-                                    (i32.const -9)
                                   )
                                 )
                                 (if
-                                  (i32.and
-                                    (i32.gt_s
-                                      (get_local $14)
-                                      (i32.const 9)
-                                    )
-                                    (i32.lt_u
-                                      (set_local $5
-                                        (i32.add
-                                          (get_local $5)
-                                          (i32.const 4)
-                                        )
-                                      )
-                                      (get_local $23)
-                                    )
-                                  )
-                                  (set_local $14
-                                    (get_local $1)
-                                  )
-                                  (block
-                                    (set_local $14
-                                      (get_local $1)
-                                    )
-                                    (br $while-out$116)
-                                  )
-                                )
-                                (br $while-in$117)
-                              )
-                              (get_local $14)
-                            )
-                            (call $_pad
-                              (get_local $0)
-                              (i32.const 48)
-                              (i32.add
-                                (get_local $14)
-                                (i32.const 9)
-                              )
-                              (i32.const 9)
-                              (i32.const 0)
-                            )
-                          )
-                          (block
-                            (set_local $11
-                              (select
-                                (get_local $23)
-                                (i32.add
-                                  (get_local $7)
-                                  (i32.const 4)
-                                )
-                                (get_local $11)
-                              )
-                            )
-                            (if
-                              (i32.gt_s
-                                (get_local $14)
-                                (i32.const -1)
-                              )
-                              (block
-                                (set_local $9
-                                  (i32.eq
-                                    (get_local $8)
-                                    (i32.const 0)
-                                  )
-                                )
-                                (set_local $5
-                                  (get_local $7)
-                                )
-                                (loop $while-out$120 $while-in$121
-                                  (set_local $8
-                                    (if
-                                      (i32.eq
-                                        (set_local $1
-                                          (call $_fmt_u
-                                            (i32.load
-                                              (get_local $5)
-                                            )
-                                            (i32.const 0)
-                                            (get_local $45)
-                                          )
-                                        )
-                                        (get_local $45)
-                                      )
-                                      (block
-                                        (i32.store8
-                                          (get_local $53)
-                                          (i32.const 48)
-                                        )
-                                        (get_local $53)
-                                      )
-                                      (get_local $1)
-                                    )
-                                  )
-                                  (block $do-once$122
-                                    (if
-                                      (i32.eq
-                                        (get_local $5)
-                                        (get_local $7)
-                                      )
-                                      (block
-                                        (set_local $1
+                                  (i32.eqz
+                                    (i32.and
+                                      (i32.lt_u
+                                        (set_local $5
                                           (i32.add
-                                            (get_local $8)
-                                            (i32.const 1)
+                                            (get_local $5)
+                                            (i32.const 4)
                                           )
                                         )
-                                        (if
-                                          (i32.eq
-                                            (i32.and
-                                              (i32.load
-                                                (get_local $0)
-                                              )
-                                              (i32.const 32)
-                                            )
-                                            (i32.const 0)
-                                          )
-                                          (call $___fwritex
-                                            (get_local $8)
-                                            (i32.const 1)
-                                            (get_local $0)
-                                          )
-                                        )
-                                        (if
-                                          (i32.and
-                                            (get_local $9)
-                                            (i32.lt_s
-                                              (get_local $14)
-                                              (i32.const 1)
-                                            )
-                                          )
-                                          (br $do-once$122)
-                                        )
-                                        (if
-                                          (i32.ne
-                                            (i32.and
-                                              (i32.load
-                                                (get_local $0)
-                                              )
-                                              (i32.const 32)
-                                            )
-                                            (i32.const 0)
-                                          )
-                                          (br $do-once$122)
-                                        )
-                                        (call $___fwritex
-                                          (i32.const 4143)
-                                          (i32.const 1)
-                                          (get_local $0)
-                                        )
+                                        (get_local $11)
                                       )
-                                      (block
-                                        (if
-                                          (i32.gt_u
-                                            (get_local $8)
-                                            (get_local $29)
-                                          )
-                                          (set_local $1
+                                      (i32.gt_s
+                                        (set_local $14
+                                          (i32.sub
+                                            (get_local $14)
                                             (get_local $8)
                                           )
-                                          (block
-                                            (set_local $1
-                                              (get_local $8)
-                                            )
-                                            (br $do-once$122)
-                                          )
                                         )
-                                        (loop $while-out$124 $while-in$125
-                                          (i32.store8
-                                            (set_local $1
-                                              (i32.add
-                                                (get_local $1)
-                                                (i32.const -1)
-                                              )
-                                            )
-                                            (i32.const 48)
-                                          )
-                                          (if
-                                            (i32.gt_u
-                                              (get_local $1)
-                                              (get_local $29)
-                                            )
-                                            (get_local $1)
-                                            (br $while-out$124)
-                                          )
-                                          (br $while-in$125)
-                                        )
+                                        (i32.const -1)
                                       )
                                     )
                                   )
-                                  (set_local $8
-                                    (i32.sub
-                                      (get_local $75)
-                                      (get_local $1)
-                                    )
-                                  )
-                                  (if
-                                    (i32.eq
-                                      (i32.and
-                                        (i32.load
-                                          (get_local $0)
-                                        )
-                                        (i32.const 32)
-                                      )
-                                      (i32.const 0)
-                                    )
-                                    (call $___fwritex
-                                      (get_local $1)
-                                      (select
-                                        (get_local $8)
-                                        (get_local $14)
-                                        (i32.gt_s
-                                          (get_local $14)
-                                          (get_local $8)
-                                        )
-                                      )
-                                      (get_local $0)
-                                    )
-                                  )
-                                  (if
-                                    (i32.eqz
-                                      (i32.and
-                                        (i32.lt_u
-                                          (set_local $5
-                                            (i32.add
-                                              (get_local $5)
-                                              (i32.const 4)
-                                            )
-                                          )
-                                          (get_local $11)
-                                        )
-                                        (i32.gt_s
-                                          (set_local $14
-                                            (i32.sub
-                                              (get_local $14)
-                                              (get_local $8)
-                                            )
-                                          )
-                                          (i32.const -1)
-                                        )
-                                      )
-                                    )
-                                    (br $while-out$120)
-                                  )
-                                  (br $while-in$121)
+                                  (br $while-out$120)
                                 )
-                              )
-                              (get_local $14)
-                            )
-                            (call $_pad
-                              (get_local $0)
-                              (i32.const 48)
-                              (i32.add
-                                (get_local $14)
-                                (i32.const 18)
-                              )
-                              (i32.const 18)
-                              (i32.const 0)
-                            )
-                            (br_if $do-once$106
-                              (i32.ne
-                                (i32.and
-                                  (i32.load
-                                    (get_local $0)
-                                  )
-                                  (i32.const 32)
-                                )
-                                (i32.const 0)
+                                (br $while-in$121)
                               )
                             )
-                            (call $___fwritex
-                              (get_local $13)
-                              (i32.sub
-                                (get_local $40)
-                                (get_local $13)
-                              )
-                              (get_local $0)
-                            )
+                            (get_local $14)
                           )
-                        )
-                      )
-                      (call $_pad
-                        (get_local $0)
-                        (i32.const 32)
-                        (get_local $16)
-                        (get_local $6)
-                        (i32.xor
-                          (get_local $18)
-                          (i32.const 8192)
-                        )
-                      )
-                      (select
-                        (get_local $16)
-                        (get_local $6)
-                        (i32.lt_s
-                          (get_local $6)
-                          (get_local $16)
-                        )
-                      )
-                    )
-                    (block
-                      (set_local $5
-                        (select
-                          (i32.const 4127)
-                          (i32.const 4131)
-                          (set_local $8
+                          (call $_pad
+                            (get_local $0)
+                            (i32.const 48)
+                            (i32.add
+                              (get_local $14)
+                              (i32.const 18)
+                            )
+                            (i32.const 18)
+                            (i32.const 0)
+                          )
+                          (br_if $do-once$106
                             (i32.ne
                               (i32.and
-                                (get_local $26)
+                                (i32.load
+                                  (get_local $0)
+                                )
                                 (i32.const 32)
                               )
                               (i32.const 0)
                             )
                           )
+                          (call $___fwritex
+                            (get_local $13)
+                            (i32.sub
+                              (get_local $40)
+                              (get_local $13)
+                            )
+                            (get_local $0)
+                          )
                         )
                       )
-                      (set_local $6
+                    )
+                    (call $_pad
+                      (get_local $0)
+                      (i32.const 32)
+                      (get_local $16)
+                      (get_local $6)
+                      (i32.xor
+                        (get_local $18)
+                        (i32.const 8192)
+                      )
+                    )
+                    (select
+                      (get_local $16)
+                      (get_local $6)
+                      (i32.lt_s
+                        (get_local $6)
+                        (get_local $16)
+                      )
+                    )
+                  )
+                  (block
+                    (set_local $5
+                      (select
+                        (i32.const 4127)
+                        (i32.const 4131)
+                        (set_local $8
+                          (i32.ne
+                            (i32.and
+                              (get_local $26)
+                              (i32.const 32)
+                            )
+                            (i32.const 0)
+                          )
+                        )
+                      )
+                    )
+                    (set_local $6
+                      (select
+                        (i32.const 0)
+                        (get_local $51)
+                        (set_local $1
+                          (i32.or
+                            (f64.ne
+                              (get_local $15)
+                              (get_local $15)
+                            )
+                            (i32.const 0)
+                          )
+                        )
+                      )
+                    )
+                    (set_local $8
+                      (select
                         (select
-                          (i32.const 0)
-                          (get_local $51)
-                          (set_local $1
-                            (i32.or
-                              (f64.ne
-                                (get_local $15)
-                                (get_local $15)
+                          (i32.const 4135)
+                          (i32.const 4139)
+                          (get_local $8)
+                        )
+                        (get_local $5)
+                        (get_local $1)
+                      )
+                    )
+                    (call $_pad
+                      (get_local $0)
+                      (i32.const 32)
+                      (get_local $16)
+                      (set_local $5
+                        (i32.add
+                          (get_local $6)
+                          (i32.const 3)
+                        )
+                      )
+                      (get_local $7)
+                    )
+                    (if
+                      (i32.eq
+                        (i32.and
+                          (if
+                            (i32.eq
+                              (i32.and
+                                (set_local $1
+                                  (i32.load
+                                    (get_local $0)
+                                  )
+                                )
+                                (i32.const 32)
                               )
                               (i32.const 0)
                             )
-                          )
-                        )
-                      )
-                      (set_local $8
-                        (select
-                          (select
-                            (i32.const 4135)
-                            (i32.const 4139)
-                            (get_local $8)
-                          )
-                          (get_local $5)
-                          (get_local $1)
-                        )
-                      )
-                      (call $_pad
-                        (get_local $0)
-                        (i32.const 32)
-                        (get_local $16)
-                        (set_local $5
-                          (i32.add
-                            (get_local $6)
-                            (i32.const 3)
-                          )
-                        )
-                        (get_local $7)
-                      )
-                      (if
-                        (i32.eq
-                          (i32.and
-                            (if
-                              (i32.eq
-                                (i32.and
-                                  (set_local $1
-                                    (i32.load
-                                      (get_local $0)
-                                    )
-                                  )
-                                  (i32.const 32)
-                                )
-                                (i32.const 0)
+                            (block
+                              (call $___fwritex
+                                (get_local $39)
+                                (get_local $6)
+                                (get_local $0)
                               )
-                              (block
-                                (call $___fwritex
-                                  (get_local $39)
-                                  (get_local $6)
-                                  (get_local $0)
-                                )
-                                (i32.load
-                                  (get_local $0)
-                                )
+                              (i32.load
+                                (get_local $0)
                               )
-                              (get_local $1)
                             )
-                            (i32.const 32)
+                            (get_local $1)
                           )
-                          (i32.const 0)
+                          (i32.const 32)
                         )
-                        (call $___fwritex
-                          (get_local $8)
-                          (i32.const 3)
-                          (get_local $0)
-                        )
+                        (i32.const 0)
                       )
-                      (call $_pad
+                      (call $___fwritex
+                        (get_local $8)
+                        (i32.const 3)
                         (get_local $0)
-                        (i32.const 32)
-                        (get_local $16)
-                        (get_local $5)
-                        (i32.xor
-                          (get_local $18)
-                          (i32.const 8192)
-                        )
                       )
-                      (select
-                        (get_local $16)
+                    )
+                    (call $_pad
+                      (get_local $0)
+                      (i32.const 32)
+                      (get_local $16)
+                      (get_local $5)
+                      (i32.xor
+                        (get_local $18)
+                        (i32.const 8192)
+                      )
+                    )
+                    (select
+                      (get_local $16)
+                      (get_local $5)
+                      (i32.lt_s
                         (get_local $5)
-                        (i32.lt_s
-                          (get_local $5)
-                          (get_local $16)
-                        )
+                        (get_local $16)
                       )
                     )
                   )
                 )
               )
-              (set_local $8
-                (get_local $21)
-              )
-              (br $label$continue$L1)
             )
-            (set_local $47
-              (get_local $20)
+            (set_local $8
+              (get_local $21)
             )
-            (set_local $37
-              (get_local $18)
-            )
-            (set_local $42
-              (get_local $10)
-            )
-            (set_local $43
-              (i32.const 0)
-            )
-            (set_local $48
-              (i32.const 4091)
-            )
-            (set_local $49
-              (get_local $28)
-            )
+            (br $label$continue$L1)
+          )
+          (set_local $47
+            (get_local $20)
+          )
+          (set_local $37
+            (get_local $18)
+          )
+          (set_local $42
+            (get_local $10)
+          )
+          (set_local $43
+            (i32.const 0)
+          )
+          (set_local $48
+            (i32.const 4091)
+          )
+          (set_local $49
+            (get_local $28)
           )
         )
       )
@@ -8741,51 +8733,22 @@
           (i32.const 20)
         )
         (block $switch-default$14
-          (block $switch-default$14
-            (block $switch-case$13
-              (block $switch-case$12
-                (block $switch-case$11
-                  (block $switch-case$10
-                    (block $switch-case$9
-                      (block $switch-case$8
-                        (block $switch-case$7
-                          (block $switch-case$6
-                            (block $switch-case$5
-                              (block $switch-case$4
-                                (br_table $switch-case$4 $switch-case$5 $switch-case$6 $switch-case$7 $switch-case$8 $switch-case$9 $switch-case$10 $switch-case$11 $switch-case$12 $switch-case$13 $switch-default$14
-                                  (i32.sub
-                                    (get_local $1)
-                                    (i32.const 9)
-                                  )
-                                )
-                              )
-                              (set_local $3
-                                (i32.load
-                                  (set_local $1
-                                    (i32.and
-                                      (i32.add
-                                        (i32.load
-                                          (get_local $2)
-                                        )
-                                        (i32.const 3)
-                                      )
-                                      (i32.const -4)
-                                    )
-                                  )
-                                )
-                              )
-                              (i32.store
-                                (get_local $2)
-                                (i32.add
+          (block $switch-case$13
+            (block $switch-case$12
+              (block $switch-case$11
+                (block $switch-case$10
+                  (block $switch-case$9
+                    (block $switch-case$8
+                      (block $switch-case$7
+                        (block $switch-case$6
+                          (block $switch-case$5
+                            (block $switch-case$4
+                              (br_table $switch-case$4 $switch-case$5 $switch-case$6 $switch-case$7 $switch-case$8 $switch-case$9 $switch-case$10 $switch-case$11 $switch-case$12 $switch-case$13 $switch-default$14
+                                (i32.sub
                                   (get_local $1)
-                                  (i32.const 4)
+                                  (i32.const 9)
                                 )
                               )
-                              (i32.store
-                                (get_local $0)
-                                (get_local $3)
-                              )
-                              (br $label$break$L1)
                             )
                             (set_local $3
                               (i32.load
@@ -8812,19 +8775,6 @@
                             (i32.store
                               (get_local $0)
                               (get_local $3)
-                            )
-                            (i32.store offset=4
-                              (get_local $0)
-                              (i32.shr_s
-                                (i32.shl
-                                  (i32.lt_s
-                                    (get_local $3)
-                                    (i32.const 0)
-                                  )
-                                  (i32.const 31)
-                                )
-                                (i32.const 31)
-                              )
                             )
                             (br $label$break$L1)
                           )
@@ -8856,101 +8806,87 @@
                           )
                           (i32.store offset=4
                             (get_local $0)
-                            (i32.const 0)
+                            (i32.shr_s
+                              (i32.shl
+                                (i32.lt_s
+                                  (get_local $3)
+                                  (i32.const 0)
+                                )
+                                (i32.const 31)
+                              )
+                              (i32.const 31)
+                            )
                           )
                           (br $label$break$L1)
                         )
-                        (set_local $5
+                        (set_local $3
                           (i32.load
-                            (set_local $3
-                              (set_local $1
-                                (i32.and
-                                  (i32.add
-                                    (i32.load
-                                      (get_local $2)
-                                    )
-                                    (i32.const 7)
+                            (set_local $1
+                              (i32.and
+                                (i32.add
+                                  (i32.load
+                                    (get_local $2)
                                   )
-                                  (i32.const -8)
+                                  (i32.const 3)
                                 )
+                                (i32.const -4)
                               )
                             )
-                          )
-                        )
-                        (set_local $3
-                          (i32.load offset=4
-                            (get_local $3)
                           )
                         )
                         (i32.store
                           (get_local $2)
                           (i32.add
                             (get_local $1)
-                            (i32.const 8)
+                            (i32.const 4)
                           )
                         )
                         (i32.store
                           (get_local $0)
-                          (get_local $5)
+                          (get_local $3)
                         )
                         (i32.store offset=4
                           (get_local $0)
-                          (get_local $3)
+                          (i32.const 0)
                         )
                         (br $label$break$L1)
                       )
-                      (set_local $3
+                      (set_local $5
                         (i32.load
-                          (set_local $1
-                            (i32.and
-                              (i32.add
-                                (i32.load
-                                  (get_local $2)
+                          (set_local $3
+                            (set_local $1
+                              (i32.and
+                                (i32.add
+                                  (i32.load
+                                    (get_local $2)
+                                  )
+                                  (i32.const 7)
                                 )
-                                (i32.const 3)
+                                (i32.const -8)
                               )
-                              (i32.const -4)
                             )
                           )
+                        )
+                      )
+                      (set_local $3
+                        (i32.load offset=4
+                          (get_local $3)
                         )
                       )
                       (i32.store
                         (get_local $2)
                         (i32.add
                           (get_local $1)
-                          (i32.const 4)
-                        )
-                      )
-                      (set_local $2
-                        (i32.shr_s
-                          (i32.shl
-                            (i32.lt_s
-                              (set_local $1
-                                (i32.shr_s
-                                  (i32.shl
-                                    (i32.and
-                                      (get_local $3)
-                                      (i32.const 65535)
-                                    )
-                                    (i32.const 16)
-                                  )
-                                  (i32.const 16)
-                                )
-                              )
-                              (i32.const 0)
-                            )
-                            (i32.const 31)
-                          )
-                          (i32.const 31)
+                          (i32.const 8)
                         )
                       )
                       (i32.store
                         (get_local $0)
-                        (get_local $1)
+                        (get_local $5)
                       )
                       (i32.store offset=4
                         (get_local $0)
-                        (get_local $2)
+                        (get_local $3)
                       )
                       (br $label$break$L1)
                     )
@@ -8976,16 +8912,36 @@
                         (i32.const 4)
                       )
                     )
+                    (set_local $2
+                      (i32.shr_s
+                        (i32.shl
+                          (i32.lt_s
+                            (set_local $1
+                              (i32.shr_s
+                                (i32.shl
+                                  (i32.and
+                                    (get_local $3)
+                                    (i32.const 65535)
+                                  )
+                                  (i32.const 16)
+                                )
+                                (i32.const 16)
+                              )
+                            )
+                            (i32.const 0)
+                          )
+                          (i32.const 31)
+                        )
+                        (i32.const 31)
+                      )
+                    )
                     (i32.store
                       (get_local $0)
-                      (i32.and
-                        (get_local $3)
-                        (i32.const 65535)
-                      )
+                      (get_local $1)
                     )
                     (i32.store offset=4
                       (get_local $0)
-                      (i32.const 0)
+                      (get_local $2)
                     )
                     (br $label$break$L1)
                   )
@@ -9011,36 +8967,16 @@
                       (i32.const 4)
                     )
                   )
-                  (set_local $2
-                    (i32.shr_s
-                      (i32.shl
-                        (i32.lt_s
-                          (set_local $1
-                            (i32.shr_s
-                              (i32.shl
-                                (i32.and
-                                  (get_local $3)
-                                  (i32.const 255)
-                                )
-                                (i32.const 24)
-                              )
-                              (i32.const 24)
-                            )
-                          )
-                          (i32.const 0)
-                        )
-                        (i32.const 31)
-                      )
-                      (i32.const 31)
-                    )
-                  )
                   (i32.store
                     (get_local $0)
-                    (get_local $1)
+                    (i32.and
+                      (get_local $3)
+                      (i32.const 65535)
+                    )
                   )
                   (i32.store offset=4
                     (get_local $0)
-                    (get_local $2)
+                    (i32.const 0)
                   )
                   (br $label$break$L1)
                 )
@@ -9066,30 +9002,50 @@
                     (i32.const 4)
                   )
                 )
+                (set_local $2
+                  (i32.shr_s
+                    (i32.shl
+                      (i32.lt_s
+                        (set_local $1
+                          (i32.shr_s
+                            (i32.shl
+                              (i32.and
+                                (get_local $3)
+                                (i32.const 255)
+                              )
+                              (i32.const 24)
+                            )
+                            (i32.const 24)
+                          )
+                        )
+                        (i32.const 0)
+                      )
+                      (i32.const 31)
+                    )
+                    (i32.const 31)
+                  )
+                )
                 (i32.store
                   (get_local $0)
-                  (i32.and
-                    (get_local $3)
-                    (i32.const 255)
-                  )
+                  (get_local $1)
                 )
                 (i32.store offset=4
                   (get_local $0)
-                  (i32.const 0)
+                  (get_local $2)
                 )
                 (br $label$break$L1)
               )
-              (set_local $4
-                (f64.load
+              (set_local $3
+                (i32.load
                   (set_local $1
                     (i32.and
                       (i32.add
                         (i32.load
                           (get_local $2)
                         )
-                        (i32.const 7)
+                        (i32.const 3)
                       )
-                      (i32.const -8)
+                      (i32.const -4)
                     )
                   )
                 )
@@ -9098,12 +9054,19 @@
                 (get_local $2)
                 (i32.add
                   (get_local $1)
-                  (i32.const 8)
+                  (i32.const 4)
                 )
               )
-              (f64.store
+              (i32.store
                 (get_local $0)
-                (get_local $4)
+                (i32.and
+                  (get_local $3)
+                  (i32.const 255)
+                )
+              )
+              (i32.store offset=4
+                (get_local $0)
+                (i32.const 0)
               )
               (br $label$break$L1)
             )
@@ -9133,6 +9096,33 @@
               (get_local $0)
               (get_local $4)
             )
+            (br $label$break$L1)
+          )
+          (set_local $4
+            (f64.load
+              (set_local $1
+                (i32.and
+                  (i32.add
+                    (i32.load
+                      (get_local $2)
+                    )
+                    (i32.const 7)
+                  )
+                  (i32.const -8)
+                )
+              )
+            )
+          )
+          (i32.store
+            (get_local $2)
+            (i32.add
+              (get_local $1)
+              (i32.const 8)
+            )
+          )
+          (f64.store
+            (get_local $0)
+            (get_local $4)
           )
         )
       )

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -904,19 +904,17 @@ optimized:
     )
   )
   (func $loop-tail (type $v)
-    (block $block$3$break
-      (loop $shape$0$continue
-        (call_import $check
-          (i32.const 0)
-        )
-        (call_import $check
-          (i32.const 1)
-        )
-        (if
-          (i32.const 10)
-          (br $shape$0$continue)
-          (br $block$3$break)
-        )
+    (loop $block$3$break $shape$0$continue
+      (call_import $check
+        (i32.const 0)
+      )
+      (call_import $check
+        (i32.const 1)
+      )
+      (if
+        (i32.const 10)
+        (br $shape$0$continue)
+        (br $block$3$break)
       )
     )
     (call_import $check
@@ -928,22 +926,20 @@ optimized:
       (i32.const 0)
     )
     (block $block$7$break
-      (block $block$4$break
-        (loop $shape$1$continue
-          (call_import $check
-            (i32.const 1)
-          )
-          (br_if $block$7$break
-            (i32.const 0)
-          )
-          (call_import $check
-            (i32.const 2)
-          )
-          (if
-            (i32.const -6)
-            (br $block$4$break)
-            (br $shape$1$continue)
-          )
+      (loop $block$4$break $shape$1$continue
+        (call_import $check
+          (i32.const 1)
+        )
+        (br_if $block$7$break
+          (i32.const 0)
+        )
+        (call_import $check
+          (i32.const 2)
+        )
+        (if
+          (i32.const -6)
+          (br $block$4$break)
+          (br $shape$1$continue)
         )
       )
       (call_import $check
@@ -2751,19 +2747,17 @@ optimized:
     )
   )
   (func $loop-tail (type $v)
-    (block $block$3$break
-      (loop $shape$0$continue
-        (call_import $check
-          (i32.const 0)
-        )
-        (call_import $check
-          (i32.const 1)
-        )
-        (if
-          (i32.const 10)
-          (br $shape$0$continue)
-          (br $block$3$break)
-        )
+    (loop $block$3$break $shape$0$continue
+      (call_import $check
+        (i32.const 0)
+      )
+      (call_import $check
+        (i32.const 1)
+      )
+      (if
+        (i32.const 10)
+        (br $shape$0$continue)
+        (br $block$3$break)
       )
     )
     (call_import $check
@@ -2775,22 +2769,20 @@ optimized:
       (i32.const 0)
     )
     (block $block$7$break
-      (block $block$4$break
-        (loop $shape$1$continue
-          (call_import $check
-            (i32.const 1)
-          )
-          (br_if $block$7$break
-            (i32.const 0)
-          )
-          (call_import $check
-            (i32.const 2)
-          )
-          (if
-            (i32.const -6)
-            (br $block$4$break)
-            (br $shape$1$continue)
-          )
+      (loop $block$4$break $shape$1$continue
+        (call_import $check
+          (i32.const 1)
+        )
+        (br_if $block$7$break
+          (i32.const 0)
+        )
+        (call_import $check
+          (i32.const 2)
+        )
+        (if
+          (i32.const -6)
+          (br $block$4$break)
+          (br $shape$1$continue)
         )
       )
       (call_import $check

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -370,40 +370,56 @@ raw:
 (module
   (memory 0)
   (type $v (func))
+  (type $vi (func (param i32)))
   (type $i (func (result i32)))
+  (import $check "module" "check" (param i32))
   (func $just-one-block (type $v)
     (local $0 i32)
-    (i32.const 1337)
+    (call_import $check
+      (i32.const 1337)
+    )
   )
   (func $two-blocks (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
     )
     (block
-      (i32.const 1)
+      (call_import $check
+        (i32.const 1)
+      )
     )
   )
   (func $two-blocks-plus-code (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block
         (i32.const 77)
       )
     )
     (block
-      (i32.const 1)
+      (call_import $check
+        (i32.const 1)
+      )
     )
   )
   (func $loop (type $v)
     (local $0 i32)
     (loop $shape$0$break $shape$0$continue
       (block
-        (i32.const 0)
+        (call_import $check
+          (i32.const 0)
+        )
       )
       (block
-        (i32.const 1)
+        (call_import $check
+          (i32.const 1)
+        )
         (block
           (br $shape$0$continue)
         )
@@ -414,13 +430,17 @@ raw:
     (local $0 i32)
     (loop $shape$0$break $shape$0$continue
       (block
-        (i32.const 0)
+        (call_import $check
+          (i32.const 0)
+        )
         (block
           (i32.const 33)
         )
       )
       (block
-        (i32.const 1)
+        (call_import $check
+          (i32.const 1)
+        )
         (block
           (i32.const -66)
           (br $shape$0$continue)
@@ -430,35 +450,47 @@ raw:
   )
   (func $split (type $v)
     (local $0 i32)
-    (i32.const 0)
+    (call_import $check
+      (i32.const 0)
+    )
     (block $shape$1$break
       (if
         (i32.const 55)
         (block
-          (i32.const 1)
+          (call_import $check
+            (i32.const 1)
+          )
         )
         (block
-          (i32.const 2)
+          (call_import $check
+            (i32.const 2)
+          )
         )
       )
     )
   )
   (func $split-plus-code (type $v)
     (local $0 i32)
-    (i32.const 0)
+    (call_import $check
+      (i32.const 0)
+    )
     (block $shape$1$break
       (if
         (i32.const 55)
         (block
           (i32.const 10)
           (block
-            (i32.const 1)
+            (call_import $check
+              (i32.const 1)
+            )
           )
         )
         (block
           (i32.const 20)
           (block
-            (i32.const 2)
+            (call_import $check
+              (i32.const 2)
+            )
           )
         )
       )
@@ -467,12 +499,16 @@ raw:
   (func $if (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block $shape$1$break
         (if
           (i32.const 55)
           (block
-            (i32.const 1)
+            (call_import $check
+              (i32.const 1)
+            )
             (block
               (br $shape$1$break)
             )
@@ -481,20 +517,26 @@ raw:
       )
     )
     (block
-      (i32.const 2)
+      (call_import $check
+        (i32.const 2)
+      )
     )
   )
   (func $if-plus-code (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block $shape$1$break
         (if
           (i32.const 55)
           (block
             (i32.const -1)
             (block
-              (i32.const 1)
+              (call_import $check
+                (i32.const 1)
+              )
               (block
                 (i32.const -3)
                 (br $shape$1$break)
@@ -506,24 +548,32 @@ raw:
       )
     )
     (block
-      (i32.const 2)
+      (call_import $check
+        (i32.const 2)
+      )
     )
   )
   (func $if-else (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block $shape$1$break
         (if
           (i32.const 55)
           (block
-            (i32.const 1)
+            (call_import $check
+              (i32.const 1)
+            )
             (block
               (br $shape$1$break)
             )
           )
           (block
-            (i32.const 2)
+            (call_import $check
+              (i32.const 2)
+            )
             (block
               (br $shape$1$break)
             )
@@ -532,17 +582,23 @@ raw:
       )
     )
     (block
-      (i32.const 3)
+      (call_import $check
+        (i32.const 3)
+      )
     )
   )
   (func $loop-tail (type $v)
     (local $0 i32)
     (loop $shape$0$break $shape$0$continue
       (block
-        (i32.const 0)
+        (call_import $check
+          (i32.const 0)
+        )
       )
       (block
-        (i32.const 1)
+        (call_import $check
+          (i32.const 1)
+        )
         (if
           (i32.const 10)
           (br $shape$0$continue)
@@ -551,13 +607,17 @@ raw:
       )
     )
     (block
-      (i32.const 2)
+      (call_import $check
+        (i32.const 2)
+      )
     )
   )
   (func $nontrivial-loop-plus-phi-to-head (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block
         (i32.const 10)
       )
@@ -565,7 +625,9 @@ raw:
     (block
       (loop $shape$1$break $shape$1$continue
         (block
-          (i32.const 1)
+          (call_import $check
+            (i32.const 1)
+          )
           (if
             (i32.eqz
               (i32.const -2)
@@ -577,7 +639,9 @@ raw:
           )
         )
         (block
-          (i32.const 2)
+          (call_import $check
+            (i32.const 2)
+          )
           (if
             (i32.const -6)
             (block
@@ -602,12 +666,16 @@ raw:
             )
             (block
               (block
-                (i32.const 3)
+                (call_import $check
+                  (i32.const 3)
+                )
                 (block $shape$6$break
                   (if
                     (i32.const -10)
                     (block
-                      (i32.const 4)
+                      (call_import $check
+                        (i32.const 4)
+                      )
                       (block
                         (br $shape$6$break)
                       )
@@ -616,7 +684,9 @@ raw:
                 )
               )
               (block
-                (i32.const 5)
+                (call_import $check
+                  (i32.const 5)
+                )
                 (block
                   (i32.const 40)
                   (br $shape$4$break)
@@ -626,14 +696,18 @@ raw:
           )
         )
         (block
-          (i32.const 6)
+          (call_import $check
+            (i32.const 6)
+          )
         )
       )
     )
   )
   (func $switch (type $v)
     (local $0 i32)
-    (i32.const 0)
+    (call_import $check
+      (i32.const 0)
+    )
     (block $shape$1$break
       (block $switch$1$leave
         (block $switch$1$default
@@ -645,7 +719,9 @@ raw:
             )
             (block
               (block
-                (i32.const 1)
+                (call_import $check
+                  (i32.const 1)
+                )
               )
             )
             (br $switch$1$leave)
@@ -653,14 +729,18 @@ raw:
           (block
             (i32.const 55)
             (block
-              (i32.const 2)
+              (call_import $check
+                (i32.const 2)
+              )
             )
           )
           (br $switch$1$leave)
         )
         (block
           (block
-            (i32.const 3)
+            (call_import $check
+              (i32.const 3)
+            )
           )
         )
         (br $switch$1$leave)
@@ -676,7 +756,9 @@ raw:
     (local $5 f64)
     (local $6 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (if
         (i32.const 10)
         (set_local $3
@@ -698,7 +780,9 @@ raw:
             (set_local $3
               (i32.const 0)
             )
-            (i32.const 1)
+            (call_import $check
+              (i32.const 1)
+            )
             (block
               (set_local $3
                 (i32.const 3)
@@ -715,7 +799,9 @@ raw:
               (set_local $3
                 (i32.const 0)
               )
-              (i32.const 2)
+              (call_import $check
+                (i32.const 2)
+              )
               (block
                 (set_local $3
                   (i32.const 2)
@@ -731,7 +817,9 @@ raw:
   (func $return (type $i) (result i32)
     (local $0 i32)
     (block $the-list
-      (i32.const 42)
+      (call_import $check
+        (i32.const 42)
+      )
       (return
         (i32.const 1337)
       )
@@ -742,12 +830,193 @@ optimized:
 (module
   (memory 0)
   (type $v (func))
+  (type $vi (func (param i32)))
   (type $i (func (result i32)))
+  (import $check "module" "check" (param i32))
   (func $just-one-block (type $v)
-    (nop)
+    (call_import $check
+      (i32.const 1337)
+    )
+  )
+  (func $two-blocks (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (call_import $check
+      (i32.const 1)
+    )
+  )
+  (func $loop (type $v)
+    (loop $shape$0$break $shape$0$continue
+      (call_import $check
+        (i32.const 0)
+      )
+      (call_import $check
+        (i32.const 1)
+      )
+      (br $shape$0$continue)
+    )
+  )
+  (func $split (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (if
+      (i32.const 55)
+      (call_import $check
+        (i32.const 1)
+      )
+      (call_import $check
+        (i32.const 2)
+      )
+    )
+  )
+  (func $if (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (if
+      (i32.const 55)
+      (call_import $check
+        (i32.const 1)
+      )
+    )
+    (call_import $check
+      (i32.const 2)
+    )
+  )
+  (func $if-plus-code (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (if
+      (i32.const 55)
+      (call_import $check
+        (i32.const 1)
+      )
+      (i32.const -2)
+    )
+    (call_import $check
+      (i32.const 2)
+    )
+  )
+  (func $if-else (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (if
+      (i32.const 55)
+      (call_import $check
+        (i32.const 1)
+      )
+      (call_import $check
+        (i32.const 2)
+      )
+    )
+    (call_import $check
+      (i32.const 3)
+    )
+  )
+  (func $loop-tail (type $v)
+    (loop $shape$0$break $shape$0$continue
+      (call_import $check
+        (i32.const 0)
+      )
+      (call_import $check
+        (i32.const 1)
+      )
+      (if
+        (i32.const 10)
+        (br $shape$0$continue)
+        (br $shape$0$break)
+      )
+    )
+    (call_import $check
+      (i32.const 2)
+    )
+  )
+  (func $nontrivial-loop-plus-phi-to-head (type $v)
+    (local $0 i32)
+    (call_import $check
+      (i32.const 0)
+    )
+    (loop $shape$1$break $shape$1$continue
+      (call_import $check
+        (i32.const 1)
+      )
+      (br_if $shape$1$break
+        (i32.const 0)
+      )
+      (call_import $check
+        (i32.const 2)
+      )
+      (if
+        (i32.const -6)
+        (block
+          (set_local $0
+            (i32.const 4)
+          )
+          (br $shape$1$break)
+        )
+        (br $shape$1$continue)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $0)
+        (i32.const 4)
+      )
+      (block
+        (call_import $check
+          (i32.const 3)
+        )
+        (if
+          (i32.const -10)
+          (call_import $check
+            (i32.const 4)
+          )
+        )
+        (call_import $check
+          (i32.const 5)
+        )
+      )
+    )
+    (call_import $check
+      (i32.const 6)
+    )
+  )
+  (func $switch (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (block $switch$1$leave
+      (block $switch$1$default
+        (block $switch$1$case$3
+          (block $switch$1$case$2
+            (br_table $switch$1$default $switch$1$default $switch$1$case$2 $switch$1$default $switch$1$case$3 $switch$1$case$2 $switch$1$default
+              (i32.const -99)
+            )
+          )
+          (call_import $check
+            (i32.const 1)
+          )
+          (br $switch$1$leave)
+        )
+        (call_import $check
+          (i32.const 2)
+        )
+        (br $switch$1$leave)
+      )
+      (call_import $check
+        (i32.const 3)
+      )
+    )
   )
   (func $duffs-device (type $v)
     (local $0 i32)
+    (call_import $check
+      (i32.const 0)
+    )
     (set_local $0
       (i32.const 2)
     )
@@ -758,6 +1027,9 @@ optimized:
           (i32.const 2)
         )
         (block
+          (call_import $check
+            (i32.const 1)
+          )
           (set_local $0
             (i32.const 3)
           )
@@ -769,6 +1041,9 @@ optimized:
             (i32.const 3)
           )
           (block
+            (call_import $check
+              (i32.const 2)
+            )
             (set_local $0
               (i32.const 2)
             )
@@ -779,6 +1054,9 @@ optimized:
     )
   )
   (func $return (type $i) (result i32)
+    (call_import $check
+      (i32.const 42)
+    )
     (i32.const 1337)
   )
 )
@@ -1517,303 +1795,496 @@ int main() {
     BinaryenIndex paramTypes[] = { 0 };
     functionTypes[0] = BinaryenAddFunctionType(the_module, "v", 0, paramTypes, 0);
   }
+  {
+    BinaryenIndex paramTypes[] = { 1 };
+    functionTypes[1] = BinaryenAddFunctionType(the_module, "vi", 0, paramTypes, 1);
+  }
+  BinaryenAddImport(the_module, "check", "module", "check", functionTypes[1]);
   the_relooper = RelooperCreate();
   expressions[1] = BinaryenConst(the_module, BinaryenLiteralInt32(1337));
-  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[1]);
-  expressions[2] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  {
+    BinaryenExpressionRef operands[] = { expressions[1] };
+    expressions[2] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[2]);
+  expressions[3] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
   {
     BinaryenType varTypes[] = { 1 };
-    functions[0] = BinaryenAddFunction(the_module, "just-one-block", functionTypes[0], varTypes, 1, expressions[2]);
+    functions[0] = BinaryenAddFunction(the_module, "just-one-block", functionTypes[0], varTypes, 1, expressions[3]);
   }
   the_relooper = RelooperCreate();
-  expressions[3] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[3]);
-  expressions[4] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[4]);
-  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
-  expressions[5] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  expressions[4] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
-    BinaryenType varTypes[] = { 1 };
-    functions[1] = BinaryenAddFunction(the_module, "two-blocks", functionTypes[0], varTypes, 1, expressions[5]);
+    BinaryenExpressionRef operands[] = { expressions[4] };
+    expressions[5] = BinaryenCallImport(the_module, "check", operands, 1, 0);
   }
-  the_relooper = RelooperCreate();
-  expressions[6] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[6]);
-  expressions[7] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
+  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[5]);
+  expressions[6] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
+  {
+    BinaryenExpressionRef operands[] = { expressions[6] };
+    expressions[7] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
   relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[7]);
-  expressions[8] = BinaryenConst(the_module, BinaryenLiteralInt32(77));
-  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[8]);
-  expressions[9] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
+  expressions[8] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
   {
     BinaryenType varTypes[] = { 1 };
-    functions[2] = BinaryenAddFunction(the_module, "two-blocks-plus-code", functionTypes[0], varTypes, 1, expressions[9]);
+    functions[1] = BinaryenAddFunction(the_module, "two-blocks", functionTypes[0], varTypes, 1, expressions[8]);
   }
   the_relooper = RelooperCreate();
-  expressions[10] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
+  expressions[9] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
+  {
+    BinaryenExpressionRef operands[] = { expressions[9] };
+    expressions[10] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
   relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[10]);
   expressions[11] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[11]);
+  {
+    BinaryenExpressionRef operands[] = { expressions[11] };
+    expressions[12] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[12]);
+  expressions[13] = BinaryenConst(the_module, BinaryenLiteralInt32(77));
+  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[13]);
+  expressions[14] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  {
+    BinaryenType varTypes[] = { 1 };
+    functions[2] = BinaryenAddFunction(the_module, "two-blocks-plus-code", functionTypes[0], varTypes, 1, expressions[14]);
+  }
+  the_relooper = RelooperCreate();
+  expressions[15] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
+  {
+    BinaryenExpressionRef operands[] = { expressions[15] };
+    expressions[16] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[16]);
+  expressions[17] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
+  {
+    BinaryenExpressionRef operands[] = { expressions[17] };
+    expressions[18] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[18]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[0]);
-  expressions[12] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  expressions[19] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
   {
     BinaryenType varTypes[] = { 1 };
-    functions[3] = BinaryenAddFunction(the_module, "loop", functionTypes[0], varTypes, 1, expressions[12]);
+    functions[3] = BinaryenAddFunction(the_module, "loop", functionTypes[0], varTypes, 1, expressions[19]);
   }
   the_relooper = RelooperCreate();
-  expressions[13] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[13]);
-  expressions[14] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[14]);
-  expressions[15] = BinaryenConst(the_module, BinaryenLiteralInt32(33));
-  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[15]);
-  expressions[16] = BinaryenConst(the_module, BinaryenLiteralInt32(-66));
-  RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[16]);
-  expressions[17] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  expressions[20] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
+  {
+    BinaryenExpressionRef operands[] = { expressions[20] };
+    expressions[21] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[21]);
+  expressions[22] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
+  {
+    BinaryenExpressionRef operands[] = { expressions[22] };
+    expressions[23] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[23]);
+  expressions[24] = BinaryenConst(the_module, BinaryenLiteralInt32(33));
+  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[24]);
+  expressions[25] = BinaryenConst(the_module, BinaryenLiteralInt32(-66));
+  RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[0], expressions[25]);
+  expressions[26] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
   {
     BinaryenType varTypes[] = { 1 };
-    functions[4] = BinaryenAddFunction(the_module, "loop-plus-code", functionTypes[0], varTypes, 1, expressions[17]);
+    functions[4] = BinaryenAddFunction(the_module, "loop-plus-code", functionTypes[0], varTypes, 1, expressions[26]);
   }
   the_relooper = RelooperCreate();
-  expressions[18] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[18]);
-  expressions[19] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[19]);
-  expressions[20] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
-  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[20]);
-  expressions[21] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
-  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[21], expressions[0]);
-  RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[0]);
-  expressions[22] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  expressions[27] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
   {
-    BinaryenType varTypes[] = { 1 };
-    functions[5] = BinaryenAddFunction(the_module, "split", functionTypes[0], varTypes, 1, expressions[22]);
+    BinaryenExpressionRef operands[] = { expressions[27] };
+    expressions[28] = BinaryenCallImport(the_module, "check", operands, 1, 0);
   }
-  the_relooper = RelooperCreate();
-  expressions[23] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[23]);
-  expressions[24] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[24]);
-  expressions[25] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
-  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[25]);
-  expressions[26] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
-  expressions[27] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
-  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[27], expressions[26]);
-  expressions[28] = BinaryenConst(the_module, BinaryenLiteralInt32(20));
-  RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[28]);
-  expressions[29] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[28]);
+  expressions[29] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
   {
-    BinaryenType varTypes[] = { 1 };
-    functions[6] = BinaryenAddFunction(the_module, "split-plus-code", functionTypes[0], varTypes, 1, expressions[29]);
+    BinaryenExpressionRef operands[] = { expressions[29] };
+    expressions[30] = BinaryenCallImport(the_module, "check", operands, 1, 0);
   }
-  the_relooper = RelooperCreate();
-  expressions[30] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[30]);
-  expressions[31] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[31]);
-  expressions[32] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
+  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[30]);
+  expressions[31] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
+  {
+    BinaryenExpressionRef operands[] = { expressions[31] };
+    expressions[32] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
   relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[32]);
   expressions[33] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[33], expressions[0]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[0]);
-  RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[0]);
   expressions[34] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
   {
     BinaryenType varTypes[] = { 1 };
-    functions[7] = BinaryenAddFunction(the_module, "if", functionTypes[0], varTypes, 1, expressions[34]);
+    functions[5] = BinaryenAddFunction(the_module, "split", functionTypes[0], varTypes, 1, expressions[34]);
   }
   the_relooper = RelooperCreate();
   expressions[35] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[35]);
-  expressions[36] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[36]);
-  expressions[37] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
-  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[37]);
-  expressions[38] = BinaryenConst(the_module, BinaryenLiteralInt32(-1));
-  expressions[39] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
-  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[39], expressions[38]);
-  expressions[40] = BinaryenConst(the_module, BinaryenLiteralInt32(-2));
-  RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[40]);
-  expressions[41] = BinaryenConst(the_module, BinaryenLiteralInt32(-3));
-  RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[41]);
-  expressions[42] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  {
+    BinaryenExpressionRef operands[] = { expressions[35] };
+    expressions[36] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[36]);
+  expressions[37] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
+  {
+    BinaryenExpressionRef operands[] = { expressions[37] };
+    expressions[38] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[38]);
+  expressions[39] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
+  {
+    BinaryenExpressionRef operands[] = { expressions[39] };
+    expressions[40] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[40]);
+  expressions[41] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
+  expressions[42] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
+  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[42], expressions[41]);
+  expressions[43] = BinaryenConst(the_module, BinaryenLiteralInt32(20));
+  RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[43]);
+  expressions[44] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
   {
     BinaryenType varTypes[] = { 1 };
-    functions[8] = BinaryenAddFunction(the_module, "if-plus-code", functionTypes[0], varTypes, 1, expressions[42]);
+    functions[6] = BinaryenAddFunction(the_module, "split-plus-code", functionTypes[0], varTypes, 1, expressions[44]);
   }
   the_relooper = RelooperCreate();
-  expressions[43] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[43]);
-  expressions[44] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[44]);
-  expressions[45] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
-  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[45]);
-  expressions[46] = BinaryenConst(the_module, BinaryenLiteralInt32(3));
-  relooperBlocks[3] = RelooperAddBlock(the_relooper, expressions[46]);
-  expressions[47] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
-  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[47], expressions[0]);
+  expressions[45] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
+  {
+    BinaryenExpressionRef operands[] = { expressions[45] };
+    expressions[46] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[46]);
+  expressions[47] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
+  {
+    BinaryenExpressionRef operands[] = { expressions[47] };
+    expressions[48] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[48]);
+  expressions[49] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
+  {
+    BinaryenExpressionRef operands[] = { expressions[49] };
+    expressions[50] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[50]);
+  expressions[51] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
+  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[51], expressions[0]);
+  RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[0]);
+  RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[0]);
+  expressions[52] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  {
+    BinaryenType varTypes[] = { 1 };
+    functions[7] = BinaryenAddFunction(the_module, "if", functionTypes[0], varTypes, 1, expressions[52]);
+  }
+  the_relooper = RelooperCreate();
+  expressions[53] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
+  {
+    BinaryenExpressionRef operands[] = { expressions[53] };
+    expressions[54] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[54]);
+  expressions[55] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
+  {
+    BinaryenExpressionRef operands[] = { expressions[55] };
+    expressions[56] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[56]);
+  expressions[57] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
+  {
+    BinaryenExpressionRef operands[] = { expressions[57] };
+    expressions[58] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[58]);
+  expressions[59] = BinaryenConst(the_module, BinaryenLiteralInt32(-1));
+  expressions[60] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
+  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[60], expressions[59]);
+  expressions[61] = BinaryenConst(the_module, BinaryenLiteralInt32(-2));
+  RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[61]);
+  expressions[62] = BinaryenConst(the_module, BinaryenLiteralInt32(-3));
+  RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[62]);
+  expressions[63] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  {
+    BinaryenType varTypes[] = { 1 };
+    functions[8] = BinaryenAddFunction(the_module, "if-plus-code", functionTypes[0], varTypes, 1, expressions[63]);
+  }
+  the_relooper = RelooperCreate();
+  expressions[64] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
+  {
+    BinaryenExpressionRef operands[] = { expressions[64] };
+    expressions[65] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[65]);
+  expressions[66] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
+  {
+    BinaryenExpressionRef operands[] = { expressions[66] };
+    expressions[67] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[67]);
+  expressions[68] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
+  {
+    BinaryenExpressionRef operands[] = { expressions[68] };
+    expressions[69] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[69]);
+  expressions[70] = BinaryenConst(the_module, BinaryenLiteralInt32(3));
+  {
+    BinaryenExpressionRef operands[] = { expressions[70] };
+    expressions[71] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[3] = RelooperAddBlock(the_relooper, expressions[71]);
+  expressions[72] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
+  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[72], expressions[0]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[0]);
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[3], expressions[0], expressions[0]);
   RelooperAddBranch(relooperBlocks[2], relooperBlocks[3], expressions[0], expressions[0]);
-  expressions[48] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  expressions[73] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
   {
     BinaryenType varTypes[] = { 1 };
-    functions[9] = BinaryenAddFunction(the_module, "if-else", functionTypes[0], varTypes, 1, expressions[48]);
+    functions[9] = BinaryenAddFunction(the_module, "if-else", functionTypes[0], varTypes, 1, expressions[73]);
   }
   the_relooper = RelooperCreate();
-  expressions[49] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[49]);
-  expressions[50] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[50]);
-  expressions[51] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
-  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[51]);
+  expressions[74] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
+  {
+    BinaryenExpressionRef operands[] = { expressions[74] };
+    expressions[75] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[75]);
+  expressions[76] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
+  {
+    BinaryenExpressionRef operands[] = { expressions[76] };
+    expressions[77] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[77]);
+  expressions[78] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
+  {
+    BinaryenExpressionRef operands[] = { expressions[78] };
+    expressions[79] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[79]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[0]);
-  expressions[52] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
-  RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[52], expressions[0]);
+  expressions[80] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
+  RelooperAddBranch(relooperBlocks[1], relooperBlocks[0], expressions[80], expressions[0]);
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[0]);
-  expressions[53] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  expressions[81] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
   {
     BinaryenType varTypes[] = { 1 };
-    functions[10] = BinaryenAddFunction(the_module, "loop-tail", functionTypes[0], varTypes, 1, expressions[53]);
+    functions[10] = BinaryenAddFunction(the_module, "loop-tail", functionTypes[0], varTypes, 1, expressions[81]);
   }
   the_relooper = RelooperCreate();
-  expressions[54] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[54]);
-  expressions[55] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[55]);
-  expressions[56] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
-  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[56]);
-  expressions[57] = BinaryenConst(the_module, BinaryenLiteralInt32(3));
-  relooperBlocks[3] = RelooperAddBlock(the_relooper, expressions[57]);
-  expressions[58] = BinaryenConst(the_module, BinaryenLiteralInt32(4));
-  relooperBlocks[4] = RelooperAddBlock(the_relooper, expressions[58]);
-  expressions[59] = BinaryenConst(the_module, BinaryenLiteralInt32(5));
-  relooperBlocks[5] = RelooperAddBlock(the_relooper, expressions[59]);
-  expressions[60] = BinaryenConst(the_module, BinaryenLiteralInt32(6));
-  relooperBlocks[6] = RelooperAddBlock(the_relooper, expressions[60]);
-  expressions[61] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
-  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[61]);
-  expressions[62] = BinaryenConst(the_module, BinaryenLiteralInt32(-2));
-  RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[62], expressions[0]);
-  expressions[63] = BinaryenConst(the_module, BinaryenLiteralInt32(20));
-  RelooperAddBranch(relooperBlocks[1], relooperBlocks[6], expressions[0], expressions[63]);
-  expressions[64] = BinaryenConst(the_module, BinaryenLiteralInt32(-6));
-  RelooperAddBranch(relooperBlocks[2], relooperBlocks[3], expressions[64], expressions[0]);
-  expressions[65] = BinaryenConst(the_module, BinaryenLiteralInt32(30));
-  RelooperAddBranch(relooperBlocks[2], relooperBlocks[1], expressions[0], expressions[65]);
-  expressions[66] = BinaryenConst(the_module, BinaryenLiteralInt32(-10));
-  RelooperAddBranch(relooperBlocks[3], relooperBlocks[4], expressions[66], expressions[0]);
+  expressions[82] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
+  {
+    BinaryenExpressionRef operands[] = { expressions[82] };
+    expressions[83] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[83]);
+  expressions[84] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
+  {
+    BinaryenExpressionRef operands[] = { expressions[84] };
+    expressions[85] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[85]);
+  expressions[86] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
+  {
+    BinaryenExpressionRef operands[] = { expressions[86] };
+    expressions[87] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[87]);
+  expressions[88] = BinaryenConst(the_module, BinaryenLiteralInt32(3));
+  {
+    BinaryenExpressionRef operands[] = { expressions[88] };
+    expressions[89] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[3] = RelooperAddBlock(the_relooper, expressions[89]);
+  expressions[90] = BinaryenConst(the_module, BinaryenLiteralInt32(4));
+  {
+    BinaryenExpressionRef operands[] = { expressions[90] };
+    expressions[91] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[4] = RelooperAddBlock(the_relooper, expressions[91]);
+  expressions[92] = BinaryenConst(the_module, BinaryenLiteralInt32(5));
+  {
+    BinaryenExpressionRef operands[] = { expressions[92] };
+    expressions[93] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[5] = RelooperAddBlock(the_relooper, expressions[93]);
+  expressions[94] = BinaryenConst(the_module, BinaryenLiteralInt32(6));
+  {
+    BinaryenExpressionRef operands[] = { expressions[94] };
+    expressions[95] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[6] = RelooperAddBlock(the_relooper, expressions[95]);
+  expressions[96] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
+  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[0], expressions[96]);
+  expressions[97] = BinaryenConst(the_module, BinaryenLiteralInt32(-2));
+  RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[97], expressions[0]);
+  expressions[98] = BinaryenConst(the_module, BinaryenLiteralInt32(20));
+  RelooperAddBranch(relooperBlocks[1], relooperBlocks[6], expressions[0], expressions[98]);
+  expressions[99] = BinaryenConst(the_module, BinaryenLiteralInt32(-6));
+  RelooperAddBranch(relooperBlocks[2], relooperBlocks[3], expressions[99], expressions[0]);
+  expressions[100] = BinaryenConst(the_module, BinaryenLiteralInt32(30));
+  RelooperAddBranch(relooperBlocks[2], relooperBlocks[1], expressions[0], expressions[100]);
+  expressions[101] = BinaryenConst(the_module, BinaryenLiteralInt32(-10));
+  RelooperAddBranch(relooperBlocks[3], relooperBlocks[4], expressions[101], expressions[0]);
   RelooperAddBranch(relooperBlocks[3], relooperBlocks[5], expressions[0], expressions[0]);
   RelooperAddBranch(relooperBlocks[4], relooperBlocks[5], expressions[0], expressions[0]);
-  expressions[67] = BinaryenConst(the_module, BinaryenLiteralInt32(40));
-  RelooperAddBranch(relooperBlocks[5], relooperBlocks[6], expressions[0], expressions[67]);
-  expressions[68] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  expressions[102] = BinaryenConst(the_module, BinaryenLiteralInt32(40));
+  RelooperAddBranch(relooperBlocks[5], relooperBlocks[6], expressions[0], expressions[102]);
+  expressions[103] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
   {
     BinaryenType varTypes[] = { 1 };
-    functions[11] = BinaryenAddFunction(the_module, "nontrivial-loop-plus-phi-to-head", functionTypes[0], varTypes, 1, expressions[68]);
+    functions[11] = BinaryenAddFunction(the_module, "nontrivial-loop-plus-phi-to-head", functionTypes[0], varTypes, 1, expressions[103]);
   }
   the_relooper = RelooperCreate();
-  expressions[69] = BinaryenConst(the_module, BinaryenLiteralInt32(-99));
-  expressions[70] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  relooperBlocks[0] = RelooperAddBlockWithSwitch(the_relooper, expressions[70], expressions[69]);
-  expressions[71] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[71]);
-  expressions[72] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
-  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[72]);
-  expressions[73] = BinaryenConst(the_module, BinaryenLiteralInt32(3));
-  relooperBlocks[3] = RelooperAddBlock(the_relooper, expressions[73]);
+  expressions[104] = BinaryenConst(the_module, BinaryenLiteralInt32(-99));
+  expressions[105] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
+  {
+    BinaryenExpressionRef operands[] = { expressions[105] };
+    expressions[106] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[0] = RelooperAddBlockWithSwitch(the_relooper, expressions[106], expressions[104]);
+  expressions[107] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
+  {
+    BinaryenExpressionRef operands[] = { expressions[107] };
+    expressions[108] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[108]);
+  expressions[109] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
+  {
+    BinaryenExpressionRef operands[] = { expressions[109] };
+    expressions[110] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[110]);
+  expressions[111] = BinaryenConst(the_module, BinaryenLiteralInt32(3));
+  {
+    BinaryenExpressionRef operands[] = { expressions[111] };
+    expressions[112] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[3] = RelooperAddBlock(the_relooper, expressions[112]);
   {
     BinaryenIndex indexes[] = { 2, 5 };
     RelooperAddBranchForSwitch(relooperBlocks[0], relooperBlocks[1], indexes, 2, expressions[0]);
   }
-  expressions[74] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
+  expressions[113] = BinaryenConst(the_module, BinaryenLiteralInt32(55));
   {
     BinaryenIndex indexes[] = { 4 };
-    RelooperAddBranchForSwitch(relooperBlocks[0], relooperBlocks[2], indexes, 1, expressions[74]);
+    RelooperAddBranchForSwitch(relooperBlocks[0], relooperBlocks[2], indexes, 1, expressions[113]);
   }
   {
     BinaryenIndex indexes[] = { 0 };
     RelooperAddBranchForSwitch(relooperBlocks[0], relooperBlocks[3], indexes, 0, expressions[0]);
   }
-  expressions[75] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  expressions[114] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
   {
     BinaryenType varTypes[] = { 1 };
-    functions[12] = BinaryenAddFunction(the_module, "switch", functionTypes[0], varTypes, 1, expressions[75]);
+    functions[12] = BinaryenAddFunction(the_module, "switch", functionTypes[0], varTypes, 1, expressions[114]);
   }
   the_relooper = RelooperCreate();
-  expressions[76] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
-  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[76]);
-  expressions[77] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
-  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[77]);
-  expressions[78] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
-  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[78]);
-  expressions[79] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
-  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[79], expressions[0]);
+  expressions[115] = BinaryenConst(the_module, BinaryenLiteralInt32(0));
+  {
+    BinaryenExpressionRef operands[] = { expressions[115] };
+    expressions[116] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[116]);
+  expressions[117] = BinaryenConst(the_module, BinaryenLiteralInt32(1));
+  {
+    BinaryenExpressionRef operands[] = { expressions[117] };
+    expressions[118] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[1] = RelooperAddBlock(the_relooper, expressions[118]);
+  expressions[119] = BinaryenConst(the_module, BinaryenLiteralInt32(2));
+  {
+    BinaryenExpressionRef operands[] = { expressions[119] };
+    expressions[120] = BinaryenCallImport(the_module, "check", operands, 1, 0);
+  }
+  relooperBlocks[2] = RelooperAddBlock(the_relooper, expressions[120]);
+  expressions[121] = BinaryenConst(the_module, BinaryenLiteralInt32(10));
+  RelooperAddBranch(relooperBlocks[0], relooperBlocks[1], expressions[121], expressions[0]);
   RelooperAddBranch(relooperBlocks[0], relooperBlocks[2], expressions[0], expressions[0]);
   RelooperAddBranch(relooperBlocks[1], relooperBlocks[2], expressions[0], expressions[0]);
   RelooperAddBranch(relooperBlocks[2], relooperBlocks[1], expressions[0], expressions[0]);
-  expressions[80] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 3, the_module);
+  expressions[122] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 3, the_module);
   {
     BinaryenType varTypes[] = { 1, 1, 2, 1, 3, 4, 1 };
-    functions[13] = BinaryenAddFunction(the_module, "duffs-device", functionTypes[0], varTypes, 7, expressions[80]);
+    functions[13] = BinaryenAddFunction(the_module, "duffs-device", functionTypes[0], varTypes, 7, expressions[122]);
   }
   {
     BinaryenIndex paramTypes[] = { 0 };
-    functionTypes[1] = BinaryenAddFunctionType(the_module, "i", 1, paramTypes, 0);
+    functionTypes[2] = BinaryenAddFunctionType(the_module, "i", 1, paramTypes, 0);
   }
   the_relooper = RelooperCreate();
-  expressions[81] = BinaryenConst(the_module, BinaryenLiteralInt32(42));
-  expressions[82] = BinaryenConst(the_module, BinaryenLiteralInt32(1337));
-  expressions[83] = BinaryenReturn(the_module, expressions[82]);
+  expressions[123] = BinaryenConst(the_module, BinaryenLiteralInt32(42));
   {
-    BinaryenExpressionRef children[] = { expressions[81], expressions[83] };
-    expressions[84] = BinaryenBlock(the_module, "the-list", children, 2);
+    BinaryenExpressionRef operands[] = { expressions[123] };
+    expressions[124] = BinaryenCallImport(the_module, "check", operands, 1, 0);
   }
-  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[84]);
-  expressions[85] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
+  expressions[125] = BinaryenConst(the_module, BinaryenLiteralInt32(1337));
+  expressions[126] = BinaryenReturn(the_module, expressions[125]);
+  {
+    BinaryenExpressionRef children[] = { expressions[124], expressions[126] };
+    expressions[127] = BinaryenBlock(the_module, "the-list", children, 2);
+  }
+  relooperBlocks[0] = RelooperAddBlock(the_relooper, expressions[127]);
+  expressions[128] = RelooperRenderAndDispose(the_relooper, relooperBlocks[0], 0, the_module);
   {
     BinaryenType varTypes[] = { 1 };
-    functions[14] = BinaryenAddFunction(the_module, "return", functionTypes[1], varTypes, 1, expressions[85]);
+    functions[14] = BinaryenAddFunction(the_module, "return", functionTypes[2], varTypes, 1, expressions[128]);
   }
 raw:
   BinaryenModulePrint(the_module);
 (module
   (memory 0)
   (type $v (func))
+  (type $vi (func (param i32)))
   (type $i (func (result i32)))
+  (import $check "module" "check" (param i32))
   (func $just-one-block (type $v)
     (local $0 i32)
-    (i32.const 1337)
+    (call_import $check
+      (i32.const 1337)
+    )
   )
   (func $two-blocks (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
     )
     (block
-      (i32.const 1)
+      (call_import $check
+        (i32.const 1)
+      )
     )
   )
   (func $two-blocks-plus-code (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block
         (i32.const 77)
       )
     )
     (block
-      (i32.const 1)
+      (call_import $check
+        (i32.const 1)
+      )
     )
   )
   (func $loop (type $v)
     (local $0 i32)
     (loop $shape$0$break $shape$0$continue
       (block
-        (i32.const 0)
+        (call_import $check
+          (i32.const 0)
+        )
       )
       (block
-        (i32.const 1)
+        (call_import $check
+          (i32.const 1)
+        )
         (block
           (br $shape$0$continue)
         )
@@ -1824,13 +2295,17 @@ raw:
     (local $0 i32)
     (loop $shape$0$break $shape$0$continue
       (block
-        (i32.const 0)
+        (call_import $check
+          (i32.const 0)
+        )
         (block
           (i32.const 33)
         )
       )
       (block
-        (i32.const 1)
+        (call_import $check
+          (i32.const 1)
+        )
         (block
           (i32.const -66)
           (br $shape$0$continue)
@@ -1840,35 +2315,47 @@ raw:
   )
   (func $split (type $v)
     (local $0 i32)
-    (i32.const 0)
+    (call_import $check
+      (i32.const 0)
+    )
     (block $shape$1$break
       (if
         (i32.const 55)
         (block
-          (i32.const 1)
+          (call_import $check
+            (i32.const 1)
+          )
         )
         (block
-          (i32.const 2)
+          (call_import $check
+            (i32.const 2)
+          )
         )
       )
     )
   )
   (func $split-plus-code (type $v)
     (local $0 i32)
-    (i32.const 0)
+    (call_import $check
+      (i32.const 0)
+    )
     (block $shape$1$break
       (if
         (i32.const 55)
         (block
           (i32.const 10)
           (block
-            (i32.const 1)
+            (call_import $check
+              (i32.const 1)
+            )
           )
         )
         (block
           (i32.const 20)
           (block
-            (i32.const 2)
+            (call_import $check
+              (i32.const 2)
+            )
           )
         )
       )
@@ -1877,12 +2364,16 @@ raw:
   (func $if (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block $shape$1$break
         (if
           (i32.const 55)
           (block
-            (i32.const 1)
+            (call_import $check
+              (i32.const 1)
+            )
             (block
               (br $shape$1$break)
             )
@@ -1891,20 +2382,26 @@ raw:
       )
     )
     (block
-      (i32.const 2)
+      (call_import $check
+        (i32.const 2)
+      )
     )
   )
   (func $if-plus-code (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block $shape$1$break
         (if
           (i32.const 55)
           (block
             (i32.const -1)
             (block
-              (i32.const 1)
+              (call_import $check
+                (i32.const 1)
+              )
               (block
                 (i32.const -3)
                 (br $shape$1$break)
@@ -1916,24 +2413,32 @@ raw:
       )
     )
     (block
-      (i32.const 2)
+      (call_import $check
+        (i32.const 2)
+      )
     )
   )
   (func $if-else (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block $shape$1$break
         (if
           (i32.const 55)
           (block
-            (i32.const 1)
+            (call_import $check
+              (i32.const 1)
+            )
             (block
               (br $shape$1$break)
             )
           )
           (block
-            (i32.const 2)
+            (call_import $check
+              (i32.const 2)
+            )
             (block
               (br $shape$1$break)
             )
@@ -1942,17 +2447,23 @@ raw:
       )
     )
     (block
-      (i32.const 3)
+      (call_import $check
+        (i32.const 3)
+      )
     )
   )
   (func $loop-tail (type $v)
     (local $0 i32)
     (loop $shape$0$break $shape$0$continue
       (block
-        (i32.const 0)
+        (call_import $check
+          (i32.const 0)
+        )
       )
       (block
-        (i32.const 1)
+        (call_import $check
+          (i32.const 1)
+        )
         (if
           (i32.const 10)
           (br $shape$0$continue)
@@ -1961,13 +2472,17 @@ raw:
       )
     )
     (block
-      (i32.const 2)
+      (call_import $check
+        (i32.const 2)
+      )
     )
   )
   (func $nontrivial-loop-plus-phi-to-head (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block
         (i32.const 10)
       )
@@ -1975,7 +2490,9 @@ raw:
     (block
       (loop $shape$1$break $shape$1$continue
         (block
-          (i32.const 1)
+          (call_import $check
+            (i32.const 1)
+          )
           (if
             (i32.eqz
               (i32.const -2)
@@ -1987,7 +2504,9 @@ raw:
           )
         )
         (block
-          (i32.const 2)
+          (call_import $check
+            (i32.const 2)
+          )
           (if
             (i32.const -6)
             (block
@@ -2012,12 +2531,16 @@ raw:
             )
             (block
               (block
-                (i32.const 3)
+                (call_import $check
+                  (i32.const 3)
+                )
                 (block $shape$6$break
                   (if
                     (i32.const -10)
                     (block
-                      (i32.const 4)
+                      (call_import $check
+                        (i32.const 4)
+                      )
                       (block
                         (br $shape$6$break)
                       )
@@ -2026,7 +2549,9 @@ raw:
                 )
               )
               (block
-                (i32.const 5)
+                (call_import $check
+                  (i32.const 5)
+                )
                 (block
                   (i32.const 40)
                   (br $shape$4$break)
@@ -2036,14 +2561,18 @@ raw:
           )
         )
         (block
-          (i32.const 6)
+          (call_import $check
+            (i32.const 6)
+          )
         )
       )
     )
   )
   (func $switch (type $v)
     (local $0 i32)
-    (i32.const 0)
+    (call_import $check
+      (i32.const 0)
+    )
     (block $shape$1$break
       (block $switch$1$leave
         (block $switch$1$default
@@ -2055,7 +2584,9 @@ raw:
             )
             (block
               (block
-                (i32.const 1)
+                (call_import $check
+                  (i32.const 1)
+                )
               )
             )
             (br $switch$1$leave)
@@ -2063,14 +2594,18 @@ raw:
           (block
             (i32.const 55)
             (block
-              (i32.const 2)
+              (call_import $check
+                (i32.const 2)
+              )
             )
           )
           (br $switch$1$leave)
         )
         (block
           (block
-            (i32.const 3)
+            (call_import $check
+              (i32.const 3)
+            )
           )
         )
         (br $switch$1$leave)
@@ -2086,7 +2621,9 @@ raw:
     (local $5 f64)
     (local $6 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (if
         (i32.const 10)
         (set_local $3
@@ -2108,7 +2645,9 @@ raw:
             (set_local $3
               (i32.const 0)
             )
-            (i32.const 1)
+            (call_import $check
+              (i32.const 1)
+            )
             (block
               (set_local $3
                 (i32.const 3)
@@ -2125,7 +2664,9 @@ raw:
               (set_local $3
                 (i32.const 0)
               )
-              (i32.const 2)
+              (call_import $check
+                (i32.const 2)
+              )
               (block
                 (set_local $3
                   (i32.const 2)
@@ -2141,7 +2682,9 @@ raw:
   (func $return (type $i) (result i32)
     (local $0 i32)
     (block $the-list
-      (i32.const 42)
+      (call_import $check
+        (i32.const 42)
+      )
       (return
         (i32.const 1337)
       )
@@ -2156,12 +2699,193 @@ optimized:
 (module
   (memory 0)
   (type $v (func))
+  (type $vi (func (param i32)))
   (type $i (func (result i32)))
+  (import $check "module" "check" (param i32))
   (func $just-one-block (type $v)
-    (nop)
+    (call_import $check
+      (i32.const 1337)
+    )
+  )
+  (func $two-blocks (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (call_import $check
+      (i32.const 1)
+    )
+  )
+  (func $loop (type $v)
+    (loop $shape$0$break $shape$0$continue
+      (call_import $check
+        (i32.const 0)
+      )
+      (call_import $check
+        (i32.const 1)
+      )
+      (br $shape$0$continue)
+    )
+  )
+  (func $split (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (if
+      (i32.const 55)
+      (call_import $check
+        (i32.const 1)
+      )
+      (call_import $check
+        (i32.const 2)
+      )
+    )
+  )
+  (func $if (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (if
+      (i32.const 55)
+      (call_import $check
+        (i32.const 1)
+      )
+    )
+    (call_import $check
+      (i32.const 2)
+    )
+  )
+  (func $if-plus-code (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (if
+      (i32.const 55)
+      (call_import $check
+        (i32.const 1)
+      )
+      (i32.const -2)
+    )
+    (call_import $check
+      (i32.const 2)
+    )
+  )
+  (func $if-else (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (if
+      (i32.const 55)
+      (call_import $check
+        (i32.const 1)
+      )
+      (call_import $check
+        (i32.const 2)
+      )
+    )
+    (call_import $check
+      (i32.const 3)
+    )
+  )
+  (func $loop-tail (type $v)
+    (loop $shape$0$break $shape$0$continue
+      (call_import $check
+        (i32.const 0)
+      )
+      (call_import $check
+        (i32.const 1)
+      )
+      (if
+        (i32.const 10)
+        (br $shape$0$continue)
+        (br $shape$0$break)
+      )
+    )
+    (call_import $check
+      (i32.const 2)
+    )
+  )
+  (func $nontrivial-loop-plus-phi-to-head (type $v)
+    (local $0 i32)
+    (call_import $check
+      (i32.const 0)
+    )
+    (loop $shape$1$break $shape$1$continue
+      (call_import $check
+        (i32.const 1)
+      )
+      (br_if $shape$1$break
+        (i32.const 0)
+      )
+      (call_import $check
+        (i32.const 2)
+      )
+      (if
+        (i32.const -6)
+        (block
+          (set_local $0
+            (i32.const 4)
+          )
+          (br $shape$1$break)
+        )
+        (br $shape$1$continue)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $0)
+        (i32.const 4)
+      )
+      (block
+        (call_import $check
+          (i32.const 3)
+        )
+        (if
+          (i32.const -10)
+          (call_import $check
+            (i32.const 4)
+          )
+        )
+        (call_import $check
+          (i32.const 5)
+        )
+      )
+    )
+    (call_import $check
+      (i32.const 6)
+    )
+  )
+  (func $switch (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (block $switch$1$leave
+      (block $switch$1$default
+        (block $switch$1$case$3
+          (block $switch$1$case$2
+            (br_table $switch$1$default $switch$1$default $switch$1$case$2 $switch$1$default $switch$1$case$3 $switch$1$case$2 $switch$1$default
+              (i32.const -99)
+            )
+          )
+          (call_import $check
+            (i32.const 1)
+          )
+          (br $switch$1$leave)
+        )
+        (call_import $check
+          (i32.const 2)
+        )
+        (br $switch$1$leave)
+      )
+      (call_import $check
+        (i32.const 3)
+      )
+    )
   )
   (func $duffs-device (type $v)
     (local $0 i32)
+    (call_import $check
+      (i32.const 0)
+    )
     (set_local $0
       (i32.const 2)
     )
@@ -2172,6 +2896,9 @@ optimized:
           (i32.const 2)
         )
         (block
+          (call_import $check
+            (i32.const 1)
+          )
           (set_local $0
             (i32.const 3)
           )
@@ -2183,6 +2910,9 @@ optimized:
             (i32.const 3)
           )
           (block
+            (call_import $check
+              (i32.const 2)
+            )
             (set_local $0
               (i32.const 2)
             )
@@ -2193,6 +2923,9 @@ optimized:
     )
   )
   (func $return (type $i) (result i32)
+    (call_import $check
+      (i32.const 42)
+    )
     (i32.const 1337)
   )
 )

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -381,9 +381,12 @@ raw:
   )
   (func $two-blocks (type $v)
     (local $0 i32)
-    (block
+    (block $block$2$break
       (call_import $check
         (i32.const 0)
+      )
+      (block
+        (br $block$2$break)
       )
     )
     (block
@@ -394,12 +397,13 @@ raw:
   )
   (func $two-blocks-plus-code (type $v)
     (local $0 i32)
-    (block
+    (block $block$2$break
       (call_import $check
         (i32.const 0)
       )
       (block
         (i32.const 77)
+        (br $block$2$break)
       )
     )
     (block
@@ -410,10 +414,13 @@ raw:
   )
   (func $loop (type $v)
     (local $0 i32)
-    (loop $shape$0$break $shape$0$continue
-      (block
+    (loop $shape$0$continue
+      (block $block$2$break
         (call_import $check
           (i32.const 0)
+        )
+        (block
+          (br $block$2$break)
         )
       )
       (block
@@ -428,13 +435,14 @@ raw:
   )
   (func $loop-plus-code (type $v)
     (local $0 i32)
-    (loop $shape$0$break $shape$0$continue
-      (block
+    (loop $shape$0$continue
+      (block $block$2$break
         (call_import $check
           (i32.const 0)
         )
         (block
           (i32.const 33)
+          (br $block$2$break)
         )
       )
       (block
@@ -453,18 +461,16 @@ raw:
     (call_import $check
       (i32.const 0)
     )
-    (block $shape$1$break
-      (if
-        (i32.const 55)
-        (block
-          (call_import $check
-            (i32.const 1)
-          )
+    (if
+      (i32.const 55)
+      (block
+        (call_import $check
+          (i32.const 1)
         )
-        (block
-          (call_import $check
-            (i32.const 2)
-          )
+      )
+      (block
+        (call_import $check
+          (i32.const 2)
         )
       )
     )
@@ -474,23 +480,21 @@ raw:
     (call_import $check
       (i32.const 0)
     )
-    (block $shape$1$break
-      (if
-        (i32.const 55)
+    (if
+      (i32.const 55)
+      (block
+        (i32.const 10)
         (block
-          (i32.const 10)
-          (block
-            (call_import $check
-              (i32.const 1)
-            )
+          (call_import $check
+            (i32.const 1)
           )
         )
+      )
+      (block
+        (i32.const 20)
         (block
-          (i32.const 20)
-          (block
-            (call_import $check
-              (i32.const 2)
-            )
+          (call_import $check
+            (i32.const 2)
           )
         )
       )
@@ -498,22 +502,21 @@ raw:
   )
   (func $if (type $v)
     (local $0 i32)
-    (block
+    (block $block$3$break
       (call_import $check
         (i32.const 0)
       )
-      (block $shape$1$break
-        (if
-          (i32.const 55)
+      (if
+        (i32.const 55)
+        (block
+          (call_import $check
+            (i32.const 1)
+          )
           (block
-            (call_import $check
-              (i32.const 1)
-            )
-            (block
-              (br $shape$1$break)
-            )
+            (br $block$3$break)
           )
         )
+        (br $block$3$break)
       )
     )
     (block
@@ -524,26 +527,27 @@ raw:
   )
   (func $if-plus-code (type $v)
     (local $0 i32)
-    (block
+    (block $block$3$break
       (call_import $check
         (i32.const 0)
       )
-      (block $shape$1$break
-        (if
-          (i32.const 55)
+      (if
+        (i32.const 55)
+        (block
+          (i32.const -1)
           (block
-            (i32.const -1)
+            (call_import $check
+              (i32.const 1)
+            )
             (block
-              (call_import $check
-                (i32.const 1)
-              )
-              (block
-                (i32.const -3)
-                (br $shape$1$break)
-              )
+              (i32.const -3)
+              (br $block$3$break)
             )
           )
+        )
+        (block
           (i32.const -2)
+          (br $block$3$break)
         )
       )
     )
@@ -555,28 +559,26 @@ raw:
   )
   (func $if-else (type $v)
     (local $0 i32)
-    (block
+    (block $block$4$break
       (call_import $check
         (i32.const 0)
       )
-      (block $shape$1$break
-        (if
-          (i32.const 55)
-          (block
-            (call_import $check
-              (i32.const 1)
-            )
-            (block
-              (br $shape$1$break)
-            )
+      (if
+        (i32.const 55)
+        (block
+          (call_import $check
+            (i32.const 1)
           )
           (block
-            (call_import $check
-              (i32.const 2)
-            )
-            (block
-              (br $shape$1$break)
-            )
+            (br $block$4$break)
+          )
+        )
+        (block
+          (call_import $check
+            (i32.const 2)
+          )
+          (block
+            (br $block$4$break)
           )
         )
       )
@@ -589,20 +591,25 @@ raw:
   )
   (func $loop-tail (type $v)
     (local $0 i32)
-    (loop $shape$0$break $shape$0$continue
-      (block
-        (call_import $check
-          (i32.const 0)
+    (block $block$3$break
+      (loop $shape$0$continue
+        (block $block$2$break
+          (call_import $check
+            (i32.const 0)
+          )
+          (block
+            (br $block$2$break)
+          )
         )
-      )
-      (block
-        (call_import $check
-          (i32.const 1)
-        )
-        (if
-          (i32.const 10)
-          (br $shape$0$continue)
-          (br $shape$0$break)
+        (block
+          (call_import $check
+            (i32.const 1)
+          )
+          (if
+            (i32.const 10)
+            (br $shape$0$continue)
+            (br $block$3$break)
+          )
         )
       )
     )
@@ -614,91 +621,79 @@ raw:
   )
   (func $nontrivial-loop-plus-phi-to-head (type $v)
     (local $0 i32)
-    (block
+    (block $block$2$break
       (call_import $check
         (i32.const 0)
       )
       (block
         (i32.const 10)
+        (br $block$2$break)
       )
     )
     (block
-      (loop $shape$1$break $shape$1$continue
-        (block
-          (call_import $check
-            (i32.const 1)
-          )
-          (if
-            (i32.eqz
-              (i32.const -2)
+      (block $block$7$break
+        (block $block$4$break
+          (loop $shape$1$continue
+            (block $block$3$break
+              (call_import $check
+                (i32.const 1)
+              )
+              (if
+                (i32.const -2)
+                (br $block$3$break)
+                (block
+                  (i32.const 20)
+                  (br $block$7$break)
+                )
+              )
             )
             (block
-              (i32.const 20)
-              (br $shape$1$break)
+              (call_import $check
+                (i32.const 2)
+              )
+              (if
+                (i32.const -6)
+                (br $block$4$break)
+                (block
+                  (i32.const 30)
+                  (br $shape$1$continue)
+                )
+              )
             )
           )
         )
         (block
-          (call_import $check
-            (i32.const 2)
-          )
-          (if
-            (i32.const -6)
-            (block
-              (set_local $0
-                (i32.const 4)
+          (block $block$6$break
+            (call_import $check
+              (i32.const 3)
+            )
+            (if
+              (i32.const -10)
+              (block
+                (call_import $check
+                  (i32.const 4)
+                )
+                (block
+                  (br $block$6$break)
+                )
               )
-              (br $shape$1$break)
+              (br $block$6$break)
+            )
+          )
+          (block
+            (call_import $check
+              (i32.const 5)
             )
             (block
-              (i32.const 30)
-              (br $shape$1$continue)
+              (i32.const 40)
+              (br $block$7$break)
             )
           )
         )
       )
       (block
-        (block $shape$4$break
-          (if
-            (i32.eq
-              (get_local $0)
-              (i32.const 4)
-            )
-            (block
-              (block
-                (call_import $check
-                  (i32.const 3)
-                )
-                (block $shape$6$break
-                  (if
-                    (i32.const -10)
-                    (block
-                      (call_import $check
-                        (i32.const 4)
-                      )
-                      (block
-                        (br $shape$6$break)
-                      )
-                    )
-                  )
-                )
-              )
-              (block
-                (call_import $check
-                  (i32.const 5)
-                )
-                (block
-                  (i32.const 40)
-                  (br $shape$4$break)
-                )
-              )
-            )
-          )
-        )
-        (block
-          (call_import $check
-            (i32.const 6)
-          )
+        (call_import $check
+          (i32.const 6)
         )
       )
     )
@@ -708,43 +703,41 @@ raw:
     (call_import $check
       (i32.const 0)
     )
-    (block $shape$1$break
-      (block $switch$1$leave
-        (block $switch$1$default
-          (block $switch$1$case$3
-            (block $switch$1$case$2
-              (br_table $switch$1$default $switch$1$default $switch$1$case$2 $switch$1$default $switch$1$case$3 $switch$1$case$2 $switch$1$default
-                (i32.const -99)
-              )
+    (block $switch$1$leave
+      (block $switch$1$default
+        (block $switch$1$case$3
+          (block $switch$1$case$2
+            (br_table $switch$1$default $switch$1$default $switch$1$case$2 $switch$1$default $switch$1$case$3 $switch$1$case$2 $switch$1$default
+              (i32.const -99)
             )
-            (block
-              (block
-                (call_import $check
-                  (i32.const 1)
-                )
-              )
-            )
-            (br $switch$1$leave)
           )
           (block
-            (i32.const 55)
             (block
               (call_import $check
-                (i32.const 2)
+                (i32.const 1)
               )
             )
           )
           (br $switch$1$leave)
         )
         (block
+          (i32.const 55)
           (block
             (call_import $check
-              (i32.const 3)
+              (i32.const 2)
             )
           )
         )
         (br $switch$1$leave)
       )
+      (block
+        (block
+          (call_import $check
+            (i32.const 3)
+          )
+        )
+      )
+      (br $switch$1$leave)
     )
   )
   (func $duffs-device (type $v)
@@ -756,58 +749,66 @@ raw:
     (local $5 f64)
     (local $6 i32)
     (block
-      (call_import $check
-        (i32.const 0)
-      )
-      (if
-        (i32.const 10)
-        (set_local $3
-          (i32.const 2)
-        )
-        (set_local $3
-          (i32.const 3)
+      (block $block$3$break
+        (block $block$2$break
+          (call_import $check
+            (i32.const 0)
+          )
+          (if
+            (i32.const 10)
+            (block
+              (set_local $3
+                (i32.const 2)
+              )
+              (br $block$2$break)
+            )
+            (block
+              (set_local $3
+                (i32.const 3)
+              )
+              (br $block$3$break)
+            )
+          )
         )
       )
     )
-    (loop $shape$1$break $shape$1$continue
-      (block $shape$2$break
+    (loop $shape$1$continue
+      (if
+        (i32.eq
+          (get_local $3)
+          (i32.const 2)
+        )
+        (block
+          (set_local $3
+            (i32.const 0)
+          )
+          (call_import $check
+            (i32.const 1)
+          )
+          (block
+            (set_local $3
+              (i32.const 3)
+            )
+            (br $shape$1$continue)
+          )
+        )
         (if
           (i32.eq
             (get_local $3)
-            (i32.const 2)
+            (i32.const 3)
           )
           (block
             (set_local $3
               (i32.const 0)
             )
             (call_import $check
-              (i32.const 1)
+              (i32.const 2)
             )
             (block
               (set_local $3
-                (i32.const 3)
-              )
-              (br $shape$1$continue)
-            )
-          )
-          (if
-            (i32.eq
-              (get_local $3)
-              (i32.const 3)
-            )
-            (block
-              (set_local $3
-                (i32.const 0)
-              )
-              (call_import $check
                 (i32.const 2)
               )
-              (block
-                (set_local $3
-                  (i32.const 2)
-                )
-                (br $shape$1$continue)
-              )
+              (br $shape$1$continue)
             )
           )
         )
@@ -847,7 +848,7 @@ optimized:
     )
   )
   (func $loop (type $v)
-    (loop $shape$0$break $shape$0$continue
+    (loop $shape$0$continue
       (call_import $check
         (i32.const 0)
       )
@@ -885,21 +886,6 @@ optimized:
       (i32.const 2)
     )
   )
-  (func $if-plus-code (type $v)
-    (call_import $check
-      (i32.const 0)
-    )
-    (if
-      (i32.const 55)
-      (call_import $check
-        (i32.const 1)
-      )
-      (i32.const -2)
-    )
-    (call_import $check
-      (i32.const 2)
-    )
-  )
   (func $if-else (type $v)
     (call_import $check
       (i32.const 0)
@@ -918,17 +904,19 @@ optimized:
     )
   )
   (func $loop-tail (type $v)
-    (loop $shape$0$break $shape$0$continue
-      (call_import $check
-        (i32.const 0)
-      )
-      (call_import $check
-        (i32.const 1)
-      )
-      (if
-        (i32.const 10)
-        (br $shape$0$continue)
-        (br $shape$0$break)
+    (block $block$3$break
+      (loop $shape$0$continue
+        (call_import $check
+          (i32.const 0)
+        )
+        (call_import $check
+          (i32.const 1)
+        )
+        (if
+          (i32.const 10)
+          (br $shape$0$continue)
+          (br $block$3$break)
+        )
       )
     )
     (call_import $check
@@ -936,49 +924,39 @@ optimized:
     )
   )
   (func $nontrivial-loop-plus-phi-to-head (type $v)
-    (local $0 i32)
     (call_import $check
       (i32.const 0)
     )
-    (loop $shape$1$break $shape$1$continue
-      (call_import $check
-        (i32.const 1)
+    (block $block$7$break
+      (block $block$4$break
+        (loop $shape$1$continue
+          (call_import $check
+            (i32.const 1)
+          )
+          (br_if $block$7$break
+            (i32.const 0)
+          )
+          (call_import $check
+            (i32.const 2)
+          )
+          (if
+            (i32.const -6)
+            (br $block$4$break)
+            (br $shape$1$continue)
+          )
+        )
       )
-      (br_if $shape$1$break
-        (i32.const 0)
-      )
       (call_import $check
-        (i32.const 2)
+        (i32.const 3)
       )
       (if
-        (i32.const -6)
-        (block
-          (set_local $0
-            (i32.const 4)
-          )
-          (br $shape$1$break)
-        )
-        (br $shape$1$continue)
-      )
-    )
-    (if
-      (i32.eq
-        (get_local $0)
-        (i32.const 4)
-      )
-      (block
+        (i32.const -10)
         (call_import $check
-          (i32.const 3)
+          (i32.const 4)
         )
-        (if
-          (i32.const -10)
-          (call_import $check
-            (i32.const 4)
-          )
-        )
-        (call_import $check
-          (i32.const 5)
-        )
+      )
+      (call_import $check
+        (i32.const 5)
       )
     )
     (call_import $check
@@ -1020,7 +998,7 @@ optimized:
     (set_local $0
       (i32.const 2)
     )
-    (loop $shape$1$break $shape$1$continue
+    (loop $shape$1$continue
       (if
         (i32.eq
           (get_local $0)
@@ -2246,9 +2224,12 @@ raw:
   )
   (func $two-blocks (type $v)
     (local $0 i32)
-    (block
+    (block $block$2$break
       (call_import $check
         (i32.const 0)
+      )
+      (block
+        (br $block$2$break)
       )
     )
     (block
@@ -2259,12 +2240,13 @@ raw:
   )
   (func $two-blocks-plus-code (type $v)
     (local $0 i32)
-    (block
+    (block $block$2$break
       (call_import $check
         (i32.const 0)
       )
       (block
         (i32.const 77)
+        (br $block$2$break)
       )
     )
     (block
@@ -2275,10 +2257,13 @@ raw:
   )
   (func $loop (type $v)
     (local $0 i32)
-    (loop $shape$0$break $shape$0$continue
-      (block
+    (loop $shape$0$continue
+      (block $block$2$break
         (call_import $check
           (i32.const 0)
+        )
+        (block
+          (br $block$2$break)
         )
       )
       (block
@@ -2293,13 +2278,14 @@ raw:
   )
   (func $loop-plus-code (type $v)
     (local $0 i32)
-    (loop $shape$0$break $shape$0$continue
-      (block
+    (loop $shape$0$continue
+      (block $block$2$break
         (call_import $check
           (i32.const 0)
         )
         (block
           (i32.const 33)
+          (br $block$2$break)
         )
       )
       (block
@@ -2318,18 +2304,16 @@ raw:
     (call_import $check
       (i32.const 0)
     )
-    (block $shape$1$break
-      (if
-        (i32.const 55)
-        (block
-          (call_import $check
-            (i32.const 1)
-          )
+    (if
+      (i32.const 55)
+      (block
+        (call_import $check
+          (i32.const 1)
         )
-        (block
-          (call_import $check
-            (i32.const 2)
-          )
+      )
+      (block
+        (call_import $check
+          (i32.const 2)
         )
       )
     )
@@ -2339,23 +2323,21 @@ raw:
     (call_import $check
       (i32.const 0)
     )
-    (block $shape$1$break
-      (if
-        (i32.const 55)
+    (if
+      (i32.const 55)
+      (block
+        (i32.const 10)
         (block
-          (i32.const 10)
-          (block
-            (call_import $check
-              (i32.const 1)
-            )
+          (call_import $check
+            (i32.const 1)
           )
         )
+      )
+      (block
+        (i32.const 20)
         (block
-          (i32.const 20)
-          (block
-            (call_import $check
-              (i32.const 2)
-            )
+          (call_import $check
+            (i32.const 2)
           )
         )
       )
@@ -2363,22 +2345,21 @@ raw:
   )
   (func $if (type $v)
     (local $0 i32)
-    (block
+    (block $block$3$break
       (call_import $check
         (i32.const 0)
       )
-      (block $shape$1$break
-        (if
-          (i32.const 55)
+      (if
+        (i32.const 55)
+        (block
+          (call_import $check
+            (i32.const 1)
+          )
           (block
-            (call_import $check
-              (i32.const 1)
-            )
-            (block
-              (br $shape$1$break)
-            )
+            (br $block$3$break)
           )
         )
+        (br $block$3$break)
       )
     )
     (block
@@ -2389,26 +2370,27 @@ raw:
   )
   (func $if-plus-code (type $v)
     (local $0 i32)
-    (block
+    (block $block$3$break
       (call_import $check
         (i32.const 0)
       )
-      (block $shape$1$break
-        (if
-          (i32.const 55)
+      (if
+        (i32.const 55)
+        (block
+          (i32.const -1)
           (block
-            (i32.const -1)
+            (call_import $check
+              (i32.const 1)
+            )
             (block
-              (call_import $check
-                (i32.const 1)
-              )
-              (block
-                (i32.const -3)
-                (br $shape$1$break)
-              )
+              (i32.const -3)
+              (br $block$3$break)
             )
           )
+        )
+        (block
           (i32.const -2)
+          (br $block$3$break)
         )
       )
     )
@@ -2420,28 +2402,26 @@ raw:
   )
   (func $if-else (type $v)
     (local $0 i32)
-    (block
+    (block $block$4$break
       (call_import $check
         (i32.const 0)
       )
-      (block $shape$1$break
-        (if
-          (i32.const 55)
-          (block
-            (call_import $check
-              (i32.const 1)
-            )
-            (block
-              (br $shape$1$break)
-            )
+      (if
+        (i32.const 55)
+        (block
+          (call_import $check
+            (i32.const 1)
           )
           (block
-            (call_import $check
-              (i32.const 2)
-            )
-            (block
-              (br $shape$1$break)
-            )
+            (br $block$4$break)
+          )
+        )
+        (block
+          (call_import $check
+            (i32.const 2)
+          )
+          (block
+            (br $block$4$break)
           )
         )
       )
@@ -2454,20 +2434,25 @@ raw:
   )
   (func $loop-tail (type $v)
     (local $0 i32)
-    (loop $shape$0$break $shape$0$continue
-      (block
-        (call_import $check
-          (i32.const 0)
+    (block $block$3$break
+      (loop $shape$0$continue
+        (block $block$2$break
+          (call_import $check
+            (i32.const 0)
+          )
+          (block
+            (br $block$2$break)
+          )
         )
-      )
-      (block
-        (call_import $check
-          (i32.const 1)
-        )
-        (if
-          (i32.const 10)
-          (br $shape$0$continue)
-          (br $shape$0$break)
+        (block
+          (call_import $check
+            (i32.const 1)
+          )
+          (if
+            (i32.const 10)
+            (br $shape$0$continue)
+            (br $block$3$break)
+          )
         )
       )
     )
@@ -2479,91 +2464,79 @@ raw:
   )
   (func $nontrivial-loop-plus-phi-to-head (type $v)
     (local $0 i32)
-    (block
+    (block $block$2$break
       (call_import $check
         (i32.const 0)
       )
       (block
         (i32.const 10)
+        (br $block$2$break)
       )
     )
     (block
-      (loop $shape$1$break $shape$1$continue
-        (block
-          (call_import $check
-            (i32.const 1)
-          )
-          (if
-            (i32.eqz
-              (i32.const -2)
+      (block $block$7$break
+        (block $block$4$break
+          (loop $shape$1$continue
+            (block $block$3$break
+              (call_import $check
+                (i32.const 1)
+              )
+              (if
+                (i32.const -2)
+                (br $block$3$break)
+                (block
+                  (i32.const 20)
+                  (br $block$7$break)
+                )
+              )
             )
             (block
-              (i32.const 20)
-              (br $shape$1$break)
+              (call_import $check
+                (i32.const 2)
+              )
+              (if
+                (i32.const -6)
+                (br $block$4$break)
+                (block
+                  (i32.const 30)
+                  (br $shape$1$continue)
+                )
+              )
             )
           )
         )
         (block
-          (call_import $check
-            (i32.const 2)
-          )
-          (if
-            (i32.const -6)
-            (block
-              (set_local $0
-                (i32.const 4)
+          (block $block$6$break
+            (call_import $check
+              (i32.const 3)
+            )
+            (if
+              (i32.const -10)
+              (block
+                (call_import $check
+                  (i32.const 4)
+                )
+                (block
+                  (br $block$6$break)
+                )
               )
-              (br $shape$1$break)
+              (br $block$6$break)
+            )
+          )
+          (block
+            (call_import $check
+              (i32.const 5)
             )
             (block
-              (i32.const 30)
-              (br $shape$1$continue)
+              (i32.const 40)
+              (br $block$7$break)
             )
           )
         )
       )
       (block
-        (block $shape$4$break
-          (if
-            (i32.eq
-              (get_local $0)
-              (i32.const 4)
-            )
-            (block
-              (block
-                (call_import $check
-                  (i32.const 3)
-                )
-                (block $shape$6$break
-                  (if
-                    (i32.const -10)
-                    (block
-                      (call_import $check
-                        (i32.const 4)
-                      )
-                      (block
-                        (br $shape$6$break)
-                      )
-                    )
-                  )
-                )
-              )
-              (block
-                (call_import $check
-                  (i32.const 5)
-                )
-                (block
-                  (i32.const 40)
-                  (br $shape$4$break)
-                )
-              )
-            )
-          )
-        )
-        (block
-          (call_import $check
-            (i32.const 6)
-          )
+        (call_import $check
+          (i32.const 6)
         )
       )
     )
@@ -2573,43 +2546,41 @@ raw:
     (call_import $check
       (i32.const 0)
     )
-    (block $shape$1$break
-      (block $switch$1$leave
-        (block $switch$1$default
-          (block $switch$1$case$3
-            (block $switch$1$case$2
-              (br_table $switch$1$default $switch$1$default $switch$1$case$2 $switch$1$default $switch$1$case$3 $switch$1$case$2 $switch$1$default
-                (i32.const -99)
-              )
+    (block $switch$1$leave
+      (block $switch$1$default
+        (block $switch$1$case$3
+          (block $switch$1$case$2
+            (br_table $switch$1$default $switch$1$default $switch$1$case$2 $switch$1$default $switch$1$case$3 $switch$1$case$2 $switch$1$default
+              (i32.const -99)
             )
-            (block
-              (block
-                (call_import $check
-                  (i32.const 1)
-                )
-              )
-            )
-            (br $switch$1$leave)
           )
           (block
-            (i32.const 55)
             (block
               (call_import $check
-                (i32.const 2)
+                (i32.const 1)
               )
             )
           )
           (br $switch$1$leave)
         )
         (block
+          (i32.const 55)
           (block
             (call_import $check
-              (i32.const 3)
+              (i32.const 2)
             )
           )
         )
         (br $switch$1$leave)
       )
+      (block
+        (block
+          (call_import $check
+            (i32.const 3)
+          )
+        )
+      )
+      (br $switch$1$leave)
     )
   )
   (func $duffs-device (type $v)
@@ -2621,58 +2592,66 @@ raw:
     (local $5 f64)
     (local $6 i32)
     (block
-      (call_import $check
-        (i32.const 0)
-      )
-      (if
-        (i32.const 10)
-        (set_local $3
-          (i32.const 2)
-        )
-        (set_local $3
-          (i32.const 3)
+      (block $block$3$break
+        (block $block$2$break
+          (call_import $check
+            (i32.const 0)
+          )
+          (if
+            (i32.const 10)
+            (block
+              (set_local $3
+                (i32.const 2)
+              )
+              (br $block$2$break)
+            )
+            (block
+              (set_local $3
+                (i32.const 3)
+              )
+              (br $block$3$break)
+            )
+          )
         )
       )
     )
-    (loop $shape$1$break $shape$1$continue
-      (block $shape$2$break
+    (loop $shape$1$continue
+      (if
+        (i32.eq
+          (get_local $3)
+          (i32.const 2)
+        )
+        (block
+          (set_local $3
+            (i32.const 0)
+          )
+          (call_import $check
+            (i32.const 1)
+          )
+          (block
+            (set_local $3
+              (i32.const 3)
+            )
+            (br $shape$1$continue)
+          )
+        )
         (if
           (i32.eq
             (get_local $3)
-            (i32.const 2)
+            (i32.const 3)
           )
           (block
             (set_local $3
               (i32.const 0)
             )
             (call_import $check
-              (i32.const 1)
+              (i32.const 2)
             )
             (block
               (set_local $3
-                (i32.const 3)
-              )
-              (br $shape$1$continue)
-            )
-          )
-          (if
-            (i32.eq
-              (get_local $3)
-              (i32.const 3)
-            )
-            (block
-              (set_local $3
-                (i32.const 0)
-              )
-              (call_import $check
                 (i32.const 2)
               )
-              (block
-                (set_local $3
-                  (i32.const 2)
-                )
-                (br $shape$1$continue)
-              )
+              (br $shape$1$continue)
             )
           )
         )
@@ -2716,7 +2695,7 @@ optimized:
     )
   )
   (func $loop (type $v)
-    (loop $shape$0$break $shape$0$continue
+    (loop $shape$0$continue
       (call_import $check
         (i32.const 0)
       )
@@ -2754,21 +2733,6 @@ optimized:
       (i32.const 2)
     )
   )
-  (func $if-plus-code (type $v)
-    (call_import $check
-      (i32.const 0)
-    )
-    (if
-      (i32.const 55)
-      (call_import $check
-        (i32.const 1)
-      )
-      (i32.const -2)
-    )
-    (call_import $check
-      (i32.const 2)
-    )
-  )
   (func $if-else (type $v)
     (call_import $check
       (i32.const 0)
@@ -2787,17 +2751,19 @@ optimized:
     )
   )
   (func $loop-tail (type $v)
-    (loop $shape$0$break $shape$0$continue
-      (call_import $check
-        (i32.const 0)
-      )
-      (call_import $check
-        (i32.const 1)
-      )
-      (if
-        (i32.const 10)
-        (br $shape$0$continue)
-        (br $shape$0$break)
+    (block $block$3$break
+      (loop $shape$0$continue
+        (call_import $check
+          (i32.const 0)
+        )
+        (call_import $check
+          (i32.const 1)
+        )
+        (if
+          (i32.const 10)
+          (br $shape$0$continue)
+          (br $block$3$break)
+        )
       )
     )
     (call_import $check
@@ -2805,49 +2771,39 @@ optimized:
     )
   )
   (func $nontrivial-loop-plus-phi-to-head (type $v)
-    (local $0 i32)
     (call_import $check
       (i32.const 0)
     )
-    (loop $shape$1$break $shape$1$continue
-      (call_import $check
-        (i32.const 1)
+    (block $block$7$break
+      (block $block$4$break
+        (loop $shape$1$continue
+          (call_import $check
+            (i32.const 1)
+          )
+          (br_if $block$7$break
+            (i32.const 0)
+          )
+          (call_import $check
+            (i32.const 2)
+          )
+          (if
+            (i32.const -6)
+            (br $block$4$break)
+            (br $shape$1$continue)
+          )
+        )
       )
-      (br_if $shape$1$break
-        (i32.const 0)
-      )
       (call_import $check
-        (i32.const 2)
+        (i32.const 3)
       )
       (if
-        (i32.const -6)
-        (block
-          (set_local $0
-            (i32.const 4)
-          )
-          (br $shape$1$break)
-        )
-        (br $shape$1$continue)
-      )
-    )
-    (if
-      (i32.eq
-        (get_local $0)
-        (i32.const 4)
-      )
-      (block
+        (i32.const -10)
         (call_import $check
-          (i32.const 3)
+          (i32.const 4)
         )
-        (if
-          (i32.const -10)
-          (call_import $check
-            (i32.const 4)
-          )
-        )
-        (call_import $check
-          (i32.const 5)
-        )
+      )
+      (call_import $check
+        (i32.const 5)
       )
     )
     (call_import $check
@@ -2889,7 +2845,7 @@ optimized:
     (set_local $0
       (i32.const 2)
     )
-    (loop $shape$1$break $shape$1$continue
+    (loop $shape$1$continue
       (if
         (i32.eq
           (get_local $0)

--- a/test/example/c-api-kitchen-sink.txt.txt
+++ b/test/example/c-api-kitchen-sink.txt.txt
@@ -897,19 +897,17 @@
     )
   )
   (func $loop-tail (type $v)
-    (block $block$3$break
-      (loop $shape$0$continue
-        (call_import $check
-          (i32.const 0)
-        )
-        (call_import $check
-          (i32.const 1)
-        )
-        (if
-          (i32.const 10)
-          (br $shape$0$continue)
-          (br $block$3$break)
-        )
+    (loop $block$3$break $shape$0$continue
+      (call_import $check
+        (i32.const 0)
+      )
+      (call_import $check
+        (i32.const 1)
+      )
+      (if
+        (i32.const 10)
+        (br $shape$0$continue)
+        (br $block$3$break)
       )
     )
     (call_import $check
@@ -921,22 +919,20 @@
       (i32.const 0)
     )
     (block $block$7$break
-      (block $block$4$break
-        (loop $shape$1$continue
-          (call_import $check
-            (i32.const 1)
-          )
-          (br_if $block$7$break
-            (i32.const 0)
-          )
-          (call_import $check
-            (i32.const 2)
-          )
-          (if
-            (i32.const -6)
-            (br $block$4$break)
-            (br $shape$1$continue)
-          )
+      (loop $block$4$break $shape$1$continue
+        (call_import $check
+          (i32.const 1)
+        )
+        (br_if $block$7$break
+          (i32.const 0)
+        )
+        (call_import $check
+          (i32.const 2)
+        )
+        (if
+          (i32.const -6)
+          (br $block$4$break)
+          (br $shape$1$continue)
         )
       )
       (call_import $check

--- a/test/example/c-api-kitchen-sink.txt.txt
+++ b/test/example/c-api-kitchen-sink.txt.txt
@@ -375,9 +375,12 @@
   )
   (func $two-blocks (type $v)
     (local $0 i32)
-    (block
+    (block $block$2$break
       (call_import $check
         (i32.const 0)
+      )
+      (block
+        (br $block$2$break)
       )
     )
     (block
@@ -388,12 +391,13 @@
   )
   (func $two-blocks-plus-code (type $v)
     (local $0 i32)
-    (block
+    (block $block$2$break
       (call_import $check
         (i32.const 0)
       )
       (block
         (i32.const 77)
+        (br $block$2$break)
       )
     )
     (block
@@ -404,10 +408,13 @@
   )
   (func $loop (type $v)
     (local $0 i32)
-    (loop $shape$0$break $shape$0$continue
-      (block
+    (loop $shape$0$continue
+      (block $block$2$break
         (call_import $check
           (i32.const 0)
+        )
+        (block
+          (br $block$2$break)
         )
       )
       (block
@@ -422,13 +429,14 @@
   )
   (func $loop-plus-code (type $v)
     (local $0 i32)
-    (loop $shape$0$break $shape$0$continue
-      (block
+    (loop $shape$0$continue
+      (block $block$2$break
         (call_import $check
           (i32.const 0)
         )
         (block
           (i32.const 33)
+          (br $block$2$break)
         )
       )
       (block
@@ -447,18 +455,16 @@
     (call_import $check
       (i32.const 0)
     )
-    (block $shape$1$break
-      (if
-        (i32.const 55)
-        (block
-          (call_import $check
-            (i32.const 1)
-          )
+    (if
+      (i32.const 55)
+      (block
+        (call_import $check
+          (i32.const 1)
         )
-        (block
-          (call_import $check
-            (i32.const 2)
-          )
+      )
+      (block
+        (call_import $check
+          (i32.const 2)
         )
       )
     )
@@ -468,23 +474,21 @@
     (call_import $check
       (i32.const 0)
     )
-    (block $shape$1$break
-      (if
-        (i32.const 55)
+    (if
+      (i32.const 55)
+      (block
+        (i32.const 10)
         (block
-          (i32.const 10)
-          (block
-            (call_import $check
-              (i32.const 1)
-            )
+          (call_import $check
+            (i32.const 1)
           )
         )
+      )
+      (block
+        (i32.const 20)
         (block
-          (i32.const 20)
-          (block
-            (call_import $check
-              (i32.const 2)
-            )
+          (call_import $check
+            (i32.const 2)
           )
         )
       )
@@ -492,22 +496,21 @@
   )
   (func $if (type $v)
     (local $0 i32)
-    (block
+    (block $block$3$break
       (call_import $check
         (i32.const 0)
       )
-      (block $shape$1$break
-        (if
-          (i32.const 55)
+      (if
+        (i32.const 55)
+        (block
+          (call_import $check
+            (i32.const 1)
+          )
           (block
-            (call_import $check
-              (i32.const 1)
-            )
-            (block
-              (br $shape$1$break)
-            )
+            (br $block$3$break)
           )
         )
+        (br $block$3$break)
       )
     )
     (block
@@ -518,26 +521,27 @@
   )
   (func $if-plus-code (type $v)
     (local $0 i32)
-    (block
+    (block $block$3$break
       (call_import $check
         (i32.const 0)
       )
-      (block $shape$1$break
-        (if
-          (i32.const 55)
+      (if
+        (i32.const 55)
+        (block
+          (i32.const -1)
           (block
-            (i32.const -1)
+            (call_import $check
+              (i32.const 1)
+            )
             (block
-              (call_import $check
-                (i32.const 1)
-              )
-              (block
-                (i32.const -3)
-                (br $shape$1$break)
-              )
+              (i32.const -3)
+              (br $block$3$break)
             )
           )
+        )
+        (block
           (i32.const -2)
+          (br $block$3$break)
         )
       )
     )
@@ -549,28 +553,26 @@
   )
   (func $if-else (type $v)
     (local $0 i32)
-    (block
+    (block $block$4$break
       (call_import $check
         (i32.const 0)
       )
-      (block $shape$1$break
-        (if
-          (i32.const 55)
-          (block
-            (call_import $check
-              (i32.const 1)
-            )
-            (block
-              (br $shape$1$break)
-            )
+      (if
+        (i32.const 55)
+        (block
+          (call_import $check
+            (i32.const 1)
           )
           (block
-            (call_import $check
-              (i32.const 2)
-            )
-            (block
-              (br $shape$1$break)
-            )
+            (br $block$4$break)
+          )
+        )
+        (block
+          (call_import $check
+            (i32.const 2)
+          )
+          (block
+            (br $block$4$break)
           )
         )
       )
@@ -583,20 +585,25 @@
   )
   (func $loop-tail (type $v)
     (local $0 i32)
-    (loop $shape$0$break $shape$0$continue
-      (block
-        (call_import $check
-          (i32.const 0)
+    (block $block$3$break
+      (loop $shape$0$continue
+        (block $block$2$break
+          (call_import $check
+            (i32.const 0)
+          )
+          (block
+            (br $block$2$break)
+          )
         )
-      )
-      (block
-        (call_import $check
-          (i32.const 1)
-        )
-        (if
-          (i32.const 10)
-          (br $shape$0$continue)
-          (br $shape$0$break)
+        (block
+          (call_import $check
+            (i32.const 1)
+          )
+          (if
+            (i32.const 10)
+            (br $shape$0$continue)
+            (br $block$3$break)
+          )
         )
       )
     )
@@ -608,91 +615,79 @@
   )
   (func $nontrivial-loop-plus-phi-to-head (type $v)
     (local $0 i32)
-    (block
+    (block $block$2$break
       (call_import $check
         (i32.const 0)
       )
       (block
         (i32.const 10)
+        (br $block$2$break)
       )
     )
     (block
-      (loop $shape$1$break $shape$1$continue
-        (block
-          (call_import $check
-            (i32.const 1)
-          )
-          (if
-            (i32.eqz
-              (i32.const -2)
+      (block $block$7$break
+        (block $block$4$break
+          (loop $shape$1$continue
+            (block $block$3$break
+              (call_import $check
+                (i32.const 1)
+              )
+              (if
+                (i32.const -2)
+                (br $block$3$break)
+                (block
+                  (i32.const 20)
+                  (br $block$7$break)
+                )
+              )
             )
             (block
-              (i32.const 20)
-              (br $shape$1$break)
+              (call_import $check
+                (i32.const 2)
+              )
+              (if
+                (i32.const -6)
+                (br $block$4$break)
+                (block
+                  (i32.const 30)
+                  (br $shape$1$continue)
+                )
+              )
             )
           )
         )
         (block
-          (call_import $check
-            (i32.const 2)
-          )
-          (if
-            (i32.const -6)
-            (block
-              (set_local $0
-                (i32.const 4)
+          (block $block$6$break
+            (call_import $check
+              (i32.const 3)
+            )
+            (if
+              (i32.const -10)
+              (block
+                (call_import $check
+                  (i32.const 4)
+                )
+                (block
+                  (br $block$6$break)
+                )
               )
-              (br $shape$1$break)
+              (br $block$6$break)
+            )
+          )
+          (block
+            (call_import $check
+              (i32.const 5)
             )
             (block
-              (i32.const 30)
-              (br $shape$1$continue)
+              (i32.const 40)
+              (br $block$7$break)
             )
           )
         )
       )
       (block
-        (block $shape$4$break
-          (if
-            (i32.eq
-              (get_local $0)
-              (i32.const 4)
-            )
-            (block
-              (block
-                (call_import $check
-                  (i32.const 3)
-                )
-                (block $shape$6$break
-                  (if
-                    (i32.const -10)
-                    (block
-                      (call_import $check
-                        (i32.const 4)
-                      )
-                      (block
-                        (br $shape$6$break)
-                      )
-                    )
-                  )
-                )
-              )
-              (block
-                (call_import $check
-                  (i32.const 5)
-                )
-                (block
-                  (i32.const 40)
-                  (br $shape$4$break)
-                )
-              )
-            )
-          )
-        )
-        (block
-          (call_import $check
-            (i32.const 6)
-          )
+        (call_import $check
+          (i32.const 6)
         )
       )
     )
@@ -702,43 +697,41 @@
     (call_import $check
       (i32.const 0)
     )
-    (block $shape$1$break
-      (block $switch$1$leave
-        (block $switch$1$default
-          (block $switch$1$case$3
-            (block $switch$1$case$2
-              (br_table $switch$1$default $switch$1$default $switch$1$case$2 $switch$1$default $switch$1$case$3 $switch$1$case$2 $switch$1$default
-                (i32.const -99)
-              )
+    (block $switch$1$leave
+      (block $switch$1$default
+        (block $switch$1$case$3
+          (block $switch$1$case$2
+            (br_table $switch$1$default $switch$1$default $switch$1$case$2 $switch$1$default $switch$1$case$3 $switch$1$case$2 $switch$1$default
+              (i32.const -99)
             )
-            (block
-              (block
-                (call_import $check
-                  (i32.const 1)
-                )
-              )
-            )
-            (br $switch$1$leave)
           )
           (block
-            (i32.const 55)
             (block
               (call_import $check
-                (i32.const 2)
+                (i32.const 1)
               )
             )
           )
           (br $switch$1$leave)
         )
         (block
+          (i32.const 55)
           (block
             (call_import $check
-              (i32.const 3)
+              (i32.const 2)
             )
           )
         )
         (br $switch$1$leave)
       )
+      (block
+        (block
+          (call_import $check
+            (i32.const 3)
+          )
+        )
+      )
+      (br $switch$1$leave)
     )
   )
   (func $duffs-device (type $v)
@@ -750,58 +743,66 @@
     (local $5 f64)
     (local $6 i32)
     (block
-      (call_import $check
-        (i32.const 0)
-      )
-      (if
-        (i32.const 10)
-        (set_local $3
-          (i32.const 2)
-        )
-        (set_local $3
-          (i32.const 3)
+      (block $block$3$break
+        (block $block$2$break
+          (call_import $check
+            (i32.const 0)
+          )
+          (if
+            (i32.const 10)
+            (block
+              (set_local $3
+                (i32.const 2)
+              )
+              (br $block$2$break)
+            )
+            (block
+              (set_local $3
+                (i32.const 3)
+              )
+              (br $block$3$break)
+            )
+          )
         )
       )
     )
-    (loop $shape$1$break $shape$1$continue
-      (block $shape$2$break
+    (loop $shape$1$continue
+      (if
+        (i32.eq
+          (get_local $3)
+          (i32.const 2)
+        )
+        (block
+          (set_local $3
+            (i32.const 0)
+          )
+          (call_import $check
+            (i32.const 1)
+          )
+          (block
+            (set_local $3
+              (i32.const 3)
+            )
+            (br $shape$1$continue)
+          )
+        )
         (if
           (i32.eq
             (get_local $3)
-            (i32.const 2)
+            (i32.const 3)
           )
           (block
             (set_local $3
               (i32.const 0)
             )
             (call_import $check
-              (i32.const 1)
+              (i32.const 2)
             )
             (block
               (set_local $3
-                (i32.const 3)
-              )
-              (br $shape$1$continue)
-            )
-          )
-          (if
-            (i32.eq
-              (get_local $3)
-              (i32.const 3)
-            )
-            (block
-              (set_local $3
-                (i32.const 0)
-              )
-              (call_import $check
                 (i32.const 2)
               )
-              (block
-                (set_local $3
-                  (i32.const 2)
-                )
-                (br $shape$1$continue)
-              )
+              (br $shape$1$continue)
             )
           )
         )
@@ -840,7 +841,7 @@
     )
   )
   (func $loop (type $v)
-    (loop $shape$0$break $shape$0$continue
+    (loop $shape$0$continue
       (call_import $check
         (i32.const 0)
       )
@@ -878,21 +879,6 @@
       (i32.const 2)
     )
   )
-  (func $if-plus-code (type $v)
-    (call_import $check
-      (i32.const 0)
-    )
-    (if
-      (i32.const 55)
-      (call_import $check
-        (i32.const 1)
-      )
-      (i32.const -2)
-    )
-    (call_import $check
-      (i32.const 2)
-    )
-  )
   (func $if-else (type $v)
     (call_import $check
       (i32.const 0)
@@ -911,17 +897,19 @@
     )
   )
   (func $loop-tail (type $v)
-    (loop $shape$0$break $shape$0$continue
-      (call_import $check
-        (i32.const 0)
-      )
-      (call_import $check
-        (i32.const 1)
-      )
-      (if
-        (i32.const 10)
-        (br $shape$0$continue)
-        (br $shape$0$break)
+    (block $block$3$break
+      (loop $shape$0$continue
+        (call_import $check
+          (i32.const 0)
+        )
+        (call_import $check
+          (i32.const 1)
+        )
+        (if
+          (i32.const 10)
+          (br $shape$0$continue)
+          (br $block$3$break)
+        )
       )
     )
     (call_import $check
@@ -929,49 +917,39 @@
     )
   )
   (func $nontrivial-loop-plus-phi-to-head (type $v)
-    (local $0 i32)
     (call_import $check
       (i32.const 0)
     )
-    (loop $shape$1$break $shape$1$continue
-      (call_import $check
-        (i32.const 1)
+    (block $block$7$break
+      (block $block$4$break
+        (loop $shape$1$continue
+          (call_import $check
+            (i32.const 1)
+          )
+          (br_if $block$7$break
+            (i32.const 0)
+          )
+          (call_import $check
+            (i32.const 2)
+          )
+          (if
+            (i32.const -6)
+            (br $block$4$break)
+            (br $shape$1$continue)
+          )
+        )
       )
-      (br_if $shape$1$break
-        (i32.const 0)
-      )
       (call_import $check
-        (i32.const 2)
+        (i32.const 3)
       )
       (if
-        (i32.const -6)
-        (block
-          (set_local $0
-            (i32.const 4)
-          )
-          (br $shape$1$break)
-        )
-        (br $shape$1$continue)
-      )
-    )
-    (if
-      (i32.eq
-        (get_local $0)
-        (i32.const 4)
-      )
-      (block
+        (i32.const -10)
         (call_import $check
-          (i32.const 3)
+          (i32.const 4)
         )
-        (if
-          (i32.const -10)
-          (call_import $check
-            (i32.const 4)
-          )
-        )
-        (call_import $check
-          (i32.const 5)
-        )
+      )
+      (call_import $check
+        (i32.const 5)
       )
     )
     (call_import $check
@@ -1013,7 +991,7 @@
     (set_local $0
       (i32.const 2)
     )
-    (loop $shape$1$break $shape$1$continue
+    (loop $shape$1$continue
       (if
         (i32.eq
           (get_local $0)

--- a/test/example/c-api-kitchen-sink.txt.txt
+++ b/test/example/c-api-kitchen-sink.txt.txt
@@ -364,40 +364,56 @@
 (module
   (memory 0)
   (type $v (func))
+  (type $vi (func (param i32)))
   (type $i (func (result i32)))
+  (import $check "module" "check" (param i32))
   (func $just-one-block (type $v)
     (local $0 i32)
-    (i32.const 1337)
+    (call_import $check
+      (i32.const 1337)
+    )
   )
   (func $two-blocks (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
     )
     (block
-      (i32.const 1)
+      (call_import $check
+        (i32.const 1)
+      )
     )
   )
   (func $two-blocks-plus-code (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block
         (i32.const 77)
       )
     )
     (block
-      (i32.const 1)
+      (call_import $check
+        (i32.const 1)
+      )
     )
   )
   (func $loop (type $v)
     (local $0 i32)
     (loop $shape$0$break $shape$0$continue
       (block
-        (i32.const 0)
+        (call_import $check
+          (i32.const 0)
+        )
       )
       (block
-        (i32.const 1)
+        (call_import $check
+          (i32.const 1)
+        )
         (block
           (br $shape$0$continue)
         )
@@ -408,13 +424,17 @@
     (local $0 i32)
     (loop $shape$0$break $shape$0$continue
       (block
-        (i32.const 0)
+        (call_import $check
+          (i32.const 0)
+        )
         (block
           (i32.const 33)
         )
       )
       (block
-        (i32.const 1)
+        (call_import $check
+          (i32.const 1)
+        )
         (block
           (i32.const -66)
           (br $shape$0$continue)
@@ -424,35 +444,47 @@
   )
   (func $split (type $v)
     (local $0 i32)
-    (i32.const 0)
+    (call_import $check
+      (i32.const 0)
+    )
     (block $shape$1$break
       (if
         (i32.const 55)
         (block
-          (i32.const 1)
+          (call_import $check
+            (i32.const 1)
+          )
         )
         (block
-          (i32.const 2)
+          (call_import $check
+            (i32.const 2)
+          )
         )
       )
     )
   )
   (func $split-plus-code (type $v)
     (local $0 i32)
-    (i32.const 0)
+    (call_import $check
+      (i32.const 0)
+    )
     (block $shape$1$break
       (if
         (i32.const 55)
         (block
           (i32.const 10)
           (block
-            (i32.const 1)
+            (call_import $check
+              (i32.const 1)
+            )
           )
         )
         (block
           (i32.const 20)
           (block
-            (i32.const 2)
+            (call_import $check
+              (i32.const 2)
+            )
           )
         )
       )
@@ -461,12 +493,16 @@
   (func $if (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block $shape$1$break
         (if
           (i32.const 55)
           (block
-            (i32.const 1)
+            (call_import $check
+              (i32.const 1)
+            )
             (block
               (br $shape$1$break)
             )
@@ -475,20 +511,26 @@
       )
     )
     (block
-      (i32.const 2)
+      (call_import $check
+        (i32.const 2)
+      )
     )
   )
   (func $if-plus-code (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block $shape$1$break
         (if
           (i32.const 55)
           (block
             (i32.const -1)
             (block
-              (i32.const 1)
+              (call_import $check
+                (i32.const 1)
+              )
               (block
                 (i32.const -3)
                 (br $shape$1$break)
@@ -500,24 +542,32 @@
       )
     )
     (block
-      (i32.const 2)
+      (call_import $check
+        (i32.const 2)
+      )
     )
   )
   (func $if-else (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block $shape$1$break
         (if
           (i32.const 55)
           (block
-            (i32.const 1)
+            (call_import $check
+              (i32.const 1)
+            )
             (block
               (br $shape$1$break)
             )
           )
           (block
-            (i32.const 2)
+            (call_import $check
+              (i32.const 2)
+            )
             (block
               (br $shape$1$break)
             )
@@ -526,17 +576,23 @@
       )
     )
     (block
-      (i32.const 3)
+      (call_import $check
+        (i32.const 3)
+      )
     )
   )
   (func $loop-tail (type $v)
     (local $0 i32)
     (loop $shape$0$break $shape$0$continue
       (block
-        (i32.const 0)
+        (call_import $check
+          (i32.const 0)
+        )
       )
       (block
-        (i32.const 1)
+        (call_import $check
+          (i32.const 1)
+        )
         (if
           (i32.const 10)
           (br $shape$0$continue)
@@ -545,13 +601,17 @@
       )
     )
     (block
-      (i32.const 2)
+      (call_import $check
+        (i32.const 2)
+      )
     )
   )
   (func $nontrivial-loop-plus-phi-to-head (type $v)
     (local $0 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (block
         (i32.const 10)
       )
@@ -559,7 +619,9 @@
     (block
       (loop $shape$1$break $shape$1$continue
         (block
-          (i32.const 1)
+          (call_import $check
+            (i32.const 1)
+          )
           (if
             (i32.eqz
               (i32.const -2)
@@ -571,7 +633,9 @@
           )
         )
         (block
-          (i32.const 2)
+          (call_import $check
+            (i32.const 2)
+          )
           (if
             (i32.const -6)
             (block
@@ -596,12 +660,16 @@
             )
             (block
               (block
-                (i32.const 3)
+                (call_import $check
+                  (i32.const 3)
+                )
                 (block $shape$6$break
                   (if
                     (i32.const -10)
                     (block
-                      (i32.const 4)
+                      (call_import $check
+                        (i32.const 4)
+                      )
                       (block
                         (br $shape$6$break)
                       )
@@ -610,7 +678,9 @@
                 )
               )
               (block
-                (i32.const 5)
+                (call_import $check
+                  (i32.const 5)
+                )
                 (block
                   (i32.const 40)
                   (br $shape$4$break)
@@ -620,14 +690,18 @@
           )
         )
         (block
-          (i32.const 6)
+          (call_import $check
+            (i32.const 6)
+          )
         )
       )
     )
   )
   (func $switch (type $v)
     (local $0 i32)
-    (i32.const 0)
+    (call_import $check
+      (i32.const 0)
+    )
     (block $shape$1$break
       (block $switch$1$leave
         (block $switch$1$default
@@ -639,7 +713,9 @@
             )
             (block
               (block
-                (i32.const 1)
+                (call_import $check
+                  (i32.const 1)
+                )
               )
             )
             (br $switch$1$leave)
@@ -647,14 +723,18 @@
           (block
             (i32.const 55)
             (block
-              (i32.const 2)
+              (call_import $check
+                (i32.const 2)
+              )
             )
           )
           (br $switch$1$leave)
         )
         (block
           (block
-            (i32.const 3)
+            (call_import $check
+              (i32.const 3)
+            )
           )
         )
         (br $switch$1$leave)
@@ -670,7 +750,9 @@
     (local $5 f64)
     (local $6 i32)
     (block
-      (i32.const 0)
+      (call_import $check
+        (i32.const 0)
+      )
       (if
         (i32.const 10)
         (set_local $3
@@ -692,7 +774,9 @@
             (set_local $3
               (i32.const 0)
             )
-            (i32.const 1)
+            (call_import $check
+              (i32.const 1)
+            )
             (block
               (set_local $3
                 (i32.const 3)
@@ -709,7 +793,9 @@
               (set_local $3
                 (i32.const 0)
               )
-              (i32.const 2)
+              (call_import $check
+                (i32.const 2)
+              )
               (block
                 (set_local $3
                   (i32.const 2)
@@ -725,7 +811,9 @@
   (func $return (type $i) (result i32)
     (local $0 i32)
     (block $the-list
-      (i32.const 42)
+      (call_import $check
+        (i32.const 42)
+      )
       (return
         (i32.const 1337)
       )
@@ -735,12 +823,193 @@
 (module
   (memory 0)
   (type $v (func))
+  (type $vi (func (param i32)))
   (type $i (func (result i32)))
+  (import $check "module" "check" (param i32))
   (func $just-one-block (type $v)
-    (nop)
+    (call_import $check
+      (i32.const 1337)
+    )
+  )
+  (func $two-blocks (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (call_import $check
+      (i32.const 1)
+    )
+  )
+  (func $loop (type $v)
+    (loop $shape$0$break $shape$0$continue
+      (call_import $check
+        (i32.const 0)
+      )
+      (call_import $check
+        (i32.const 1)
+      )
+      (br $shape$0$continue)
+    )
+  )
+  (func $split (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (if
+      (i32.const 55)
+      (call_import $check
+        (i32.const 1)
+      )
+      (call_import $check
+        (i32.const 2)
+      )
+    )
+  )
+  (func $if (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (if
+      (i32.const 55)
+      (call_import $check
+        (i32.const 1)
+      )
+    )
+    (call_import $check
+      (i32.const 2)
+    )
+  )
+  (func $if-plus-code (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (if
+      (i32.const 55)
+      (call_import $check
+        (i32.const 1)
+      )
+      (i32.const -2)
+    )
+    (call_import $check
+      (i32.const 2)
+    )
+  )
+  (func $if-else (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (if
+      (i32.const 55)
+      (call_import $check
+        (i32.const 1)
+      )
+      (call_import $check
+        (i32.const 2)
+      )
+    )
+    (call_import $check
+      (i32.const 3)
+    )
+  )
+  (func $loop-tail (type $v)
+    (loop $shape$0$break $shape$0$continue
+      (call_import $check
+        (i32.const 0)
+      )
+      (call_import $check
+        (i32.const 1)
+      )
+      (if
+        (i32.const 10)
+        (br $shape$0$continue)
+        (br $shape$0$break)
+      )
+    )
+    (call_import $check
+      (i32.const 2)
+    )
+  )
+  (func $nontrivial-loop-plus-phi-to-head (type $v)
+    (local $0 i32)
+    (call_import $check
+      (i32.const 0)
+    )
+    (loop $shape$1$break $shape$1$continue
+      (call_import $check
+        (i32.const 1)
+      )
+      (br_if $shape$1$break
+        (i32.const 0)
+      )
+      (call_import $check
+        (i32.const 2)
+      )
+      (if
+        (i32.const -6)
+        (block
+          (set_local $0
+            (i32.const 4)
+          )
+          (br $shape$1$break)
+        )
+        (br $shape$1$continue)
+      )
+    )
+    (if
+      (i32.eq
+        (get_local $0)
+        (i32.const 4)
+      )
+      (block
+        (call_import $check
+          (i32.const 3)
+        )
+        (if
+          (i32.const -10)
+          (call_import $check
+            (i32.const 4)
+          )
+        )
+        (call_import $check
+          (i32.const 5)
+        )
+      )
+    )
+    (call_import $check
+      (i32.const 6)
+    )
+  )
+  (func $switch (type $v)
+    (call_import $check
+      (i32.const 0)
+    )
+    (block $switch$1$leave
+      (block $switch$1$default
+        (block $switch$1$case$3
+          (block $switch$1$case$2
+            (br_table $switch$1$default $switch$1$default $switch$1$case$2 $switch$1$default $switch$1$case$3 $switch$1$case$2 $switch$1$default
+              (i32.const -99)
+            )
+          )
+          (call_import $check
+            (i32.const 1)
+          )
+          (br $switch$1$leave)
+        )
+        (call_import $check
+          (i32.const 2)
+        )
+        (br $switch$1$leave)
+      )
+      (call_import $check
+        (i32.const 3)
+      )
+    )
   )
   (func $duffs-device (type $v)
     (local $0 i32)
+    (call_import $check
+      (i32.const 0)
+    )
     (set_local $0
       (i32.const 2)
     )
@@ -751,6 +1020,9 @@
           (i32.const 2)
         )
         (block
+          (call_import $check
+            (i32.const 1)
+          )
           (set_local $0
             (i32.const 3)
           )
@@ -762,6 +1034,9 @@
             (i32.const 3)
           )
           (block
+            (call_import $check
+              (i32.const 2)
+            )
             (set_local $0
               (i32.const 2)
             )
@@ -772,6 +1047,9 @@
     )
   )
   (func $return (type $i) (result i32)
+    (call_import $check
+      (i32.const 42)
+    )
     (i32.const 1337)
   )
 )

--- a/test/example/relooper-fuzz.c
+++ b/test/example/relooper-fuzz.c
@@ -256,11 +256,13 @@ int main() {
   // memory
   BinaryenSetMemory(module, 1, 1, "mem", NULL, NULL, NULL, 0);
 
+  assert(BinaryenModuleValidate(module));
+
+  BinaryenModulePrint(module);
+
   BinaryenModuleOptimize(module);
 
   assert(BinaryenModuleValidate(module));
-
-  // write it out
 
   BinaryenModulePrint(module);
 

--- a/test/example/relooper-fuzz.txt
+++ b/test/example/relooper-fuzz.txt
@@ -154,44 +154,49 @@
     )
     (block
       (block
-        (block
-          (call_import $print
-            (i32.const 0)
-          )
-          (set_local $0
-            (call $check)
-          )
-        )
-        (block $shape$1$break
-          (if
-            (i32.eq
-              (i32.rem_u
-                (get_local $0)
-                (i32.const 2)
-              )
-              (i32.const 0)
-            )
-            (set_local $1
-              (i32.const 6)
-            )
+        (block $block$6$break
+          (block $block$5$break
             (block
-              (block
-                (call_import $print
-                  (i32.const 8)
+              (call_import $print
+                (i32.const 0)
+              )
+              (set_local $0
+                (call $check)
+              )
+            )
+            (if
+              (i32.eq
+                (i32.rem_u
+                  (get_local $0)
+                  (i32.const 2)
                 )
-                (set_local $0
-                  (call $check)
-                )
+                (i32.const 0)
               )
               (block
-                (br $shape$1$break)
+                (set_local $1
+                  (i32.const 6)
+                )
+                (br $block$6$break)
+              )
+              (block
+                (block
+                  (call_import $print
+                    (i32.const 8)
+                  )
+                  (set_local $0
+                    (call $check)
+                  )
+                )
+                (block
+                  (br $block$5$break)
+                )
               )
             )
           )
         )
       )
-      (loop $shape$3$break $shape$3$continue
-        (block $shape$4$break
+      (loop $shape$3$continue
+        (block $block$5$break
           (if
             (i32.eq
               (get_local $1)
@@ -229,7 +234,7 @@
           )
         )
         (block
-          (block
+          (block $block$3$break
             (block
               (call_import $print
                 (i32.const 4)
@@ -261,6 +266,7 @@
                   )
                   (br $shape$3$continue)
                 )
+                (br $block$3$break)
               )
             )
           )
@@ -460,7 +466,7 @@
         (call $check)
       )
     )
-    (loop $shape$3$break $shape$3$continue
+    (loop $shape$3$continue
       (if
         (i32.eq
           (get_local $0)

--- a/test/example/relooper-fuzz1.c
+++ b/test/example/relooper-fuzz1.c
@@ -1,0 +1,332 @@
+
+
+#include <assert.h>
+#include <stdio.h>
+
+#include "binaryen-c.h"
+
+// globals: address 4 is index
+// decisions are at address 8+
+
+int main() {
+  BinaryenModuleRef module = BinaryenModuleCreate();
+
+  // check()
+
+  // if the end, halt
+  BinaryenExpressionRef halter = BinaryenIf(module,
+    BinaryenBinary(module,
+      BinaryenEqInt32(),
+      BinaryenLoad(module, 4, 0, 0, 0, BinaryenInt32(),
+                   BinaryenConst(module, BinaryenLiteralInt32(4))),
+      BinaryenConst(module, BinaryenLiteralInt32(4 * 30)) // jumps of 4 bytes
+    ),
+    BinaryenUnreachable(module),
+    NULL
+  );
+  // increment index
+  BinaryenExpressionRef incer = BinaryenStore(module,
+    4, 0, 0,
+    BinaryenConst(module, BinaryenLiteralInt32(4)),
+    BinaryenBinary(module,
+      BinaryenAddInt32(),
+      BinaryenLoad(module, 4, 0, 0, 0, BinaryenInt32(),
+                   BinaryenConst(module, BinaryenLiteralInt32(4))),
+      BinaryenConst(module, BinaryenLiteralInt32(4))
+    )
+  );
+
+  // optionally, print the return value
+  BinaryenExpressionRef args[] = {
+    BinaryenBinary(module,
+      BinaryenSubInt32(),
+      BinaryenConst(module, BinaryenLiteralInt32(0)),
+      BinaryenLoad(module,
+        4, 0, 4, 0, BinaryenInt32(),
+        BinaryenLoad(module, 4, 0, 0, 0, BinaryenInt32(),
+                     BinaryenConst(module, BinaryenLiteralInt32(4)))
+      )
+    )
+  };
+  BinaryenExpressionRef debugger;
+  if (1) debugger = BinaryenCallImport(module, "print", args, 1,
+                                       BinaryenNone());
+  else debugger = BinaryenNop(module);
+
+  // return the decision. need to subtract 4 that we just added,
+  // and add 8 since that's where we start, so overall offset 4
+  BinaryenExpressionRef returner = BinaryenLoad(module,
+    4, 0, 4, 0, BinaryenInt32(),
+    BinaryenLoad(module, 4, 0, 0, 0, BinaryenInt32(),
+    BinaryenConst(module, BinaryenLiteralInt32(4)))
+  );
+  BinaryenExpressionRef checkBodyList[] = { halter, incer, debugger,
+                                            returner };
+  BinaryenExpressionRef checkBody = BinaryenBlock(module,
+    NULL, checkBodyList, sizeof(checkBodyList) / sizeof(BinaryenExpressionRef)
+  );
+  BinaryenFunctionTypeRef i = BinaryenAddFunctionType(module, "i",
+                                                      BinaryenInt32(),
+                                                      NULL, 0);
+  BinaryenAddFunction(module, "check", i, NULL, 0, checkBody);
+
+  // contents of main() begin here
+
+  RelooperRef relooper = RelooperCreate();
+
+
+  RelooperBlockRef b0;
+  {
+    BinaryenExpressionRef args[] = {
+      BinaryenConst(module, BinaryenLiteralInt32(0))
+    };
+    BinaryenExpressionRef list[] = {
+      BinaryenCallImport(module, "print", args, 1, BinaryenNone()),
+      BinaryenSetLocal(module, 0, BinaryenCall(module, "check", NULL, 0,
+                                               BinaryenInt32()))
+    };
+
+    b0 = RelooperAddBlock(relooper, BinaryenBlock(module, NULL, list, 2));
+
+  }
+
+  RelooperBlockRef b1;
+  {
+    BinaryenExpressionRef args[] = {
+      BinaryenConst(module, BinaryenLiteralInt32(1))
+    };
+    BinaryenExpressionRef list[] = {
+      BinaryenCallImport(module, "print", args, 1, BinaryenNone()),
+      BinaryenSetLocal(module, 0, BinaryenCall(module, "check", NULL, 0,
+                                               BinaryenInt32()))
+    };
+
+    b1 = RelooperAddBlock(relooper, BinaryenBlock(module, NULL, list, 2));
+
+  }
+
+  RelooperBlockRef b2;
+  {
+    BinaryenExpressionRef args[] = {
+      BinaryenConst(module, BinaryenLiteralInt32(2))
+    };
+    BinaryenExpressionRef list[] = {
+      BinaryenCallImport(module, "print", args, 1, BinaryenNone()),
+      BinaryenSetLocal(module, 0, BinaryenCall(module, "check", NULL, 0,
+                                               BinaryenInt32()))
+    };
+
+    b2 = RelooperAddBlock(relooper, BinaryenBlock(module, NULL, list, 2));
+
+  }
+
+  RelooperBlockRef b3;
+  {
+    BinaryenExpressionRef args[] = {
+      BinaryenConst(module, BinaryenLiteralInt32(3))
+    };
+    BinaryenExpressionRef list[] = {
+      BinaryenCallImport(module, "print", args, 1, BinaryenNone()),
+      BinaryenSetLocal(module, 0, BinaryenCall(module, "check", NULL, 0,
+                                               BinaryenInt32()))
+    };
+
+    b3 = RelooperAddBlock(relooper, BinaryenBlock(module, NULL, list, 2));
+
+  }
+
+  RelooperBlockRef b4;
+  {
+    BinaryenExpressionRef args[] = {
+      BinaryenConst(module, BinaryenLiteralInt32(4))
+    };
+    BinaryenExpressionRef list[] = {
+      BinaryenCallImport(module, "print", args, 1, BinaryenNone()),
+      BinaryenSetLocal(module, 0, BinaryenCall(module, "check", NULL, 0,
+                                               BinaryenInt32()))
+    };
+
+    b4 = RelooperAddBlock(relooper, BinaryenBlock(module, NULL, list, 2));
+
+  }
+
+  RelooperBlockRef b5;
+  {
+    BinaryenExpressionRef args[] = {
+      BinaryenConst(module, BinaryenLiteralInt32(5))
+    };
+    BinaryenExpressionRef list[] = {
+      BinaryenCallImport(module, "print", args, 1, BinaryenNone()),
+      BinaryenSetLocal(module, 0, BinaryenCall(module, "check", NULL, 0,
+                                               BinaryenInt32()))
+    };
+
+    b5 = RelooperAddBlock(relooper, BinaryenBlock(module, NULL, list, 2));
+
+  }
+
+  RelooperBlockRef b6;
+  {
+    BinaryenExpressionRef args[] = {
+      BinaryenConst(module, BinaryenLiteralInt32(6))
+    };
+    BinaryenExpressionRef list[] = {
+      BinaryenCallImport(module, "print", args, 1, BinaryenNone()),
+      BinaryenSetLocal(module, 0, BinaryenCall(module, "check", NULL, 0,
+                                               BinaryenInt32()))
+    };
+
+    b6 = RelooperAddBlock(relooper, BinaryenBlock(module, NULL, list, 2));
+
+  }
+
+  RelooperBlockRef b7;
+  {
+    BinaryenExpressionRef args[] = {
+      BinaryenConst(module, BinaryenLiteralInt32(7))
+    };
+    BinaryenExpressionRef list[] = {
+      BinaryenCallImport(module, "print", args, 1, BinaryenNone()),
+      BinaryenSetLocal(module, 0, BinaryenCall(module, "check", NULL, 0,
+                                               BinaryenInt32()))
+    };
+
+    b7 = RelooperAddBlock(relooper, BinaryenBlock(module, NULL, list, 2));
+
+  }
+
+  RelooperBlockRef b8;
+  {
+    BinaryenExpressionRef args[] = {
+      BinaryenConst(module, BinaryenLiteralInt32(8))
+    };
+    BinaryenExpressionRef list[] = {
+      BinaryenCallImport(module, "print", args, 1, BinaryenNone()),
+      BinaryenSetLocal(module, 0, BinaryenCall(module, "check", NULL, 0,
+                                               BinaryenInt32()))
+    };
+
+    b8 = RelooperAddBlock(relooper, BinaryenBlock(module, NULL, list, 2));
+
+  }
+
+  RelooperBlockRef b9;
+  {
+    BinaryenExpressionRef args[] = {
+      BinaryenConst(module, BinaryenLiteralInt32(9))
+    };
+    BinaryenExpressionRef list[] = {
+      BinaryenCallImport(module, "print", args, 1, BinaryenNone()),
+      BinaryenSetLocal(module, 0, BinaryenCall(module, "check", NULL, 0,
+                                               BinaryenInt32()))
+    };
+
+    b9 = RelooperAddBlock(relooper, BinaryenBlock(module, NULL, list, 2));
+
+  }
+
+  RelooperAddBranch(b0, b2, BinaryenBinary(module,
+    BinaryenEqInt32(),
+    BinaryenBinary(module,
+      BinaryenRemUInt32(),
+      BinaryenGetLocal(module, 0, BinaryenInt32()),
+      BinaryenConst(module, BinaryenLiteralInt32(4))
+    ),
+    BinaryenConst(module, BinaryenLiteralInt32(0))
+  ), NULL);
+
+  RelooperAddBranch(b0, b7, BinaryenBinary(module,
+    BinaryenEqInt32(),
+    BinaryenBinary(module,
+      BinaryenRemUInt32(),
+      BinaryenGetLocal(module, 0, BinaryenInt32()),
+      BinaryenConst(module, BinaryenLiteralInt32(4))
+    ),
+    BinaryenConst(module, BinaryenLiteralInt32(2))
+  ), NULL);
+
+  RelooperAddBranch(b0, b3, NULL, NULL);
+
+  RelooperAddBranch(b2, b3, BinaryenBinary(module,
+    BinaryenEqInt32(),
+    BinaryenBinary(module,
+      BinaryenRemUInt32(),
+      BinaryenGetLocal(module, 0, BinaryenInt32()),
+      BinaryenConst(module, BinaryenLiteralInt32(2))
+    ),
+    BinaryenConst(module, BinaryenLiteralInt32(0))
+  ), NULL);
+
+  RelooperAddBranch(b2, b9, NULL, NULL);
+
+  RelooperAddBranch(b3, b3, NULL, NULL);
+
+  RelooperAddBranch(b7, b2, BinaryenBinary(module,
+    BinaryenEqInt32(),
+    BinaryenBinary(module,
+      BinaryenRemUInt32(),
+      BinaryenGetLocal(module, 0, BinaryenInt32()),
+      BinaryenConst(module, BinaryenLiteralInt32(3))
+    ),
+    BinaryenConst(module, BinaryenLiteralInt32(0))
+  ), NULL);
+
+  RelooperAddBranch(b7, b9, NULL, NULL);
+
+  BinaryenExpressionRef body = RelooperRenderAndDispose(relooper, b0, 1,
+                                                        module);
+
+  int decisions[] = { 67, 131, 49, 36, 112, 161, 62, 166, 16, 88, 176, 152, 161, 194, 117, 180, 60, 166, 55, 183, 150, 73, 196, 143, 76, 182, 97, 140, 126, 3 };
+  int numDecisions = sizeof(decisions)/sizeof(int);
+
+  // write out all the decisions, then the body of the function
+  BinaryenExpressionRef full[numDecisions + 1];
+
+  {
+    int i;
+    for (i = 0; i < numDecisions; i++) {
+      full[i] = BinaryenStore(module,
+        4, 0, 0,
+        BinaryenConst(module, BinaryenLiteralInt32(8 + 4 * i)),
+        BinaryenConst(module, BinaryenLiteralInt32(decisions[i]))
+      );
+    }
+  }
+  full[numDecisions] = body;
+  BinaryenExpressionRef all = BinaryenBlock(module, NULL, full,
+                                            numDecisions + 1);
+
+  BinaryenFunctionTypeRef v = BinaryenAddFunctionType(module, "v",
+                                                      BinaryenNone(),
+                                                      NULL, 0);
+  // locals: state, free-for-label
+  BinaryenType localTypes[] = { BinaryenInt32(), BinaryenInt32() };
+  BinaryenFunctionRef theMain = BinaryenAddFunction(module, "main", v,
+                                                    localTypes, 2, all);
+  BinaryenSetStart(module, theMain);
+
+  // import
+
+  BinaryenType iparams[] = { BinaryenInt32() };
+  BinaryenFunctionTypeRef vi = BinaryenAddFunctionType(module, "vi",
+                                                       BinaryenNone(),
+                                                       iparams, 1);
+  BinaryenAddImport(module, "print", "spectest", "print", vi);
+
+  // memory
+  BinaryenSetMemory(module, 1, 1, "mem", NULL, NULL, NULL, 0);
+
+  assert(BinaryenModuleValidate(module));
+
+  BinaryenModulePrint(module);
+
+  BinaryenModuleOptimize(module);
+
+  assert(BinaryenModuleValidate(module));
+
+  BinaryenModulePrint(module);
+
+  BinaryenModuleDispose(module);
+
+  return 0;
+}

--- a/test/example/relooper-fuzz1.txt
+++ b/test/example/relooper-fuzz1.txt
@@ -12,7 +12,7 @@
         (i32.load
           (i32.const 4)
         )
-        (i32.const 108)
+        (i32.const 120)
       )
       (unreachable)
     )
@@ -46,111 +46,123 @@
     (local $1 i32)
     (i32.store
       (i32.const 8)
-      (i32.const 89)
+      (i32.const 67)
     )
     (i32.store
       (i32.const 12)
-      (i32.const 12)
+      (i32.const 131)
     )
     (i32.store
       (i32.const 16)
-      (i32.const 78)
+      (i32.const 49)
     )
     (i32.store
       (i32.const 20)
-      (i32.const 149)
+      (i32.const 36)
     )
     (i32.store
       (i32.const 24)
-      (i32.const 118)
+      (i32.const 112)
     )
     (i32.store
       (i32.const 28)
-      (i32.const 179)
+      (i32.const 161)
     )
     (i32.store
       (i32.const 32)
-      (i32.const 127)
+      (i32.const 62)
     )
     (i32.store
       (i32.const 36)
-      (i32.const 80)
-    )
-    (i32.store
-      (i32.const 40)
-      (i32.const 21)
-    )
-    (i32.store
-      (i32.const 44)
-      (i32.const 34)
-    )
-    (i32.store
-      (i32.const 48)
-      (i32.const 119)
-    )
-    (i32.store
-      (i32.const 52)
-      (i32.const 98)
-    )
-    (i32.store
-      (i32.const 56)
-      (i32.const 38)
-    )
-    (i32.store
-      (i32.const 60)
-      (i32.const 29)
-    )
-    (i32.store
-      (i32.const 64)
-      (i32.const 36)
-    )
-    (i32.store
-      (i32.const 68)
-      (i32.const 147)
-    )
-    (i32.store
-      (i32.const 72)
-      (i32.const 13)
-    )
-    (i32.store
-      (i32.const 76)
-      (i32.const 55)
-    )
-    (i32.store
-      (i32.const 80)
       (i32.const 166)
     )
     (i32.store
-      (i32.const 84)
+      (i32.const 40)
       (i32.const 16)
     )
     (i32.store
+      (i32.const 44)
       (i32.const 88)
-      (i32.const 143)
     )
     (i32.store
-      (i32.const 92)
-      (i32.const 52)
-    )
-    (i32.store
-      (i32.const 96)
-      (i32.const 130)
-    )
-    (i32.store
-      (i32.const 100)
-      (i32.const 150)
-    )
-    (i32.store
-      (i32.const 104)
+      (i32.const 48)
       (i32.const 176)
     )
     (i32.store
+      (i32.const 52)
+      (i32.const 152)
+    )
+    (i32.store
+      (i32.const 56)
+      (i32.const 161)
+    )
+    (i32.store
+      (i32.const 60)
+      (i32.const 194)
+    )
+    (i32.store
+      (i32.const 64)
+      (i32.const 117)
+    )
+    (i32.store
+      (i32.const 68)
+      (i32.const 180)
+    )
+    (i32.store
+      (i32.const 72)
+      (i32.const 60)
+    )
+    (i32.store
+      (i32.const 76)
+      (i32.const 166)
+    )
+    (i32.store
+      (i32.const 80)
+      (i32.const 55)
+    )
+    (i32.store
+      (i32.const 84)
+      (i32.const 183)
+    )
+    (i32.store
+      (i32.const 88)
+      (i32.const 150)
+    )
+    (i32.store
+      (i32.const 92)
+      (i32.const 73)
+    )
+    (i32.store
+      (i32.const 96)
+      (i32.const 196)
+    )
+    (i32.store
+      (i32.const 100)
+      (i32.const 143)
+    )
+    (i32.store
+      (i32.const 104)
+      (i32.const 76)
+    )
+    (i32.store
       (i32.const 108)
-      (i32.const 91)
+      (i32.const 182)
     )
     (i32.store
       (i32.const 112)
-      (i32.const 34)
+      (i32.const 97)
+    )
+    (i32.store
+      (i32.const 116)
+      (i32.const 140)
+    )
+    (i32.store
+      (i32.const 120)
+      (i32.const 126)
+    )
+    (i32.store
+      (i32.const 124)
+      (i32.const 3)
     )
     (block
       (block
@@ -167,43 +179,70 @@
             (i32.eq
               (i32.rem_u
                 (get_local $0)
-                (i32.const 2)
+                (i32.const 4)
               )
               (i32.const 0)
             )
             (set_local $1
-              (i32.const 6)
+              (i32.const 3)
             )
-            (block
-              (block
-                (call_import $print
-                  (i32.const 8)
+            (if
+              (i32.eq
+                (i32.rem_u
+                  (get_local $0)
+                  (i32.const 4)
                 )
-                (set_local $0
-                  (call $check)
-                )
+                (i32.const 2)
               )
               (block
-                (br $shape$1$break)
+                (block
+                  (call_import $print
+                    (i32.const 7)
+                  )
+                  (set_local $0
+                    (call $check)
+                  )
+                )
+                (if
+                  (i32.eq
+                    (i32.rem_u
+                      (get_local $0)
+                      (i32.const 3)
+                    )
+                    (i32.const 0)
+                  )
+                  (block
+                    (set_local $1
+                      (i32.const 3)
+                    )
+                    (br $shape$1$break)
+                  )
+                  (block
+                    (set_local $1
+                      (i32.const 10)
+                    )
+                    (br $shape$1$break)
+                  )
+                )
+              )
+              (set_local $1
+                (i32.const 4)
               )
             )
           )
         )
       )
-      (loop $shape$3$break $shape$3$continue
-        (block $shape$4$break
+      (block
+        (block $shape$3$break
           (if
             (i32.eq
               (get_local $1)
-              (i32.const 6)
+              (i32.const 3)
             )
             (block
-              (set_local $1
-                (i32.const 0)
-              )
               (block
                 (call_import $print
-                  (i32.const 5)
+                  (i32.const 2)
                 )
                 (set_local $0
                   (call $check)
@@ -217,67 +256,60 @@
                   )
                   (i32.const 0)
                 )
-                (br $shape$3$continue)
                 (block
                   (set_local $1
-                    (i32.const 6)
+                    (i32.const 4)
                   )
-                  (br $shape$3$continue)
+                  (br $shape$3$break)
+                )
+                (block
+                  (set_local $1
+                    (i32.const 10)
+                  )
+                  (br $shape$3$break)
                 )
               )
             )
           )
         )
-        (block
-          (block
-            (block
-              (call_import $print
-                (i32.const 4)
+        (block $shape$5$break
+          (if
+            (i32.eq
+              (get_local $1)
+              (i32.const 4)
+            )
+            (loop $shape$6$break $shape$6$continue
+              (set_local $1
+                (i32.const 0)
               )
-              (set_local $0
-                (call $check)
+              (block
+                (call_import $print
+                  (i32.const 3)
+                )
+                (set_local $0
+                  (call $check)
+                )
+              )
+              (block
+                (set_local $1
+                  (i32.const 4)
+                )
+                (br $shape$6$continue)
               )
             )
             (if
               (i32.eq
-                (i32.rem_u
-                  (get_local $0)
-                  (i32.const 3)
-                )
-                (i32.const 0)
+                (get_local $1)
+                (i32.const 10)
               )
-              (br $shape$3$continue)
-              (if
-                (i32.eq
-                  (i32.rem_u
-                    (get_local $0)
-                    (i32.const 3)
-                  )
-                  (i32.const 1)
+              (block
+                (call_import $print
+                  (i32.const 9)
                 )
-                (block
-                  (set_local $1
-                    (i32.const 6)
-                  )
-                  (br $shape$3$continue)
+                (set_local $0
+                  (call $check)
                 )
               )
-            )
-          )
-          (block
-            (block
-              (call_import $print
-                (i32.const 2)
-              )
-              (set_local $0
-                (call $check)
-              )
-            )
-            (block
-              (set_local $1
-                (i32.const 6)
-              )
-              (br $shape$3$continue)
             )
           )
         )
@@ -299,7 +331,7 @@
         (i32.load
           (i32.const 4)
         )
-        (i32.const 108)
+        (i32.const 120)
       )
       (unreachable)
     )
@@ -330,149 +362,178 @@
   )
   (func $main (type $v)
     (local $0 i32)
-    (local $1 i32)
     (i32.store
       (i32.const 8)
-      (i32.const 89)
+      (i32.const 67)
     )
     (i32.store
       (i32.const 12)
-      (i32.const 12)
+      (i32.const 131)
     )
     (i32.store
       (i32.const 16)
-      (i32.const 78)
+      (i32.const 49)
     )
     (i32.store
       (i32.const 20)
-      (i32.const 149)
+      (i32.const 36)
     )
     (i32.store
       (i32.const 24)
-      (i32.const 118)
+      (i32.const 112)
     )
     (i32.store
       (i32.const 28)
-      (i32.const 179)
+      (i32.const 161)
     )
     (i32.store
       (i32.const 32)
-      (i32.const 127)
+      (i32.const 62)
     )
     (i32.store
       (i32.const 36)
-      (i32.const 80)
-    )
-    (i32.store
-      (i32.const 40)
-      (i32.const 21)
-    )
-    (i32.store
-      (i32.const 44)
-      (i32.const 34)
-    )
-    (i32.store
-      (i32.const 48)
-      (i32.const 119)
-    )
-    (i32.store
-      (i32.const 52)
-      (i32.const 98)
-    )
-    (i32.store
-      (i32.const 56)
-      (i32.const 38)
-    )
-    (i32.store
-      (i32.const 60)
-      (i32.const 29)
-    )
-    (i32.store
-      (i32.const 64)
-      (i32.const 36)
-    )
-    (i32.store
-      (i32.const 68)
-      (i32.const 147)
-    )
-    (i32.store
-      (i32.const 72)
-      (i32.const 13)
-    )
-    (i32.store
-      (i32.const 76)
-      (i32.const 55)
-    )
-    (i32.store
-      (i32.const 80)
       (i32.const 166)
     )
     (i32.store
-      (i32.const 84)
+      (i32.const 40)
       (i32.const 16)
     )
     (i32.store
+      (i32.const 44)
       (i32.const 88)
-      (i32.const 143)
     )
     (i32.store
-      (i32.const 92)
-      (i32.const 52)
-    )
-    (i32.store
-      (i32.const 96)
-      (i32.const 130)
-    )
-    (i32.store
-      (i32.const 100)
-      (i32.const 150)
-    )
-    (i32.store
-      (i32.const 104)
+      (i32.const 48)
       (i32.const 176)
     )
     (i32.store
+      (i32.const 52)
+      (i32.const 152)
+    )
+    (i32.store
+      (i32.const 56)
+      (i32.const 161)
+    )
+    (i32.store
+      (i32.const 60)
+      (i32.const 194)
+    )
+    (i32.store
+      (i32.const 64)
+      (i32.const 117)
+    )
+    (i32.store
+      (i32.const 68)
+      (i32.const 180)
+    )
+    (i32.store
+      (i32.const 72)
+      (i32.const 60)
+    )
+    (i32.store
+      (i32.const 76)
+      (i32.const 166)
+    )
+    (i32.store
+      (i32.const 80)
+      (i32.const 55)
+    )
+    (i32.store
+      (i32.const 84)
+      (i32.const 183)
+    )
+    (i32.store
+      (i32.const 88)
+      (i32.const 150)
+    )
+    (i32.store
+      (i32.const 92)
+      (i32.const 73)
+    )
+    (i32.store
+      (i32.const 96)
+      (i32.const 196)
+    )
+    (i32.store
+      (i32.const 100)
+      (i32.const 143)
+    )
+    (i32.store
+      (i32.const 104)
+      (i32.const 76)
+    )
+    (i32.store
       (i32.const 108)
-      (i32.const 91)
+      (i32.const 182)
     )
     (i32.store
       (i32.const 112)
-      (i32.const 34)
+      (i32.const 97)
+    )
+    (i32.store
+      (i32.const 116)
+      (i32.const 140)
+    )
+    (i32.store
+      (i32.const 120)
+      (i32.const 126)
+    )
+    (i32.store
+      (i32.const 124)
+      (i32.const 3)
     )
     (call_import $print
       (i32.const 0)
     )
     (if
       (i32.eq
-        (i32.rem_u
-          (call $check)
-          (i32.const 2)
+        (set_local $0
+          (if
+            (i32.eq
+              (i32.rem_u
+                (set_local $0
+                  (call $check)
+                )
+                (i32.const 4)
+              )
+              (i32.const 0)
+            )
+            (i32.const 3)
+            (if
+              (i32.eq
+                (i32.rem_u
+                  (get_local $0)
+                  (i32.const 4)
+                )
+                (i32.const 2)
+              )
+              (block
+                (call_import $print
+                  (i32.const 7)
+                )
+                (if
+                  (i32.eq
+                    (i32.rem_u
+                      (call $check)
+                      (i32.const 3)
+                    )
+                    (i32.const 0)
+                  )
+                  (i32.const 3)
+                  (i32.const 10)
+                )
+              )
+              (i32.const 4)
+            )
+          )
         )
-        (i32.const 0)
-      )
-      (set_local $0
-        (i32.const 6)
+        (i32.const 3)
       )
       (block
         (call_import $print
-          (i32.const 8)
+          (i32.const 2)
         )
-        (call $check)
-      )
-    )
-    (loop $shape$3$break $shape$3$continue
-      (if
-        (i32.eq
-          (get_local $0)
-          (i32.const 6)
-        )
-        (block
-          (set_local $0
-            (i32.const 0)
-          )
-          (call_import $print
-            (i32.const 5)
-          )
+        (set_local $0
           (if
             (i32.eq
               (i32.rem_u
@@ -481,54 +542,36 @@
               )
               (i32.const 0)
             )
-            (br $shape$3$continue)
-            (block
-              (set_local $0
-                (i32.const 6)
-              )
-              (br $shape$3$continue)
-            )
+            (i32.const 4)
+            (i32.const 10)
           )
         )
       )
-      (call_import $print
+    )
+    (if
+      (i32.eq
+        (get_local $0)
         (i32.const 4)
+      )
+      (loop $shape$6$break $shape$6$continue
+        (call_import $print
+          (i32.const 3)
+        )
+        (call $check)
+        (br $shape$6$continue)
       )
       (if
         (i32.eq
-          (i32.rem_u
-            (set_local $1
-              (call $check)
-            )
-            (i32.const 3)
-          )
-          (i32.const 0)
+          (get_local $0)
+          (i32.const 10)
         )
-        (br $shape$3$continue)
-        (if
-          (i32.eq
-            (i32.rem_u
-              (get_local $1)
-              (i32.const 3)
-            )
-            (i32.const 1)
+        (block
+          (call_import $print
+            (i32.const 9)
           )
-          (block
-            (set_local $0
-              (i32.const 6)
-            )
-            (br $shape$3$continue)
-          )
+          (call $check)
         )
       )
-      (call_import $print
-        (i32.const 2)
-      )
-      (call $check)
-      (set_local $0
-        (i32.const 6)
-      )
-      (br $shape$3$continue)
     )
   )
 )

--- a/test/example/relooper-fuzz1.txt
+++ b/test/example/relooper-fuzz1.txt
@@ -165,26 +165,16 @@
       (i32.const 3)
     )
     (block
-      (block
-        (block
-          (call_import $print
-            (i32.const 0)
-          )
-          (set_local $0
-            (call $check)
-          )
-        )
-        (block $shape$1$break
-          (if
-            (i32.eq
-              (i32.rem_u
-                (get_local $0)
-                (i32.const 4)
+      (block $block$10$break
+        (block $block$4$break
+          (block $block$3$break
+            (block
+              (call_import $print
+                (i32.const 0)
               )
-              (i32.const 0)
-            )
-            (set_local $1
-              (i32.const 3)
+              (set_local $0
+                (call $check)
+              )
             )
             (if
               (i32.eq
@@ -192,125 +182,85 @@
                   (get_local $0)
                   (i32.const 4)
                 )
-                (i32.const 2)
+                (i32.const 0)
               )
-              (block
-                (block
-                  (call_import $print
-                    (i32.const 7)
-                  )
-                  (set_local $0
-                    (call $check)
-                  )
-                )
-                (if
-                  (i32.eq
-                    (i32.rem_u
-                      (get_local $0)
-                      (i32.const 3)
-                    )
-                    (i32.const 0)
-                  )
-                  (block
-                    (set_local $1
-                      (i32.const 3)
-                    )
-                    (br $shape$1$break)
-                  )
-                  (block
-                    (set_local $1
-                      (i32.const 10)
-                    )
-                    (br $shape$1$break)
-                  )
-                )
-              )
-              (set_local $1
-                (i32.const 4)
-              )
-            )
-          )
-        )
-      )
-      (block
-        (block $shape$3$break
-          (if
-            (i32.eq
-              (get_local $1)
-              (i32.const 3)
-            )
-            (block
-              (block
-                (call_import $print
-                  (i32.const 2)
-                )
-                (set_local $0
-                  (call $check)
-                )
-              )
+              (br $block$3$break)
               (if
                 (i32.eq
                   (i32.rem_u
                     (get_local $0)
-                    (i32.const 2)
-                  )
-                  (i32.const 0)
-                )
-                (block
-                  (set_local $1
                     (i32.const 4)
                   )
-                  (br $shape$3$break)
+                  (i32.const 2)
                 )
                 (block
-                  (set_local $1
-                    (i32.const 10)
+                  (block
+                    (call_import $print
+                      (i32.const 7)
+                    )
+                    (set_local $0
+                      (call $check)
+                    )
                   )
-                  (br $shape$3$break)
+                  (if
+                    (i32.eq
+                      (i32.rem_u
+                        (get_local $0)
+                        (i32.const 3)
+                      )
+                      (i32.const 0)
+                    )
+                    (br $block$3$break)
+                    (br $block$10$break)
+                  )
                 )
+                (br $block$4$break)
               )
             )
           )
-        )
-        (block $shape$5$break
-          (if
-            (i32.eq
-              (get_local $1)
-              (i32.const 4)
-            )
-            (loop $shape$6$break $shape$6$continue
-              (set_local $1
-                (i32.const 0)
+          (block
+            (block
+              (call_import $print
+                (i32.const 2)
               )
-              (block
-                (call_import $print
-                  (i32.const 3)
-                )
-                (set_local $0
-                  (call $check)
-                )
-              )
-              (block
-                (set_local $1
-                  (i32.const 4)
-                )
-                (br $shape$6$continue)
+              (set_local $0
+                (call $check)
               )
             )
             (if
               (i32.eq
-                (get_local $1)
-                (i32.const 10)
-              )
-              (block
-                (call_import $print
-                  (i32.const 9)
+                (i32.rem_u
+                  (get_local $0)
+                  (i32.const 2)
                 )
-                (set_local $0
-                  (call $check)
-                )
+                (i32.const 0)
               )
+              (br $block$4$break)
+              (br $block$10$break)
             )
+          )
+        )
+        (loop $shape$6$continue
+          (block
+            (call_import $print
+              (i32.const 3)
+            )
+            (set_local $0
+              (call $check)
+            )
+          )
+          (block
+            (br $shape$6$continue)
+          )
+        )
+      )
+      (block
+        (block
+          (call_import $print
+            (i32.const 9)
+          )
+          (set_local $0
+            (call $check)
           )
         )
       )
@@ -482,96 +432,70 @@
       (i32.const 124)
       (i32.const 3)
     )
-    (call_import $print
-      (i32.const 0)
-    )
-    (if
-      (i32.eq
-        (set_local $0
-          (if
-            (i32.eq
-              (i32.rem_u
-                (set_local $0
-                  (call $check)
-                )
-                (i32.const 4)
-              )
-              (i32.const 0)
-            )
-            (i32.const 3)
-            (if
-              (i32.eq
-                (i32.rem_u
-                  (get_local $0)
-                  (i32.const 4)
-                )
-                (i32.const 2)
-              )
-              (block
-                (call_import $print
-                  (i32.const 7)
-                )
-                (if
-                  (i32.eq
-                    (i32.rem_u
-                      (call $check)
-                      (i32.const 3)
-                    )
-                    (i32.const 0)
-                  )
-                  (i32.const 3)
-                  (i32.const 10)
-                )
+    (block $block$10$break
+      (block $block$4$break
+        (call_import $print
+          (i32.const 0)
+        )
+        (if
+          (i32.ne
+            (i32.rem_u
+              (set_local $0
+                (call $check)
               )
               (i32.const 4)
             )
+            (i32.const 0)
           )
-        )
-        (i32.const 3)
-      )
-      (block
-        (call_import $print
-          (i32.const 2)
-        )
-        (set_local $0
           (if
             (i32.eq
               (i32.rem_u
-                (call $check)
-                (i32.const 2)
+                (get_local $0)
+                (i32.const 4)
               )
-              (i32.const 0)
+              (i32.const 2)
             )
-            (i32.const 4)
-            (i32.const 10)
+            (block
+              (call_import $print
+                (i32.const 7)
+              )
+              (br_if $block$10$break
+                (i32.ne
+                  (i32.rem_u
+                    (call $check)
+                    (i32.const 3)
+                  )
+                  (i32.const 0)
+                )
+              )
+            )
+            (br $block$4$break)
+          )
+        )
+        (call_import $print
+          (i32.const 2)
+        )
+        (br_if $block$10$break
+          (i32.ne
+            (i32.rem_u
+              (call $check)
+              (i32.const 2)
+            )
+            (i32.const 0)
           )
         )
       )
-    )
-    (if
-      (i32.eq
-        (get_local $0)
-        (i32.const 4)
-      )
-      (loop $shape$6$break $shape$6$continue
+      (loop $shape$6$continue
         (call_import $print
           (i32.const 3)
         )
         (call $check)
         (br $shape$6$continue)
       )
-      (if
-        (i32.eq
-          (get_local $0)
-          (i32.const 10)
-        )
-        (block
-          (call_import $print
-            (i32.const 9)
-          )
-          (call $check)
-        )
-      )
     )
+    (call_import $print
+      (i32.const 9)
+    )
+    (call $check)
   )
 )

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -5312,7 +5312,7 @@
                   (i32.const 24)
                 )
               )
-              (loop $do-out$73 $do-in$74
+              (loop $do-in$74
                 (i32.store
                   (set_local $1
                     (i32.add
@@ -5852,7 +5852,7 @@
               (set_local $4
                 (i32.const 0)
               )
-              (loop $do-out$44 $do-in$45
+              (loop $do-in$45
                 (i32.store offset=12
                   (set_local $15
                     (i32.add

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -5311,7 +5311,7 @@
                   (i32.const 24)
                 )
               )
-              (loop $do-out$73 $do-in$74
+              (loop $do-in$74
                 (i32.store
                   (set_local $1
                     (i32.add
@@ -5851,7 +5851,7 @@
               (set_local $4
                 (i32.const 0)
               )
-              (loop $do-out$44 $do-in$45
+              (loop $do-in$45
                 (i32.store offset=12
                   (set_local $15
                     (i32.add

--- a/test/passes/remove-unused-names.txt
+++ b/test/passes/remove-unused-names.txt
@@ -29,10 +29,32 @@
         (br $in)
       )
     )
-    (loop $in
-      (block $out
-        (br $out)
-        (br $in)
+    (loop $out $in
+      (br $out)
+      (br $in)
+    )
+    (loop $out $in
+      (br $out)
+      (br $in)
+    )
+    (loop $out $in
+      (br $out)
+      (br $in)
+    )
+  )
+  (func $merges
+    (block $b
+      (br $b)
+      (br $b)
+    )
+    (block $b
+      (br_table $b $b
+        (i32.const 3)
+      )
+    )
+    (block $b
+      (br_table $b $b
+        (i32.const 3)
       )
     )
   )

--- a/test/passes/remove-unused-names.txt
+++ b/test/passes/remove-unused-names.txt
@@ -3,4 +3,37 @@
   (func $b0 (param $i1 i32) (result i32)
     (i32.const 0)
   )
+  (func $loops
+    (loop $out $in
+      (br $out)
+      (br $in)
+    )
+    (block $out
+      (br $out)
+    )
+    (loop $in
+      (br $in)
+    )
+    (loop
+      (nop)
+    )
+    (loop
+      (loop $out $in
+        (br $out)
+        (br $in)
+      )
+    )
+    (block
+      (loop $out $in
+        (br $out)
+        (br $in)
+      )
+    )
+    (loop $in
+      (block $out
+        (br $out)
+        (br $in)
+      )
+    )
+  )
 )

--- a/test/passes/remove-unused-names.wast
+++ b/test/passes/remove-unused-names.wast
@@ -5,5 +5,38 @@
       (i32.const 0)
     )
   )
+  (func $loops
+    (loop $out $in
+      (br $out)
+      (br $in)
+    )
+    (loop $out $in
+      (br $out)
+    )
+    (loop $out $in
+      (br $in)
+    )
+    (loop $out $in
+      (nop)
+    )
+    (loop $out $in
+      (loop $out $in
+        (br $out)
+        (br $in)
+      )
+    )
+    (block $out
+      (loop $out $in
+        (br $out)
+        (br $in)
+      )
+    )
+    (loop $out $in
+      (block $out
+        (br $out)
+        (br $in)
+      )
+    )
+  )
 )
 

--- a/test/passes/remove-unused-names.wast
+++ b/test/passes/remove-unused-names.wast
@@ -37,6 +37,36 @@
         (br $in)
       )
     )
+    (loop $in
+      (block $out
+        (br $out)
+        (br $in)
+      )
+    )
+    (block $out
+      (loop $in
+        (br $out)
+        (br $in)
+      )
+    )
+  )
+  (func $merges
+    (block $a
+      (block $b
+        (br $a)
+        (br $b)
+      )
+    )
+    (block $a
+      (block $b
+        (br_table $a $b (i32.const 3))
+      )
+    )
+    (block $a
+      (block $b
+        (br_table $b $a (i32.const 3))
+      )
+    )
   )
 )
 

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -160,12 +160,11 @@
             )
             (br $label$break$Lout)
           )
-          (loop $while-out$10 $while-in$11
-            (br $while-out$10)
+          (block $while-out$10
           )
           (br $label$break$Lout)
         )
-        (loop $while-out$13 $while-in$14
+        (loop
           (br $label$break$Lout)
         )
       )
@@ -174,25 +173,23 @@
       (loop $label$break$L3 $label$continue$L3
         (block $switch$17
           (block $switch-default$21
-            (block $switch-default$21
-              (block $switch-case$20
-                (block $switch-case$19
-                  (block $switch-case$18
-                    (br_table $switch-case$18 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-case$20 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-case$19 $switch-default$21
-                      (i32.sub
-                        (get_local $0)
-                        (i32.const -1)
-                      )
+            (block $switch-case$20
+              (block $switch-case$19
+                (block $switch-case$18
+                  (br_table $switch-case$18 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-case$20 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-case$19 $switch-default$21
+                    (i32.sub
+                      (get_local $0)
+                      (i32.const -1)
                     )
                   )
-                  (br $label$break$L1)
                 )
-                (br $switch$17)
+                (br $label$break$L1)
               )
-              (br $label$break$L3)
+              (br $switch$17)
             )
-            (br $label$break$L1)
+            (br $label$break$L3)
           )
+          (br $label$break$L1)
         )
         (br $label$continue$L3)
       )
@@ -332,11 +329,11 @@
     )
   )
   (func $continues
-    (loop $while-out$0 $while-in$1
+    (loop $while-in$1
       (call_import $print
         (i32.const 1)
       )
-      (loop $do-once$2 $unlikely-continue$3
+      (loop $unlikely-continue$3
         (call_import $print
           (i32.const 5)
         )

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -143,30 +143,28 @@
         (i32.const 51)
       )
     )
-    (block $label$break$Lout
-      (block $switch-default$16
-        (block $switch-case$15
-          (block $switch-case$12
-            (block $switch-case$9
-              (block $switch-case$8
-                (br_table $switch-case$15 $switch-default$16 $switch-default$16 $switch-case$12 $switch-default$16 $switch-default$16 $switch-default$16 $switch-default$16 $switch-case$9 $switch-default$16 $switch-case$8 $switch-default$16
-                  (i32.sub
-                    (get_local $0)
-                    (i32.const 2)
-                  )
+    (block $switch-default$16
+      (block $switch-case$15
+        (block $switch-case$12
+          (block $switch-case$9
+            (block $switch-case$8
+              (br_table $switch-case$15 $switch-default$16 $switch-default$16 $switch-case$12 $switch-default$16 $switch-default$16 $switch-default$16 $switch-default$16 $switch-case$9 $switch-default$16 $switch-case$8 $switch-default$16
+                (i32.sub
+                  (get_local $0)
+                  (i32.const 2)
                 )
               )
-              (br $label$break$Lout)
             )
-            (br $label$break$Lout)
+            (br $switch-default$16)
           )
-          (block $while-out$10
-          )
-          (br $label$break$Lout)
+          (br $switch-default$16)
         )
-        (loop
-          (br $label$break$Lout)
+        (block $while-out$10
         )
+        (br $switch-default$16)
+      )
+      (loop
+        (br $switch-default$16)
       )
     )
     (loop $label$break$L1 $label$continue$L1

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -150,12 +150,11 @@
             )
             (br $label$break$Lout)
           )
-          (loop $while-out$10 $while-in$11
-            (br $while-out$10)
+          (block $while-out$10
           )
           (br $label$break$Lout)
         )
-        (loop $while-out$13 $while-in$14
+        (loop
           (br $label$break$Lout)
         )
       )
@@ -164,25 +163,23 @@
       (loop $label$break$L3 $label$continue$L3
         (block $switch$17
           (block $switch-default$21
-            (block $switch-default$21
-              (block $switch-case$20
-                (block $switch-case$19
-                  (block $switch-case$18
-                    (br_table $switch-case$18 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-case$20 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-case$19 $switch-default$21
-                      (i32.sub
-                        (get_local $0)
-                        (i32.const -1)
-                      )
+            (block $switch-case$20
+              (block $switch-case$19
+                (block $switch-case$18
+                  (br_table $switch-case$18 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-case$20 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-case$19 $switch-default$21
+                    (i32.sub
+                      (get_local $0)
+                      (i32.const -1)
                     )
                   )
-                  (br $label$break$L1)
                 )
-                (br $switch$17)
+                (br $label$break$L1)
               )
-              (br $label$break$L3)
+              (br $switch$17)
             )
-            (br $label$break$L1)
+            (br $label$break$L3)
           )
+          (br $label$break$L1)
         )
         (br $label$continue$L3)
       )
@@ -316,11 +313,11 @@
     )
   )
   (func $continues
-    (loop $while-out$0 $while-in$1
+    (loop $while-in$1
       (call_import $print
         (i32.const 1)
       )
-      (loop $do-once$2 $unlikely-continue$3
+      (loop $unlikely-continue$3
         (call_import $print
           (i32.const 5)
         )

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -133,30 +133,28 @@
         (i32.const 51)
       )
     )
-    (block $label$break$Lout
-      (block $switch-default$16
-        (block $switch-case$15
-          (block $switch-case$12
-            (block $switch-case$9
-              (block $switch-case$8
-                (br_table $switch-case$15 $switch-default$16 $switch-default$16 $switch-case$12 $switch-default$16 $switch-default$16 $switch-default$16 $switch-default$16 $switch-case$9 $switch-default$16 $switch-case$8 $switch-default$16
-                  (i32.sub
-                    (get_local $0)
-                    (i32.const 2)
-                  )
+    (block $switch-default$16
+      (block $switch-case$15
+        (block $switch-case$12
+          (block $switch-case$9
+            (block $switch-case$8
+              (br_table $switch-case$15 $switch-default$16 $switch-default$16 $switch-case$12 $switch-default$16 $switch-default$16 $switch-default$16 $switch-default$16 $switch-case$9 $switch-default$16 $switch-case$8 $switch-default$16
+                (i32.sub
+                  (get_local $0)
+                  (i32.const 2)
                 )
               )
-              (br $label$break$Lout)
             )
-            (br $label$break$Lout)
+            (br $switch-default$16)
           )
-          (block $while-out$10
-          )
-          (br $label$break$Lout)
+          (br $switch-default$16)
         )
-        (loop
-          (br $label$break$Lout)
+        (block $while-out$10
         )
+        (br $switch-default$16)
+      )
+      (loop
+        (br $switch-default$16)
       )
     )
     (loop $label$break$L1 $label$continue$L1


### PR DESCRIPTION
This improves the relooper by using @sunfishcode's "stack" approach to forward jumps, using a stack of blocks. This should remove all usage of a helper variable except for actually irreducible control flow, while still reconstructing control flow into ifs, if-elses, etc.

The implementation is fairly simple, basically, each `Process()` call in the relooper receives a self-contained set of blocks, and can ignore the outside (as branches outside have already been handled/"solipsized"). Forward jumps in that set must be implementable using a block stack, as our output is a linked list of shapes, and we simply emit the stack by looking forward in the list, each Multiple shape entry is a jump target, and the final shape is also a target as well (we can't jump to after it, as we must enter a basic block if it isn't a Multiple; this was an implicit assumption before and is now explicit). This does add a little overhead in that Loop shapes must now track their entries, however, loops are fairly rare and typically have one entry, so it should be ok.

This only affects control flow that couldn't be composed of ifs, if-elses, switches, etc., so we still have the benefits there. Only forward branches that do not work in that model end up using the block stack.

This does add more blocks and breaks initially, but binaryen optimizations should get rid of them.
