### PR TITLE
Fix a broken size adjustment in finishSection

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -572,7 +572,7 @@ public:
   }
 
   void finishSection(int32_t start) {
-    int32_t size = o.size() - start - 6; // section size does not include the 6 bytes of the code and size field
+    int32_t size = o.size() - start - 5; // section size does not include the 5 bytes of the size field
     o.writeAt(start, U32LEB(size));
   }
 


### PR DESCRIPTION
The section size adjustment should be 5 byte, instead of 6 byte, because the section code written by startSection() is not counted in the unadjusted size, and writeU32LEBPlaceholder writes 5 byte blank field.