### PR TITLE
Validate get_local type

### DIFF
--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -230,6 +230,9 @@ public:
       }
     }
   }
+  void visitGetLocal(GetLocal* curr) {
+    shouldBeTrue(isConcreteWasmType(curr->type), curr, "get_local must have a valid type - check what you provided when you constructed the node");
+  }
   void visitSetLocal(SetLocal *curr) {
     shouldBeTrue(curr->index < getFunction()->getNumLocals(), curr, "set_local index must be small enough");
     if (curr->value->type != unreachable) {


### PR DESCRIPTION
It's valid by construction in s-parsing, but when generating IR (e.g. using the C API in mir2wasm) it is possible to get it wrong.