### PR TITLE
Update binary encoding for block, loop, and if signatures

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -162,6 +162,9 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     if (curr->name.is()) {
       o << ' ' << curr->name;
     }
+    if (isConcreteWasmType(curr->type)) {
+      o << ' ' << printWasmType(curr->type);
+    }
     incIndent();
     auto block = curr->body->dynCast<Block>();
     if (!full && block && block->name.isNull()) {

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -652,7 +652,6 @@ private:
     }
     if (autoBlock) {
       autoBlock->finalize();
-      autoBlock->type = result;
     }
     if (!currFunction) {
       makeFunction();

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -652,6 +652,7 @@ private:
     }
     if (autoBlock) {
       autoBlock->finalize();
+      autoBlock->type = result;
     }
     if (!currFunction) {
       makeFunction();

--- a/src/wasm.cpp
+++ b/src/wasm.cpp
@@ -27,7 +27,7 @@ Name WASM("wasm"),
 
 namespace BinaryConsts {
 namespace UserSections {
-const char* Names = "names";
+const char* Name = "name";
 }
 }
 

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -415,12 +415,12 @@ BinaryenFloat64: 4
               )
             )
             (drop
-              (loop $in
+              (loop $in i32
                 (i32.const 0)
               )
             )
             (drop
-              (loop
+              (loop i32
                 (i32.const 0)
               )
             )
@@ -1958,12 +1958,12 @@ int main() {
               )
             )
             (drop
-              (loop $in
+              (loop $in i32
                 (i32.const 0)
               )
             )
             (drop
-              (loop
+              (loop i32
                 (i32.const 0)
               )
             )

--- a/test/example/c-api-kitchen-sink.txt.txt
+++ b/test/example/c-api-kitchen-sink.txt.txt
@@ -410,12 +410,12 @@
               )
             )
             (drop
-              (loop $in
+              (loop $in i32
                 (i32.const 0)
               )
             )
             (drop
-              (loop
+              (loop i32
                 (i32.const 0)
               )
             )

--- a/test/passes/nm.txt
+++ b/test/passes/nm.txt
@@ -9,7 +9,7 @@
   )
   (func $b (type $0)
     (drop
-      (loop $loop-in1
+      (loop $loop-in1 i32
         (nop)
         (i32.const 1000)
       )

--- a/test/passes/simplify-locals.txt
+++ b/test/passes/simplify-locals.txt
@@ -323,7 +323,7 @@
         (i32.const 1337)
       )
       (drop
-        (loop $loop-in5
+        (loop $loop-in5 i32
           (drop
             (get_local $a)
           )

--- a/test/unit.wast
+++ b/test/unit.wast
@@ -429,7 +429,7 @@
     (i32.const 0)
   )
   (func $loop-roundtrip (type $7) (param $0 f64) (result f64)
-    (loop $loop-in1
+    (loop $loop-in1 f64
       (drop
         (get_local $0)
       )

--- a/test/unit.wast.fromBinary
+++ b/test/unit.wast.fromBinary
@@ -439,7 +439,7 @@
     )
   )
   (func $loop-roundtrip (type $7) (param $var$0 f64) (result f64)
-    (loop $label$0
+    (loop $label$0 f64
       (drop
         (get_local $var$0)
       )

--- a/test/unit.wast.fromBinary.noDebugInfo
+++ b/test/unit.wast.fromBinary.noDebugInfo
@@ -439,7 +439,7 @@
     )
   )
   (func $20 (type $7) (param $var$0 f64) (result f64)
-    (loop $label$0
+    (loop $label$0 f64
       (drop
         (get_local $var$0)
       )


### PR DESCRIPTION
As noted in the individual commits. There's still some kind of problem with autoblock types/breaks which target the function implicit block, so not merging yet