### PR TITLE
Validate drop

### DIFF
--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -303,12 +303,7 @@ public:
   }
 
   void visitDrop(Drop* curr) {
-    // TODO: assert on this, when tests pass
-    if (getenv("BINARYEN_WARN_DROP")) {
-      if (!(isConcreteWasmType(curr->value->type) || curr->value->type == unreachable)) {
-        std::cerr << "warning: bad drop " << curr << " in " << (getFunction() ? getFunction()->name : Name("?")) << '\n';
-      }
-    }
+    shouldBeTrue(isConcreteWasmType(curr->value->type) || curr->value->type == unreachable, curr, "can only drop a valid value");
   }
 
   void visitReturn(Return* curr) {

--- a/test/passes/vacuum.txt
+++ b/test/passes/vacuum.txt
@@ -145,17 +145,17 @@
   )
   (func $if-drop (type $3) (result i32)
     (block $out
-      (drop
-        (if
-          (call $if-drop)
+      (if
+        (call $if-drop)
+        (drop
           (call $int)
-          (br $out)
         )
+        (br $out)
       )
-      (drop
-        (if
-          (call $if-drop)
-          (br $out)
+      (if
+        (call $if-drop)
+        (br $out)
+        (drop
           (call $int)
         )
       )

--- a/test/passes/vacuum.wast
+++ b/test/passes/vacuum.wast
@@ -302,13 +302,15 @@
   (func $if-drop (result i32)
     (block $out
       (drop
-        (if (call $if-drop)
+        (if i32
+          (call $if-drop)
           (call $int)
           (br $out)
         )
       )
       (drop
-        (if (call $if-drop)
+        (if i32
+          (call $if-drop)
           (br $out)
           (call $int)
         )


### PR DESCRIPTION
This makes the validator enforce drop being used on a value that is droppable. Apparently no spec test checks this, so it wasn't done already. The new pass fuzzer noticed this.

Spec tests are updated here since the previous version had some incorrect drops (which I meanwhile noticed and fixed in https://github.com/WebAssembly/spec/pull/351.

This can't be merged yet due to #708, we need to fix either the wasm backend or s2wasm to emit proper drops, so they pass this new validation.
