### PR TITLE
Autodrop fix

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -797,13 +797,17 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
           switch (curr->type) {
             case i32: replaceCurrent(parent->builder.makeUnary(TruncSFloat64ToInt32, curr)); break;
             case f32: replaceCurrent(parent->builder.makeUnary(DemoteFloat64, curr)); break;
-            case none: replaceCurrent(parent->builder.makeDrop(curr)); break;
+            case none: {
+              // this function returns a value, but we are not using it, so it must be dropped.
+              // autodrop will do that for us.
+              break;
+            }
             default: WASM_UNREACHABLE();
           }
         } else {
           assert(curr->type == none);
           // we don't want a return value here, but the import does provide one
-          replaceCurrent(parent->builder.makeDrop(curr));
+          // autodrop will do that for us.
         }
         curr->type = importResult;
       }

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -351,9 +351,8 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals, 
   // optimize set_locals from both sides of an if into a return value
   void optimizeIfReturn(If* iff, Expression** currp, Sinkables& ifTrue) {
     assert(iff->ifFalse);
-    // if this if already has a result that is used, we can't do anything
-    assert(expressionStack.back() == iff);
-    if (ExpressionAnalyzer::isResultUsed(expressionStack, getFunction())) return;
+    // if this if already has a result, we can't do anything
+    if (isConcreteWasmType(iff->type)) return;
     // We now have the sinkables from both sides of the if.
     Sinkables& ifFalse = sinkables;
     Index sharedIndex = -1;

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -399,10 +399,12 @@ BinaryenFloat64: 4
             )
             (block
             )
-            (drop
-              (if
-                (i32.const 1)
+            (if
+              (i32.const 1)
+              (drop
                 (i32.const 2)
+              )
+              (drop
                 (i32.const 3)
               )
             )
@@ -1992,10 +1994,12 @@ int main() {
             )
             (block
             )
-            (drop
-              (if
-                (i32.const 1)
+            (if
+              (i32.const 1)
+              (drop
                 (i32.const 2)
+              )
+              (drop
                 (i32.const 3)
               )
             )

--- a/test/example/c-api-kitchen-sink.txt.txt
+++ b/test/example/c-api-kitchen-sink.txt.txt
@@ -394,10 +394,12 @@
             )
             (block
             )
-            (drop
-              (if
-                (i32.const 1)
+            (if
+              (i32.const 1)
+              (drop
                 (i32.const 2)
+              )
+              (drop
                 (i32.const 3)
               )
             )

--- a/test/passes/simplify-locals.txt
+++ b/test/passes/simplify-locals.txt
@@ -9,6 +9,7 @@
   (type $6 (func (param i32 i32 i32 i32 i32 i32)))
   (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
   (type $8 (func (param i32 i32)))
+  (type $9 (func (param i32 i32 i32) (result i32)))
   (import "env" "waka" (func $waka))
   (import "env" "waka_int" (func $waka_int (result i32)))
   (import "env" "i64sub" (func $_i64Subtract (param i32 i32 i32 i32) (result i32)))
@@ -734,5 +735,33 @@
       )
     )
     (get_local $a)
+  )
+  (func $drop-if-value (type $9) (param $x i32) (param $y i32) (param $z i32) (result i32)
+    (local $temp i32)
+    (drop
+      (if
+        (get_local $x)
+        (block $block53 i32
+          (nop)
+          (set_local $temp
+            (get_local $y)
+          )
+          (get_local $z)
+        )
+        (block $block54 i32
+          (nop)
+          (set_local $temp
+            (get_local $y)
+          )
+          (get_local $z)
+        )
+      )
+    )
+    (drop
+      (get_local $temp)
+    )
+    (return
+      (i32.const 0)
+    )
   )
 )

--- a/test/passes/simplify-locals.wast
+++ b/test/passes/simplify-locals.wast
@@ -775,4 +775,30 @@
     )
     (get_local $a)
   )
+  (func $drop-if-value (param $x i32) (param $y i32) (param $z i32) (result i32)
+    (local $temp i32)
+    (drop
+      (if
+        (get_local $x)
+        (block $block53 i32
+          (nop)
+          (set_local $temp
+            (get_local $y)
+          )
+          (get_local $z)
+        )
+        (block $block54 i32
+          (nop)
+          (set_local $temp
+            (get_local $y)
+          )
+          (get_local $z)
+        )
+      )
+    )
+    (drop (get_local $temp))
+    (return
+      (i32.const 0)
+    )
+  )
 )

--- a/test/passes/vacuum.txt
+++ b/test/passes/vacuum.txt
@@ -207,4 +207,14 @@
   (func $relooperJumpThreading3 (type $0)
     (nop)
   )
