### PR TITLE
Make the linker always create a table segment

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -634,6 +634,8 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     }
     doIndent(o, indent);
     for (auto& segment : curr->segments) {
+      // Don't print empty segments
+      if (segment.data.empty()) break;
       printOpening(o, "elem ", true);
       visit(segment.offset);
       for (auto name : segment.data) {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -635,7 +635,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     doIndent(o, indent);
     for (auto& segment : curr->segments) {
       // Don't print empty segments
-      if (segment.data.empty()) break;
+      if (segment.data.empty()) continue;
       printOpening(o, "elem ", true);
       visit(segment.offset);
       for (auto name : segment.data) {

--- a/test/dot_s/alternate-lcomm.wast
+++ b/test/dot_s/alternate-lcomm.wast
@@ -1,5 +1,7 @@
 (module
   (memory $0 1)
   (export "memory" (memory $0))
+  (table 0 anyfunc)
+  
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 16, "initializers": [] }

--- a/test/dot_s/asm_const.wast
+++ b/test/dot_s/asm_const.wast
@@ -5,6 +5,8 @@
   (import "env" "emscripten_asm_const_vi" (func $emscripten_asm_const_vi (param i32)))
   (export "memory" (memory $0))
   (export "main" (func $main))
+  (table 0 anyfunc)
+  
   (func $main (result i32)
     (call $emscripten_asm_const_vi
       (i32.const 0)

--- a/test/dot_s/data-offset-folding.wast
+++ b/test/dot_s/data-offset-folding.wast
@@ -3,5 +3,7 @@
   (data (i32.const 12) "\00\00\00\00")
   (data (i32.const 416) "`\00\00\00")
   (export "memory" (memory $0))
+  (table 0 anyfunc)
+  
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 420, "initializers": [] }

--- a/test/dot_s/debug.wast
+++ b/test/dot_s/debug.wast
@@ -2,6 +2,8 @@
   (memory $0 1)
   (export "memory" (memory $0))
   (export "fib" (func $fib))
+  (table 0 anyfunc)
+  
   (func $fib (param $0 i32) (result i32)
     (local $1 i32)
     (local $2 i32)

--- a/test/dot_s/dso_handle.wast
+++ b/test/dot_s/dso_handle.wast
@@ -2,6 +2,8 @@
   (memory $0 1)
   (export "memory" (memory $0))
   (export "main" (func $main))
+  (table 0 anyfunc)
+  
   (func $main (result i32)
     (return
       (i32.const 8)

--- a/test/dot_s/exit.wast
+++ b/test/dot_s/exit.wast
@@ -4,6 +4,8 @@
   (import "env" "exit" (func $exit (param i32)))
   (export "memory" (memory $0))
   (export "main" (func $main))
+  (table 0 anyfunc)
+  
   (func $main (result i32)
     (local $0 i32)
     (call $exit

--- a/test/dot_s/export_malloc_free.wast
+++ b/test/dot_s/export_malloc_free.wast
@@ -5,6 +5,8 @@
   (export "malloc" (func $malloc))
   (export "free" (func $free))
   (export "realloc" (func $realloc))
+  (table 0 anyfunc)
+  
   (func $main (result i32)
     (i32.const 0)
   )

--- a/test/dot_s/function-data-sections.wast
+++ b/test/dot_s/function-data-sections.wast
@@ -7,6 +7,8 @@
   (export "foo" (func $foo))
   (export "bar" (func $bar))
   (export "qux" (func $qux))
+  (table 0 anyfunc)
+  
   (func $foo
     (return)
   )

--- a/test/dot_s/hostFinalize.wast
+++ b/test/dot_s/hostFinalize.wast
@@ -1,6 +1,8 @@
 (module
   (memory $0 1)
   (export "memory" (memory $0))
+  (table 0 anyfunc)
+  
   (func $_main
     (drop
       (grow_memory

--- a/test/dot_s/initializers.wast
+++ b/test/dot_s/initializers.wast
@@ -4,6 +4,8 @@
   (export "main" (func $main))
   (export "f1" (func $f1))
   (export "f2" (func $f2))
+  (table 0 anyfunc)
+  
   (func $main (result i32)
     (return
       (i32.const 5)

--- a/test/dot_s/lcomm-in-text-segment.wast
+++ b/test/dot_s/lcomm-in-text-segment.wast
@@ -2,5 +2,7 @@
   (memory $0 1)
   (data (i32.const 20) "\10\00\00\00")
   (export "memory" (memory $0))
+  (table 0 anyfunc)
+  
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 24, "initializers": [] }

--- a/test/dot_s/local_align.wast
+++ b/test/dot_s/local_align.wast
@@ -2,6 +2,8 @@
   (memory $0 1)
   (export "memory" (memory $0))
   (export "main" (func $main))
+  (table 0 anyfunc)
+  
   (func $foo (param $0 i32)
   )
   (func $main (result i32)

--- a/test/dot_s/macClangMetaData.wast
+++ b/test/dot_s/macClangMetaData.wast
@@ -5,6 +5,8 @@
   (import "env" "puts" (func $puts (param i32) (result i32)))
   (export "memory" (memory $0))
   (export "main" (func $main))
+  (table 0 anyfunc)
+  
   (func $main (param $0 i32) (param $1 i32) (result i32)
     (drop
       (call $puts

--- a/test/dot_s/memops.wast
+++ b/test/dot_s/memops.wast
@@ -5,6 +5,8 @@
   (import "env" "emscripten_asm_const_vi" (func $emscripten_asm_const_vi (param i32)))
   (export "memory" (memory $0))
   (export "main" (func $main))
+  (table 0 anyfunc)
+  
   (func $_Z6reporti (param $0 i32)
     (i32.store
       (i32.const 8)

--- a/test/dot_s/minimal.wast
+++ b/test/dot_s/minimal.wast
@@ -2,6 +2,8 @@
   (memory $0 1)
   (export "memory" (memory $0))
   (export "main" (func $main))
+  (table 0 anyfunc)
+  
   (func $main (result i32)
     (return
       (i32.const 5)

--- a/test/dot_s/permute.wast
+++ b/test/dot_s/permute.wast
@@ -2,5 +2,7 @@
   (memory $0 1)
   (data (i32.const 16) "hE?\8ds\0e7\db[g\8f\955it\c4k\0b\e2\ef\bcld\e0\fd\8c\9e\86&~\d8\94\89+\c8\a4\c2\f2\fb\12\1cej\d99\b7\b3W\c6w\af\ae\caM>\92ub\96\84\b6\b0N\ec;q\11\f7\bf\e31\e6\a7\90\fc\03\e4\aa\d7\cc- \15\83DH\80r\fa\01X\eb:_\00A\cd\e9o`n\ac(\ad\ba0\dcyS#\f4$\"\82\7f}\8e\f6\93L\'\bb\bdZ\ed4\18\f3\c0\cf\ff\a3\f8\07\05\9c\d3\0f\a0\06m%\\\f9^B<\e7\b1\17\98]\0c\dd\c5\f5p\e5\fezJ\ab,F\a5@\08R\85!\b8\1a\ce\d5\04\nI\a6\d1\9f\8a\c9\a9|\97\9aG\be8Y\8b\c1\1b\d4\ea\b9\19\14\9b\9163\d0\1d\d2\df=C\1f\0dc\e1\c7QUv\02\b5aK\b4\tV\c3x\e8\a1\1e\81\de/{\da\d6Pf\10T\f0)\88\16\ee\a8\9d\f1\cbO*\b2\99\132\87.\a2")
   (export "memory" (memory $0))
+  (table 0 anyfunc)
+  
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 272, "initializers": [] }

--- a/test/dot_s/relocation.wast
+++ b/test/dot_s/relocation.wast
@@ -4,6 +4,8 @@
   (data (i32.const 16) "\0c\00\00\00")
   (export "memory" (memory $0))
   (export "main" (func $main))
+  (table 0 anyfunc)
+  
   (func $main (result i32)
     (local $0 i32)
     (return

--- a/test/dot_s/return.wast
+++ b/test/dot_s/return.wast
@@ -3,6 +3,8 @@
   (export "memory" (memory $0))
   (export "return_i32" (func $return_i32))
   (export "return_void" (func $return_void))
+  (table 0 anyfunc)
+  
   (func $return_i32 (result i32)
     (i32.const 5)
   )

--- a/test/dot_s/start_main0.wast
+++ b/test/dot_s/start_main0.wast
@@ -4,6 +4,8 @@
   (export "memory" (memory $0))
   (export "main" (func $main))
   (export "_start" (func $_start))
+  (table 0 anyfunc)
+  
   (func $main
   )
   (func $_start

--- a/test/dot_s/start_main2.wast
+++ b/test/dot_s/start_main2.wast
@@ -4,6 +4,8 @@
   (export "memory" (memory $0))
   (export "main" (func $main))
   (export "_start" (func $_start))
+  (table 0 anyfunc)
+  
   (func $main (param $0 i32) (param $1 i32) (result i32)
     (return
       (get_local $0)

--- a/test/dot_s/symbolic-offset.wast
+++ b/test/dot_s/symbolic-offset.wast
@@ -3,6 +3,8 @@
   (data (i32.const 12) "\01\00\00\00\00\00\00\00\00\00\00\00")
   (export "memory" (memory $0))
   (export "f" (func $f))
+  (table 0 anyfunc)
+  
   (func $f (param $0 i32) (param $1 i32)
     (i32.store offset=16
       (get_local $0)

--- a/test/dot_s/text_before_type.wast
+++ b/test/dot_s/text_before_type.wast
@@ -2,6 +2,8 @@
   (memory $0 1)
   (export "memory" (memory $0))
   (export "main" (func $main))
+  (table 0 anyfunc)
+  
   (func $main (result i32)
     (call $foo)
     (i32.const 0)

--- a/test/dot_s/visibilities.wast
+++ b/test/dot_s/visibilities.wast
@@ -4,6 +4,8 @@
   (export "foo" (func $foo))
   (export "bar" (func $bar))
   (export "qux" (func $qux))
+  (table 0 anyfunc)
+  
   (func $foo
     (return)
   )

--- a/test/llvm_autogenerated/byval.wast
+++ b/test/llvm_autogenerated/byval.wast
@@ -19,6 +19,8 @@
   (export "byval_empty_caller" (func $byval_empty_caller))
   (export "byval_empty_callee" (func $byval_empty_callee))
   (export "big_byval" (func $big_byval))
+  (table 0 anyfunc)
+  
   (func $byval_arg (param $0 i32)
     (local $1 i32)
     (i32.store offset=4

--- a/test/llvm_autogenerated/cfg-stackify.wast
+++ b/test/llvm_autogenerated/cfg-stackify.wast
@@ -34,6 +34,8 @@
   (export "test13" (func $test13))
   (export "test14" (func $test14))
   (export "test15" (func $test15))
+  (table 0 anyfunc)
+  
   (func $test0 (param $0 i32)
     (local $1 i32)
     (set_local $1

--- a/test/llvm_autogenerated/comparisons_f32.wast
+++ b/test/llvm_autogenerated/comparisons_f32.wast
@@ -16,6 +16,8 @@
   (export "ule_f32" (func $ule_f32))
   (export "ugt_f32" (func $ugt_f32))
   (export "uge_f32" (func $uge_f32))
+  (table 0 anyfunc)
+  
   (func $ord_f32 (param $0 f32) (param $1 f32) (result i32)
     (return
       (i32.and

--- a/test/llvm_autogenerated/comparisons_f64.wast
+++ b/test/llvm_autogenerated/comparisons_f64.wast
@@ -16,6 +16,8 @@
   (export "ule_f64" (func $ule_f64))
   (export "ugt_f64" (func $ugt_f64))
   (export "uge_f64" (func $uge_f64))
+  (table 0 anyfunc)
+  
   (func $ord_f64 (param $0 f64) (param $1 f64) (result i32)
     (return
       (i32.and

--- a/test/llvm_autogenerated/comparisons_i32.wast
+++ b/test/llvm_autogenerated/comparisons_i32.wast
@@ -12,6 +12,8 @@
   (export "sge_i32" (func $sge_i32))
   (export "ugt_i32" (func $ugt_i32))
   (export "uge_i32" (func $uge_i32))
+  (table 0 anyfunc)
+  
   (func $eq_i32 (param $0 i32) (param $1 i32) (result i32)
     (return
       (i32.eq

--- a/test/llvm_autogenerated/comparisons_i64.wast
+++ b/test/llvm_autogenerated/comparisons_i64.wast
@@ -12,6 +12,8 @@
   (export "sge_i64" (func $sge_i64))
   (export "ugt_i64" (func $ugt_i64))
   (export "uge_i64" (func $uge_i64))
+  (table 0 anyfunc)
+  
   (func $eq_i64 (param $0 i64) (param $1 i64) (result i32)
     (return
       (i64.eq

--- a/test/llvm_autogenerated/conv.wast
+++ b/test/llvm_autogenerated/conv.wast
@@ -28,6 +28,8 @@
   (export "bitcast_float_to_i32" (func $bitcast_float_to_i32))
   (export "bitcast_i64_to_double" (func $bitcast_i64_to_double))
   (export "bitcast_double_to_i64" (func $bitcast_double_to_i64))
+  (table 0 anyfunc)
+  
   (func $i32_wrap_i64 (param $0 i64) (result i32)
     (return
       (i32.wrap/i64

--- a/test/llvm_autogenerated/copysign-casts.wast
+++ b/test/llvm_autogenerated/copysign-casts.wast
@@ -4,6 +4,8 @@
   (export "memory" (memory $0))
   (export "fold_promote" (func $fold_promote))
   (export "fold_demote" (func $fold_demote))
+  (table 0 anyfunc)
+  
   (func $fold_promote (param $0 f64) (param $1 f32) (result f64)
     (f64.copysign
       (get_local $0)

--- a/test/llvm_autogenerated/cpus.wast
+++ b/test/llvm_autogenerated/cpus.wast
@@ -3,6 +3,8 @@
   (data (i32.const 4) "\10\04\00\00")
   (export "memory" (memory $0))
   (export "f" (func $f))
+  (table 0 anyfunc)
+  
   (func $f (param $0 i32) (result i32)
     (get_local $0)
   )

--- a/test/llvm_autogenerated/dead-vreg.wast
+++ b/test/llvm_autogenerated/dead-vreg.wast
@@ -3,6 +3,8 @@
   (data (i32.const 4) "\10\04\00\00")
   (export "memory" (memory $0))
   (export "foo" (func $foo))
+  (table 0 anyfunc)
+  
   (func $foo (param $0 i32) (param $1 i32) (param $2 i32)
     (local $3 i32)
     (local $4 i32)

--- a/test/llvm_autogenerated/divrem-constant.wast
+++ b/test/llvm_autogenerated/divrem-constant.wast
@@ -10,6 +10,8 @@
   (export "test_urem_5" (func $test_urem_5))
   (export "test_srem_2" (func $test_srem_2))
   (export "test_srem_5" (func $test_srem_5))
+  (table 0 anyfunc)
+  
   (func $test_udiv_2 (param $0 i32) (result i32)
     (i32.shr_u
       (get_local $0)

--- a/test/llvm_autogenerated/f32.wast
+++ b/test/llvm_autogenerated/f32.wast
@@ -20,6 +20,8 @@
   (export "fmin32" (func $fmin32))
   (export "fmax32" (func $fmax32))
   (export "fma32" (func $fma32))
+  (table 0 anyfunc)
+  
   (func $fadd32 (param $0 f32) (param $1 f32) (result f32)
     (return
       (f32.add

--- a/test/llvm_autogenerated/f64.wast
+++ b/test/llvm_autogenerated/f64.wast
@@ -20,6 +20,8 @@
   (export "fmin64" (func $fmin64))
   (export "fmax64" (func $fmax64))
   (export "fma64" (func $fma64))
+  (table 0 anyfunc)
+  
   (func $fadd64 (param $0 f64) (param $1 f64) (result f64)
     (return
       (f64.add

--- a/test/llvm_autogenerated/fast-isel.wast
+++ b/test/llvm_autogenerated/fast-isel.wast
@@ -8,6 +8,8 @@
   (export "bitcast_f32_i32" (func $bitcast_f32_i32))
   (export "bitcast_i64_f64" (func $bitcast_i64_f64))
   (export "bitcast_f64_i64" (func $bitcast_f64_i64))
+  (table 0 anyfunc)
+  
   (func $immediate_f32 (result f32)
     (f32.const 2.5)
   )

--- a/test/llvm_autogenerated/frem.wast
+++ b/test/llvm_autogenerated/frem.wast
@@ -8,6 +8,8 @@
   (export "memory" (memory $0))
   (export "frem32" (func $frem32))
   (export "frem64" (func $frem64))
+  (table 0 anyfunc)
+  
   (func $frem32 (param $0 f32) (param $1 f32) (result f32)
     (return
       (call $fmodf

--- a/test/llvm_autogenerated/func.wast
+++ b/test/llvm_autogenerated/func.wast
@@ -8,6 +8,8 @@
   (export "f3" (func $f3))
   (export "f4" (func $f4))
   (export "f5" (func $f5))
+  (table 0 anyfunc)
+  
   (func $f0
     (return)
   )

--- a/test/llvm_autogenerated/global.wast
+++ b/test/llvm_autogenerated/global.wast
@@ -18,6 +18,8 @@
   (export "memory" (memory $0))
   (export "foo" (func $foo))
   (export "call_memcpy" (func $call_memcpy))
+  (table 0 anyfunc)
+  
   (func $foo (result i32)
     (return
       (i32.load offset=32

--- a/test/llvm_autogenerated/globl.wast
+++ b/test/llvm_autogenerated/globl.wast
@@ -3,6 +3,8 @@
   (data (i32.const 4) "\10\04\00\00")
   (export "memory" (memory $0))
   (export "foo" (func $foo))
+  (table 0 anyfunc)
+  
   (func $foo
   )
 )

--- a/test/llvm_autogenerated/i128.wast
+++ b/test/llvm_autogenerated/i128.wast
@@ -35,6 +35,8 @@
   (export "masked_rotl" (func $masked_rotl))
   (export "rotr" (func $rotr))
   (export "masked_rotr" (func $masked_rotr))
+  (table 0 anyfunc)
+  
   (func $add128 (param $0 i32) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64)
     (local $5 i64)
     (i64.store

--- a/test/llvm_autogenerated/i32-load-store-alignment.wast
+++ b/test/llvm_autogenerated/i32-load-store-alignment.wast
@@ -22,6 +22,8 @@
   (export "sti16_a1" (func $sti16_a1))
   (export "sti16_a2" (func $sti16_a2))
   (export "sti16_a4" (func $sti16_a4))
+  (table 0 anyfunc)
+  
   (func $ldi32_a1 (param $0 i32) (result i32)
     (return
       (i32.load align=1

--- a/test/llvm_autogenerated/i32.wast
+++ b/test/llvm_autogenerated/i32.wast
@@ -25,6 +25,8 @@
   (export "masked_rotl" (func $masked_rotl))
   (export "rotr" (func $rotr))
   (export "masked_rotr" (func $masked_rotr))
+  (table 0 anyfunc)
+  
   (func $add32 (param $0 i32) (param $1 i32) (result i32)
     (return
       (i32.add

--- a/test/llvm_autogenerated/i64-load-store-alignment.wast
+++ b/test/llvm_autogenerated/i64-load-store-alignment.wast
@@ -32,6 +32,8 @@
   (export "sti32_a2" (func $sti32_a2))
   (export "sti32_a4" (func $sti32_a4))
   (export "sti32_a8" (func $sti32_a8))
+  (table 0 anyfunc)
+  
   (func $ldi64_a1 (param $0 i32) (result i64)
     (return
       (i64.load align=1

--- a/test/llvm_autogenerated/i64.wast
+++ b/test/llvm_autogenerated/i64.wast
@@ -25,6 +25,8 @@
   (export "masked_rotl" (func $masked_rotl))
   (export "rotr" (func $rotr))
   (export "masked_rotr" (func $masked_rotr))
+  (table 0 anyfunc)
+  
   (func $add64 (param $0 i64) (param $1 i64) (result i64)
     (return
       (i64.add

--- a/test/llvm_autogenerated/ident.wast
+++ b/test/llvm_autogenerated/ident.wast
@@ -2,5 +2,7 @@
   (memory $0 1)
   (data (i32.const 4) "\10\04\00\00")
   (export "memory" (memory $0))
+  (table 0 anyfunc)
+  
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/immediates.wast
+++ b/test/llvm_autogenerated/immediates.wast
@@ -30,6 +30,8 @@
   (export "neginf_f64" (func $neginf_f64))
   (export "custom_nan_f64" (func $custom_nan_f64))
   (export "custom_nans_f64" (func $custom_nans_f64))
+  (table 0 anyfunc)
+  
   (func $zero_i32 (result i32)
     (return
       (i32.const 0)

--- a/test/llvm_autogenerated/irreducible-cfg.wast
+++ b/test/llvm_autogenerated/irreducible-cfg.wast
@@ -4,6 +4,8 @@
   (export "memory" (memory $0))
   (export "test0" (func $test0))
   (export "test1" (func $test1))
+  (table 0 anyfunc)
+  
   (func $test0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
     (local $4 f64)
     (local $5 i32)

--- a/test/llvm_autogenerated/legalize.wast
+++ b/test/llvm_autogenerated/legalize.wast
@@ -11,6 +11,8 @@
   (export "fpext_f32_f64" (func $fpext_f32_f64))
   (export "fpconv_f64_f32" (func $fpconv_f64_f32))
   (export "bigshift" (func $bigshift))
+  (table 0 anyfunc)
+  
   (func $shl_i3 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (return
       (i32.shl

--- a/test/llvm_autogenerated/load-ext.wast
+++ b/test/llvm_autogenerated/load-ext.wast
@@ -12,6 +12,8 @@
   (export "zext_i16_i64" (func $zext_i16_i64))
   (export "sext_i32_i64" (func $sext_i32_i64))
   (export "zext_i32_i64" (func $zext_i32_i64))
+  (table 0 anyfunc)
+  
   (func $sext_i8_i32 (param $0 i32) (result i32)
     (return
       (i32.load8_s

--- a/test/llvm_autogenerated/load-store-i1.wast
+++ b/test/llvm_autogenerated/load-store-i1.wast
@@ -8,6 +8,8 @@
   (export "load_s_i1_i64" (func $load_s_i1_i64))
   (export "store_i32_i1" (func $store_i32_i1))
   (export "store_i64_i1" (func $store_i64_i1))
+  (table 0 anyfunc)
+  
   (func $load_u_i1_i32 (param $0 i32) (result i32)
     (return
       (i32.load8_u

--- a/test/llvm_autogenerated/load.wast
+++ b/test/llvm_autogenerated/load.wast
@@ -6,6 +6,8 @@
   (export "ldi64" (func $ldi64))
   (export "ldf32" (func $ldf32))
   (export "ldf64" (func $ldf64))
+  (table 0 anyfunc)
+  
   (func $ldi32 (param $0 i32) (result i32)
     (return
       (i32.load

--- a/test/llvm_autogenerated/mem-intrinsics.wast
+++ b/test/llvm_autogenerated/mem-intrinsics.wast
@@ -19,6 +19,8 @@
   (export "frame_index" (func $frame_index))
   (export "drop_result" (func $drop_result))
   (export "tail_dup_to_reuse_result" (func $tail_dup_to_reuse_result))
+  (table 0 anyfunc)
+  
   (func $copy_yes (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (return
       (call $memcpy

--- a/test/llvm_autogenerated/memory-addr32.wast
+++ b/test/llvm_autogenerated/memory-addr32.wast
@@ -4,6 +4,8 @@
   (export "memory" (memory $0))
   (export "current_memory" (func $current_memory))
   (export "grow_memory" (func $grow_memory))
+  (table 0 anyfunc)
+  
   (func $current_memory (result i32)
     (return
       (current_memory)

--- a/test/llvm_autogenerated/non-executable-stack.wast
+++ b/test/llvm_autogenerated/non-executable-stack.wast
@@ -2,5 +2,7 @@
   (memory $0 1)
   (data (i32.const 4) "\10\04\00\00")
   (export "memory" (memory $0))
+  (table 0 anyfunc)
+  
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 1040, "initializers": [] }

--- a/test/llvm_autogenerated/offset.wast
+++ b/test/llvm_autogenerated/offset.wast
@@ -38,6 +38,8 @@
   (export "aggregate_load_store" (func $aggregate_load_store))
   (export "aggregate_return" (func $aggregate_return))
   (export "aggregate_return_without_merge" (func $aggregate_return_without_merge))
+  (table 0 anyfunc)
+  
   (func $load_i32_with_folded_offset (param $0 i32) (result i32)
     (i32.load offset=24
       (get_local $0)

--- a/test/llvm_autogenerated/phi.wast
+++ b/test/llvm_autogenerated/phi.wast
@@ -4,6 +4,8 @@
   (export "memory" (memory $0))
   (export "test0" (func $test0))
   (export "test1" (func $test1))
+  (table 0 anyfunc)
+  
   (func $test0 (param $0 i32) (result i32)
     (block $label$0
       (br_if $label$0

--- a/test/llvm_autogenerated/reg-stackify.wast
+++ b/test/llvm_autogenerated/reg-stackify.wast
@@ -45,6 +45,8 @@
   (export "no_stackify_past_epilogue" (func $no_stackify_past_epilogue))
   (export "stackify_indvar" (func $stackify_indvar))
   (export "stackpointer_dependency" (func $stackpointer_dependency))
+  (table 0 anyfunc)
+  
   (func $no0 (param $0 i32) (param $1 i32) (result i32)
     (set_local $1
       (i32.load

--- a/test/llvm_autogenerated/return-int32.wast
+++ b/test/llvm_autogenerated/return-int32.wast
@@ -4,6 +4,8 @@
   (export "memory" (memory $0))
   (export "return_i32" (func $return_i32))
   (export "return_i32_twice" (func $return_i32_twice))
+  (table 0 anyfunc)
+  
   (func $return_i32 (param $0 i32) (result i32)
     (get_local $0)
   )

--- a/test/llvm_autogenerated/return-void.wast
+++ b/test/llvm_autogenerated/return-void.wast
@@ -4,6 +4,8 @@
   (export "memory" (memory $0))
   (export "return_void" (func $return_void))
   (export "return_void_twice" (func $return_void_twice))
+  (table 0 anyfunc)
+  
   (func $return_void
   )
   (func $return_void_twice (param $0 i32)

--- a/test/llvm_autogenerated/select.wast
+++ b/test/llvm_autogenerated/select.wast
@@ -14,6 +14,8 @@
   (export "select_f64_bool" (func $select_f64_bool))
   (export "select_f64_eq" (func $select_f64_eq))
   (export "select_f64_ne" (func $select_f64_ne))
+  (table 0 anyfunc)
+  
   (func $select_i32_bool (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (return
       (select

--- a/test/llvm_autogenerated/signext-zeroext.wast
+++ b/test/llvm_autogenerated/signext-zeroext.wast
@@ -6,6 +6,8 @@
   (export "s2z_func" (func $s2z_func))
   (export "z2s_call" (func $z2s_call))
   (export "s2z_call" (func $s2z_call))
+  (table 0 anyfunc)
+  
   (func $z2s_func (param $0 i32) (result i32)
     (return
       (i32.shr_s

--- a/test/llvm_autogenerated/store-trunc.wast
+++ b/test/llvm_autogenerated/store-trunc.wast
@@ -7,6 +7,8 @@
   (export "trunc_i8_i64" (func $trunc_i8_i64))
   (export "trunc_i16_i64" (func $trunc_i16_i64))
   (export "trunc_i32_i64" (func $trunc_i32_i64))
+  (table 0 anyfunc)
+  
   (func $trunc_i8_i32 (param $0 i32) (param $1 i32)
     (i32.store8
       (get_local $0)

--- a/test/llvm_autogenerated/store.wast
+++ b/test/llvm_autogenerated/store.wast
@@ -6,6 +6,8 @@
   (export "sti64" (func $sti64))
   (export "stf32" (func $stf32))
   (export "stf64" (func $stf64))
+  (table 0 anyfunc)
+  
   (func $sti32 (param $0 i32) (param $1 i32)
     (i32.store
       (get_local $0)

--- a/test/llvm_autogenerated/switch.wast
+++ b/test/llvm_autogenerated/switch.wast
@@ -11,6 +11,8 @@
   (export "memory" (memory $0))
   (export "bar32" (func $bar32))
   (export "bar64" (func $bar64))
+  (table 0 anyfunc)
+  
   (func $bar32 (param $0 i32)
     (block $label$0
       (br_if $label$0

--- a/test/llvm_autogenerated/unreachable.wast
+++ b/test/llvm_autogenerated/unreachable.wast
@@ -7,6 +7,8 @@
   (export "f1" (func $f1))
   (export "f2" (func $f2))
   (export "f3" (func $f3))
+  (table 0 anyfunc)
+  
   (func $f1 (result i32)
     (call $abort)
     (unreachable)

--- a/test/llvm_autogenerated/unused-argument.wast
+++ b/test/llvm_autogenerated/unused-argument.wast
@@ -7,6 +7,8 @@
   (export "unused_first" (func $unused_first))
   (export "unused_second" (func $unused_second))
   (export "call_something" (func $call_something))
+  (table 0 anyfunc)
+  
   (func $unused_first (param $0 i32) (param $1 i32) (result i32)
     (return
       (get_local $1)

--- a/test/llvm_autogenerated/userstack.wast
+++ b/test/llvm_autogenerated/userstack.wast
@@ -18,6 +18,8 @@
   (export "frameaddress_0" (func $frameaddress_0))
   (export "frameaddress_1" (func $frameaddress_1))
   (export "inline_asm" (func $inline_asm))
+  (table 0 anyfunc)
+  
   (func $alloca32
     (local $0 i32)
     (i32.store offset=4

--- a/test/llvm_autogenerated/varargs.wast
+++ b/test/llvm_autogenerated/varargs.wast
@@ -14,6 +14,8 @@
   (export "caller_none" (func $caller_none))
   (export "caller_some" (func $caller_some))
   (export "startbb" (func $startbb))
+  (table 0 anyfunc)
+  
   (func $start (param $0 i32) (param $1 i32)
     (i32.store
       (get_local $0)

--- a/test/s2wasm_known_binaryen_shell_test_failures.txt
+++ b/test/s2wasm_known_binaryen_shell_test_failures.txt
@@ -151,6 +151,4 @@ vprintf-chk-1.c.s.wast # vprintf
 vprintf-1.c.s.wast # vprintf
 
 # new in 0xc
-20021118-2.c.s.wast # [parse exception: no table]
-921208-1.c.s.wast # [parse exception: no table]
 930126-1.c.s.wast # called abort()

--- a/test/s2wasm_known_binaryen_shell_test_failures.txt
+++ b/test/s2wasm_known_binaryen_shell_test_failures.txt
@@ -28,7 +28,6 @@ multi-ix.c.s.wast
 pr37573.c.s.wast
 pr43236.c.s.wast
 pr44852.c.s.wast
-pr44942.c.s.wast
 pr51877.c.s.wast
 pr51933.c.s.wast
 pr54471.c.s.wast
@@ -56,6 +55,7 @@ complex-7.c.s.wast
 920612-1.c.s.wast
 920625-1.c.s.wast
 920711-1.c.s.wast
+930126-1.c.s.wast
 931004-10.c.s.wast
 931004-12.c.s.wast
 931004-14.c.s.wast


### PR DESCRIPTION
Previously it was only created if there were any address-taken
functions. However new module validation rules require the existence of
a table for any call-indirects to validate (even if they are dead and
never called). However this use case seems common enough that we might
want to make it continue to work. So create the dummy-nullptr function
if there are any call_indirect instructions even if there are no
address-taken functions. (They will trap at runtime if called, as before).