### PR TITLE
Ordering bug fixes for windows

### DIFF
--- a/src/support/threads.h
+++ b/src/support/threads.h
@@ -105,6 +105,24 @@ private:
   bool areThreadsReady();
 };
 
+// Verify a code segment is only entered once. Usage:
+//    static OnlyOnce onlyOnce;
+//    onlyOnce.verify();
+
+class OnlyOnce {
+  std::atomic<int> created;
+
+public:
+  OnlyOnce() {
+    created.store(0);
+  }
+
+  void verify() {
+    auto before = created.fetch_add(1);
+    assert(before == 0);
+  }
+};
+
 } // namespace wasm
 
 #endif  // wasm_support_threads_h

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1328,19 +1328,22 @@ public:
   }
   uint16_t getInt16() {
     if (debug) std::cerr << "<==" << std::endl;
-    auto ret = uint16_t(getInt8()) | (uint16_t(getInt8()) << 8);
+    auto ret = uint16_t(getInt8());
+    ret |= uint16_t(getInt8()) << 8;
     if (debug) std::cerr << "getInt16: " << ret << " ==>" << std::endl;
     return ret;
   }
   uint32_t getInt32() {
     if (debug) std::cerr << "<==" << std::endl;
-    auto ret = uint32_t(getInt16()) | (uint32_t(getInt16()) << 16);
+    auto ret = uint32_t(getInt16());
+    ret |= uint32_t(getInt16()) << 16;
     if (debug) std::cerr << "getInt32: " << ret << " ==>" << std::endl;
     return ret;
   }
   uint64_t getInt64() {
     if (debug) std::cerr << "<==" << std::endl;
-    auto ret = uint64_t(getInt32()) | (uint64_t(getInt32()) << 32);
+    auto ret = uint64_t(getInt32());
+    ret |= uint64_t(getInt32()) << 32;
     if (debug) std::cerr << "getInt64: " << ret << " ==>" << std::endl;
     return ret;
   }

--- a/src/wasm-module-building.h
+++ b/src/wasm-module-building.h
@@ -96,6 +96,14 @@ public:
       return;
     }
 
+    // Before parallelism, create all passes on the main thread here, to ensure
+    // constructors run at least once on the main thread, for one-time init things.
+    {
+      PassRunner passRunner(wasm);
+      addPrePasses(passRunner);
+      passRunner.addDefaultFunctionOptimizationPasses();
+    }
+
     // prepare work list
     endMarker = new Function();
     list = new std::atomic<Function*>[numFunctions];


### PR DESCRIPTION
First commit fixes call order being unspecified over `|`.

Second fixes #692, where we relied on the order of global ctors.