+  (func $if2drops (type $3) (result i32)
+    (drop
+      (if
+        (i32.const 1)
+        (call $if2drops)
+        (call $if2drops)
+      )
+    )
+    (i32.const 2)
+  )
 )

--- a/test/passes/vacuum.wast
+++ b/test/passes/vacuum.wast
@@ -412,4 +412,16 @@
       )
     )
   )
+  (func $if2drops (result i32)
+    (if
+      (i32.const 1)
+      (drop
+        (call $if2drops)
+      )
+      (drop
+        (call $if2drops)
+      )
+    )
+    (i32.const 2)
+  )
 )

--- a/test/unit.asm.js
+++ b/test/unit.asm.js
@@ -587,6 +587,20 @@ function asm(global, env, buffer) {
    return;
   }
 
+  function dropIgnoredImportsInIf($0,$1,$2) {
+   $0 = $0|0;
+   $1 = $1|0;
+   $2 = $2|0;
+   do {
+    if ($0) {
+     lb($1 | 0) | 0;
+    } else {
+     lb($2 | 0) | 0;
+    }
+   } while(0);
+   return;
+  }
+
   var FUNCTION_TABLE_a = [ z, big_negative, z, z ];
   var FUNCTION_TABLE_b = [ w, w, importedDoubles, w ];
   var FUNCTION_TABLE_c = [ z, cneg ];

--- a/test/unit.asm.js
+++ b/test/unit.asm.js
@@ -572,6 +572,21 @@ function asm(global, env, buffer) {
     return temp | 0;
   }
 
+  function dropIgnoredImportInIf($0,$1,$2) {
+   $0 = $0|0;
+   $1 = $1|0;
+   $2 = $2|0;
+   do {
+    if ($0) {
+     $0 = 1;
+     lb($2 | 0) | 0;
+    } else {
+     break;
+    }
+   } while(0);
+   return;
+  }
+
   var FUNCTION_TABLE_a = [ z, big_negative, z, z ];
   var FUNCTION_TABLE_b = [ w, w, importedDoubles, w ];
   var FUNCTION_TABLE_c = [ z, cneg ];

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -508,13 +508,11 @@
     )
   )
   (func $smallIf
-    (block $do-once$0
-      (if
-        (i32.const 2)
-        (drop
-          (call $lb
-            (i32.const 3)
-          )
+    (if
+      (i32.const 2)
+      (drop
+        (call $lb
+          (i32.const 3)
         )
       )
     )
@@ -1022,5 +1020,15 @@
     (block $jumpthreading$outer$2
     )
     (get_local $0)
+  )
+  (func $dropIgnoredImportInIf (param $0 i32) (param $1 i32) (param $2 i32)
+    (if
+      (get_local $0)
+      (drop
+        (call $lb
+          (get_local $2)
+        )
+      )
+    )
   )
 )

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -1031,4 +1031,17 @@
       )
     )
   )
+  (func $dropIgnoredImportsInIf (param $0 i32) (param $1 i32) (param $2 i32)
+    (drop
+      (if
+        (get_local $0)
+        (call $lb
+          (get_local $1)
+        )
+        (call $lb
+          (get_local $2)
+        )
+      )
+    )
+  )
 )

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -1012,4 +1012,17 @@
       )
     )
   )
+  (func $dropIgnoredImportsInIf (param $0 i32) (param $1 i32) (param $2 i32)
+    (drop
+      (if
+        (get_local $0)
+        (call $lb
+          (get_local $1)
+        )
+        (call $lb
+          (get_local $2)
+        )
+      )
+    )
+  )
 )

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -489,13 +489,11 @@
     )
   )
   (func $smallIf
-    (block $do-once$0
-      (if
-        (i32.const 2)
-        (drop
-          (call $lb
-            (i32.const 3)
-          )
+    (if
+      (i32.const 2)
+      (drop
+        (call $lb
+          (i32.const 3)
         )
       )
     )
@@ -1003,5 +1001,15 @@
     (block $jumpthreading$outer$2
     )
     (get_local $0)
+  )
+  (func $dropIgnoredImportInIf (param $0 i32) (param $1 i32) (param $2 i32)
+    (if
+      (get_local $0)
+      (drop
+        (call $lb
+          (get_local $2)
+        )
+      )
+    )
   )
 )

--- a/test/unit.fromasm.imprecise.no-opts
+++ b/test/unit.fromasm.imprecise.no-opts
@@ -1644,4 +1644,23 @@
     )
     (return)
   )
+  (func $dropIgnoredImportsInIf (param $$0 i32) (param $$1 i32) (param $$2 i32)
+    (block $do-once$0
+      (if
+        (get_local $$0)
+        (drop
+          (call $lb
+            (get_local $$1)
+          )
+        )
+        (drop
+          (call $lb
+            (get_local $$2)
+          )
+        )
+      )
+      (nop)
+    )
+    (return)
+  )
 )

