### PR TITLE
Precompute breaks and returns

### DIFF
--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -76,7 +76,7 @@ public:
     }
     return ret;
   }
-  If* makeIf(Expression* condition, Expression* ifTrue, Expression* ifFalse=nullptr) {
+  If* makeIf(Expression* condition, Expression* ifTrue, Expression* ifFalse = nullptr) {
     auto* ret = allocator.alloc<If>();
     ret->condition = condition; ret->ifTrue = ifTrue; ret->ifFalse = ifFalse;
     ret->finalize();
@@ -88,7 +88,7 @@ public:
     ret->finalize();
     return ret;
   }
-  Break* makeBreak(Name name, Expression* value=nullptr, Expression* condition=nullptr) {
+  Break* makeBreak(Name name, Expression* value = nullptr, Expression* condition = nullptr) {
     auto* ret = allocator.alloc<Break>();
     ret->name = name; ret->value = value; ret->condition = condition;
     ret->finalize();
@@ -202,7 +202,7 @@ public:
     ret->finalize();
     return ret;
   }
-  Return* makeReturn(Expression *value) {
+  Return* makeReturn(Expression *value = nullptr) {
     auto* ret = allocator.alloc<Return>();
     ret->value = value;
     return ret;

--- a/test/passes/O.txt
+++ b/test/passes/O.txt
@@ -1,0 +1,18 @@
+(module
+  (memory 0)
+  (type $0 (func (result i32)))
+  (func $ret (type $0) (result i32)
+    (block $out i32
+      (drop
+        (call $ret)
+      )
+      (if
+        (call $ret)
+        (return
+          (i32.const 1)
+        )
+      )
+      (i32.const 999)
+    )
+  )
+)

--- a/test/passes/O.wast
+++ b/test/passes/O.wast
@@ -1,0 +1,17 @@
+(module
+  (func $ret (result i32)
+    (block $out
+      (drop (call $ret))
+      (if (call $ret)
+        (return
+          (return
+            (i32.const 1)
+          )
+        )
+      )
+      (drop (br_if $out (i32.const 999) (i32.const 1)))
+      (unreachable)
+    )
+  )
+)
+

--- a/test/passes/precompute.txt
+++ b/test/passes/precompute.txt
@@ -1,6 +1,8 @@
 (module
   (memory 0)
   (type $0 (func (param i32)))
+  (type $1 (func (result i32)))
+  (type $2 (func))
   (func $x (type $0) (param $x i32)
     (nop)
     (drop
@@ -21,9 +23,83 @@
       (call $x
         (i32.const 4)
       )
-      (br_if $c
+      (br $c)
+      (br $c)
+    )
+    (drop
+      (block $val i32
+        (nop)
+        (call $x
+          (i32.const 4)
+        )
+        (br $val
+          (i32.const 101)
+        )
+        (br $val
+          (i32.const 102)
+        )
+      )
+    )
+    (nop)
+    (drop
+      (block $d i32
+        (call $x
+          (i32.const 5)
+        )
+        (nop)
         (i32.const 1)
       )
+    )
+    (drop
+      (block $d i32
+        (call $x
+          (i32.const 6)
+        )
+        (nop)
+        (i32.const 1)
+      )
+    )
+    (drop
+      (block $d i32
+        (call $x
+          (i32.const 7)
+        )
+        (nop)
+        (i32.const 2)
+      )
+    )
+    (call $x
+      (i32.const 2)
+    )
+    (call $x
+      (i32.const 1)
+    )
+    (call $x
+      (i32.const 0)
+    )
+    (call $x
+      (i32.const 0)
+    )
+  )
+  (func $ret (type $1) (result i32)
+    (if
+      (call $ret)
+      (return
+        (i32.const 0)
+      )
+    )
+    (if
+      (call $ret)
+      (return
+        (i32.const 1)
+      )
+    )
+    (i32.const 1)
+  )
+  (func $noret (type $2)
+    (if
+      (call $ret)
+      (return)
     )
   )
 )

--- a/test/passes/precompute.wast
+++ b/test/passes/precompute.wast
@@ -50,6 +50,134 @@
       (br_if $c (i32.const 0))
       (call $x (i32.const 4))
       (br_if $c (i32.const 1))
+      (br $c)
+    )
+    (drop
+      (block $val
+        (drop (br_if $val (i32.const 100) (i32.const 0)))
+        (call $x (i32.const 4))
+        (drop (br_if $val (i32.const 101) (i32.const 1)))
+        (br $val (i32.const 102))
+      )
+    )
+    (block $d
+      (block $e
+        (br_if $d (br $e))
+        (call $x (i32.const 4))
+        (br_if $e (br $d))
+      )
+    )
+    (drop
+      (block $d
+        (call $x (i32.const 5))
+        (block $e
+          (drop (br_if $d (br $e) (i32.const 1)))
+          (drop (br_if $d (br $e) (i32.const 0)))
+          (drop (br_if $d (i32.const 1) (br $e)))
+          (drop (br_if $d (i32.const 0) (br $e)))
+          (unreachable)
+        )
+        (i32.const 1)
+      )
+    )
+    (drop
+      (block $d
+        (call $x (i32.const 6))
+        (block $e
+          (drop (br_if $d (br $e) (i32.const 0)))
+          (drop (br_if $d (i32.const 1) (br $e)))
+          (drop (br_if $d (i32.const 0) (br $e)))
+          (unreachable)
+        )
+        (i32.const 1)
+      )
+    )
+    (drop
+      (block $d
+        (call $x (i32.const 7))
+        (block $e
+          (drop (br_if $d (i32.const 1) (br $e)))
+        )
+        (i32.const 2)
+      )
+    )
+    (call $x
+      (block $out
+        (block $waka1
+          (block $waka2
+            (block $waka3
+              (br_table $waka1 $waka2 $waka3
+                (i32.const 0)
+              )
+            )
+            (br $out (i32.const 0))
+          )
+          (br $out (i32.const 1))
+        )
+        (br $out (i32.const 2))
+      )
+    )
+    (call $x
+      (block $out
+        (block $waka1
+          (block $waka2
+            (block $waka3
+              (br_table $waka1 $waka2 $waka3
+                (i32.const 1)
+              )
+            )
+            (br $out (i32.const 0))
+          )
+          (br $out (i32.const 1))
+        )
+        (br $out (i32.const 2))
+      )
+    )
+    (call $x
+      (block $out
+        (block $waka1
+          (block $waka2
+            (block $waka3
+              (br_table $waka1 $waka2 $waka3
+                (i32.const 2)
+              )
+            )
+            (br $out (i32.const 0))
+          )
+          (br $out (i32.const 1))
+        )
+        (br $out (i32.const 2))
+      )
+    )
+    (call $x
+      (block $out
+        (block $waka1
+          (block $waka2
+            (block $waka3
+              (br_table $waka1 $waka2 $waka3
+                (i32.const 3)
+              )
+            )
+            (br $out (i32.const 0))
+          )
+          (br $out (i32.const 1))
+        )
+        (br $out (i32.const 2))
+      )
+    )
+  )
+  (func $ret (result i32)
+    (if (call $ret)
+      (return (i32.const 0))
+    )
+    (if (call $ret)
+      (return (return (i32.const 1)))
+    )
+    (i32.const 1)
+  )
+  (func $noret
+    (if (call $ret)
+      (return)
     )
   )
 )


### PR DESCRIPTION
Normal code doesn't generally benefit from it, but might as well do it for completeness, since it's easy (the only reason it's more than a few lines is to avoid unnecessary allocations), and we might as well optimize silly code too.