### PR TITLE
Color support for Windows

### DIFF
--- a/src/support/colors.cpp
+++ b/src/support/colors.cpp
@@ -36,9 +36,7 @@ void Colors::outputColorCode(std::ostream& stream, const char* colorCode) {
   }();
   if (has_color && !colors_disabled) stream << colorCode;
 }
-#endif
-
-#if defined(_WIN32)
+#elif defined(_WIN32)
 #include <windows.h>
 #include <io.h>
 #include <iostream>

--- a/src/support/colors.h
+++ b/src/support/colors.h
@@ -32,9 +32,7 @@ inline void grey(std::ostream& stream) { outputColorCode(stream,"\033[37m"); }
 inline void green(std::ostream& stream) { outputColorCode(stream,"\033[32m"); }
 inline void blue(std::ostream& stream) { outputColorCode(stream,"\033[34m"); }
 inline void bold(std::ostream& stream) { outputColorCode(stream,"\033[1m"); }
-#endif
-
-#if defined(_WIN32)
+#elif defined(_WIN32)
 void outputColorCode(std::ostream& stream, const unsigned short &colorCode);
 inline void normal(std::ostream& stream) { outputColorCode(stream, 0x07); }
 inline void red(std::ostream& stream) { outputColorCode(stream, 0x0c); }

--- a/src/support/colors.h
+++ b/src/support/colors.h
@@ -21,7 +21,9 @@
 
 namespace Colors {
 void disable();
-void outputColorCode(std::ostream&stream, const char *colorCode);
+
+#if defined(__linux__) || defined(__APPLE__)
+void outputColorCode(std::ostream& stream, const char *colorCode);
 inline void normal(std::ostream& stream) { outputColorCode(stream,"\033[0m"); }
 inline void red(std::ostream& stream) { outputColorCode(stream,"\033[31m"); }
 inline void magenta(std::ostream& stream) { outputColorCode(stream,"\033[35m"); }
@@ -30,6 +32,19 @@ inline void grey(std::ostream& stream) { outputColorCode(stream,"\033[37m"); }
 inline void green(std::ostream& stream) { outputColorCode(stream,"\033[32m"); }
 inline void blue(std::ostream& stream) { outputColorCode(stream,"\033[34m"); }
 inline void bold(std::ostream& stream) { outputColorCode(stream,"\033[1m"); }
+#endif
+
+#if defined(_WIN32)
+void outputColorCode(std::ostream& stream, const unsigned short &colorCode);
+inline void normal(std::ostream& stream) { outputColorCode(stream, 0x07); }
+inline void red(std::ostream& stream) { outputColorCode(stream, 0x0c); }
+inline void magenta(std::ostream& stream) { outputColorCode(stream, 0x05); }
+inline void orange(std::ostream& stream) { outputColorCode(stream, 0x06); }
+inline void grey(std::ostream& stream) { outputColorCode(stream, 0x08); }
+inline void green(std::ostream& stream) { outputColorCode(stream, 0x02); }
+inline void blue(std::ostream& stream) { outputColorCode(stream, 0x09); }
+inline void bold(std::ostream& stream) { /* Do nothing */ }
+#endif
 };
 
 #endif // wasm_support_color_h


### PR DESCRIPTION
The only feature Windows does not support is changing font type to bold. Tested with Mingw64 gcc 5.4.0, should work with MSVC as well.

![capture](https://cloud.githubusercontent.com/assets/13115060/18270653/a5d311ea-7460-11e6-8b10-92296cbe7aea.PNG)