### PR TITLE
Refactor Import::Kind and Export::Kind into a Kind enum class

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -619,7 +619,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
       // we need imported globals to be mutable, but wasm doesn't support that yet, so we must
       // import an immutable and create a mutable global initialized to its value
       import->name = Name(std::string(import->name.str) + "$asm2wasm$import");
-      import->kind = Import::Global;
+      import->kind = ExternalKind::Global;
       import->globalType = type;
       mappedGlobals.emplace(name, type);
       {
@@ -631,7 +631,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
         wasm.addGlobal(global);
       }
     } else {
-      import->kind = Import::Function;
+      import->kind = ExternalKind::Function;
     }
     wasm.addImport(import);
   };
@@ -826,7 +826,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
           auto* export_ = new Export;
           export_->name = key;
           export_->value = value;
-          export_->kind = Export::Function;
+          export_->kind = ExternalKind::Function;
           wasm.addExport(export_);
           exported[key] = export_;
         }
@@ -850,7 +850,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
   std::vector<IString> toErase;
 
   for (auto& import : wasm.imports) {
-    if (import->kind != Import::Function) continue;
+    if (import->kind != ExternalKind::Function) continue;
     IString name = import->name;
     if (importedFunctionTypes.find(name) != importedFunctionTypes.end()) {
       // special math builtins
@@ -977,7 +977,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
   auto memoryExport = make_unique<Export>();
   memoryExport->name = MEMORY;
   memoryExport->value = Name::fromInt(0);
-  memoryExport->kind = Export::Memory;
+  memoryExport->kind = ExternalKind::Memory;
   wasm.addExport(memoryExport.release());
 #else
   // import memory
@@ -985,7 +985,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
   memoryImport->name = MEMORY;
   memoryImport->module = ENV;
   memoryImport->base = MEMORY;
-  memoryImport->kind = Import::Memory;
+  memoryImport->kind = ExternalKind::Memory;
   wasm.addImport(memoryImport.release());
 
   // import table
@@ -993,7 +993,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
   tableImport->name = TABLE;
   tableImport->module = ENV;
   tableImport->base = TABLE;
-  tableImport->kind = Import::Table;
+  tableImport->kind = ExternalKind::Table;
   wasm.addImport(tableImport.release());
 
   // Import memory offset
@@ -1002,7 +1002,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
     import->name = Name("memoryBase");
     import->module = Name("env");
     import->base = Name("memoryBase");
-    import->kind = Import::Global;
+    import->kind = ExternalKind::Global;
     import->globalType = i32;
     wasm.addImport(import);
   }
@@ -1013,7 +1013,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
     import->name = Name("tableBase");
     import->module = Name("env");
     import->base = Name("tableBase");
-    import->kind = Import::Global;
+    import->kind = ExternalKind::Global;
     import->globalType = i32;
     wasm.addImport(import);
   }
@@ -1236,7 +1236,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
           import->module = ASM2WASM;
           import->base = F64_REM;
           import->functionType = ensureFunctionType("ddd", &wasm);
-          import->kind = Import::Function;
+          import->kind = ExternalKind::Function;
           wasm.addImport(import);
         }
         return call;
@@ -1262,7 +1262,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
           import->module = ASM2WASM;
           import->base = call->target;
           import->functionType = ensureFunctionType("iii", &wasm);
-          import->kind = Import::Function;
+          import->kind = ExternalKind::Function;
           wasm.addImport(import);
         }
         return call;
@@ -1301,7 +1301,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
           import->module = ASM2WASM;
           import->base = DEBUGGER;
           import->functionType = ensureFunctionType("v", &wasm);
-          import->kind = Import::Function;
+          import->kind = ExternalKind::Function;
           wasm.addImport(import);
         }
         return call;
@@ -1407,7 +1407,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
               import->module = ASM2WASM;
               import->base = F64_TO_INT;
               import->functionType = ensureFunctionType("id", &wasm);
