### PR TITLE
Binary format support for wasm globals

### DIFF
--- a/src/wasm.cpp
+++ b/src/wasm.cpp
@@ -33,6 +33,7 @@ namespace Section {
   const char* FunctionSignatures = "function";
   const char* Functions = "code";
   const char* ExportTable = "export";
+  const char* Globals = "global";
   const char* DataSegments = "data";
   const char* FunctionTable = "table";
   const char* Names = "name";


### PR DESCRIPTION
I think this is right, but not sure I read the spec correctly.

Each global has a type and a normally-emitted expression, with a 0 ending, and it must contain one expression which is popped and used as the initial value for the global. @rossberg-chromium, is that correct?