### PR TITLE
Make wasm-as emit the names section/debug info only with -g

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -93,19 +93,23 @@ print '\n[ checking binary format testcases... ]\n'
 
 for wast in sorted(os.listdir('test')):
   if wast.endswith('.wast') and not wast in []: # blacklist some known failures
-    cmd = [os.path.join('bin', 'wasm-as'), os.path.join('test', wast), '-o', 'a.wasm']
-    print ' '.join(cmd)
-    if os.path.exists('a.wasm'): os.unlink('a.wasm')
-    subprocess.check_call(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    assert os.path.exists('a.wasm')
+    for debug_info in [0, 1]:
+      cmd = [os.path.join('bin', 'wasm-as'), os.path.join('test', wast), '-o', 'a.wasm']
+      if debug_info: cmd += ['-g']
+      print ' '.join(cmd)
+      if os.path.exists('a.wasm'): os.unlink('a.wasm')
+      subprocess.check_call(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      assert os.path.exists('a.wasm')
 
-    cmd = [os.path.join('bin', 'wasm-dis'), 'a.wasm', '-o', 'a.wast']
-    print ' '.join(cmd)
-    if os.path.exists('a.wast'): os.unlink('a.wast')
-    subprocess.check_call(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    assert os.path.exists('a.wast')
-    actual = open('a.wast').read()
-    with open(os.path.join('test', wast + '.fromBinary'), 'w') as o: o.write(actual)
+      cmd = [os.path.join('bin', 'wasm-dis'), 'a.wasm', '-o', 'a.wast']
+      print ' '.join(cmd)
+      if os.path.exists('a.wast'): os.unlink('a.wast')
+      subprocess.check_call(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      assert os.path.exists('a.wast')
+      actual = open('a.wast').read()
+      binary_name = wast + '.fromBinary'
+      if not debug_info: binary_name += '.noDebugInfo'
+      with open(os.path.join('test', binary_name), 'w') as o: o.write(actual)
 
 print '\n[ checking example testcases... ]\n'
 

--- a/check.py
+++ b/check.py
@@ -360,8 +360,8 @@ for t in tests:
     if actual != expected:
       fail(actual, expected)
 
-    binary_format_check(t, wasm_as_args = ['-g']) # test with debuginfo
-    binary_format_check(t, wasm_as_args = [], binary_suffix='.fromBinary.noDebugInfo') # test without debuginfo
+    binary_format_check(t, wasm_as_args=['-g']) # test with debuginfo
+    binary_format_check(t, wasm_as_args=[], binary_suffix='.fromBinary.noDebugInfo') # test without debuginfo
 
     minify_check(t)
 

--- a/check.py
+++ b/check.py
@@ -306,7 +306,7 @@ for asm in tests:
         if actual != expected:
           fail(actual, expected)
 
-        binary_format_check(wasm, verify_final_result = False)
+        binary_format_check(wasm, verify_final_result=False)
 
         # verify in wasm
         if interpreter:

--- a/check.py
+++ b/check.py
@@ -186,11 +186,11 @@ if not has_vanilla_emcc:
 
 # check utilities
 
-def binary_format_check(wast, verify_final_result=True):
+def binary_format_check(wast, verify_final_result=True, wasm_as_args=['-g'], binary_suffix='.fromBinary'):
   # checks we can convert the wast to binary and back
 
   print '     (binary format check)'
-  cmd = [os.path.join('bin', 'wasm-as'), wast, '-o', 'a.wasm']
+  cmd = [os.path.join('bin', 'wasm-as'), wast, '-o', 'a.wasm'] + wasm_as_args
   print '      ', ' '.join(cmd)
   if os.path.exists('a.wasm'): os.unlink('a.wasm')
   subprocess.check_call(cmd, stdout=subprocess.PIPE)
@@ -208,7 +208,7 @@ def binary_format_check(wast, verify_final_result=True):
   subprocess.check_call(cmd, stdout=subprocess.PIPE)
 
   if verify_final_result:
-    expected = open(wast + '.fromBinary').read()
+    expected = open(wast + binary_suffix).read()
     actual = open('ab.wast').read()
     if actual != expected:
       fail(actual, expected)
@@ -306,7 +306,7 @@ for asm in tests:
         if actual != expected:
           fail(actual, expected)
 
-        binary_format_check(wasm, verify_final_result=False)
+        binary_format_check(wasm, verify_final_result = False)
 
         # verify in wasm
         if interpreter:
@@ -360,7 +360,9 @@ for t in tests:
     if actual != expected:
       fail(actual, expected)
 
-    binary_format_check(t)
+    binary_format_check(t, wasm_as_args = ['-g']) # test with debuginfo
+    binary_format_check(t, wasm_as_args = [], binary_suffix='.fromBinary.noDebugInfo') # test without debuginfo
+
     minify_check(t)
 
 print '\n[ checking wasm-shell spec testcases... ]\n'

--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -28,6 +28,7 @@ using namespace cashew;
 using namespace wasm;
 
 int main(int argc, const char *argv[]) {
+  bool debugInfo = false;
   Options options("wasm-as", "Assemble a .wast (WebAssembly text format) into a .wasm (WebAssembly binary format)");
   options.extra["validate"] = "wasm";
   options
@@ -46,6 +47,9 @@ int main(int argc, const char *argv[]) {
              }
              o->extra["validate"] = argument;
            })
+      .add("--debuginfo", "-g", "Emit names section and debug info",
+           Options::Arguments::Zero,
+           [&](Options *o, const std::string &arguments) { debugInfo = true; })
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options *o, const std::string &argument) {
                         o->extra["infile"] = argument;
@@ -78,6 +82,7 @@ int main(int argc, const char *argv[]) {
   if (options.debug) std::cerr << "binarification..." << std::endl;
   BufferWithRandomAccess buffer(options.debug);
   WasmBinaryWriter writer(&wasm, buffer, options.debug);
+  writer.setDebugInfo(debugInfo);
   writer.write();
 
   if (options.debug) std::cerr << "writing to output..." << std::endl;

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -466,6 +466,7 @@ class WasmBinaryWriter : public Visitor<WasmBinaryWriter, void> {
   Module* wasm;
   BufferWithRandomAccess& o;
   bool debug;
+  bool debugInfo = true;
 
   MixedArena allocator;
 
@@ -484,6 +485,10 @@ public:
     prepare();
   }
 
+  void setDebugInfo(bool set) {
+    debugInfo = set;
+  }
+
   void write() {
     writeHeader();
 
@@ -497,7 +502,7 @@ public:
     writeStart();
     writeFunctions();
     writeDataSegments();
-    writeNames();
+    if (debugInfo) writeNames();
 
     finishUp();
   }

--- a/test/hello_world.wast.fromBinary.noDebugInfo
+++ b/test/hello_world.wast.fromBinary.noDebugInfo
@@ -1,0 +1,12 @@
+(module
+  (memory 256 256)
+  (type $0 (func (param i32 i32) (result i32)))
+  (export "add" (func $0))
+  (func $0 (type $0) (param $var$0 i32) (param $var$1 i32) (result i32)
+    (i32.add
+      (get_local $var$0)
+      (get_local $var$1)
+    )
+  )
+)
+

--- a/test/kitchen_sink.wast.fromBinary.noDebugInfo
+++ b/test/kitchen_sink.wast.fromBinary.noDebugInfo
@@ -1,0 +1,668 @@
+(module
+  (memory 4096 4096)
+  (data (i32.const 1026) "\14\00")
+  (type $0 (func (result i32)))
+  (func $0 (type $0) (result i32)
+    (block $label$0 i32
+      (drop
+        (i32.add
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.sub
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.mul
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.div_s
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.div_u
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.rem_s
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.rem_u
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.and
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.or
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.xor
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.shl
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.shr_u
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.shr_s
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.eq
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.ne
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.lt_s
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.le_s
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.lt_u
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.le_u
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.gt_s
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.ge_s
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.gt_u
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.ge_u
+          (i32.const 10)
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.clz
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.ctz
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i32.popcnt
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i64.add
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.sub
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.mul
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.div_s
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.div_u
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.rem_s
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.rem_u
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.and
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.or
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.xor
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.shl
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.shr_u
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.shr_s
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.eq
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.ne
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.lt_s
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.le_s
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.lt_u
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.le_u
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.gt_s
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.ge_s
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.gt_u
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.ge_u
+          (i64.const 100)
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.clz
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.ctz
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.popcnt
+          (i64.const 100)
+        )
+      )
+      (drop
+        (f32.add
+          (f32.const 10)
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.sub
+          (f32.const 10)
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.mul
+          (f32.const 10)
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.div
+          (f32.const 10)
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.min
+          (f32.const 10)
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.max
+          (f32.const 10)
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.abs
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.neg
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.copysign
+          (f32.const 10)
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.ceil
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.floor
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.trunc
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.nearest
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.sqrt
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.eq
+          (f32.const 10)
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.ne
+          (f32.const 10)
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.lt
+          (f32.const 10)
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.le
+          (f32.const 10)
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.gt
+          (f32.const 10)
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f32.ge
+          (f32.const 10)
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f64.add
+          (f64.const 10)
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.sub
+          (f64.const 10)
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.mul
+          (f64.const 10)
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.div
+          (f64.const 10)
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.min
+          (f64.const 10)
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.max
+          (f64.const 10)
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.abs
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.neg
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.copysign
+          (f64.const 10)
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.ceil
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.floor
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.trunc
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.nearest
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.sqrt
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.eq
+          (f64.const 10)
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.ne
+          (f64.const 10)
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.lt
+          (f64.const 10)
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.le
+          (f64.const 10)
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.gt
+          (f64.const 10)
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f64.ge
+          (f64.const 10)
+          (f64.const 10)
+        )
+      )
+      (drop
+        (i32.trunc_s/f32
+          (f32.const 10)
+        )
+      )
+      (drop
+        (i32.trunc_s/f64
+          (f64.const 10)
+        )
+      )
+      (drop
+        (i32.trunc_u/f32
+          (f32.const 10)
+        )
+      )
+      (drop
+        (i32.trunc_u/f64
+          (f64.const 10)
+        )
+      )
+      (drop
+        (i32.wrap/i64
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i64.trunc_s/f32
+          (f32.const 10)
+        )
+      )
+      (drop
+        (i64.trunc_s/f64
+          (f64.const 10)
+        )
+      )
+      (drop
+        (i64.trunc_u/f32
+          (f32.const 10)
+        )
+      )
+      (drop
+        (i64.trunc_u/f64
+          (f64.const 10)
+        )
+      )
+      (drop
+        (i64.extend_s/i32
+          (i32.const 10)
+        )
+      )
+      (drop
+        (i64.extend_u/i32
+          (i32.const 10)
+        )
+      )
+      (drop
+        (f32.convert_s/i32
+          (i32.const 10)
+        )
+      )
+      (drop
+        (f32.convert_u/i32
+          (i32.const 10)
+        )
+      )
+      (drop
+        (f32.convert_s/i64
+          (i64.const 100)
+        )
+      )
+      (drop
+        (f32.convert_u/i64
+          (i64.const 100)
+        )
+      )
+      (drop
+        (f32.demote/f64
+          (f64.const 10)
+        )
+      )
+      (drop
+        (f32.reinterpret/i32
+          (i32.const 10)
+        )
+      )
+      (drop
+        (f64.convert_s/i32
+          (i32.const 10)
+        )
+      )
+      (drop
+        (f64.convert_u/i32
+          (i32.const 10)
+        )
+      )
+      (drop
+        (f64.convert_s/i64
+          (i64.const 100)
+        )
+      )
+      (drop
+        (f64.convert_u/i64
+          (i64.const 100)
+        )
+      )
+      (drop
+        (f64.promote/f32
+          (f32.const 10)
+        )
+      )
+      (drop
+        (f64.reinterpret/i64
+          (i64.const 100)
+        )
+      )
+      (drop
+        (i32.reinterpret/f32
+          (f32.const 10)
+        )
+      )
+      (drop
+        (i64.reinterpret/f64
+          (f64.const 10)
+        )
+      )
+      (i32.const 0)
+    )
+  )
+)
+

--- a/test/min.wast.fromBinary.noDebugInfo
+++ b/test/min.wast.fromBinary.noDebugInfo
@@ -1,0 +1,58 @@
+(module
+  (memory 256 256)
+  (type $0 (func (param f32) (result f32)))
+  (type $1 (func (param i32 i32) (result f32)))
+  (type $2 (func (param i32) (result i32)))
+  (type $3 (func (param i32 i32 i32) (result i32)))
+  (export "floats" (func $0))
+  (func $0 (type $0) (param $var$0 f32) (result f32)
+    (local $var$1 f32)
+    (f32.add
+      (get_local $var$1)
+      (get_local $var$0)
+    )
+  )
+  (func $1 (type $1) (param $var$0 i32) (param $var$1 i32) (result f32)
+    (local $var$2 f32)
+    (tee_local $var$2
+      (f32.neg
+        (block $label$0 f32
+          (i32.store
+            (get_local $var$0)
+            (get_local $var$1)
+          )
+          (f32.load
+            (get_local $var$0)
+          )
+        )
+      )
+    )
+  )
+  (func $2 (type $2) (param $var$0 i32) (result i32)
+    (block $label$0 i32
+      (block $label$1
+        (block $label$2
+          (br_table $label$2 $label$1 $label$2
+            (i32.sub
+              (get_local $var$0)
+              (i32.const 1)
+            )
+          )
+        )
+        (br $label$0
+          (i32.const 1)
+        )
+      )
+      (br $label$0
+        (i32.const 2)
+      )
+      (i32.const 0)
+    )
+  )
+  (func $3 (type $3) (param $var$0 i32) (param $var$1 i32) (param $var$2 i32) (result i32)
+    (block $label$0 i32
+      (get_local $var$2)
+    )
+  )
+)
+

--- a/test/reg_switch.wast.fromBinary.noDebugInfo
+++ b/test/reg_switch.wast.fromBinary.noDebugInfo
@@ -1,0 +1,17 @@
+(module
+  (memory 0)
+  (type $0 (func))
+  (func $0 (type $0)
+    (if
+      (i32.const 0)
+      (block $label$0
+        (block $label$1
+          (br_table $label$1
+            (i32.const 0)
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/test/unit.wast.fromBinary.noDebugInfo
+++ b/test/unit.wast.fromBinary.noDebugInfo
@@ -1,0 +1,450 @@
+(module
+  (memory 4096 4096)
+  (data (i32.const 1026) "\14\00")
+  (type $0 (func (param f32)))
+  (type $1 (func))
+  (type $2 (func (param f64) (result i32)))
+  (type $3 (func (param f64 f64) (result f64)))
+  (type $4 (func (result f64)))
+  (type $5 (func (result i32)))
+  (type $6 (func (param i32) (result i32)))
+  (type $7 (func (param f64) (result f64)))
+  (import "env" "_emscripten_asm_const_vi" (func $import$0))
+  (import "asm2wasm" "f64-to-int" (func $import$1 (param f64) (result i32)))
+  (import "asm2wasm" "f64-rem" (func $import$2 (param f64 f64) (result f64)))
+  (export "big_negative" (func $0))
+  (table 10 anyfunc)
+  (elem (i32.const 0) $17 $0 $17 $17 $18 $18 $1 $18 $17 $15)
+  (func $0 (type $1)
+    (local $var$0 f64)
+    (block $label$0
+      (set_local $var$0
+        (f64.const -2147483648)
+      )
+      (set_local $var$0
+        (f64.const -2147483648)
+      )
+      (set_local $var$0
+        (f64.const -21474836480)
+      )
+      (set_local $var$0
+        (f64.const 0.039625)
+      )
+      (set_local $var$0
+        (f64.const -0.039625)
+      )
+    )
+  )
+  (func $1 (type $4) (result f64)
+    (local $var$0 f64)
+    (block $label$0 f64
+      (set_local $var$0
+        (f64.add
+          (f64.add
+            (f64.add
+              (f64.load
+                (i32.const 8)
+              )
+              (f64.load
+                (i32.const 16)
+              )
+            )
+            (f64.neg
+              (f64.load
+                (i32.const 16)
+              )
+            )
+          )
+          (f64.neg
+            (f64.load
+              (i32.const 8)
+            )
+          )
+        )
+      )
+      (if
+        (i32.gt_s
+          (i32.load
+            (i32.const 24)
+          )
+          (i32.const 0)
+        )
+        (block $label$1
+          (br $label$0
+            (f64.const -3.4)
+          )
+        )
+      )
+      (if
+        (f64.gt
+          (f64.load
+            (i32.const 32)
+          )
+          (f64.const 0)
+        )
+        (block $label$2
+          (br $label$0
+            (f64.const 5.6)
+          )
+        )
+      )
+      (f64.const 1.2)
+    )
+  )
+  (func $2 (type $3) (param $var$0 f64) (param $var$1 f64) (result f64)
+    (local $var$2 i32)
+    (local $var$3 f64)
+    (local $var$4 f64)
+    (block $label$0 f64
+      (if
+        (f64.gt
+          (get_local $var$0)
+          (f64.const 0)
+        )
+        (block $label$1
+          (br $label$0
+            (f64.const 1.2)
+          )
+        )
+      )
+      (if
+        (f64.gt
+          (get_local $var$4)
+          (f64.const 0)
+        )
+        (block $label$2
+          (br $label$0
+            (f64.const -3.4)
+          )
+        )
+      )
+      (if
+        (i32.gt_s
+          (get_local $var$2)
+          (i32.const 0)
+        )
+        (block $label$3
+          (br $label$0
+            (f64.const 5.6)
+          )
+        )
+      )
+      (if
+        (f64.lt
+          (get_local $var$0)
+          (get_local $var$1)
+        )
+        (block $label$4
+          (br $label$0
+            (get_local $var$0)
+          )
+        )
+      )
+      (get_local $var$1)
+    )
+  )
+  (func $3 (type $5) (result i32)
+    (local $var$0 i32)
+    (i32.eq
+      (get_local $var$0)
+      (i32.const 0)
+    )
+  )
+  (func $4 (type $1)
+    (drop
+      (i32.add
+        (i32.add
+          (i32.const 0)
+          (i32.const 313249263)
+        )
+        (i32.const -19088752)
+      )
+    )
+  )
+  (func $5 (type $1)
+    (local $var$0 i32)
+    (local $var$1 f64)
+    (block $label$0
+      (set_local $var$0
+        (call $import$1
+          (get_local $var$1)
+        )
+      )
+      (set_local $var$1
+        (f64.convert_s/i32
+          (get_local $var$0)
+        )
+      )
+      (set_local $var$1
+        (f64.convert_u/i32
+          (i32.shr_u
+            (get_local $var$0)
+            (i32.const 0)
+          )
+        )
+      )
+    )
+  )
+  (func $6 (type $1)
+    (local $var$0 f64)
+    (set_local $var$0
+      (f64.sub
+        (block $label$0 f64
+          (drop
+            (f64.const 0.1)
+          )
+          (f64.const 5.1)
+        )
+        (block $label$1 f64
+          (drop
+            (f64.const 3.2)
+          )
+          (f64.const 4.2)
+        )
+      )
+    )
+  )
+  (func $7 (type $6) (param $var$0 i32) (result i32)
+    (block $label$0 i32
+      (block $label$1
+        (block $label$2
+          (block $label$3
+            (block $label$4
+              (br_table $label$4 $label$3 $label$2
+                (i32.sub
+                  (get_local $var$0)
+                  (i32.const 1)
+                )
+              )
+            )
+            (br $label$0
+              (i32.const 1)
+            )
+          )
+          (br $label$0
+            (i32.const 2)
+          )
+        )
+        (nop)
+      )
+      (block $label$5
+        (block $label$6
+          (block $label$7
+            (block $label$8
+              (br_table $label$7 $label$6 $label$6 $label$6 $label$6 $label$6 $label$6 $label$8 $label$6
+                (i32.sub
+                  (get_local $var$0)
+                  (i32.const 5)
+                )
+              )
+            )
+            (br $label$0
+              (i32.const 121)
+            )
+          )
+          (br $label$0
+            (i32.const 51)
+          )
+        )
+        (nop)
+      )
+      (block $label$9
+        (block $label$10
+          (block $label$11
+            (block $label$12
+              (block $label$13
+                (block $label$14
+                  (br_table $label$11 $label$10 $label$10 $label$12 $label$10 $label$10 $label$10 $label$10 $label$13 $label$10 $label$14 $label$10
+                    (i32.sub
+                      (get_local $var$0)
+                      (i32.const 2)
+                    )
+                  )
+                )
+                (br $label$9)
+              )
+              (br $label$9)
+            )
+            (block $label$15
+              (loop $label$16
+                (br $label$15)
+                (br $label$16)
+              )
+              (br $label$9)
+            )
+          )
+          (block $label$17
+            (loop $label$18
+              (br $label$9)
+              (br $label$18)
+            )
+            (br $label$9)
+          )
+        )
+        (nop)
+      )
+      (i32.const 0)
+    )
+  )
+  (func $8 (type $1)
+    (block $label$0
+      (br $label$0)
+    )
+  )
+  (func $9 (type $4) (result f64)
+    (call $import$2
+      (f64.const 5.5)
+      (f64.const 1.2)
+    )
+  )
+  (func $10 (type $5) (result i32)
+    (local $var$0 i32)
+    (block $label$0 i32
+      (set_local $var$0
+        (i32.and
+          (i32.div_u
+            (i32.const -1)
+            (i32.const 2)
+          )
+          (i32.const -1)
+        )
+      )
+      (get_local $var$0)
+    )
+  )
+  (func $11 (type $0) (param $var$0 f32)
+    (local $var$1 f32)
+    (local $var$2 f64)
+    (block $label$0
+      (drop
+        (f32.demote/f64
+          (get_local $var$2)
+        )
+      )
+      (drop
+        (get_local $var$1)
+      )
+      (drop
+        (f32.const 5)
+      )
+      (drop
+        (f32.const 0)
+      )
+      (drop
+        (f32.const 5)
+      )
+      (drop
+        (f32.const 0)
+      )
+    )
+  )
+  (func $12 (type $4) (result f64)
+    (f64.const -0)
+  )
+  (func $13 (type $1)
+    (local $var$0 i32)
+    (local $var$1 i32)
+    (local $var$2 f32)
+    (local $var$3 f64)
+    (block $label$0
+      (set_local $var$0
+        (block $label$1 i32
+          (set_local $var$1
+            (i32.const 0)
+          )
+          (select
+            (i32.sub
+              (i32.const 0)
+              (get_local $var$1)
+            )
+            (get_local $var$1)
+            (i32.lt_s
+              (get_local $var$1)
+              (i32.const 0)
+            )
+          )
+        )
+      )
+      (set_local $var$3
+        (f64.abs
+          (f64.const 0)
+        )
+      )
+      (set_local $var$2
+        (f32.abs
+          (f32.const 0)
+        )
+      )
+    )
+  )
+  (func $14 (type $1)
+    (local $var$0 f32)
+    (block $label$0
+      (set_local $var$0
+        (f32.neg
+          (get_local $var$0)
+        )
+      )
+      (call_indirect $0
+        (get_local $var$0)
+        (i32.add
+          (i32.and
+            (i32.const 1)
+            (i32.const 7)
+          )
+          (i32.const 8)
+        )
+      )
+    )
+  )
+  (func $15 (type $0) (param $var$0 f32)
+    (call_indirect $0
+      (get_local $var$0)
+      (i32.add
+        (i32.and
+          (i32.const 1)
+          (i32.const 7)
+        )
+        (i32.const 8)
+      )
+    )
+  )
+  (func $16 (type $1)
+    (local $var$0 i32)
+    (drop
+      (i32.gt_u
+        (i32.shr_u
+          (get_local $var$0)
+          (i32.const 0)
+        )
+        (i32.const -4096)
+      )
+    )
+  )
+  (func $17 (type $1)
+    (nop)
+  )
+  (func $18 (type $1)
+    (nop)
+  )
+  (func $19 (type $5) (result i32)
+    (block $label$0 i32
+      (block $label$1
+        (drop
+          (i32.const 1)
+        )
+        (br $label$1)
+      )
+      (i32.const 0)
+    )
+  )
+  (func $20 (type $7) (param $var$0 f64) (result f64)
+    (loop $label$0
+      (drop
+        (get_local $var$0)
+      )
+      (get_local $var$0)
+    )
+  )
+)
+


### PR DESCRIPTION
As discussed in #700.

This also needs emscripten repo support (to invoke with `-g` when appropriate), I'll add that next.

This touches wasm-binary.h so it should wait to be rebased and merged after the 0xc binary changes are done.