### PR TITLE
Fix a parsing bug introduced by #615

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -399,6 +399,10 @@ class S2WasmBuilder {
       // add data aliases
       } else {
         Name lhs = getStrToSep();
+        // When the current line contains only one word, e.g.".text"
+        if (match("\n"))
+          continue;
+        // When the current line contains more than one word
         if (!skipEqual()){
           s = strchr(s, '\n');
           if (!s) break;

--- a/test/dot_s/text_before_type.s
+++ b/test/dot_s/text_before_type.s
@@ -1,0 +1,19 @@
+	.text
+	.file	"/tmp/tmpGckQku/foo.bc"
+	.hidden	main
+	.globl	main
+	.type	main,@function
+main:
+	.result 	i32
+	call    	foo@FUNCTION
+	i32.const	$push0=, 0
+	.endfunc
+.Lfunc_end1:
+	.size	main, .Lfunc_end1-main
+	.text
+	.type	foo,@function
+foo:
+	.endfunc
+.Lfunc_end0:
+	.size	foo, .Lfunc_end0-foo
+

--- a/test/dot_s/text_before_type.wast
+++ b/test/dot_s/text_before_type.wast
@@ -1,0 +1,12 @@
+(module
+  (memory 1)
+  (export "memory" memory)
+  (export "main" $main)
+  (func $main (result i32)
+    (call $foo)
+    (i32.const 0)
+  )
+  (func $foo
+  )
+)
+;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }


### PR DESCRIPTION
```
Name lhs = getStrToSep();
if (!skipEqual()){
  s = strchr(s, '\n');
  if (!s) break;
  continue;
}
```
The above code snippet introduced by #615 by @ddcc has a bug when there is 
only one word (e.g. ".text") in a line. If there is only one word in a line,
skipEqual() also skips the newline character at the end of the line, and
strchr(s, '\n') moves the cursor to the end of the next line,
effectively skipping the whole next line.
This patch fixes this bug.