--- a/test/unit.fromasm.imprecise.no-opts
+++ b/test/unit.fromasm.imprecise.no-opts
@@ -856,14 +856,14 @@
   )
   (func $smallIf
     (block $do-once$0
-      (drop
-        (if
-          (i32.const 2)
+      (if
+        (i32.const 2)
+        (drop
           (call $lb
             (i32.const 3)
           )
-          (br $do-once$0)
         )
+        (br $do-once$0)
       )
       (nop)
     )
@@ -930,23 +930,23 @@
   )
   (func $breakThroughMany (param $$s i32)
     (block $label$break$L1
-      (drop
-        (if
-          (get_local $$s)
-          (loop $while-in$2
-            (block $while-out$1
-              (if
-                (i32.eqz
-                  (get_local $$s)
-                )
-                (br $label$break$L1)
+      (if
+        (get_local $$s)
+        (loop $while-in$2
+          (block $while-out$1
+            (if
+              (i32.eqz
+                (get_local $$s)
               )
-              (call $zeroInit
-                (i32.const 0)
-              )
-              (br $while-in$2)
+              (br $label$break$L1)
             )
+            (call $zeroInit
+              (i32.const 0)
+            )
+            (br $while-in$2)
           )
+        )
+        (drop
           (i32.const 1337)
         )
       )
@@ -1623,5 +1623,25 @@
     (return
       (get_local $temp)
     )
+  )
+  (func $dropIgnoredImportInIf (param $$0 i32) (param $$1 i32) (param $$2 i32)
+    (block $do-once$0
+      (if
+        (get_local $$0)
+        (block
+          (set_local $$0
+            (i32.const 1)
+          )
+          (drop
+            (call $lb
+              (get_local $$2)
+            )
+          )
+        )
+        (br $do-once$0)
+      )
+      (nop)
+    )
+    (return)
   )
 )

--- a/test/unit.fromasm.no-opts
+++ b/test/unit.fromasm.no-opts
@@ -1650,4 +1650,23 @@
     )
     (return)
   )
+  (func $dropIgnoredImportsInIf (param $$0 i32) (param $$1 i32) (param $$2 i32)
+    (block $do-once$0
+      (if
+        (get_local $$0)
+        (drop
+          (call $lb
+            (get_local $$1)
+          )
+        )
+        (drop
+          (call $lb
+            (get_local $$2)
+          )
+        )
+      )
+      (nop)
+    )
+    (return)
+  )
 )

--- a/test/unit.fromasm.no-opts
+++ b/test/unit.fromasm.no-opts
@@ -862,14 +862,14 @@
   )
   (func $smallIf
     (block $do-once$0
-      (drop
-        (if
-          (i32.const 2)
+      (if
+        (i32.const 2)
+        (drop
           (call $lb
             (i32.const 3)
           )
-          (br $do-once$0)
         )
+        (br $do-once$0)
       )
       (nop)
     )
@@ -936,23 +936,23 @@
   )
   (func $breakThroughMany (param $$s i32)
     (block $label$break$L1
-      (drop
-        (if
-          (get_local $$s)
-          (loop $while-in$2
-            (block $while-out$1
-              (if
-                (i32.eqz
-                  (get_local $$s)
-                )
-                (br $label$break$L1)
+      (if
+        (get_local $$s)
+        (loop $while-in$2
+          (block $while-out$1
+            (if
+              (i32.eqz
+                (get_local $$s)
               )
-              (call $zeroInit
-                (i32.const 0)
-              )
-              (br $while-in$2)
+              (br $label$break$L1)
             )
+            (call $zeroInit
+              (i32.const 0)
+            )
+            (br $while-in$2)
           )
+        )
+        (drop
           (i32.const 1337)
         )
       )
@@ -1629,5 +1629,25 @@
     (return
       (get_local $temp)
     )
+  )
+  (func $dropIgnoredImportInIf (param $$0 i32) (param $$1 i32) (param $$2 i32)
+    (block $do-once$0
+      (if
+        (get_local $$0)
+        (block
+          (set_local $$0
+            (i32.const 1)
+          )
+          (drop
+            (call $lb
+              (get_local $$2)
+            )
+          )
+        )
+        (br $do-once$0)
+      )
+      (nop)
+    )
+    (return)
   )
 )


### PR DESCRIPTION
Found by the new fuzzer, the autodrop logic was not quite right, sometimes dropping an already dropped value higher in the AST. This fixes that, and as a bonus optimizes two drops in an if into a single drop of the if.