### PR TITLE
Fix alignment bug in .lcomm

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -1328,11 +1328,12 @@ class S2WasmBuilder {
     mustMatch(name.str);
     skipComma();
     Address size = getInt();
+    Address localAlign = 1;
     if (*s == ',') {
       skipComma();
-      getInt();
+      localAlign = 1 << getInt();
     }
-    linkerObj->addStatic(size, align, name);
+    linkerObj->addStatic(size, std::max(align, localAlign), name);
   }
 
   void skipImports() {

--- a/test/dot_s/local_align.s
+++ b/test/dot_s/local_align.s
@@ -1,0 +1,26 @@
+	.text
+	.file	"local_align.bc"
+	.type	foo,@function
+foo:
+	.param  	i32
+	.endfunc
+.Lfunc_end0:
+	.size	foo, .Lfunc_end0-foo
+
+	.hidden	main
+	.globl	main
+	.type	main,@function
+main:
+	.result 	i32
+	i32.const	$push0=, buf
+	call    	foo@FUNCTION, $pop0
+	i32.const	$push1=, 0
+	.endfunc
+.Lfunc_end1:
+	.size	main, .Lfunc_end1-main
+
+	.type	temp,@object
+	.lcomm	temp,1,1
+
+	.type	buf,@object
+	.lcomm	buf,156,4

--- a/test/dot_s/local_align.wast
+++ b/test/dot_s/local_align.wast
@@ -1,0 +1,14 @@
+(module
+  (memory 1)
+  (export "memory" memory)
+  (export "main" $main)
+  (func $foo (param $0 i32)
+  )
+  (func $main (result i32)
+    (call $foo
+      (i32.const 16)
+    )
+    (i32.const 0)
+  )
+)
+;; METADATA: { "asmConsts": {},"staticBump": 172, "initializers": [] }


### PR DESCRIPTION
When parsing .lcomm directives, s2wasm does not parse the alignment number and skips it. This causes alignment bugs in some cases. (In the test case attached, 'buf' should be 4 bytes aligned, but it does not align it properly, so this code was generated:
```
(call $foo
  (i32.const 13)
)
```
13 is not 4-bytes aligned. This patch fixes this bug.

@dschuff @jpporto 