### PR TITLE
In AsmConstWalker, don't assume a segment exists

### DIFF
--- a/src/wasm-emscripten.cpp
+++ b/src/wasm-emscripten.cpp
@@ -105,8 +105,16 @@ struct AsmConstWalker : public PostWalker<AsmConstWalker, Visitor<AsmConstWalker
 void AsmConstWalker::visitCallImport(CallImport* curr) {
   if (curr->target == EMSCRIPTEN_ASM_CONST) {
     auto arg = curr->operands[0]->cast<Const>();
-    Address segmentIndex = segmentsByAddress[arg->value.geti32()];
-    std::string code = escape(&wasm.memory.segments[segmentIndex].data[0]);
+    auto address = arg->value.geti32();
+    auto segmentIterator = segmentsByAddress.find(address);
+    std::string code;
+    if (segmentIterator != segmentsByAddress.end()) {
+      Address segmentIndex = segmentsByAddress[address];
+      code = escape(&wasm.memory.segments[segmentIndex].data[0]);
+    } else {
+      // If we can't find the segment corresponding with the address, then we omitted the segment and the address points to an empty string.
+      code = escape("");
+    }
     int32_t id;
     if (ids.count(code) == 0) {
       id = ids.size();


### PR DESCRIPTION
It's possible to generate an EM_ASM call with empty contents (due to
ifdefs, for example), and this gets converted to an empty string.
AsmConstWalker assumes that by this point any addresses it is pointing
to have a corresponding data section, which is reasonable. However in
the case of an empty string, we don't create a data section, but just
leave that address uninitialized, i.e. set to 0.
In the case of AsmConstWalker, a correct thing to do is to emit the
empty string as metadata, which becomes an empty emscripten_asm_v call.