### PR TITLE
More binary updates for 0xc 

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -777,6 +777,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
           // TODO: when not using aliasing function pointers, we could merge them by noticing that
           //       index 0 in each table is the null func, and each other index should only have one
           //       non-null func. However, that breaks down when function pointer casts are emulated.
+          wasm.table.exists = true;
           if (wasm.table.segments.size() == 0) {
             wasm.table.segments.emplace_back(wasm.allocator.alloc<Const>()->set(Literal(uint32_t(0))));
           }

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -756,6 +756,7 @@ void BinaryenSetFunctionTable(BinaryenModuleRef module, BinaryenFunctionRef* fun
   }
 
   auto* wasm = (Module*)module;
+  wasm->table.exists = true;
   Table::Segment segment(wasm->allocator.alloc<Const>()->set(Literal(int32_t(0))));
   for (BinaryenIndex i = 0; i < numFuncs; i++) {
     segment.data.push_back(((Function*)funcs[i])->name);

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -726,7 +726,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
       visitGlobal(child.get());
       o << maybeNewLine;
     }
-    if (curr->table.segments.size() > 0 || curr->table.initial > 0 || curr->table.max != Table::kMaxSize) {
+    if (curr->table.exists) {
       visitTable(&curr->table);
       o << maybeNewLine;
     }

--- a/src/wasm-linker.h
+++ b/src/wasm-linker.h
@@ -269,7 +269,7 @@ class Linker {
 
   // Makes sure the table has a single segment, with offset 0,
   // to which we can add content.
-  void ensureTableIsPopulated();
+  void ensureTableSegment();
 
   std::vector<Name>& getTableDataRef();
   std::vector<Name> getTableData();

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -1346,7 +1346,7 @@ private:
   }
 
   Expression* makeCallIndirect(Element& s) {
-    if (!seenTable) throw ParseException("no table");
+    if (!wasm.table.exists) throw ParseException("no table");
     auto ret = allocator.alloc<CallIndirect>();
     IString type = s[1]->str();
     auto* fullType = wasm.checkFunctionType(type);
@@ -1609,8 +1609,8 @@ private:
         hasMemory = true;
       } else if ((*s[3])[0]->str() == TABLE) {
         im->kind = Import::Table;
-        if (seenTable) throw ParseException("more than one table");
-        seenTable = true;
+        if (wasm.table.exists) throw ParseException("more than one table");
+        wasm.table.exists = true;
       } else if ((*s[3])[0]->str() == GLOBAL) {
         im->kind = Import::Global;
       } else {
@@ -1781,11 +1781,10 @@ private:
     wasm.addGlobal(global.release());
   }
 
-  bool seenTable = false;
 
   void parseTable(Element& s, bool preParseImport = false) {
-    if (seenTable) throw ParseException("more than one table");
-    seenTable = true;
+    if (wasm.table.exists) throw ParseException("more than one table");
+    wasm.table.exists = true;
     Index i = 1;
     if (i == s.size()) return; // empty table in old notation
     if (s[i]->dollared()) {
@@ -1855,7 +1854,7 @@ private:
   }
 
   void parseInnerElem(Element& s, Index i = 1, Expression* offset = nullptr) {
-    if (!seenTable) throw ParseException("elem without table", s.line, s.col);
+    if (!wasm.table.exists) throw ParseException("elem without table", s.line, s.col);
     if (!offset) {
       offset = allocator.alloc<Const>()->set(Literal(int32_t(0)));
     }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1473,11 +1473,14 @@ public:
     }
   };
 
+  // Currently the wasm object always 'has' one Table. It 'exists' if it has been defined or imported.
+  // The table can exist but be empty and have no defined initial or max size.
+  bool exists;
   Name name;
   Address initial, max;
   std::vector<Segment> segments;
 
-  Table() : initial(0), max(kMaxSize) {
+  Table() : exists(false), initial(0), max(kMaxSize) {
     name = Name::fromInt(0);
   }
 };


### PR DESCRIPTION
Refine tables to explicitly exist or not. Previously they were printed
or encoded if it had any segments, or an initial or max size. However
tables can be defined but empty, so we had a special hack that defined
an empty segment when we really just wanted an empty table. Now, just
make the existence explicit.

Update Function table encoding for 0xc (Table and Element sections)

Add end opcodes after function bodies (these are consumed by
getMaybeBlock with the same behavior that it had before when it reached
the function end, so no explicit decode)

Update call_indirect encoding for 0xc (no arity, call target is last)