### PR TITLE
Binary 0xc: Remove arity on return instruction

### DIFF
--- a/check.py
+++ b/check.py
@@ -433,6 +433,8 @@ for t in spec_tests:
 
     # we must ignore some binary format splits
     splits_to_skip = {
+        'func.wast': [2],
+        'return.wast': [2]
     }
 
     # check binary format. here we can verify execution of the final result, no need for an output verification

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1313,7 +1313,7 @@ public:
     if (curr->value) {
       recurse(curr->value);
     }
-    o << int8_t(BinaryConsts::Return) << U32LEB(curr->value ? 1 : 0);
+    o << int8_t(BinaryConsts::Return);
   }
   void visitHost(Host *curr) {
     if (debug) std::cerr << "zz node: Host" << std::endl;
@@ -2378,9 +2378,7 @@ public:
   }
   void visitReturn(Return *curr) {
     if (debug) std::cerr << "zz node: Return" << std::endl;
-    auto arity = getU32LEB();
-    assert(arity == 0 || arity == 1);
-    if (arity == 1) {
+    if (currFunction->result != none) {
       curr->value = popExpression();
     }
   }


### PR DESCRIPTION
Also skip binary roundtrip on stacky spec tests