-              import->kind = Import::Function;
+              import->kind = ExternalKind::Function;
               wasm.addImport(import);
             }
             return ret;

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -719,7 +719,7 @@ BinaryenImportRef BinaryenAddImport(BinaryenModuleRef module, const char* intern
   ret->module = externalModuleName;
   ret->base = externalBaseName;
   ret->functionType = (FunctionType*)type;
-  ret->kind = Import::Function;
+  ret->kind = ExternalKind::Function;
   wasm->addImport(ret);
   return ret;
 }
@@ -811,7 +811,7 @@ void BinaryenSetMemory(BinaryenModuleRef module, BinaryenIndex initial, Binaryen
     auto memoryExport = make_unique<Export>();
     memoryExport->name = exportName;
     memoryExport->value = Name::fromInt(0);
-    memoryExport->kind = Export::Memory;
+    memoryExport->kind = ExternalKind::Memory;
     wasm->addExport(memoryExport.release());
   }
   for (BinaryenIndex i = 0; i < numSegments; i++) {

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -36,7 +36,7 @@ struct LegalizeJSInterface : public Pass {
   void run(PassRunner* runner, Module* module) override {
     // for each illegal export, we must export a legalized stub instead
     for (auto& ex : module->exports) {
-      if (ex->kind == Export::Function) {
+      if (ex->kind == ExternalKind::Function) {
         // if it's an import, ignore it
         if (auto* func = module->checkFunction(ex->value)) {
           if (isIllegal(func)) {
@@ -49,7 +49,7 @@ struct LegalizeJSInterface : public Pass {
     // for each illegal import, we must call a legalized stub instead
     std::vector<Import*> newImports; // add them at the end, to not invalidate the iter
     for (auto& im : module->imports) {
-      if (im->kind == Import::Function && isIllegal(im->functionType)) {
+      if (im->kind == ExternalKind::Function && isIllegal(im->functionType)) {
         Name funcName;
         auto* legal = makeLegalStub(im.get(), module, funcName);
         illegalToLegal[im->name] = funcName;
@@ -158,7 +158,7 @@ private:
     legal->name = Name(std::string("legalimport$") + im->name.str);
     legal->module = im->module;
     legal->base = im->base;
-    legal->kind = Import::Function;
+    legal->kind = ExternalKind::Function;
     legal->functionType = type;
     auto* func = new Function();
     func->name = Name(std::string("legalfunc$") + im->name.str);

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -545,10 +545,10 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     printText(o, curr->module.str) << ' ';
     printText(o, curr->base.str) << ' ';
     switch (curr->kind) {
-      case Export::Function: if (curr->functionType) visitFunctionType(curr->functionType, &curr->name); break;
-      case Export::Table:    printTableHeader(&currModule->table); break;
-      case Export::Memory:   printMemoryHeader(&currModule->memory); break;
-      case Export::Global:   o << "(global " << curr->name << ' ' << printWasmType(curr->globalType) << ")"; break;
+      case ExternalKind::Function: if (curr->functionType) visitFunctionType(curr->functionType, &curr->name); break;
+      case ExternalKind::Table:    printTableHeader(&currModule->table); break;
+      case ExternalKind::Memory:   printMemoryHeader(&currModule->memory); break;
+      case ExternalKind::Global:   o << "(global " << curr->name << ' ' << printWasmType(curr->globalType) << ")"; break;
       default: WASM_UNREACHABLE();
     }
     o << ')';
@@ -557,10 +557,10 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     printOpening(o, "export ");
     printText(o, curr->name.str) << " (";
     switch (curr->kind) {
-      case Export::Function: o << "func"; break;
-      case Export::Table:    o << "table"; break;
-      case Export::Memory:   o << "memory"; break;
-      case Export::Global:   o << "global"; break;
+      case ExternalKind::Function: o << "func"; break;
+      case ExternalKind::Table:    o << "table"; break;
+      case ExternalKind::Memory:   o << "memory"; break;
+      case ExternalKind::Global:   o << "global"; break;
       default: WASM_UNREACHABLE();
     }
     o << ' ';
@@ -622,7 +622,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     // if table wasn't imported, declare it
     bool found = false;
     for (auto& import : currModule->imports) {
-      if (import->kind == Import::Table) {
+      if (import->kind == ExternalKind::Table) {
         found = true;
         break;
       }
@@ -656,7 +656,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     // if memory wasn't imported, declare it
     bool found = false;
     for (auto& import : currModule->imports) {
-      if (import->kind == Import::Memory) {
+      if (import->kind == ExternalKind::Memory) {
         found = true;
         break;
       }

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -114,7 +114,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
   void importGlobals(std::map<Name, Literal>& globals, Module& wasm) override {
     // add spectest globals
     for (auto& import : wasm.imports) {
-      if (import->kind == Import::Global && import->module == SPECTEST && import->base == GLOBAL) {
+      if (import->kind == ExternalKind::Global && import->module == SPECTEST && import->base == GLOBAL) {
         switch (import->globalType) {
           case i32: globals[import->name] = Literal(int32_t(666)); break;
           case i64: globals[import->name] = Literal(int64_t(666)); break;
@@ -122,7 +122,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
           case f64: globals[import->name] = Literal(double(666.6)); break;
           default: WASM_UNREACHABLE();
         }
-      } else if (import->kind == Import::Memory && import->module == SPECTEST && import->base == MEMORY) {
+      } else if (import->kind == ExternalKind::Memory && import->module == SPECTEST && import->base == MEMORY) {
         // imported memory has initial 1 and max 2
         wasm.memory.initial = 1;
         wasm.memory.max = 2;

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -160,8 +160,8 @@ static void run_asserts(Name moduleName, size_t* i, bool* checked, Module* wasm,
         // validate "instantiating" the mdoule
         for (auto& import : wasm.imports) {
           if (import->module == SPECTEST && import->base == PRINT) {
-            if (import->kind != Import::Function) {
-              std::cerr << "spectest.print should be a function, but is " << import->kind << '\n';
+            if (import->kind != ExternalKind::Function) {
+              std::cerr << "spectest.print should be a function, but is " << int32_t(import->kind) << '\n';
               invalid = true;
               break;
             }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -633,20 +633,20 @@ public:
       if (debug) std::cerr << "write one" << std::endl;
       writeInlineString(import->module.str);
       writeInlineString(import->base.str);
-      o << U32LEB(import->kind);
+      o << U32LEB(int32_t(import->kind));
       switch (import->kind) {
-        case Export::Function: o << U32LEB(getFunctionTypeIndex(import->functionType->name)); break;
-        case Export::Table: {
+        case ExternalKind::Function: o << U32LEB(getFunctionTypeIndex(import->functionType->name)); break;
+        case ExternalKind::Table: {
           o << U32LEB(BinaryConsts::ElementType::AnyFunc);
           auto max = wasm->table.max == Table::kMaxSize ? Address(0) : wasm->table.max;
           writeResizableLimits(wasm->table.initial, max);
           break;
         }
-        case Export::Memory: {
+        case ExternalKind::Memory: {
           auto max = wasm->memory.max == Memory::kMaxSize ? Address(0) : wasm->memory.max;
           writeResizableLimits(wasm->memory.initial, max); break;
         }
-        case Export::Global:
+        case ExternalKind::Global:
           o << binaryWasmType(import->globalType);
           o << U32LEB(0); // Mutable global's can't be imported for now.
           break;
@@ -770,12 +770,12 @@ public:
     for (auto& curr : wasm->exports) {
       if (debug) std::cerr << "write one" << std::endl;
       writeInlineString(curr->name.str);
-      o << U32LEB(curr->kind);
+      o << U32LEB(int32_t(curr->kind));
       switch (curr->kind) {
-        case Export::Function: o << U32LEB(getFunctionIndex(curr->value)); break;
-        case Export::Table: o << U32LEB(0); break;
-        case Export::Memory: o << U32LEB(0); break;
-        case Export::Global: o << U32LEB(getGlobalIndex(curr->value)); break;
+        case ExternalKind::Function: o << U32LEB(getFunctionIndex(curr->value)); break;
+        case ExternalKind::Table: o << U32LEB(0); break;
+        case ExternalKind::Memory: o << U32LEB(0); break;
+        case ExternalKind::Global: o << U32LEB(getGlobalIndex(curr->value)); break;
         default: WASM_UNREACHABLE();
       }
 
@@ -806,7 +806,7 @@ public:
     if (!mappedFunctions.size()) {
       // Create name => index mapping.
       for (auto& import : wasm->imports) {
-        if (import->kind != Import::Function) continue;
+        if (import->kind != ExternalKind::Function) continue;
         assert(mappedFunctions.count(import->name) == 0);
         auto index = mappedFunctions.size();
         mappedFunctions[import->name] = index;
@@ -826,7 +826,7 @@ public:
     if (!mappedGlobals.size()) {
       // Create name => index mapping.
       for (auto& import : wasm->imports) {
-        if (import->kind != Import::Global) continue;
+        if (import->kind != ExternalKind::Global) continue;
         assert(mappedGlobals.count(import->name) == 0);
         auto index = mappedGlobals.size();
         mappedGlobals[import->name] = index;
@@ -1582,7 +1582,7 @@ public:
   Name getFunctionIndexName(Index i) {
     if (i < functionImportIndexes.size()) {
       auto* import = wasm.getImport(functionImportIndexes[i]);
-      assert(import->kind == Import::Function);
+      assert(import->kind == ExternalKind::Function);
       return import->name;
     } else {
       i -= functionImportIndexes.size();
@@ -1608,9 +1608,9 @@ public:
       curr->name = Name(std::string("import$") + std::to_string(i));
       curr->module = getInlineString();
       curr->base = getInlineString();
-      curr->kind = (Import::Kind)getU32LEB();
+      curr->kind = (ExternalKind)getU32LEB();
       switch (curr->kind) {
-        case Import::Function: {
+        case ExternalKind::Function: {
           auto index = getU32LEB();
           assert(index < wasm.functionTypes.size());
           curr->functionType = wasm.functionTypes[index].get();
@@ -1618,15 +1618,15 @@ public:
           functionImportIndexes.push_back(curr->name);
           break;
         }
-        case Import::Table: {
+        case ExternalKind::Table: {
           auto elementType = getU32LEB();
           WASM_UNUSED(elementType);
           assert(elementType == BinaryConsts::ElementType::AnyFunc);
           getResizableLimits(wasm.table.initial, &wasm.table.max);
           break;
         }
-        case Import::Memory: getResizableLimits(wasm.memory.initial, &wasm.memory.max); break;
-        case Import::Global: {
+        case ExternalKind::Memory: getResizableLimits(wasm.memory.initial, &wasm.memory.max); break;
+        case ExternalKind::Global: {
           curr->globalType = getWasmType();
           auto globalMutable = getU32LEB();
           WASM_UNUSED(globalMutable);
@@ -1731,7 +1731,7 @@ public:
       if (debug) std::cerr << "read one" << std::endl;
       auto curr = new Export;
       curr->name = getInlineString();
-      curr->kind = (Export::Kind)getU32LEB();
+      curr->kind = (ExternalKind)getU32LEB();
       auto index = getU32LEB();
       exportIndexes[curr] = index;
     }
@@ -1792,7 +1792,7 @@ public:
     if (!mappedGlobals.size()) {
       // Create name => index mapping.
       for (auto& import : wasm.imports) {
-        if (import->kind != Import::Global) continue;
+        if (import->kind != ExternalKind::Global) continue;
         auto index = mappedGlobals.size();
         mappedGlobals[index] = import->name;
       }
@@ -1818,13 +1818,13 @@ public:
     for (auto& iter : exportIndexes) {
       Export* curr = iter.first;
       switch (curr->kind) {
-        case Export::Function: {
+        case ExternalKind::Function: {
           curr->value = getFunctionIndexName(iter.second);
           break;
         }
-        case Export::Table: curr->value = Name::fromInt(0); break;
-        case Export::Memory: curr->value = Name::fromInt(0); break;
-        case Export::Global: curr->value = getGlobalName(iter.second); break;
+        case ExternalKind::Table: curr->value = Name::fromInt(0); break;
+        case ExternalKind::Memory: curr->value = Name::fromInt(0); break;
+        case ExternalKind::Global: curr->value = getGlobalName(iter.second); break;
         default: WASM_UNREACHABLE();
       }
       wasm.addExport(curr);
@@ -2139,7 +2139,7 @@ public:
       return;
     }
     auto* import = wasm.checkImport(curr->name);
-    if (import && import->kind == Import::Global) {
+    if (import && import->kind == ExternalKind::Global) {
       curr->type = import->globalType;
       return;
     }

--- a/src/wasm-emscripten.cpp
+++ b/src/wasm-emscripten.cpp
@@ -45,7 +45,7 @@ void generateMemoryGrowthFunction(Module& wasm) {
   wasm.addFunction(growFunction);
   auto export_ = new Export;
   export_->name = export_->value = name;
-  export_->kind = Export::Function;
+  export_->kind = ExternalKind::Function;
   wasm.addExport(export_);
 }
 
@@ -134,7 +134,7 @@ void AsmConstWalker::visitCallImport(CallImport* curr) {
       import->name = import->base = curr->target;
       import->module = ENV;
       import->functionType = ensureFunctionType(getSig(curr), &wasm);
-      import->kind = Import::Function;
+      import->kind = ExternalKind::Function;
       wasm.addImport(import);
     }
   }

--- a/src/wasm-js.cpp
+++ b/src/wasm-js.cpp
@@ -145,7 +145,7 @@ extern "C" void EMSCRIPTEN_KEEPALIVE instantiate() {
     Module['asmExports'] = {};
   });
   for (auto& curr : module->exports) {
-    if (curr->kind == Export::Function) {
+    if (curr->kind == ExternalKind::Function) {
       EM_ASM_({
         var name = Pointer_stringify($0);
         Module['asmExports'][name] = function() {
@@ -176,7 +176,7 @@ extern "C" void EMSCRIPTEN_KEEPALIVE instantiate() {
         bool found = false;
         for (auto& import : wasm.imports) {
           if (import->module == ENV && import->base == MEMORY) {
-            assert(import->kind == Import::Memory);
+            assert(import->kind == ExternalKind::Memory);
             // memory is imported
             EM_ASM({
               Module['asmExports']['memory'] = Module['lookupImport']('env', 'memory');
@@ -203,7 +203,7 @@ extern "C" void EMSCRIPTEN_KEEPALIVE instantiate() {
         bool found = false;
         for (auto& import : wasm.imports) {
           if (import->module == ENV && import->base == TABLE) {
-            assert(import->kind == Import::Table);
+            assert(import->kind == ExternalKind::Table);
             // table is imported
             EM_ASM({
               Module['outside']['wasmTable'] = Module['lookupImport']('env', 'table');
@@ -263,7 +263,7 @@ extern "C" void EMSCRIPTEN_KEEPALIVE instantiate() {
 
     void importGlobals(std::map<Name, Literal>& globals, Module& wasm) override {
       for (auto& import : wasm.imports) {
-        if (import->kind == Import::Global) {
+        if (import->kind == ExternalKind::Global) {
           double ret = EM_ASM_DOUBLE({
             var mod = Pointer_stringify($0);
             var base = Pointer_stringify($1);

--- a/src/wasm-linker.cpp
+++ b/src/wasm-linker.cpp
@@ -52,7 +52,7 @@ void Linker::ensureImport(Name target, std::string signature) {
     import->name = import->base = target;
     import->module = ENV;
     import->functionType = ensureFunctionType(signature, &out.wasm);
-    import->kind = Import::Function;
+    import->kind = ExternalKind::Function;
     out.wasm.addImport(import);
   }
 }
@@ -113,7 +113,7 @@ void Linker::layout() {
   auto memoryExport = make_unique<Export>();
   memoryExport->name = MEMORY;
   memoryExport->value = Name::fromInt(0);
-  memoryExport->kind = Export::Memory;
+  memoryExport->kind = ExternalKind::Memory;
   out.wasm.addExport(memoryExport.release());
 
   // XXX For now, export all functions marked .globl.

--- a/src/wasm-linker.h
+++ b/src/wasm-linker.h
@@ -294,7 +294,7 @@ class Linker {
     if (out.wasm.checkExport(name)) return; // Already exported
     auto exp = new Export;
     exp->name = exp->value = name;
-    exp->kind = Export::Function;
+    exp->kind = ExternalKind::Function;
     out.wasm.addExport(exp);
   }
 

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -373,7 +373,7 @@ public:
 
   void visitExport(Export* curr) {
     if (!validateGlobally) return;
-    if (curr->kind == Export::Function) {
+    if (curr->kind == ExternalKind::Function) {
       if (validateWeb) {
         Function* f = getModule()->getFunction(curr->value);
         shouldBeUnequal(f->result, i64, f->name, "Exported function must not have i64 return type");

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -361,7 +361,7 @@ public:
 
   void visitImport(Import* curr) {
     if (!validateGlobally) return;
-    if (curr->kind == Import::Function) {
+    if (curr->kind == ExternalKind::Function) {
       if (validateWeb) {
         shouldBeUnequal(curr->functionType->result, i64, curr->name, "Imported function must not have i64 return type");
         for (WasmType param : curr->functionType->params) {
@@ -438,7 +438,7 @@ public:
     std::set<Name> exportNames;
     for (auto& exp : curr->exports) {
       Name name = exp->value;
-      if (exp->kind == Export::Function) {
+      if (exp->kind == ExternalKind::Function) {
         bool found = false;
         for (auto& func : curr->functions) {
           if (func->name == name) {
@@ -447,11 +447,11 @@ public:
           }
         }
         shouldBeTrue(found, name, "module function exports must be found");
-      } else if (exp->kind == Export::Global) {
+      } else if (exp->kind == ExternalKind::Global) {
         shouldBeTrue(curr->checkGlobal(name), name, "module global exports must be found");
-      } else if (exp->kind == Export::Table) {
+      } else if (exp->kind == ExternalKind::Table) {
         shouldBeTrue(name == Name("0") || name == curr->table.name, name, "module table exports must be found");
-      } else if (exp->kind == Export::Memory) {
+      } else if (exp->kind == ExternalKind::Memory) {
         shouldBeTrue(name == Name("0") || name == curr->memory.name, name, "module memory exports must be found");
       } else {
         WASM_UNREACHABLE();

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1427,35 +1427,28 @@ public:
   }
 };
 
+enum class ExternalKind {
+  Function = 0,
+  Table = 1,
+  Memory = 2,
+  Global = 3
+};
+
 class Import {
 public:
-  enum Kind {
-    Function = 0,
-    Table = 1,
-    Memory = 2,
-    Global = 3,
-  };
-
   Import() : functionType(nullptr), globalType(none) {}
 
   Name name, module, base; // name = module.base
-  Kind kind;
+  ExternalKind kind;
   FunctionType* functionType; // for Function imports
   WasmType globalType; // for Global imports
 };
 
 class Export {
 public:
-  enum Kind {
-    Function = 0,
-    Table = 1,
-    Memory = 2,
-    Global = 3,
-  };
-
   Name name;  // exported name - note that this is the key, as the internal name is non-unique (can have multiple exports for an internal, also over kinds)
   Name value; // internal name
-  Kind kind;
+  ExternalKind kind;
 };
 
 class Table {


### PR DESCRIPTION
This seems cleaner, the only reason I didn't do it this way originally is I didn't realize yet that import and export kinds are in fact the same thing.

This also makes talking about global entities easier, e.g. we can talk of a Function without knowing if its exported or imported.