### PR TITLE
Asm.js-style setjmp/longjmp support for wasm

### DIFF
--- a/src/wasm-linker.cpp
+++ b/src/wasm-linker.cpp
@@ -213,17 +213,20 @@ void Linker::layout() {
     }
   }
 
-  // Export malloc and free whenever availble. JavsScript version of malloc has
-  // some issues and it cannot be called once _sbrk() is called.
-  // TODO This should get the list of exported functions from emcc.py - it has
-  // EXPORTED_FUNCTION metadata to keep track of this. Get the list of exported
-  // functions using a command-line argument from emcc.py and export all of
-  // them.
+  // Export malloc, realloc, and free whenever availble. JavsScript version of
+  // malloc has some issues and it cannot be called once _sbrk() is called, and
+  // JS glue code does not have realloc().  TODO This should get the list of
+  // exported functions from emcc.py - it has EXPORTED_FUNCTION metadata to keep
+  // track of this. Get the list of exported functions using a command-line
+  // argument from emcc.py and export all of them.
   if (out.symbolInfo.implementedFunctions.count("malloc")) {
     exportFunction("malloc", true);
   }
   if (out.symbolInfo.implementedFunctions.count("free")) {
     exportFunction("free", true);
+  }
+  if (out.symbolInfo.implementedFunctions.count("realloc")) {
+    exportFunction("realloc", true);
   }
 
   // finalize function table

--- a/test/dot_s/export_malloc_free.s
+++ b/test/dot_s/export_malloc_free.s
@@ -27,3 +27,13 @@ free:
 	.endfunc
 .Lfunc_end21:
 	.size	free, .Lfunc_end21-free
+
+	.weak	realloc
+	.type	realloc,@function
+realloc:
+	.param  	i32, i32
+	.result 	i32
+	i32.const	$push0=, 0
+	.endfunc
+.Lfunc_end22:
+	.size	realloc, .Lfunc_end22-free

--- a/test/dot_s/export_malloc_free.wast
+++ b/test/dot_s/export_malloc_free.wast
@@ -4,6 +4,7 @@
   (export "main" $main)
   (export "malloc" $malloc)
   (export "free" $free)
+  (export "realloc" $realloc)
   (func $main (result i32)
     (i32.const 0)
   )
@@ -11,6 +12,9 @@
     (i32.const 0)
   )
   (func $free (param $0 i32)
+  )
+  (func $realloc (param $0 i32) (param $1 i32) (result i32)
+    (i32.const 0)
   )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }


### PR DESCRIPTION
To support asm.js style setjmp/longjmp, wasm needs to export realloc as well, in addition to malloc and free handled in #4469. saveSetjmp() uses realloc within it, and realloc is not implemented in JS glue code.

@dschuff @jpporto 