### PR TITLE
Fix asm2wasm dead lock caused by empty module

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -537,7 +537,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
     for (unsigned i = 1; i < body->size(); i++) {
       if (body[i][0] == DEFUN) numFunctions++;
     }
-    optimizingBuilder = std::unique_ptr<OptimizingIncrementalModuleBuilder>(new OptimizingIncrementalModuleBuilder(&wasm, numFunctions));
+    optimizingBuilder = make_unique<OptimizingIncrementalModuleBuilder>(&wasm, numFunctions);
   }
 
   // first pass - do almost everything, but function imports and indirect calls

--- a/src/cfg/Relooper.cpp
+++ b/src/cfg/Relooper.cpp
@@ -98,7 +98,7 @@ Branch::Branch(wasm::Expression* ConditionInit, wasm::Expression* CodeInit) : An
 
 Branch::Branch(std::vector<wasm::Index>&& ValuesInit, wasm::Expression* CodeInit) : Ancestor(nullptr), Code(CodeInit) {
   if (ValuesInit.size() > 0) {
-    SwitchValues = std::unique_ptr<std::vector<wasm::Index>>(new std::vector<wasm::Index>(ValuesInit));
+    SwitchValues = wasm::make_unique<std::vector<wasm::Index>>(ValuesInit);
   }
   // otherwise, it is the default
 }

--- a/src/passes/LowerIfElse.cpp
+++ b/src/passes/LowerIfElse.cpp
@@ -38,7 +38,7 @@ struct LowerIfElse : public WalkerPass<PostWalker<LowerIfElse, Visitor<LowerIfEl
 
   void prepare(PassRunner* runner, Module *module) override {
     allocator = runner->allocator;
-    namer = std::unique_ptr<NameManager>(new NameManager());
+    namer = make_unique<NameManager>();
     namer->run(runner, module);
   }
 

--- a/src/passes/LowerInt64.cpp
+++ b/src/passes/LowerInt64.cpp
@@ -35,7 +35,7 @@ struct LowerInt64 : public Pass {
 
   void prepare(PassRunner* runner, Module *module) override {
     allocator = runner->allocator;
-    namer = std::unique_ptr<NameManager>(new NameManager());
+    namer = make_unique<NameManager>();
     namer->run(runner, module);
   }
 

--- a/src/support/threads.cpp
+++ b/src/support/threads.cpp
@@ -22,6 +22,7 @@
 
 #include "threads.h"
 #include "compiler-support.h"
+#include "utilities.h"
 
 
 // debugging tools
@@ -47,7 +48,7 @@ static std::unique_ptr<ThreadPool> pool;
 
 Thread::Thread() {
   assert(!ThreadPool::get()->isRunning());
-  thread = std::unique_ptr<std::thread>(new std::thread(mainLoop, this));
+  thread = make_unique<std::thread>(mainLoop, this);
 }
 
 Thread::~Thread() {
@@ -110,7 +111,7 @@ void ThreadPool::initialize(size_t num) {
   ready.store(threads.size()); // initial state before first resetThreadsAreReady()
   resetThreadsAreReady();
   for (size_t i = 0; i < num; i++) {
-    threads.emplace_back(std::unique_ptr<Thread>(new Thread()));
+    threads.emplace_back(make_unique<Thread>());
   }
   DEBUG_POOL("initialize() waiting\n");
   condition.wait(lock, [this]() { return areThreadsReady(); });
@@ -127,7 +128,7 @@ size_t ThreadPool::getNumCores() {
 
 ThreadPool* ThreadPool::get() {
   if (!pool) {
-    pool = std::unique_ptr<ThreadPool>(new ThreadPool());
+    pool = make_unique<ThreadPool>();
     pool->initialize(getNumCores());
   }
   return pool.get();

--- a/src/wasm-module-building.h
+++ b/src/wasm-module-building.h
@@ -139,7 +139,7 @@ public:
 private:
   void createWorker() {
     DEBUG_THREAD("create a worker");
-    threads.emplace_back(std::unique_ptr<std::thread>(new std::thread(workerMain, this)));
+    threads.emplace_back(make_unique<std::thread>(workerMain, this));
   }
 
   void wakeWorker() {

--- a/src/wasm-module-building.h
+++ b/src/wasm-module-building.h
@@ -197,9 +197,8 @@ private:
     passRunner.runFunction(func);
   }
 
-  static void workerMain(void* param) {
+  static void workerMain(OptimizingIncrementalModuleBuilder* self) {
     DEBUG_THREAD("workerMain");
-    OptimizingIncrementalModuleBuilder* self = (OptimizingIncrementalModuleBuilder*)param;
     {
       std::lock_guard<std::mutex> lock(self->mutex);
       self->liveWorkers++;

--- a/src/wasm-module-building.h
+++ b/src/wasm-module-building.h
@@ -86,7 +86,15 @@ class OptimizingIncrementalModuleBuilder {
 public:
   // numFunctions must be equal to the number of functions allocated, or higher. Knowing
   // this bounds helps avoid locking.
-  OptimizingIncrementalModuleBuilder(Module* wasm, Index numFunctions) : wasm(wasm), numFunctions(numFunctions), nextFunction(0), finishing(false) {
+  OptimizingIncrementalModuleBuilder(Module* wasm, Index numFunctions)
+      : wasm(wasm), numFunctions(numFunctions), endMarker(nullptr), list(nullptr), nextFunction(0),
+        numWorkers(0), liveWorkers(0), activeWorkers(0), availableFuncs(0), finishedFuncs(0),
+        finishing(false) {
+    if (numFunctions == 0) {
+      // special case: no functions to be optimized.  Don't create any threads.
+      return;
+    }
+
     // prepare work list
     endMarker = new Function();
     list = new std::atomic<Function*>[numFunctions];

--- a/test/empty.asm.js
+++ b/test/empty.asm.js
@@ -1,0 +1,4 @@
+function EmptyModule() {
+    'use asm';
+    return {};
+}

--- a/test/empty.fromasm
+++ b/test/empty.fromasm
@@ -1,0 +1,4 @@
+(module
+  (memory 256 256)
+  (export "memory" memory)
+)

--- a/test/empty.fromasm.imprecise
+++ b/test/empty.fromasm.imprecise
@@ -1,0 +1,4 @@
+(module
+  (memory 256 256)
+  (export "memory" memory)
+)

--- a/test/empty.fromasm.imprecise.no-opts
+++ b/test/empty.fromasm.imprecise.no-opts
@@ -1,0 +1,4 @@
+(module
+  (memory 256 256)
+  (export "memory" memory)
+)

--- a/test/empty.fromasm.no-opts
+++ b/test/empty.fromasm.no-opts
@@ -1,0 +1,4 @@
+(module
+  (memory 256 256)
+  (export "memory" memory)
+)


### PR DESCRIPTION
These commits fix an asm2wasm dead lock when asm2wasm is compiling an empty module, i.e. a module without any functions.

Without this commit, worker threads are likely to leave `workerMain()` and decrease `liveWorkers` early.  Consequently, `waitUntilAllReady()` will never observe `liveWorkers == numWorkers`.