### PR TITLE
Add backend support for multiple tables

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -660,11 +660,11 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
           // TODO: when not using aliasing function pointers, we could merge them by noticing that
           //       index 0 in each table is the null func, and each other index should only have one
           //       non-null func. However, that breaks down when function pointer casts are emulated.
-          functionTableStarts[name] = wasm.table.names.size(); // this table starts here
+          functionTableStarts[name] = wasm.getDefaultTable()->values.size(); // this table starts here
           Ref contents = value[1];
           for (unsigned k = 0; k < contents->size(); k++) {
             IString curr = contents[k][1]->getIString();
-            wasm.table.names.push_back(curr);
+            wasm.getDefaultTable()->values.push_back(curr);
           }
         } else {
           abort_on("invalid var element", pair);

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -586,7 +586,7 @@ BinaryenExpressionRef BinaryenSelect(BinaryenModuleRef module, BinaryenExpressio
 }
 BinaryenExpressionRef BinaryenReturn(BinaryenModuleRef module, BinaryenExpressionRef value) {
   auto* ret = Builder(*((Module*)module)).makeReturn((Expression*)value);
- 
+
   if (tracing) {
     auto id = noteExpression(ret);
     std::cout << "  expressions[" << id << "] = BinaryenReturn(the_module, expressions[" << expressions[value] << "]);\n";
@@ -730,7 +730,7 @@ void BinaryenSetFunctionTable(BinaryenModuleRef module, BinaryenFunctionRef* fun
 
   auto* wasm = (Module*)module;
   for (BinaryenIndex i = 0; i < numFuncs; i++) {
-    wasm->table.names.push_back(((Function*)funcs[i])->name);
+    wasm->getDefaultTable()->values.push_back(((Function*)funcs[i])->name);
   }
 }
 

--- a/src/passes/DuplicateFunctionElimination.cpp
+++ b/src/passes/DuplicateFunctionElimination.cpp
@@ -123,10 +123,12 @@ struct DuplicateFunctionElimination : public Pass {
         replacerRunner.add<FunctionReplacer>(&replacements);
         replacerRunner.run();
         // replace in table
-        for (auto& name : module->table.names) {
-          auto iter = replacements.find(name);
-          if (iter != replacements.end()) {
-            name = iter->second;
+        for (auto& curr : module->tables) {
+          for (auto& name : curr->values) {
+            auto iter = replacements.find(name);
+            if (iter != replacements.end()) {
+              name = iter->second;
+            }
           }
         }
         // replace in start

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -576,7 +576,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
   }
   void visitTable(Table *curr) {
     printOpening(o, "table");
-    for (auto name : curr->names) {
+    for (auto name : curr->values) {
       o << ' ';
       printName(name);
     }
@@ -647,9 +647,9 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
       visitGlobal(child.get());
       o << maybeNewLine;
     }
-    if (curr->table.names.size() > 0) {
+    for (auto& child : curr->tables) {
       doIndent(o, indent);
-      visitTable(&curr->table);
+      visitTable(child.get());
       o << maybeNewLine;
     }
     for (auto& child : curr->functions) {

--- a/src/passes/RemoveUnusedFunctions.cpp
+++ b/src/passes/RemoveUnusedFunctions.cpp
@@ -39,8 +39,10 @@ struct RemoveUnusedFunctions : public Pass {
       root.push_back(module->getFunction(curr->value));
     }
     // For now, all functions that can be called indirectly are marked as roots.
-    for (auto& curr : module->table.names) {
-      root.push_back(module->getFunction(curr));
+    for (auto& child : module->tables) {
+      for (auto& curr : child->values) {
+        root.push_back(module->getFunction(curr));
+      }
     }
     // Compute function reachability starting from the root set.
     DirectCallGraphAnalyzer analyzer(module, root);

--- a/src/passes/ReorderFunctions.cpp
+++ b/src/passes/ReorderFunctions.cpp
@@ -38,8 +38,10 @@ struct ReorderFunctions : public WalkerPass<PostWalker<ReorderFunctions, Visitor
     for (auto& curr : module->exports) {
       counts[curr->value]++;
     }
-    for (auto& curr : module->table.names) {
-      counts[curr]++;
+    for (auto& child : module->tables) {
+      for (auto& curr : child->values) {
+        counts[curr]++;
+      }
     }
     std::sort(module->functions.begin(), module->functions.end(), [this](
       const std::unique_ptr<Function>& a,

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -666,9 +666,10 @@ private:
         LiteralList arguments;
         Flow flow = generateArguments(curr->operands, arguments);
         if (flow.breaking()) return flow;
+        Table *table = instance.wasm.getDefaultTable();
         size_t index = target.value.geti32();
-        if (index >= instance.wasm.table.names.size()) trap("callIndirect: overflow");
-        Name name = instance.wasm.table.names[index];
+        if (index >= table->values.size()) trap("callIndirect: overflow");
+        Name name = table->values[index];
         Function *func = instance.wasm.getFunction(name);
         if (func->type.is() && func->type != curr->fullType) trap("callIndirect: bad type");
         if (func->params.size() != arguments.size()) trap("callIndirect: bad # of arguments");

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -1403,7 +1403,7 @@ private:
 
   void parseTable(Element& s) {
     for (size_t i = 1; i < s.size(); i++) {
-      wasm.table.names.push_back(getFunctionName(*s[i]));
+      wasm.getDefaultTable()->values.push_back(getFunctionName(*s[i]));
     }
   }
 

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -205,7 +205,9 @@ struct Walker : public VisitorType {
     for (auto& curr : module->functions) {
       self->walkFunction(curr.get());
     }
-    self->visitTable(&module->table);
+    for (auto &curr : module->tables) {
+      self->visitTable(curr.get());
+    }
     self->visitMemory(&module->memory);
   }
 


### PR DESCRIPTION
This patch is a derivative of #642 that only updates backend data structures and implements an internal API for multiple tables. Parsing/generation of both the binary and s-expression format are unchanged.
