### PR TITLE
Add support for importing externs from JS

### DIFF
--- a/src/wasm-linker.cpp
+++ b/src/wasm-linker.cpp
@@ -149,8 +149,13 @@ void Linker::layout() {
 
     if (relocation->kind == LinkerObject::Relocation::kData) {
       const auto& symbolAddress = staticAddresses.find(name);
-      if (symbolAddress == staticAddresses.end()) Fatal() << "Unknown relocation: " << name << '\n';
-      *(relocation->data) = symbolAddress->second + relocation->addend;
+      if (symbolAddress == staticAddresses.end()) {
+        if (debug) std::cerr << "Unknown relocation: " << name << '\n';
+        out.unknownData.insert(name);
+        *(relocation->data) = 0;
+      } else {
+        *(relocation->data) = symbolAddress->second + relocation->addend;
+      }
       if (debug) std::cerr << "  ==> " << *(relocation->data) << '\n';
     } else {
       // function address
@@ -363,6 +368,16 @@ void Linker::emscriptenGlue(std::ostream& o) {
     if (first) first = false;
     else o << ", ";
     o << "\"" << func.c_str() << "\"";
+  }
+  o << "]";
+  o << ",";
+
+  o << "\"externs\": [";
+  first = true;
+  for (auto& name : out.unknownData) {
+    if (first) first = false;
+    else o << ", ";
+    o << "\"" << name.c_str() << "\"";
   }
   o << "]";
 

--- a/src/wasm-linker.h
+++ b/src/wasm-linker.h
@@ -183,6 +183,8 @@ class LinkerObject {
 
   std::vector<Name> initializerFunctions;
 
+  std::unordered_set<cashew::IString> unknownData;
+
   LinkerObject(const LinkerObject&) = delete;
   LinkerObject& operator=(const LinkerObject&) = delete;
 


### PR DESCRIPTION
I've been running into an issue where some programs are looking for the `environ` symbol, which is normally provided by libc, but we're not building it because `env` has been blacklisted in `system_libs.py`. Instead, it's provided by `library.js`, but the functionality to import external symbols from javascript wasn't available. This patch aims to implement it, though I'm not familiar with the Javascript interface and am not sure if this is correct.
