### PR TITLE
Require unique names in binaryen IR

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ Binaryen's internal IR is an AST, designed to be
  * **Flexible and fast** for optimization.
  * **As close as possible to WebAssembly** so it is simple and fast to convert it to and from WebAssembly.
 
-Binaryen IR is essentially a subset of WebAssembly, [everything but some stack machine specific things that are cumbersome to represent in an AST](https://github.com/WebAssembly/binaryen/issues/663). (In particular, that means that if you use Binaryen to load WebAssembly that contains such stack machine specific code, it might be transformed a little, and when emitted you will not necessarily get the same thing you started out with.)
+The differences between Binaryen IR and WebAssembly are:
+
+ * Binaryen IR [is an AST](https://github.com/WebAssembly/binaryen/issues/663). This differs from the WebAssembly binary format which is a stack machine.
+ * Binaryen IR requires the names of blocks and loops to be unique. This differs from the WebAssembly s-expression format which allows duplicate names (and depends on scoping to disambiguate).
+
+As a result, you might notice that round-trip conversions (wasm => Binaryen IR => wasm) change code a little in some corner cases.
 
 ## Tools
 

--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -25,8 +25,11 @@
 
 namespace wasm {
 
+// Finds if there are breaks targeting a name. Note that since names are
+// unique in our IR, we just need to look for the name, and do not need
+// to analyze scoping.
 struct BreakSeeker : public PostWalker<BreakSeeker, Visitor<BreakSeeker>> {
-  Name target; // look for this one XXX looking by name may fall prey to duplicate names
+  Name target;
   Index found;
   WasmType valueType;
 

--- a/src/cfg/Relooper.cpp
+++ b/src/cfg/Relooper.cpp
@@ -24,6 +24,7 @@
 #include <string>
 
 #include "ast_utils.h"
+#include "parsing.h"
 
 namespace CFG {
 
@@ -939,7 +940,10 @@ void Relooper::Calculate(Block *Entry) {
 
 wasm::Expression* Relooper::Render(RelooperBuilder& Builder) {
   assert(Root);
-  return Root->Render(Builder, false);
+  auto* ret = Root->Render(Builder, false);
+  // we may use the same name for more than one block in HandleFollowupMultiples
+  wasm::UniqueNameMapper::uniquify(ret);
+  return ret;
 }
 
 #ifdef RELOOPER_DEBUG

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -135,7 +135,7 @@
     (local $50 i32)
     (local $51 i32)
     (local $52 i32)
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.lt_u
           (get_local $0)
@@ -794,8 +794,8 @@
                   (set_local $0
                     (get_local $17)
                   )
-                  (loop $while-in$7
-                    (block $while-out$6
+                  (loop $while-in
+                    (block $while-out
                       (if
                         (tee_local $17
                           (i32.load offset=16
@@ -821,7 +821,7 @@
                             (set_local $1
                               (get_local $0)
                             )
-                            (br $while-out$6)
+                            (br $while-out)
                           )
                         )
                       )
@@ -858,7 +858,7 @@
                           (get_local $10)
                         )
                       )
-                      (br $while-in$7)
+                      (br $while-in)
                     )
                   )
                   (if
@@ -889,7 +889,7 @@
                       (get_local $1)
                     )
                   )
-                  (block $do-once$8
+                  (block $do-once4
                     (if
                       (i32.eq
                         (tee_local $6
@@ -937,11 +937,11 @@
                               (set_local $19
                                 (i32.const 0)
                               )
-                              (br $do-once$8)
+                              (br $do-once4)
                             )
                           )
                         )
-                        (loop $while-in$11
+                        (loop $while-in7
                           (if
                             (tee_local $13
                               (i32.load
@@ -960,7 +960,7 @@
                               (set_local $9
                                 (get_local $3)
                               )
-                              (br $while-in$11)
+                              (br $while-in7)
                             )
                           )
                           (if
@@ -981,7 +981,7 @@
                               (set_local $9
                                 (get_local $3)
                               )
-                              (br $while-in$11)
+                              (br $while-in7)
                             )
                           )
                         )
@@ -1058,7 +1058,7 @@
                       )
                     )
                   )
-                  (block $do-once$12
+                  (block $do-once8
                     (if
                       (get_local $2)
                       (block
@@ -1106,7 +1106,7 @@
                                     )
                                   )
                                 )
-                                (br $do-once$12)
+                                (br $do-once8)
                               )
                             )
                           )
@@ -1141,7 +1141,7 @@
                                 (get_local $19)
                               )
                             )
-                            (br_if $do-once$12
+                            (br_if $do-once8
                               (i32.eqz
                                 (get_local $19)
                               )
@@ -1569,7 +1569,7 @@
                       (set_local $7
                         (i32.const 0)
                       )
-                      (loop $while-in$18
+                      (loop $while-in14
                         (if
                           (i32.lt_u
                             (tee_local $3
@@ -1688,7 +1688,7 @@
                                 )
                               )
                             )
-                            (br $while-in$18)
+                            (br $while-in14)
                           )
                         )
                       )
@@ -1750,7 +1750,7 @@
                               (set_local $8
                                 (get_local $2)
                               )
-                              (br $do-once$0)
+                              (br $do-once)
                             )
                           )
                           (set_local $3
@@ -1882,7 +1882,7 @@
                     (get_local $6)
                     (i32.const 90)
                   )
-                  (loop $while-in$20
+                  (loop $while-in16
                     (set_local $6
                       (i32.const 0)
                     )
@@ -1932,7 +1932,7 @@
                         (set_local $29
                           (get_local $7)
                         )
-                        (br $while-in$20)
+                        (br $while-in16)
                       )
                     )
                     (if
@@ -1948,7 +1948,7 @@
                         (set_local $29
                           (get_local $7)
                         )
-                        (br $while-in$20)
+                        (br $while-in16)
                       )
                       (block
                         (set_local $4
@@ -2007,7 +2007,7 @@
                         (get_local $11)
                       )
                     )
-                    (block $do-once$21
+                    (block $do-once17
                       (if
                         (i32.eq
                           (tee_local $0
@@ -2055,11 +2055,11 @@
                                 (set_local $9
                                   (i32.const 0)
                                 )
-                                (br $do-once$21)
+                                (br $do-once17)
                               )
                             )
                           )
-                          (loop $while-in$24
+                          (loop $while-in20
                             (if
                               (tee_local $3
                                 (i32.load
@@ -2078,7 +2078,7 @@
                                 (set_local $0
                                   (get_local $8)
                                 )
-                                (br $while-in$24)
+                                (br $while-in20)
                               )
                             )
                             (if
@@ -2099,7 +2099,7 @@
                                 (set_local $0
                                   (get_local $8)
                                 )
-                                (br $while-in$24)
+                                (br $while-in20)
                               )
                             )
                           )
@@ -2176,7 +2176,7 @@
                         )
                       )
                     )
-                    (block $do-once$25
+                    (block $do-once21
                       (if
                         (get_local $5)
                         (block
@@ -2224,7 +2224,7 @@
                                       )
                                     )
                                   )
-                                  (br $do-once$25)
+                                  (br $do-once21)
                                 )
                               )
                             )
@@ -2259,7 +2259,7 @@
                                   (get_local $9)
                                 )
                               )
-                              (br_if $do-once$25
+                              (br_if $do-once21
                                 (i32.eqz
                                   (get_local $9)
                                 )
@@ -2334,7 +2334,7 @@
                         )
                       )
                     )
-                    (block $do-once$29
+                    (block $do-once25
                       (if
                         (i32.ge_u
                           (get_local $4)
@@ -2461,7 +2461,7 @@
                                 (get_local $7)
                                 (get_local $10)
                               )
-                              (br $do-once$29)
+                              (br $do-once25)
                             )
                           )
                           (set_local $5
@@ -2626,7 +2626,7 @@
                                 (get_local $7)
                                 (get_local $7)
                               )
-                              (br $do-once$29)
+                              (br $do-once25)
                             )
                           )
                           (set_local $16
@@ -2653,8 +2653,8 @@
                               (get_local $5)
                             )
                           )
-                          (loop $while-in$32
-                            (block $while-out$31
+                          (loop $while-in28
+                            (block $while-out27
                               (if
                                 (i32.eq
                                   (i32.and
@@ -2672,7 +2672,7 @@
                                   (set_local $6
                                     (i32.const 148)
                                   )
-                                  (br $while-out$31)
+                                  (br $while-out27)
                                 )
                               )
                               (if
@@ -2705,7 +2705,7 @@
                                   (set_local $0
                                     (get_local $8)
                                   )
-                                  (br $while-in$32)
+                                  (br $while-in28)
                                 )
                                 (block
                                   (set_local $23
@@ -3188,8 +3188,8 @@
                             (set_local $14
                               (i32.const 624)
                             )
-                            (loop $while-in$38
-                              (block $while-out$37
+                            (loop $while-in34
+                              (block $while-out33
                                 (if
                                   (if i32
                                     (i32.le_u
@@ -3223,10 +3223,10 @@
                                     (set_local $13
                                       (get_local $9)
                                     )
-                                    (br $while-out$37)
+                                    (br $while-out33)
                                   )
                                 )
-                                (br_if $while-in$38
+                                (br_if $while-in34
                                   (tee_local $14
                                     (i32.load offset=8
                                       (get_local $14)
@@ -3306,7 +3306,7 @@
                           )
                         )
                       )
-                      (block $do-once$39
+                      (block $do-once35
                         (if
                           (if i32
                             (i32.eq
@@ -3382,7 +3382,7 @@
                                 )
                               )
                               (block
-                                (br_if $do-once$39
+                                (br_if $do-once35
                                   (select
                                     (i32.or
                                       (i32.le_u
@@ -3641,7 +3641,7 @@
             (get_local $12)
           )
         )
-        (block $do-once$44
+        (block $do-once40
           (if
             (tee_local $12
               (i32.load
@@ -3652,8 +3652,8 @@
               (set_local $1
                 (i32.const 624)
               )
-              (loop $do-in$47
-                (block $do-out$46
+              (loop $do-in
+                (block $do-out
                   (if
                     (i32.eq
                       (get_local $20)
@@ -3691,10 +3691,10 @@
                       (set_local $6
                         (i32.const 203)
                       )
-                      (br $do-out$46)
+                      (br $do-out)
                     )
                   )
-                  (br_if $do-in$47
+                  (br_if $do-in
                     (i32.ne
                       (tee_local $1
                         (i32.load offset=8
@@ -3808,7 +3808,7 @@
                       (i32.const 664)
                     )
                   )
-                  (br $do-once$44)
+                  (br $do-once40)
                 )
               )
               (set_local $17
@@ -3840,8 +3840,8 @@
               (set_local $1
                 (i32.const 624)
               )
-              (loop $while-in$49
-                (block $while-out$48
+              (loop $while-in43
+                (block $while-out42
                   (if
                     (i32.eq
                       (i32.load
@@ -3859,10 +3859,10 @@
                       (set_local $6
                         (i32.const 211)
                       )
-                      (br $while-out$48)
+                      (br $while-out42)
                     )
                   )
-                  (br_if $while-in$49
+                  (br_if $while-in43
                     (tee_local $1
                       (i32.load offset=8
                         (get_local $1)
@@ -3978,7 +3978,7 @@
                         (i32.const 3)
                       )
                     )
-                    (block $do-once$50
+                    (block $do-once44
                       (if
                         (i32.ne
                           (get_local $4)
@@ -4022,7 +4022,7 @@
                                 )
                                 (get_local $0)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (i32.store
@@ -4065,7 +4065,7 @@
                                               (get_local $4)
                                             )
                                           )
-                                          (block $do-once$53
+                                          (block $do-once47
                                             (if
                                               (i32.eq
                                                 (tee_local $21
@@ -4112,11 +4112,11 @@
                                                       (set_local $24
                                                         (i32.const 0)
                                                       )
-                                                      (br $do-once$53)
+                                                      (br $do-once47)
                                                     )
                                                   )
                                                 )
-                                                (loop $while-in$56
+                                                (loop $while-in50
                                                   (if
                                                     (tee_local $3
                                                       (i32.load
@@ -4135,7 +4135,7 @@
                                                       (set_local $9
                                                         (get_local $2)
                                                       )
-                                                      (br $while-in$56)
+                                                      (br $while-in50)
                                                     )
                                                   )
                                                   (if
@@ -4156,7 +4156,7 @@
                                                       (set_local $9
                                                         (get_local $2)
                                                       )
-                                                      (br $while-in$56)
+                                                      (br $while-in50)
                                                     )
                                                   )
                                                 )
@@ -4238,7 +4238,7 @@
                                               (get_local $23)
                                             )
                                           )
-                                          (block $do-once$57
+                                          (block $do-once51
                                             (if
                                               (i32.ne
                                                 (get_local $4)
@@ -4300,7 +4300,7 @@
                                                   (get_local $2)
                                                   (get_local $24)
                                                 )
-                                                (br_if $do-once$57
+                                                (br_if $do-once51
                                                   (get_local $24)
                                                 )
                                                 (i32.store
@@ -4401,7 +4401,7 @@
                                               (get_local $4)
                                             )
                                           )
-                                          (block $do-once$61
+                                          (block $do-once55
                                             (if
                                               (i32.ne
                                                 (tee_local $9
@@ -4430,7 +4430,7 @@
                                                   )
                                                   (call $_abort)
                                                 )
-                                                (br_if $do-once$61
+                                                (br_if $do-once55
                                                   (i32.eq
                                                     (i32.load offset=12
                                                       (get_local $9)
@@ -4466,7 +4466,7 @@
                                               (br $label$break$L331)
                                             )
                                           )
-                                          (block $do-once$63
+                                          (block $do-once57
                                             (if
                                               (i32.eq
                                                 (get_local $21)
@@ -4502,7 +4502,7 @@
                                                     (set_local $41
                                                       (get_local $2)
                                                     )
-                                                    (br $do-once$63)
+                                                    (br $do-once57)
                                                   )
                                                 )
                                                 (call $_abort)
@@ -4581,7 +4581,7 @@
                                   )
                                 )
                               )
-                              (block $do-once$65
+                              (block $do-once59
                                 (if
                                   (i32.and
                                     (tee_local $23
@@ -4620,7 +4620,7 @@
                                         (set_local $34
                                           (get_local $3)
                                         )
-                                        (br $do-once$65)
+                                        (br $do-once59)
                                       )
                                     )
                                     (call $_abort)
@@ -4661,7 +4661,7 @@
                                 (get_local $1)
                                 (get_local $0)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $2
@@ -4669,7 +4669,7 @@
                               (i32.const 480)
                               (i32.shl
                                 (tee_local $3
-                                  (block $do-once$67 i32
+                                  (block $do-once61 i32
                                     (if i32
                                       (tee_local $2
                                         (i32.shr_u
@@ -4679,7 +4679,7 @@
                                       )
                                       (block i32
                                         (drop
-                                          (br_if $do-once$67
+                                          (br_if $do-once61
                                             (i32.const 31)
                                             (i32.gt_u
                                               (get_local $15)
@@ -4832,7 +4832,7 @@
                                 (get_local $1)
                                 (get_local $1)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $14
@@ -4859,8 +4859,8 @@
                               (get_local $2)
                             )
                           )
-                          (loop $while-in$70
-                            (block $while-out$69
+                          (loop $while-in64
+                            (block $while-out63
                               (if
                                 (i32.eq
                                   (i32.and
@@ -4878,7 +4878,7 @@
                                   (set_local $6
                                     (i32.const 281)
                                   )
-                                  (br $while-out$69)
+                                  (br $while-out63)
                                 )
                               )
                               (if
@@ -4911,7 +4911,7 @@
                                   (set_local $0
                                     (get_local $13)
                                   )
-                                  (br $while-in$70)
+                                  (br $while-in64)
                                 )
                                 (block
                                   (set_local $43
@@ -5050,7 +5050,7 @@
                   )
                 )
               )
-              (loop $while-in$72
+              (loop $while-in66
                 (if
                   (if i32
                     (i32.le_u
@@ -5083,7 +5083,7 @@
                         (get_local $28)
                       )
                     )
-                    (br $while-in$72)
+                    (br $while-in66)
                   )
                 )
               )
@@ -5252,7 +5252,7 @@
                   (i32.const 24)
                 )
               )
-              (loop $do-in$74
+              (loop $do-in68
                 (i32.store
                   (tee_local $1
                     (i32.add
@@ -5262,7 +5262,7 @@
                   )
                   (i32.const 7)
                 )
-                (br_if $do-in$74
+                (br_if $do-in68
                   (i32.lt_u
                     (i32.add
                       (get_local $1)
@@ -5402,7 +5402,7 @@
                         (get_local $12)
                         (get_local $18)
                       )
-                      (br $do-once$44)
+                      (br $do-once40)
                     )
                   )
                   (set_local $4
@@ -5562,7 +5562,7 @@
                         (get_local $12)
                         (get_local $12)
                       )
-                      (br $do-once$44)
+                      (br $do-once40)
                     )
                   )
                   (set_local $2
@@ -5589,8 +5589,8 @@
                       (get_local $4)
                     )
                   )
-                  (loop $while-in$76
-                    (block $while-out$75
+                  (loop $while-in70
+                    (block $while-out69
                       (if
                         (i32.eq
                           (i32.and
@@ -5608,7 +5608,7 @@
                           (set_local $6
                             (i32.const 307)
                           )
-                          (br $while-out$75)
+                          (br $while-out69)
                         )
                       )
                       (if
@@ -5641,7 +5641,7 @@
                           (set_local $0
                             (get_local $13)
                           )
-                          (br $while-in$76)
+                          (br $while-in70)
                         )
                         (block
                           (set_local $45
@@ -5792,7 +5792,7 @@
               (set_local $2
                 (i32.const 0)
               )
-              (loop $do-in$78
+              (loop $do-in72
                 (i32.store offset=12
                   (tee_local $0
                     (i32.add
@@ -5812,7 +5812,7 @@
                   (get_local $0)
                   (get_local $0)
                 )
-                (br_if $do-in$78
+                (br_if $do-in72
                   (i32.ne
                     (tee_local $2
                       (i32.add
@@ -6022,7 +6022,7 @@
         )
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.and
           (get_local $3)
@@ -6101,7 +6101,7 @@
                   (set_local $7
                     (get_local $4)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (i32.store
@@ -6215,7 +6215,7 @@
                   (set_local $7
                     (get_local $4)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (if
@@ -6270,7 +6270,7 @@
               (set_local $7
                 (get_local $4)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $11
@@ -6278,7 +6278,7 @@
               (get_local $0)
             )
           )
-          (block $do-once$2
+          (block $do-once0
             (if
               (i32.eq
                 (tee_local $1
@@ -6325,11 +6325,11 @@
                       (set_local $5
                         (i32.const 0)
                       )
-                      (br $do-once$2)
+                      (br $do-once0)
                     )
                   )
                 )
-                (loop $while-in$5
+                (loop $while-in
                   (if
                     (tee_local $10
                       (i32.load
@@ -6348,7 +6348,7 @@
                       (set_local $3
                         (get_local $6)
                       )
-                      (br $while-in$5)
+                      (br $while-in)
                     )
                   )
                   (if
@@ -6369,7 +6369,7 @@
                       (set_local $3
                         (get_local $6)
                       )
-                      (br $while-in$5)
+                      (br $while-in)
                     )
                     (block
                       (set_local $6
@@ -6507,7 +6507,7 @@
                       (set_local $7
                         (get_local $4)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -6553,7 +6553,7 @@
                       (set_local $7
                         (get_local $4)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -6817,7 +6817,7 @@
             (i32.const 3)
           )
         )
-        (block $do-once$8
+        (block $do-once4
           (if
             (i32.ge_u
               (get_local $1)
@@ -6829,7 +6829,7 @@
                   (get_local $8)
                 )
               )
-              (block $do-once$10
+              (block $do-once6
                 (if
                   (i32.eq
                     (tee_local $9
@@ -6876,11 +6876,11 @@
                           (set_local $12
                             (i32.const 0)
                           )
-                          (br $do-once$10)
+                          (br $do-once6)
                         )
                       )
                     )
-                    (loop $while-in$13
+                    (loop $while-in9
                       (if
                         (tee_local $10
                           (i32.load
@@ -6899,7 +6899,7 @@
                           (set_local $3
                             (get_local $1)
                           )
-                          (br $while-in$13)
+                          (br $while-in9)
                         )
                       )
                       (if
@@ -6920,7 +6920,7 @@
                           (set_local $3
                             (get_local $1)
                           )
-                          (br $while-in$13)
+                          (br $while-in9)
                         )
                       )
                     )
@@ -7048,7 +7048,7 @@
                               )
                             )
                           )
-                          (br $do-once$8)
+                          (br $do-once4)
                         )
                       )
                     )
@@ -7083,7 +7083,7 @@
                           (get_local $12)
                         )
                       )
-                      (br_if $do-once$8
+                      (br_if $do-once4
                         (i32.eqz
                           (get_local $12)
                         )
@@ -7231,7 +7231,7 @@
                       )
                     )
                   )
-                  (br $do-once$8)
+                  (br $do-once4)
                 )
               )
               (if
@@ -7577,8 +7577,8 @@
             (get_local $4)
           )
         )
-        (loop $while-in$19
-          (block $while-out$18
+        (loop $while-in15
+          (block $while-out14
             (if
               (i32.eq
                 (i32.and
@@ -7596,7 +7596,7 @@
                 (set_local $0
                   (i32.const 130)
                 )
-                (br $while-out$18)
+                (br $while-out14)
               )
             )
             (if
@@ -7629,7 +7629,7 @@
                 (set_local $1
                   (get_local $7)
                 )
-                (br $while-in$19)
+                (br $while-in15)
               )
               (block
                 (set_local $18
@@ -7777,7 +7777,7 @@
         (i32.const 632)
       )
     )
-    (loop $while-in$21
+    (loop $while-in17
       (if
         (tee_local $2
           (i32.load
@@ -7791,7 +7791,7 @@
               (i32.const 8)
             )
           )
-          (br $while-in$21)
+          (br $while-in17)
         )
       )
     )
@@ -7900,8 +7900,8 @@
         (get_local $2)
       )
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (if
           (i32.eq
             (get_local $3)
@@ -7971,7 +7971,7 @@
             (set_local $1
               (i32.const 6)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (if
@@ -8096,7 +8096,7 @@
             (set_local $3
               (get_local $9)
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
       )
@@ -8288,7 +8288,7 @@
                   (set_local $3
                     (get_local $1)
                   )
-                  (loop $while-in$3
+                  (loop $while-in
                     (if
                       (i32.eqz
                         (get_local $3)
@@ -8321,7 +8321,7 @@
                         (set_local $3
                           (get_local $6)
                         )
-                        (br $while-in$3)
+                        (br $while-in)
                       )
                     )
                   )
@@ -8408,7 +8408,7 @@
   (func $_fflush (param $0 i32) (result i32)
     (local $1 i32)
     (local $2 i32)
-    (block $do-once$0 i32
+    (block $do-once i32
       (if i32
         (get_local $0)
         (block i32
@@ -8419,7 +8419,7 @@
               )
               (i32.const -1)
             )
-            (br $do-once$0
+            (br $do-once
               (call $___fflush_unlocked
                 (get_local $0)
               )
@@ -8478,7 +8478,7 @@
               (set_local $2
                 (get_local $0)
               )
-              (loop $while-in$3
+              (loop $while-in
                 (set_local $0
                   (if i32
                     (i32.gt_s
@@ -8518,7 +8518,7 @@
                     (get_local $1)
                   )
                 )
-                (br_if $while-in$3
+                (br_if $while-in
                   (tee_local $1
                     (i32.load offset=56
                       (get_local $1)
@@ -8557,7 +8557,7 @@
           (set_local $4
             (get_local $3)
           )
-          (loop $while-in$2
+          (loop $while-in
             (if
               (i32.eqz
                 (i32.load8_s
@@ -8571,7 +8571,7 @@
                 (br $label$break$L1)
               )
             )
-            (br_if $while-in$2
+            (br_if $while-in
               (i32.and
                 (tee_local $4
                   (tee_local $0
@@ -8613,7 +8613,7 @@
         (set_local $2
           (get_local $1)
         )
-        (loop $while-in$4
+        (loop $while-in1
           (if
             (i32.and
               (i32.xor
@@ -8642,7 +8642,7 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$4)
+              (br $while-in1)
             )
           )
         )
@@ -8661,7 +8661,7 @@
             (set_local $1
               (get_local $0)
             )
-            (loop $while-in$6
+            (loop $while-in3
               (if
                 (i32.load8_s
                   (tee_local $0
@@ -8675,7 +8675,7 @@
                   (set_local $1
                     (get_local $0)
                   )
-                  (br $while-in$6)
+                  (br $while-in3)
                 )
               )
             )
@@ -8759,7 +8759,7 @@
         )
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.eq
           (get_local $8)
@@ -8809,7 +8809,7 @@
               (set_local $4
                 (get_local $10)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $4
@@ -8996,9 +8996,9 @@
         )
       )
       (block
-        (loop $while-in$1
-          (block $while-out$0
-            (br_if $while-out$0
+        (loop $while-in
+          (block $while-out
+            (br_if $while-out
               (i32.eqz
                 (i32.and
                   (get_local $0)
@@ -9038,10 +9038,10 @@
                 (i32.const 1)
               )
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
-        (loop $while-in$3
+        (loop $while-in1
           (if
             (i32.ge_s
               (get_local $2)
@@ -9072,13 +9072,13 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$3)
+              (br $while-in1)
             )
           )
         )
       )
     )
-    (loop $while-in$5
+    (loop $while-in3
       (if
         (i32.gt_s
           (get_local $2)
@@ -9109,7 +9109,7 @@
               (i32.const 1)
             )
           )
-          (br $while-in$5)
+          (br $while-in3)
         )
       )
     )
@@ -9184,7 +9184,7 @@
                 (get_local $3)
               )
             )
-            (loop $while-in$1
+            (loop $while-in
               (if
                 (i32.lt_s
                   (get_local $0)
@@ -9201,13 +9201,13 @@
                       (i32.const 1)
                     )
                   )
-                  (br $while-in$1)
+                  (br $while-in)
                 )
               )
             )
           )
         )
-        (loop $while-in$3
+        (loop $while-in1
           (if
             (i32.lt_s
               (get_local $0)
@@ -9224,13 +9224,13 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$3)
+              (br $while-in1)
             )
           )
         )
       )
     )
-    (loop $while-in$5
+    (loop $while-in3
       (if
         (i32.lt_s
           (get_local $0)
@@ -9247,7 +9247,7 @@
               (i32.const 1)
             )
           )
-          (br $while-in$5)
+          (br $while-in3)
         )
       )
     )
@@ -9280,7 +9280,7 @@
       )
     )
     (set_local $0
-      (block $do-once$0 i32
+      (block $do-once i32
         (if i32
           (i32.lt_s
             (call $_fputs
@@ -9328,7 +9328,7 @@
                   (get_local $2)
                   (i32.const 10)
                 )
-                (br $do-once$0
+                (br $do-once
                   (i32.const 0)
                 )
               )

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -133,7 +133,7 @@
     (local $50 i32)
     (local $51 i32)
     (local $52 i32)
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.lt_u
           (get_local $0)
@@ -792,8 +792,8 @@
                   (set_local $0
                     (get_local $17)
                   )
-                  (loop $while-in$7
-                    (block $while-out$6
+                  (loop $while-in
+                    (block $while-out
                       (if
                         (tee_local $17
                           (i32.load offset=16
@@ -819,7 +819,7 @@
                             (set_local $1
                               (get_local $0)
                             )
-                            (br $while-out$6)
+                            (br $while-out)
                           )
                         )
                       )
@@ -856,7 +856,7 @@
                           (get_local $10)
                         )
                       )
-                      (br $while-in$7)
+                      (br $while-in)
                     )
                   )
                   (if
@@ -887,7 +887,7 @@
                       (get_local $1)
                     )
                   )
-                  (block $do-once$8
+                  (block $do-once4
                     (if
                       (i32.eq
                         (tee_local $6
@@ -935,11 +935,11 @@
                               (set_local $19
                                 (i32.const 0)
                               )
-                              (br $do-once$8)
+                              (br $do-once4)
                             )
                           )
                         )
-                        (loop $while-in$11
+                        (loop $while-in7
                           (if
                             (tee_local $13
                               (i32.load
@@ -958,7 +958,7 @@
                               (set_local $9
                                 (get_local $3)
                               )
-                              (br $while-in$11)
+                              (br $while-in7)
                             )
                           )
                           (if
@@ -979,7 +979,7 @@
                               (set_local $9
                                 (get_local $3)
                               )
-                              (br $while-in$11)
+                              (br $while-in7)
                             )
                           )
                         )
@@ -1056,7 +1056,7 @@
                       )
                     )
                   )
-                  (block $do-once$12
+                  (block $do-once8
                     (if
                       (get_local $2)
                       (block
@@ -1104,7 +1104,7 @@
                                     )
                                   )
                                 )
-                                (br $do-once$12)
+                                (br $do-once8)
                               )
                             )
                           )
@@ -1139,7 +1139,7 @@
                                 (get_local $19)
                               )
                             )
-                            (br_if $do-once$12
+                            (br_if $do-once8
                               (i32.eqz
                                 (get_local $19)
                               )
@@ -1567,7 +1567,7 @@
                       (set_local $7
                         (i32.const 0)
                       )
-                      (loop $while-in$18
+                      (loop $while-in14
                         (if
                           (i32.lt_u
                             (tee_local $3
@@ -1686,7 +1686,7 @@
                                 )
                               )
                             )
-                            (br $while-in$18)
+                            (br $while-in14)
                           )
                         )
                       )
@@ -1748,7 +1748,7 @@
                               (set_local $8
                                 (get_local $2)
                               )
-                              (br $do-once$0)
+                              (br $do-once)
                             )
                           )
                           (set_local $3
@@ -1880,7 +1880,7 @@
                     (get_local $6)
                     (i32.const 90)
                   )
-                  (loop $while-in$20
+                  (loop $while-in16
                     (set_local $6
                       (i32.const 0)
                     )
@@ -1930,7 +1930,7 @@
                         (set_local $29
                           (get_local $7)
                         )
-                        (br $while-in$20)
+                        (br $while-in16)
                       )
                     )
                     (if
@@ -1946,7 +1946,7 @@
                         (set_local $29
                           (get_local $7)
                         )
-                        (br $while-in$20)
+                        (br $while-in16)
                       )
                       (block
                         (set_local $4
@@ -2005,7 +2005,7 @@
                         (get_local $11)
                       )
                     )
-                    (block $do-once$21
+                    (block $do-once17
                       (if
                         (i32.eq
                           (tee_local $0
@@ -2053,11 +2053,11 @@
                                 (set_local $9
                                   (i32.const 0)
                                 )
-                                (br $do-once$21)
+                                (br $do-once17)
                               )
                             )
                           )
-                          (loop $while-in$24
+                          (loop $while-in20
                             (if
                               (tee_local $3
                                 (i32.load
@@ -2076,7 +2076,7 @@
                                 (set_local $0
                                   (get_local $8)
                                 )
-                                (br $while-in$24)
+                                (br $while-in20)
                               )
                             )
                             (if
@@ -2097,7 +2097,7 @@
                                 (set_local $0
                                   (get_local $8)
                                 )
-                                (br $while-in$24)
+                                (br $while-in20)
                               )
                             )
                           )
@@ -2174,7 +2174,7 @@
                         )
                       )
                     )
-                    (block $do-once$25
+                    (block $do-once21
                       (if
                         (get_local $5)
                         (block
@@ -2222,7 +2222,7 @@
                                       )
                                     )
                                   )
-                                  (br $do-once$25)
+                                  (br $do-once21)
                                 )
                               )
                             )
@@ -2257,7 +2257,7 @@
                                   (get_local $9)
                                 )
                               )
-                              (br_if $do-once$25
+                              (br_if $do-once21
                                 (i32.eqz
                                   (get_local $9)
                                 )
@@ -2332,7 +2332,7 @@
                         )
                       )
                     )
-                    (block $do-once$29
+                    (block $do-once25
                       (if
                         (i32.ge_u
                           (get_local $4)
@@ -2459,7 +2459,7 @@
                                 (get_local $7)
                                 (get_local $10)
                               )
-                              (br $do-once$29)
+                              (br $do-once25)
                             )
                           )
                           (set_local $5
@@ -2624,7 +2624,7 @@
                                 (get_local $7)
                                 (get_local $7)
                               )
-                              (br $do-once$29)
+                              (br $do-once25)
                             )
                           )
                           (set_local $16
@@ -2651,8 +2651,8 @@
                               (get_local $5)
                             )
                           )
-                          (loop $while-in$32
-                            (block $while-out$31
+                          (loop $while-in28
+                            (block $while-out27
                               (if
                                 (i32.eq
                                   (i32.and
@@ -2670,7 +2670,7 @@
                                   (set_local $6
                                     (i32.const 148)
                                   )
-                                  (br $while-out$31)
+                                  (br $while-out27)
                                 )
                               )
                               (if
@@ -2703,7 +2703,7 @@
                                   (set_local $0
                                     (get_local $8)
                                   )
-                                  (br $while-in$32)
+                                  (br $while-in28)
                                 )
                                 (block
                                   (set_local $23
@@ -3186,8 +3186,8 @@
                             (set_local $14
                               (i32.const 624)
                             )
-                            (loop $while-in$38
-                              (block $while-out$37
+                            (loop $while-in34
+                              (block $while-out33
                                 (if
                                   (if i32
                                     (i32.le_u
@@ -3221,10 +3221,10 @@
                                     (set_local $13
                                       (get_local $9)
                                     )
-                                    (br $while-out$37)
+                                    (br $while-out33)
                                   )
                                 )
-                                (br_if $while-in$38
+                                (br_if $while-in34
                                   (tee_local $14
                                     (i32.load offset=8
                                       (get_local $14)
@@ -3304,7 +3304,7 @@
                           )
                         )
                       )
-                      (block $do-once$39
+                      (block $do-once35
                         (if
                           (if i32
                             (i32.eq
@@ -3380,7 +3380,7 @@
                                 )
                               )
                               (block
-                                (br_if $do-once$39
+                                (br_if $do-once35
                                   (select
                                     (i32.or
                                       (i32.le_u
@@ -3639,7 +3639,7 @@
             (get_local $12)
           )
         )
-        (block $do-once$44
+        (block $do-once40
           (if
             (tee_local $12
               (i32.load
@@ -3650,8 +3650,8 @@
               (set_local $1
                 (i32.const 624)
               )
-              (loop $do-in$47
-                (block $do-out$46
+              (loop $do-in
+                (block $do-out
                   (if
                     (i32.eq
                       (get_local $20)
@@ -3689,10 +3689,10 @@
                       (set_local $6
                         (i32.const 203)
                       )
-                      (br $do-out$46)
+                      (br $do-out)
                     )
                   )
-                  (br_if $do-in$47
+                  (br_if $do-in
                     (i32.ne
                       (tee_local $1
                         (i32.load offset=8
@@ -3806,7 +3806,7 @@
                       (i32.const 664)
                     )
                   )
-                  (br $do-once$44)
+                  (br $do-once40)
                 )
               )
               (set_local $17
@@ -3838,8 +3838,8 @@
               (set_local $1
                 (i32.const 624)
               )
-              (loop $while-in$49
-                (block $while-out$48
+              (loop $while-in43
+                (block $while-out42
                   (if
                     (i32.eq
                       (i32.load
@@ -3857,10 +3857,10 @@
                       (set_local $6
                         (i32.const 211)
                       )
-                      (br $while-out$48)
+                      (br $while-out42)
                     )
                   )
-                  (br_if $while-in$49
+                  (br_if $while-in43
                     (tee_local $1
                       (i32.load offset=8
                         (get_local $1)
@@ -3976,7 +3976,7 @@
                         (i32.const 3)
                       )
                     )
-                    (block $do-once$50
+                    (block $do-once44
                       (if
                         (i32.ne
                           (get_local $4)
@@ -4020,7 +4020,7 @@
                                 )
                                 (get_local $0)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (i32.store
@@ -4063,7 +4063,7 @@
                                               (get_local $4)
                                             )
                                           )
-                                          (block $do-once$53
+                                          (block $do-once47
                                             (if
                                               (i32.eq
                                                 (tee_local $21
@@ -4110,11 +4110,11 @@
                                                       (set_local $24
                                                         (i32.const 0)
                                                       )
-                                                      (br $do-once$53)
+                                                      (br $do-once47)
                                                     )
                                                   )
                                                 )
-                                                (loop $while-in$56
+                                                (loop $while-in50
                                                   (if
                                                     (tee_local $3
                                                       (i32.load
@@ -4133,7 +4133,7 @@
                                                       (set_local $9
                                                         (get_local $2)
                                                       )
-                                                      (br $while-in$56)
+                                                      (br $while-in50)
                                                     )
                                                   )
                                                   (if
@@ -4154,7 +4154,7 @@
                                                       (set_local $9
                                                         (get_local $2)
                                                       )
-                                                      (br $while-in$56)
+                                                      (br $while-in50)
                                                     )
                                                   )
                                                 )
@@ -4236,7 +4236,7 @@
                                               (get_local $23)
                                             )
                                           )
-                                          (block $do-once$57
+                                          (block $do-once51
                                             (if
                                               (i32.ne
                                                 (get_local $4)
@@ -4298,7 +4298,7 @@
                                                   (get_local $2)
                                                   (get_local $24)
                                                 )
-                                                (br_if $do-once$57
+                                                (br_if $do-once51
                                                   (get_local $24)
                                                 )
                                                 (i32.store
@@ -4399,7 +4399,7 @@
                                               (get_local $4)
                                             )
                                           )
-                                          (block $do-once$61
+                                          (block $do-once55
                                             (if
                                               (i32.ne
                                                 (tee_local $9
@@ -4428,7 +4428,7 @@
                                                   )
                                                   (call $_abort)
                                                 )
-                                                (br_if $do-once$61
+                                                (br_if $do-once55
                                                   (i32.eq
                                                     (i32.load offset=12
                                                       (get_local $9)
@@ -4464,7 +4464,7 @@
                                               (br $label$break$L331)
                                             )
                                           )
-                                          (block $do-once$63
+                                          (block $do-once57
                                             (if
                                               (i32.eq
                                                 (get_local $21)
@@ -4500,7 +4500,7 @@
                                                     (set_local $41
                                                       (get_local $2)
                                                     )
-                                                    (br $do-once$63)
+                                                    (br $do-once57)
                                                   )
                                                 )
                                                 (call $_abort)
@@ -4579,7 +4579,7 @@
                                   )
                                 )
                               )
-                              (block $do-once$65
+                              (block $do-once59
                                 (if
                                   (i32.and
                                     (tee_local $23
@@ -4618,7 +4618,7 @@
                                         (set_local $34
                                           (get_local $3)
                                         )
-                                        (br $do-once$65)
+                                        (br $do-once59)
                                       )
                                     )
                                     (call $_abort)
@@ -4659,7 +4659,7 @@
                                 (get_local $1)
                                 (get_local $0)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $2
@@ -4667,7 +4667,7 @@
                               (i32.const 480)
                               (i32.shl
                                 (tee_local $3
-                                  (block $do-once$67 i32
+                                  (block $do-once61 i32
                                     (if i32
                                       (tee_local $2
                                         (i32.shr_u
@@ -4677,7 +4677,7 @@
                                       )
                                       (block i32
                                         (drop
-                                          (br_if $do-once$67
+                                          (br_if $do-once61
                                             (i32.const 31)
                                             (i32.gt_u
                                               (get_local $15)
@@ -4830,7 +4830,7 @@
                                 (get_local $1)
                                 (get_local $1)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $14
@@ -4857,8 +4857,8 @@
                               (get_local $2)
                             )
                           )
-                          (loop $while-in$70
-                            (block $while-out$69
+                          (loop $while-in64
+                            (block $while-out63
                               (if
                                 (i32.eq
                                   (i32.and
@@ -4876,7 +4876,7 @@
                                   (set_local $6
                                     (i32.const 281)
                                   )
-                                  (br $while-out$69)
+                                  (br $while-out63)
                                 )
                               )
                               (if
@@ -4909,7 +4909,7 @@
                                   (set_local $0
                                     (get_local $13)
                                   )
-                                  (br $while-in$70)
+                                  (br $while-in64)
                                 )
                                 (block
                                   (set_local $43
@@ -5048,7 +5048,7 @@
                   )
                 )
               )
-              (loop $while-in$72
+              (loop $while-in66
                 (if
                   (if i32
                     (i32.le_u
@@ -5081,7 +5081,7 @@
                         (get_local $28)
                       )
                     )
-                    (br $while-in$72)
+                    (br $while-in66)
                   )
                 )
               )
@@ -5250,7 +5250,7 @@
                   (i32.const 24)
                 )
               )
-              (loop $do-in$74
+              (loop $do-in68
                 (i32.store
                   (tee_local $1
                     (i32.add
@@ -5260,7 +5260,7 @@
                   )
                   (i32.const 7)
                 )
-                (br_if $do-in$74
+                (br_if $do-in68
                   (i32.lt_u
                     (i32.add
                       (get_local $1)
@@ -5400,7 +5400,7 @@
                         (get_local $12)
                         (get_local $18)
                       )
-                      (br $do-once$44)
+                      (br $do-once40)
                     )
                   )
                   (set_local $4
@@ -5560,7 +5560,7 @@
                         (get_local $12)
                         (get_local $12)
                       )
-                      (br $do-once$44)
+                      (br $do-once40)
                     )
                   )
                   (set_local $2
@@ -5587,8 +5587,8 @@
                       (get_local $4)
                     )
                   )
-                  (loop $while-in$76
-                    (block $while-out$75
+                  (loop $while-in70
+                    (block $while-out69
                       (if
                         (i32.eq
                           (i32.and
@@ -5606,7 +5606,7 @@
                           (set_local $6
                             (i32.const 307)
                           )
-                          (br $while-out$75)
+                          (br $while-out69)
                         )
                       )
                       (if
@@ -5639,7 +5639,7 @@
                           (set_local $0
                             (get_local $13)
                           )
-                          (br $while-in$76)
+                          (br $while-in70)
                         )
                         (block
                           (set_local $45
@@ -5790,7 +5790,7 @@
               (set_local $2
                 (i32.const 0)
               )
-              (loop $do-in$78
+              (loop $do-in72
                 (i32.store offset=12
                   (tee_local $0
                     (i32.add
@@ -5810,7 +5810,7 @@
                   (get_local $0)
                   (get_local $0)
                 )
-                (br_if $do-in$78
+                (br_if $do-in72
                   (i32.ne
                     (tee_local $2
                       (i32.add
@@ -6020,7 +6020,7 @@
         )
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.and
           (get_local $3)
@@ -6099,7 +6099,7 @@
                   (set_local $7
                     (get_local $4)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (i32.store
@@ -6213,7 +6213,7 @@
                   (set_local $7
                     (get_local $4)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (if
@@ -6268,7 +6268,7 @@
               (set_local $7
                 (get_local $4)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $11
@@ -6276,7 +6276,7 @@
               (get_local $0)
             )
           )
-          (block $do-once$2
+          (block $do-once0
             (if
               (i32.eq
                 (tee_local $1
@@ -6323,11 +6323,11 @@
                       (set_local $5
                         (i32.const 0)
                       )
-                      (br $do-once$2)
+                      (br $do-once0)
                     )
                   )
                 )
-                (loop $while-in$5
+                (loop $while-in
                   (if
                     (tee_local $10
                       (i32.load
@@ -6346,7 +6346,7 @@
                       (set_local $3
                         (get_local $6)
                       )
-                      (br $while-in$5)
+                      (br $while-in)
                     )
                   )
                   (if
@@ -6367,7 +6367,7 @@
                       (set_local $3
                         (get_local $6)
                       )
-                      (br $while-in$5)
+                      (br $while-in)
                     )
                     (block
                       (set_local $6
@@ -6505,7 +6505,7 @@
                       (set_local $7
                         (get_local $4)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -6551,7 +6551,7 @@
                       (set_local $7
                         (get_local $4)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -6815,7 +6815,7 @@
             (i32.const 3)
           )
         )
-        (block $do-once$8
+        (block $do-once4
           (if
             (i32.ge_u
               (get_local $1)
@@ -6827,7 +6827,7 @@
                   (get_local $8)
                 )
               )
-              (block $do-once$10
+              (block $do-once6
                 (if
                   (i32.eq
                     (tee_local $9
@@ -6874,11 +6874,11 @@
                           (set_local $12
                             (i32.const 0)
                           )
-                          (br $do-once$10)
+                          (br $do-once6)
                         )
                       )
                     )
-                    (loop $while-in$13
+                    (loop $while-in9
                       (if
                         (tee_local $10
                           (i32.load
@@ -6897,7 +6897,7 @@
                           (set_local $3
                             (get_local $1)
                           )
-                          (br $while-in$13)
+                          (br $while-in9)
                         )
                       )
                       (if
@@ -6918,7 +6918,7 @@
                           (set_local $3
                             (get_local $1)
                           )
-                          (br $while-in$13)
+                          (br $while-in9)
                         )
                       )
                     )
@@ -7046,7 +7046,7 @@
                               )
                             )
                           )
-                          (br $do-once$8)
+                          (br $do-once4)
                         )
                       )
                     )
@@ -7081,7 +7081,7 @@
                           (get_local $12)
                         )
                       )
-                      (br_if $do-once$8
+                      (br_if $do-once4
                         (i32.eqz
                           (get_local $12)
                         )
@@ -7229,7 +7229,7 @@
                       )
                     )
                   )
-                  (br $do-once$8)
+                  (br $do-once4)
                 )
               )
               (if
@@ -7575,8 +7575,8 @@
             (get_local $4)
           )
         )
-        (loop $while-in$19
-          (block $while-out$18
+        (loop $while-in15
+          (block $while-out14
             (if
               (i32.eq
                 (i32.and
@@ -7594,7 +7594,7 @@
                 (set_local $0
                   (i32.const 130)
                 )
-                (br $while-out$18)
+                (br $while-out14)
               )
             )
             (if
@@ -7627,7 +7627,7 @@
                 (set_local $1
                   (get_local $7)
                 )
-                (br $while-in$19)
+                (br $while-in15)
               )
               (block
                 (set_local $18
@@ -7775,7 +7775,7 @@
         (i32.const 632)
       )
     )
-    (loop $while-in$21
+    (loop $while-in17
       (if
         (tee_local $2
           (i32.load
@@ -7789,7 +7789,7 @@
               (i32.const 8)
             )
           )
-          (br $while-in$21)
+          (br $while-in17)
         )
       )
     )
@@ -7898,8 +7898,8 @@
         (get_local $2)
       )
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (if
           (i32.eq
             (get_local $3)
@@ -7969,7 +7969,7 @@
             (set_local $1
               (i32.const 6)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (if
@@ -8094,7 +8094,7 @@
             (set_local $3
               (get_local $9)
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
       )
@@ -8286,7 +8286,7 @@
                   (set_local $3
                     (get_local $1)
                   )
-                  (loop $while-in$3
+                  (loop $while-in
                     (if
                       (i32.eqz
                         (get_local $3)
@@ -8319,7 +8319,7 @@
                         (set_local $3
                           (get_local $6)
                         )
-                        (br $while-in$3)
+                        (br $while-in)
                       )
                     )
                   )
@@ -8406,7 +8406,7 @@
   (func $_fflush (param $0 i32) (result i32)
     (local $1 i32)
     (local $2 i32)
-    (block $do-once$0 i32
+    (block $do-once i32
       (if i32
         (get_local $0)
         (block i32
@@ -8417,7 +8417,7 @@
               )
               (i32.const -1)
             )
-            (br $do-once$0
+            (br $do-once
               (call $___fflush_unlocked
                 (get_local $0)
               )
@@ -8476,7 +8476,7 @@
               (set_local $2
                 (get_local $0)
               )
-              (loop $while-in$3
+              (loop $while-in
                 (set_local $0
                   (if i32
                     (i32.gt_s
@@ -8516,7 +8516,7 @@
                     (get_local $1)
                   )
                 )
-                (br_if $while-in$3
+                (br_if $while-in
                   (tee_local $1
                     (i32.load offset=56
                       (get_local $1)
@@ -8555,7 +8555,7 @@
           (set_local $4
             (get_local $3)
           )
-          (loop $while-in$2
+          (loop $while-in
             (if
               (i32.eqz
                 (i32.load8_s
@@ -8569,7 +8569,7 @@
                 (br $label$break$L1)
               )
             )
-            (br_if $while-in$2
+            (br_if $while-in
               (i32.and
                 (tee_local $4
                   (tee_local $0
@@ -8611,7 +8611,7 @@
         (set_local $2
           (get_local $1)
         )
-        (loop $while-in$4
+        (loop $while-in1
           (if
             (i32.and
               (i32.xor
@@ -8640,7 +8640,7 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$4)
+              (br $while-in1)
             )
           )
         )
@@ -8659,7 +8659,7 @@
             (set_local $1
               (get_local $0)
             )
-            (loop $while-in$6
+            (loop $while-in3
               (if
                 (i32.load8_s
                   (tee_local $0
@@ -8673,7 +8673,7 @@
                   (set_local $1
                     (get_local $0)
                   )
-                  (br $while-in$6)
+                  (br $while-in3)
                 )
               )
             )
@@ -8757,7 +8757,7 @@
         )
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.eq
           (get_local $8)
@@ -8807,7 +8807,7 @@
               (set_local $4
                 (get_local $10)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $4
@@ -8994,9 +8994,9 @@
         )
       )
       (block
-        (loop $while-in$1
-          (block $while-out$0
-            (br_if $while-out$0
+        (loop $while-in
+          (block $while-out
+            (br_if $while-out
               (i32.eqz
                 (i32.and
                   (get_local $0)
@@ -9036,10 +9036,10 @@
                 (i32.const 1)
               )
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
-        (loop $while-in$3
+        (loop $while-in1
           (if
             (i32.ge_s
               (get_local $2)
@@ -9070,13 +9070,13 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$3)
+              (br $while-in1)
             )
           )
         )
       )
     )
-    (loop $while-in$5
+    (loop $while-in3
       (if
         (i32.gt_s
           (get_local $2)
@@ -9107,7 +9107,7 @@
               (i32.const 1)
             )
           )
-          (br $while-in$5)
+          (br $while-in3)
         )
       )
     )
@@ -9182,7 +9182,7 @@
                 (get_local $3)
               )
             )
-            (loop $while-in$1
+            (loop $while-in
               (if
                 (i32.lt_s
                   (get_local $0)
@@ -9199,13 +9199,13 @@
                       (i32.const 1)
                     )
                   )
-                  (br $while-in$1)
+                  (br $while-in)
                 )
               )
             )
           )
         )
-        (loop $while-in$3
+        (loop $while-in1
           (if
             (i32.lt_s
               (get_local $0)
@@ -9222,13 +9222,13 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$3)
+              (br $while-in1)
             )
           )
         )
       )
     )
-    (loop $while-in$5
+    (loop $while-in3
       (if
         (i32.lt_s
           (get_local $0)
@@ -9245,7 +9245,7 @@
               (i32.const 1)
             )
           )
-          (br $while-in$5)
+          (br $while-in3)
         )
       )
     )
@@ -9278,7 +9278,7 @@
       )
     )
     (set_local $0
-      (block $do-once$0 i32
+      (block $do-once i32
         (if i32
           (i32.lt_s
             (call $_fputs
@@ -9326,7 +9326,7 @@
                   (get_local $2)
                   (i32.const 10)
                 )
-                (br $do-once$0
+                (br $do-once
                   (i32.const 0)
                 )
               )

--- a/test/emcc_O2_hello_world.fromasm.imprecise.no-opts
+++ b/test/emcc_O2_hello_world.fromasm.imprecise.no-opts
@@ -172,7 +172,7 @@
     (local $i90 i32)
     (local $i91 i32)
     (local $i92 i32)
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.lt_u
           (get_local $i1)
@@ -264,7 +264,7 @@
                   (get_local $i10)
                 )
               )
-              (block $do-once$2
+              (block $do-once0
                 (if
                   (i32.ne
                     (get_local $i7)
@@ -302,7 +302,7 @@
                           (get_local $i8)
                           (get_local $i11)
                         )
-                        (br $do-once$2)
+                        (br $do-once0)
                       )
                       (call $_abort)
                     )
@@ -535,7 +535,7 @@
                       (get_local $i12)
                     )
                   )
-                  (block $do-once$4
+                  (block $do-once2
                     (if
                       (i32.ne
                         (get_local $i15)
@@ -578,7 +578,7 @@
                                 (i32.const 184)
                               )
                             )
-                            (br $do-once$4)
+                            (br $do-once2)
                           )
                           (call $_abort)
                         )
@@ -917,8 +917,8 @@
                   (set_local $i7
                     (get_local $i10)
                   )
-                  (loop $while-in$7
-                    (block $while-out$6
+                  (loop $while-in
+                    (block $while-out
                       (set_local $i10
                         (i32.load
                           (i32.add
@@ -951,7 +951,7 @@
                               (set_local $i22
                                 (get_local $i7)
                               )
-                              (br $while-out$6)
+                              (br $while-out)
                             )
                             (set_local $i23
                               (get_local $i15)
@@ -999,7 +999,7 @@
                           (get_local $i7)
                         )
                       )
-                      (br $while-in$7)
+                      (br $while-in)
                     )
                   )
                   (set_local $i7
@@ -1043,7 +1043,7 @@
                       )
                     )
                   )
-                  (block $do-once$8
+                  (block $do-once4
                     (if
                       (i32.eq
                         (get_local $i12)
@@ -1085,7 +1085,7 @@
                                 (set_local $i24
                                   (i32.const 0)
                                 )
-                                (br $do-once$8)
+                                (br $do-once4)
                               )
                               (block
                                 (set_local $i25
@@ -1106,8 +1106,8 @@
                             )
                           )
                         )
-                        (loop $while-in$11
-                          (block $while-out$10
+                        (loop $while-in7
+                          (block $while-out6
                             (set_local $i14
                               (i32.add
                                 (get_local $i25)
@@ -1128,7 +1128,7 @@
                                 (set_local $i26
                                   (get_local $i14)
                                 )
-                                (br $while-in$11)
+                                (br $while-in7)
                               )
                             )
                             (set_local $i14
@@ -1153,7 +1153,7 @@
                                 (set_local $i28
                                   (get_local $i26)
                                 )
-                                (br $while-out$10)
+                                (br $while-out6)
                               )
                               (block
                                 (set_local $i25
@@ -1164,7 +1164,7 @@
                                 )
                               )
                             )
-                            (br $while-in$11)
+                            (br $while-in7)
                           )
                         )
                         (if
@@ -1181,7 +1181,7 @@
                             (set_local $i24
                               (get_local $i27)
                             )
-                            (br $do-once$8)
+                            (br $do-once4)
                           )
                         )
                       )
@@ -1241,14 +1241,14 @@
                             (set_local $i24
                               (get_local $i12)
                             )
-                            (br $do-once$8)
+                            (br $do-once4)
                           )
                           (call $_abort)
                         )
                       )
                     )
                   )
-                  (block $do-once$12
+                  (block $do-once8
                     (if
                       (get_local $i5)
                       (block
@@ -1301,7 +1301,7 @@
                                     )
                                   )
                                 )
-                                (br $do-once$12)
+                                (br $do-once8)
                               )
                             )
                           )
@@ -1344,7 +1344,7 @@
                               (i32.eqz
                                 (get_local $i24)
                               )
-                              (br $do-once$12)
+                              (br $do-once8)
                             )
                           )
                         )
@@ -1375,7 +1375,7 @@
                             )
                           )
                         )
-                        (block $do-once$14
+                        (block $do-once10
                           (if
                             (get_local $i7)
                             (if
@@ -1399,7 +1399,7 @@
                                   )
                                   (get_local $i24)
                                 )
-                                (br $do-once$14)
+                                (br $do-once10)
                               )
                             )
                           )
@@ -1437,7 +1437,7 @@
                                 )
                                 (get_local $i24)
                               )
-                              (br $do-once$12)
+                              (br $do-once8)
                             )
                           )
                         )
@@ -1870,8 +1870,8 @@
                       (set_local $i8
                         (i32.const 0)
                       )
-                      (loop $while-in$18
-                        (block $while-out$17
+                      (loop $while-in14
+                        (block $while-out13
                           (set_local $i16
                             (i32.and
                               (i32.load
@@ -1994,7 +1994,7 @@
                               (set_local $i36
                                 (i32.const 86)
                               )
-                              (br $while-out$17)
+                              (br $while-out13)
                             )
                             (block
                               (set_local $i12
@@ -2020,7 +2020,7 @@
                               )
                             )
                           )
-                          (br $while-in$18)
+                          (br $while-in14)
                         )
                       )
                     )
@@ -2070,7 +2070,7 @@
                             (set_local $i31
                               (get_local $i5)
                             )
-                            (br $do-once$0)
+                            (br $do-once)
                           )
                         )
                         (set_local $i4
@@ -2222,8 +2222,8 @@
                     (get_local $i36)
                     (i32.const 90)
                   )
-                  (loop $while-in$20
-                    (block $while-out$19
+                  (loop $while-in16
+                    (block $while-out15
                       (set_local $i36
                         (i32.const 0)
                       )
@@ -2284,7 +2284,7 @@
                           (set_local $i36
                             (i32.const 90)
                           )
-                          (br $while-in$20)
+                          (br $while-in16)
                         )
                       )
                       (set_local $i38
@@ -2306,7 +2306,7 @@
                           (set_local $i44
                             (get_local $i8)
                           )
-                          (br $while-out$19)
+                          (br $while-out15)
                         )
                         (block
                           (set_local $i37
@@ -2320,7 +2320,7 @@
                           )
                         )
                       )
-                      (br $while-in$20)
+                      (br $while-in16)
                     )
                   )
                 )
@@ -2383,7 +2383,7 @@
                         )
                       )
                     )
-                    (block $do-once$21
+                    (block $do-once17
                       (if
                         (i32.eq
                           (get_local $i7)
@@ -2425,7 +2425,7 @@
                                   (set_local $i45
                                     (i32.const 0)
                                   )
-                                  (br $do-once$21)
+                                  (br $do-once17)
                                 )
                                 (block
                                   (set_local $i46
@@ -2446,8 +2446,8 @@
                               )
                             )
                           )
-                          (loop $while-in$24
-                            (block $while-out$23
+                          (loop $while-in20
+                            (block $while-out19
                               (set_local $i2
                                 (i32.add
                                   (get_local $i46)
@@ -2468,7 +2468,7 @@
                                   (set_local $i47
                                     (get_local $i2)
                                   )
-                                  (br $while-in$24)
+                                  (br $while-in20)
                                 )
                               )
                               (set_local $i2
@@ -2493,7 +2493,7 @@
                                   (set_local $i49
                                     (get_local $i47)
                                   )
-                                  (br $while-out$23)
+                                  (br $while-out19)
                                 )
                                 (block
                                   (set_local $i46
@@ -2504,7 +2504,7 @@
                                   )
                                 )
                               )
-                              (br $while-in$24)
+                              (br $while-in20)
                             )
                           )
                           (if
@@ -2521,7 +2521,7 @@
                               (set_local $i45
                                 (get_local $i48)
                               )
-                              (br $do-once$21)
+                              (br $do-once17)
                             )
                           )
                         )
@@ -2581,14 +2581,14 @@
                               (set_local $i45
                                 (get_local $i7)
                               )
-                              (br $do-once$21)
+                              (br $do-once17)
                             )
                             (call $_abort)
                           )
                         )
                       )
                     )
-                    (block $do-once$25
+                    (block $do-once21
                       (if
                         (get_local $i3)
                         (block
@@ -2641,7 +2641,7 @@
                                       )
                                     )
                                   )
-                                  (br $do-once$25)
+                                  (br $do-once21)
                                 )
                               )
                             )
@@ -2684,7 +2684,7 @@
                                 (i32.eqz
                                   (get_local $i45)
                                 )
-                                (br $do-once$25)
+                                (br $do-once21)
                               )
                             )
                           )
@@ -2715,7 +2715,7 @@
                               )
                             )
                           )
-                          (block $do-once$27
+                          (block $do-once23
                             (if
                               (get_local $i15)
                               (if
@@ -2739,7 +2739,7 @@
                                     )
                                     (get_local $i45)
                                   )
-                                  (br $do-once$27)
+                                  (br $do-once23)
                                 )
                               )
                             )
@@ -2777,14 +2777,14 @@
                                   )
                                   (get_local $i45)
                                 )
-                                (br $do-once$25)
+                                (br $do-once21)
                               )
                             )
                           )
                         )
                       )
                     )
-                    (block $do-once$29
+                    (block $do-once25
                       (if
                         (i32.ge_u
                           (get_local $i43)
@@ -2932,7 +2932,7 @@
                                 )
                                 (get_local $i15)
                               )
-                              (br $do-once$29)
+                              (br $do-once25)
                             )
                           )
                           (set_local $i15
@@ -3129,7 +3129,7 @@
                                 )
                                 (get_local $i8)
                               )
-                              (br $do-once$29)
+                              (br $do-once25)
                             )
                           )
                           (set_local $i4
@@ -3156,8 +3156,8 @@
                               (get_local $i3)
                             )
                           )
-                          (loop $while-in$32
-                            (block $while-out$31
+                          (loop $while-in28
+                            (block $while-out27
                               (if
                                 (i32.eq
                                   (i32.and
@@ -3178,7 +3178,7 @@
                                   (set_local $i36
                                     (i32.const 148)
                                   )
-                                  (br $while-out$31)
+                                  (br $while-out27)
                                 )
                               )
                               (set_local $i3
@@ -3215,7 +3215,7 @@
                                   (set_local $i36
                                     (i32.const 145)
                                   )
-                                  (br $while-out$31)
+                                  (br $while-out27)
                                 )
                                 (block
                                   (set_local $i4
@@ -3229,7 +3229,7 @@
                                   )
                                 )
                               )
-                              (br $while-in$32)
+                              (br $while-in28)
                             )
                           )
                           (if
@@ -3271,7 +3271,7 @@
                                   )
                                   (get_local $i8)
                                 )
-                                (br $do-once$29)
+                                (br $do-once25)
                               )
                             )
                             (if
@@ -3340,7 +3340,7 @@
                                       )
                                       (i32.const 0)
                                     )
-                                    (br $do-once$29)
+                                    (br $do-once25)
                                   )
                                   (call $_abort)
                                 )
@@ -3599,7 +3599,7 @@
         )
       )
     )
-    (block $do-once$33
+    (block $do-once29
       (if
         (i32.eqz
           (i32.load
@@ -3659,7 +3659,7 @@
                   (i32.const 1431655768)
                 )
               )
-              (br $do-once$33)
+              (br $do-once29)
             )
             (call $_abort)
           )
@@ -3785,8 +3785,8 @@
                 (set_local $i50
                   (i32.const 624)
                 )
-                (loop $while-in$38
-                  (block $while-out$37
+                (loop $while-in34
+                  (block $while-out33
                     (set_local $i51
                       (i32.load
                         (get_local $i50)
@@ -3824,7 +3824,7 @@
                         (set_local $i57
                           (get_local $i45)
                         )
-                        (br $while-out$37)
+                        (br $while-out33)
                       )
                     )
                     (set_local $i50
@@ -3846,7 +3846,7 @@
                         (br $label$break$L259)
                       )
                     )
-                    (br $while-in$38)
+                    (br $while-in34)
                   )
                 )
                 (set_local $i50
@@ -3921,7 +3921,7 @@
               )
             )
           )
-          (block $do-once$39
+          (block $do-once35
             (if
               (if i32
                 (i32.eq
@@ -4031,7 +4031,7 @@
                         )
                         (i32.const 0)
                       )
-                      (br $do-once$39)
+                      (br $do-once35)
                     )
                     (set_local $i45
                       (call $_sbrk
@@ -4085,7 +4085,7 @@
                     (get_local $i61)
                   )
                 )
-                (block $do-once$42
+                (block $do-once38
                   (if
                     (if i32
                       (i32.and
@@ -4156,7 +4156,7 @@
                             (get_local $i61)
                           )
                         )
-                        (br $do-once$42)
+                        (br $do-once38)
                       )
                     )
                     (set_local $i63
@@ -4313,15 +4313,15 @@
             (i32.const 200)
           )
         )
-        (block $do-once$44
+        (block $do-once40
           (if
             (get_local $i60)
             (block
               (set_local $i63
                 (i32.const 624)
               )
-              (loop $do-in$47
-                (block $do-out$46
+              (loop $do-in
+                (block $do-out
                   (set_local $i43
                     (i32.load
                       (get_local $i63)
@@ -4362,7 +4362,7 @@
                       (set_local $i36
                         (i32.const 203)
                       )
-                      (br $do-out$46)
+                      (br $do-out)
                     )
                   )
                   (set_local $i63
@@ -4373,7 +4373,7 @@
                       )
                     )
                   )
-                  (br_if $do-in$47
+                  (br_if $do-in
                     (i32.ne
                       (get_local $i63)
                       (i32.const 0)
@@ -4498,7 +4498,7 @@
                       (i32.const 664)
                     )
                   )
-                  (br $do-once$44)
+                  (br $do-once40)
                 )
               )
               (set_local $i61
@@ -4533,8 +4533,8 @@
               (set_local $i63
                 (i32.const 624)
               )
-              (loop $while-in$49
-                (block $while-out$48
+              (loop $while-in43
+                (block $while-out42
                   (if
                     (i32.eq
                       (i32.load
@@ -4552,7 +4552,7 @@
                       (set_local $i36
                         (i32.const 211)
                       )
-                      (br $while-out$48)
+                      (br $while-out42)
                     )
                   )
                   (set_local $i63
@@ -4571,10 +4571,10 @@
                       (set_local $i71
                         (i32.const 624)
                       )
-                      (br $while-out$48)
+                      (br $while-out42)
                     )
                   )
-                  (br $while-in$49)
+                  (br $while-in43)
                 )
               )
               (if
@@ -4695,7 +4695,7 @@
                         (i32.const 3)
                       )
                     )
-                    (block $do-once$50
+                    (block $do-once44
                       (if
                         (i32.ne
                           (get_local $i43)
@@ -4743,7 +4743,7 @@
                                 )
                                 (get_local $i62)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $i62
@@ -4798,7 +4798,7 @@
                                         )
                                       )
                                     )
-                                    (block $do-once$53
+                                    (block $do-once47
                                       (if
                                         (i32.eq
                                           (get_local $i55)
@@ -4840,7 +4840,7 @@
                                                   (set_local $i72
                                                     (i32.const 0)
                                                   )
-                                                  (br $do-once$53)
+                                                  (br $do-once47)
                                                 )
                                                 (block
                                                   (set_local $i73
@@ -4861,8 +4861,8 @@
                                               )
                                             )
                                           )
-                                          (loop $while-in$56
-                                            (block $while-out$55
+                                          (loop $while-in50
+                                            (block $while-out49
                                               (set_local $i5
                                                 (i32.add
                                                   (get_local $i73)
@@ -4883,7 +4883,7 @@
                                                   (set_local $i74
                                                     (get_local $i5)
                                                   )
-                                                  (br $while-in$56)
+                                                  (br $while-in50)
                                                 )
                                               )
                                               (set_local $i5
@@ -4908,7 +4908,7 @@
                                                   (set_local $i76
                                                     (get_local $i74)
                                                   )
-                                                  (br $while-out$55)
+                                                  (br $while-out49)
                                                 )
                                                 (block
                                                   (set_local $i73
@@ -4919,7 +4919,7 @@
                                                   )
                                                 )
                                               )
-                                              (br $while-in$56)
+                                              (br $while-in50)
                                             )
                                           )
                                           (if
@@ -4936,7 +4936,7 @@
                                               (set_local $i72
                                                 (get_local $i75)
                                               )
-                                              (br $do-once$53)
+                                              (br $do-once47)
                                             )
                                           )
                                         )
@@ -4996,7 +4996,7 @@
                                               (set_local $i72
                                                 (get_local $i55)
                                               )
-                                              (br $do-once$53)
+                                              (br $do-once47)
                                             )
                                             (call $_abort)
                                           )
@@ -5026,7 +5026,7 @@
                                         )
                                       )
                                     )
-                                    (block $do-once$57
+                                    (block $do-once51
                                       (if
                                         (i32.ne
                                           (get_local $i43)
@@ -5083,7 +5083,7 @@
                                           )
                                           (if
                                             (get_local $i72)
-                                            (br $do-once$57)
+                                            (br $do-once51)
                                           )
                                           (i32.store
                                             (i32.const 180)
@@ -5134,7 +5134,7 @@
                                         (get_local $i5)
                                       )
                                     )
-                                    (block $do-once$59
+                                    (block $do-once53
                                       (if
                                         (get_local $i45)
                                         (if
@@ -5158,7 +5158,7 @@
                                               )
                                               (get_local $i72)
                                             )
-                                            (br $do-once$59)
+                                            (br $do-once53)
                                           )
                                         )
                                       )
@@ -5233,7 +5233,7 @@
                                         )
                                       )
                                     )
-                                    (block $do-once$61
+                                    (block $do-once55
                                       (if
                                         (i32.ne
                                           (get_local $i45)
@@ -5257,7 +5257,7 @@
                                               )
                                               (get_local $i43)
                                             )
-                                            (br $do-once$61)
+                                            (br $do-once55)
                                           )
                                           (call $_abort)
                                         )
@@ -5287,7 +5287,7 @@
                                         (br $label$break$L331)
                                       )
                                     )
-                                    (block $do-once$63
+                                    (block $do-once57
                                       (if
                                         (i32.eq
                                           (get_local $i55)
@@ -5324,7 +5324,7 @@
                                               (set_local $i77
                                                 (get_local $i5)
                                               )
-                                              (br $do-once$63)
+                                              (br $do-once57)
                                             )
                                           )
                                           (call $_abort)
@@ -5434,7 +5434,7 @@
                                   (get_local $i56)
                                 )
                               )
-                              (block $do-once$65
+                              (block $do-once59
                                 (if
                                   (i32.eqz
                                     (i32.and
@@ -5486,7 +5486,7 @@
                                         (set_local $i81
                                           (get_local $i52)
                                         )
-                                        (br $do-once$65)
+                                        (br $do-once59)
                                       )
                                     )
                                     (call $_abort)
@@ -5518,7 +5518,7 @@
                                 )
                                 (get_local $i62)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $i5
@@ -5527,7 +5527,7 @@
                               (i32.const 8)
                             )
                           )
-                          (block $do-once$67
+                          (block $do-once61
                             (if
                               (i32.eqz
                                 (get_local $i5)
@@ -5545,7 +5545,7 @@
                                     (set_local $i82
                                       (i32.const 31)
                                     )
-                                    (br $do-once$67)
+                                    (br $do-once61)
                                   )
                                 )
                                 (set_local $i54
@@ -5722,7 +5722,7 @@
                                 )
                                 (get_local $i63)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $i50
@@ -5749,8 +5749,8 @@
                               (get_local $i5)
                             )
                           )
-                          (loop $while-in$70
-                            (block $while-out$69
+                          (loop $while-in64
+                            (block $while-out63
                               (if
                                 (i32.eq
                                   (i32.and
@@ -5771,7 +5771,7 @@
                                   (set_local $i36
                                     (i32.const 281)
                                   )
-                                  (br $while-out$69)
+                                  (br $while-out63)
                                 )
                               )
                               (set_local $i5
@@ -5808,7 +5808,7 @@
                                   (set_local $i36
                                     (i32.const 278)
                                   )
-                                  (br $while-out$69)
+                                  (br $while-out63)
                                 )
                                 (block
                                   (set_local $i50
@@ -5822,7 +5822,7 @@
                                   )
                                 )
                               )
-                              (br $while-in$70)
+                              (br $while-in64)
                             )
                           )
                           (if
@@ -5864,7 +5864,7 @@
                                   )
                                   (get_local $i63)
                                 )
-                                (br $do-once$50)
+                                (br $do-once44)
                               )
                             )
                             (if
@@ -5933,7 +5933,7 @@
                                       )
                                       (i32.const 0)
                                     )
-                                    (br $do-once$50)
+                                    (br $do-once44)
                                   )
                                   (call $_abort)
                                 )
@@ -5986,8 +5986,8 @@
                   )
                 )
               )
-              (loop $while-in$72
-                (block $while-out$71
+              (loop $while-in66
+                (block $while-out65
                   (set_local $i63
                     (i32.load
                       (get_local $i71)
@@ -6022,7 +6022,7 @@
                       (set_local $i86
                         (get_local $i53)
                       )
-                      (br $while-out$71)
+                      (br $while-out65)
                     )
                   )
                   (set_local $i71
@@ -6033,7 +6033,7 @@
                       )
                     )
                   )
-                  (br $while-in$72)
+                  (br $while-in66)
                 )
               )
               (set_local $i44
@@ -6231,8 +6231,8 @@
                   (i32.const 24)
                 )
               )
-              (loop $do-in$74
-                (block $do-out$73
+              (loop $do-in68
+                (block $do-out67
                   (set_local $i63
                     (i32.add
                       (get_local $i63)
@@ -6243,7 +6243,7 @@
                     (get_local $i63)
                     (i32.const 7)
                   )
-                  (br_if $do-in$74
+                  (br_if $do-in68
                     (i32.lt_u
                       (i32.add
                         (get_local $i63)
@@ -6403,7 +6403,7 @@
                         )
                         (get_local $i61)
                       )
-                      (br $do-once$44)
+                      (br $do-once40)
                     )
                   )
                   (set_local $i61
@@ -6594,7 +6594,7 @@
                         )
                         (get_local $i60)
                       )
-                      (br $do-once$44)
+                      (br $do-once40)
                     )
                   )
                   (set_local $i5
@@ -6621,8 +6621,8 @@
                       (get_local $i43)
                     )
                   )
-                  (loop $while-in$76
-                    (block $while-out$75
+                  (loop $while-in70
+                    (block $while-out69
                       (if
                         (i32.eq
                           (i32.and
@@ -6643,7 +6643,7 @@
                           (set_local $i36
                             (i32.const 307)
                           )
-                          (br $while-out$75)
+                          (br $while-out69)
                         )
                       )
                       (set_local $i43
@@ -6680,7 +6680,7 @@
                           (set_local $i36
                             (i32.const 304)
                           )
-                          (br $while-out$75)
+                          (br $while-out69)
                         )
                         (block
                           (set_local $i5
@@ -6694,7 +6694,7 @@
                           )
                         )
                       )
-                      (br $while-in$76)
+                      (br $while-in70)
                     )
                   )
                   (if
@@ -6736,7 +6736,7 @@
                           )
                           (get_local $i60)
                         )
-                        (br $do-once$44)
+                        (br $do-once40)
                       )
                     )
                     (if
@@ -6805,7 +6805,7 @@
                               )
                               (i32.const 0)
                             )
-                            (br $do-once$44)
+                            (br $do-once40)
                           )
                           (call $_abort)
                         )
@@ -6862,8 +6862,8 @@
               (set_local $i5
                 (i32.const 0)
               )
-              (loop $do-in$78
-                (block $do-out$77
+              (loop $do-in72
+                (block $do-out71
                   (set_local $i62
                     (i32.add
                       (i32.const 216)
@@ -6896,7 +6896,7 @@
                       (i32.const 1)
                     )
                   )
-                  (br_if $do-in$78
+                  (br_if $do-in72
                     (i32.ne
                       (get_local $i5)
                       (i32.const 32)
@@ -7155,7 +7155,7 @@
         (get_local $i5)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.eqz
           (i32.and
@@ -7231,7 +7231,7 @@
                   (set_local $i13
                     (get_local $i9)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (i32.store
@@ -7359,7 +7359,7 @@
                   (set_local $i13
                     (get_local $i9)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (if
@@ -7418,7 +7418,7 @@
               (set_local $i13
                 (get_local $i9)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $i7
@@ -7437,7 +7437,7 @@
               )
             )
           )
-          (block $do-once$2
+          (block $do-once0
             (if
               (i32.eq
                 (get_local $i10)
@@ -7479,7 +7479,7 @@
                         (set_local $i18
                           (i32.const 0)
                         )
-                        (br $do-once$2)
+                        (br $do-once0)
                       )
                       (block
                         (set_local $i19
@@ -7500,8 +7500,8 @@
                     )
                   )
                 )
-                (loop $while-in$5
-                  (block $while-out$4
+                (loop $while-in
+                  (block $while-out
                     (set_local $i11
                       (i32.add
                         (get_local $i19)
@@ -7522,7 +7522,7 @@
                         (set_local $i20
                           (get_local $i11)
                         )
-                        (br $while-in$5)
+                        (br $while-in)
                       )
                     )
                     (set_local $i11
@@ -7547,7 +7547,7 @@
                         (set_local $i22
                           (get_local $i20)
                         )
-                        (br $while-out$4)
+                        (br $while-out)
                       )
                       (block
                         (set_local $i19
@@ -7558,7 +7558,7 @@
                         )
                       )
                     )
-                    (br $while-in$5)
+                    (br $while-in)
                   )
                 )
                 (if
@@ -7575,7 +7575,7 @@
                     (set_local $i18
                       (get_local $i21)
                     )
-                    (br $do-once$2)
+                    (br $do-once0)
                   )
                 )
               )
@@ -7635,7 +7635,7 @@
                     (set_local $i18
                       (get_local $i10)
                     )
-                    (br $do-once$2)
+                    (br $do-once0)
                   )
                   (call $_abort)
                 )
@@ -7700,7 +7700,7 @@
                       (set_local $i13
                         (get_local $i9)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -7750,7 +7750,7 @@
                       (set_local $i13
                         (get_local $i9)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -7785,7 +7785,7 @@
                   (get_local $i11)
                 )
               )
-              (block $do-once$6
+              (block $do-once2
                 (if
                   (get_local $i14)
                   (if
@@ -7809,7 +7809,7 @@
                         )
                         (get_local $i18)
                       )
-                      (br $do-once$6)
+                      (br $do-once2)
                     )
                   )
                 )
@@ -7853,7 +7853,7 @@
                     (set_local $i13
                       (get_local $i9)
                     )
-                    (br $do-once$0)
+                    (br $do-once)
                   )
                 )
                 (block
@@ -8034,7 +8034,7 @@
             (i32.const 3)
           )
         )
-        (block $do-once$8
+        (block $do-once4
           (if
             (i32.ge_u
               (get_local $i2)
@@ -8057,7 +8057,7 @@
                   )
                 )
               )
-              (block $do-once$10
+              (block $do-once6
                 (if
                   (i32.eq
                     (get_local $i22)
@@ -8099,7 +8099,7 @@
                             (set_local $i23
                               (i32.const 0)
                             )
-                            (br $do-once$10)
+                            (br $do-once6)
                           )
                           (block
                             (set_local $i24
@@ -8120,8 +8120,8 @@
                         )
                       )
                     )
-                    (loop $while-in$13
-                      (block $while-out$12
+                    (loop $while-in9
+                      (block $while-out8
                         (set_local $i19
                           (i32.add
                             (get_local $i24)
@@ -8142,7 +8142,7 @@
                             (set_local $i25
                               (get_local $i19)
                             )
-                            (br $while-in$13)
+                            (br $while-in9)
                           )
                         )
                         (set_local $i19
@@ -8167,7 +8167,7 @@
                             (set_local $i27
                               (get_local $i25)
                             )
-                            (br $while-out$12)
+                            (br $while-out8)
                           )
                           (block
                             (set_local $i24
@@ -8178,7 +8178,7 @@
                             )
                           )
                         )
-                        (br $while-in$13)
+                        (br $while-in9)
                       )
                     )
                     (if
@@ -8197,7 +8197,7 @@
                         (set_local $i23
                           (get_local $i26)
                         )
-                        (br $do-once$10)
+                        (br $do-once6)
                       )
                     )
                   )
@@ -8259,7 +8259,7 @@
                         (set_local $i23
                           (get_local $i22)
                         )
-                        (br $do-once$10)
+                        (br $do-once6)
                       )
                       (call $_abort)
                     )
@@ -8318,7 +8318,7 @@
                               )
                             )
                           )
-                          (br $do-once$8)
+                          (br $do-once4)
                         )
                       )
                     )
@@ -8361,7 +8361,7 @@
                         (i32.eqz
                           (get_local $i23)
                         )
-                        (br $do-once$8)
+                        (br $do-once4)
                       )
                     )
                   )
@@ -8395,7 +8395,7 @@
                       (get_local $i9)
                     )
                   )
-                  (block $do-once$14
+                  (block $do-once10
                     (if
                       (get_local $i8)
                       (if
@@ -8419,7 +8419,7 @@
                             )
                             (get_local $i23)
                           )
-                          (br $do-once$14)
+                          (br $do-once10)
                         )
                       )
                     )
@@ -8457,7 +8457,7 @@
                           )
                           (get_local $i23)
                         )
-                        (br $do-once$8)
+                        (br $do-once4)
                       )
                     )
                   )
@@ -8543,7 +8543,7 @@
                       )
                     )
                   )
-                  (br $do-once$8)
+                  (br $do-once4)
                 )
               )
               (if
@@ -8935,7 +8935,7 @@
         (get_local $i32)
       )
     )
-    (block $do-once$16
+    (block $do-once12
       (if
         (i32.and
           (get_local $i30)
@@ -8966,8 +8966,8 @@
               (get_local $i5)
             )
           )
-          (loop $while-in$19
-            (block $while-out$18
+          (loop $while-in15
+            (block $while-out14
               (if
                 (i32.eq
                   (i32.and
@@ -8988,7 +8988,7 @@
                   (set_local $i34
                     (i32.const 130)
                   )
-                  (br $while-out$18)
+                  (br $while-out14)
                 )
               )
               (set_local $i28
@@ -9025,7 +9025,7 @@
                   (set_local $i34
                     (i32.const 127)
                   )
-                  (br $while-out$18)
+                  (br $while-out14)
                 )
                 (block
                   (set_local $i31
@@ -9039,7 +9039,7 @@
                   )
                 )
               )
-              (br $while-in$19)
+              (br $while-in15)
             )
           )
           (if
@@ -9081,7 +9081,7 @@
                   )
                   (get_local $i12)
                 )
-                (br $do-once$16)
+                (br $do-once12)
               )
             )
             (if
@@ -9150,7 +9150,7 @@
                       )
                       (i32.const 0)
                     )
-                    (br $do-once$16)
+                    (br $do-once12)
                   )
                   (call $_abort)
                 )
@@ -9215,8 +9215,8 @@
       )
       (return)
     )
-    (loop $while-in$21
-      (block $while-out$20
+    (loop $while-in17
+      (block $while-out16
         (set_local $i12
           (i32.load
             (get_local $i37)
@@ -9226,7 +9226,7 @@
           (i32.eqz
             (get_local $i12)
           )
-          (br $while-out$20)
+          (br $while-out16)
           (set_local $i37
             (i32.add
               (get_local $i12)
@@ -9234,7 +9234,7 @@
             )
           )
         )
-        (br $while-in$21)
+        (br $while-in17)
       )
     )
     (i32.store
@@ -9363,8 +9363,8 @@
         (get_local $i3)
       )
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (if
           (i32.eqz
             (i32.load
@@ -9451,7 +9451,7 @@
             (set_local $i15
               (i32.const 6)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (if
@@ -9469,7 +9469,7 @@
             (set_local $i15
               (i32.const 8)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (set_local $i11
@@ -9604,7 +9604,7 @@
         (set_local $i13
           (get_local $i11)
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
     (if
@@ -9832,8 +9832,8 @@
                 (set_local $i4
                   (get_local $i2)
                 )
-                (loop $while-in$3
-                  (block $while-out$2
+                (loop $while-in
+                  (block $while-out
                     (if
                       (i32.eqz
                         (get_local $i4)
@@ -9874,13 +9874,13 @@
                         (set_local $i15
                           (get_local $i4)
                         )
-                        (br $while-out$2)
+                        (br $while-out)
                       )
                       (set_local $i4
                         (get_local $i14)
                       )
                     )
-                    (br $while-in$3)
+                    (br $while-in)
                   )
                 )
                 (if
@@ -9985,7 +9985,7 @@
     (local $i6 i32)
     (local $i7 i32)
     (local $i8 i32)
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $i1)
         (block
@@ -10005,7 +10005,7 @@
                   (get_local $i1)
                 )
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $i3
@@ -10076,8 +10076,8 @@
               (set_local $i4
                 (get_local $i5)
               )
-              (loop $while-in$3
-                (block $while-out$2
+              (loop $while-in
+                (block $while-out
                   (if
                     (i32.gt_s
                       (i32.load
@@ -10146,13 +10146,13 @@
                       (set_local $i6
                         (get_local $i8)
                       )
-                      (br $while-out$2)
+                      (br $while-out)
                     )
                     (set_local $i4
                       (get_local $i8)
                     )
                   )
-                  (br $while-in$3)
+                  (br $while-in)
                 )
               )
             )
@@ -10207,8 +10207,8 @@
           (set_local $i6
             (get_local $i2)
           )
-          (loop $while-in$2
-            (block $while-out$1
+          (loop $while-in
+            (block $while-out
               (if
                 (i32.eqz
                   (i32.load8_s
@@ -10245,13 +10245,13 @@
                   (set_local $i4
                     (i32.const 4)
                   )
-                  (br $while-out$1)
+                  (br $while-out)
                 )
                 (set_local $i5
                   (get_local $i8)
                 )
               )
-              (br $while-in$2)
+              (br $while-in)
             )
           )
         )
@@ -10266,8 +10266,8 @@
         (set_local $i4
           (get_local $i3)
         )
-        (loop $while-in$4
-          (block $while-out$3
+        (loop $while-in1
+          (block $while-out0
             (set_local $i3
               (i32.load
                 (get_local $i4)
@@ -10302,10 +10302,10 @@
                 (set_local $i10
                   (get_local $i4)
                 )
-                (br $while-out$3)
+                (br $while-out0)
               )
             )
-            (br $while-in$4)
+            (br $while-in1)
           )
         )
         (if
@@ -10328,8 +10328,8 @@
             (set_local $i9
               (get_local $i10)
             )
-            (loop $while-in$6
-              (block $while-out$5
+            (loop $while-in3
+              (block $while-out2
                 (set_local $i10
                   (i32.add
                     (get_local $i9)
@@ -10346,13 +10346,13 @@
                     (set_local $i11
                       (get_local $i10)
                     )
-                    (br $while-out$5)
+                    (br $while-out2)
                   )
                   (set_local $i9
                     (get_local $i10)
                   )
                 )
-                (br $while-in$6)
+                (br $while-in3)
               )
             )
           )
@@ -10445,7 +10445,7 @@
         )
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.eq
           (get_local $i9)
@@ -10503,7 +10503,7 @@
               (set_local $i10
                 (get_local $i11)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (if
@@ -10721,8 +10721,8 @@
         )
       )
       (block
-        (loop $while-in$1
-          (block $while-out$0
+        (loop $while-in
+          (block $while-out
             (if
               (i32.eqz
                 (i32.and
@@ -10730,7 +10730,7 @@
                   (i32.const 3)
                 )
               )
-              (br $while-out$0)
+              (br $while-out)
             )
             (block
               (if
@@ -10766,11 +10766,11 @@
                 )
               )
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
-        (loop $while-in$3
-          (block $while-out$2
+        (loop $while-in1
+          (block $while-out0
             (if
               (i32.eqz
                 (i32.ge_s
@@ -10778,7 +10778,7 @@
                   (i32.const 4)
                 )
               )
-              (br $while-out$2)
+              (br $while-out0)
             )
             (block
               (i32.store
@@ -10806,13 +10806,13 @@
                 )
               )
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
     )
-    (loop $while-in$5
-      (block $while-out$4
+    (loop $while-in3
+      (block $while-out2
         (if
           (i32.eqz
             (i32.gt_s
@@ -10820,7 +10820,7 @@
               (i32.const 0)
             )
           )
-          (br $while-out$4)
+          (br $while-out2)
         )
         (block
           (i32.store8
@@ -10848,7 +10848,7 @@
             )
           )
         )
-        (br $while-in$5)
+        (br $while-in3)
       )
     )
     (return
@@ -10929,8 +10929,8 @@
                 (get_local $i5)
               )
             )
-            (loop $while-in$1
-              (block $while-out$0
+            (loop $while-in
+              (block $while-out
                 (if
                   (i32.eqz
                     (i32.lt_s
@@ -10938,7 +10938,7 @@
                       (get_local $i5)
                     )
                   )
-                  (br $while-out$0)
+                  (br $while-out)
                 )
                 (block
                   (i32.store8
@@ -10952,13 +10952,13 @@
                     )
                   )
                 )
-                (br $while-in$1)
+                (br $while-in)
               )
             )
           )
         )
-        (loop $while-in$3
-          (block $while-out$2
+        (loop $while-in1
+          (block $while-out0
             (if
               (i32.eqz
                 (i32.lt_s
@@ -10966,7 +10966,7 @@
                   (get_local $i7)
                 )
               )
-              (br $while-out$2)
+              (br $while-out0)
             )
             (block
               (i32.store
@@ -10980,13 +10980,13 @@
                 )
               )
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
     )
-    (loop $while-in$5
-      (block $while-out$4
+    (loop $while-in3
+      (block $while-out2
         (if
           (i32.eqz
             (i32.lt_s
@@ -10994,7 +10994,7 @@
               (get_local $i4)
             )
           )
-          (br $while-out$4)
+          (br $while-out2)
         )
         (block
           (i32.store8
@@ -11008,7 +11008,7 @@
             )
           )
         )
-        (br $while-in$5)
+        (br $while-in3)
       )
     )
     (return
@@ -11048,7 +11048,7 @@
         (i32.const 0)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.lt_s
           (call $_fputs
@@ -11113,7 +11113,7 @@
               (set_local $i4
                 (i32.const 0)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $i4

--- a/test/emcc_O2_hello_world.fromasm.no-opts
+++ b/test/emcc_O2_hello_world.fromasm.no-opts
@@ -173,7 +173,7 @@
     (local $i90 i32)
     (local $i91 i32)
     (local $i92 i32)
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.lt_u
           (get_local $i1)
@@ -265,7 +265,7 @@
                   (get_local $i10)
                 )
               )
-              (block $do-once$2
+              (block $do-once0
                 (if
                   (i32.ne
                     (get_local $i7)
@@ -303,7 +303,7 @@
                           (get_local $i8)
                           (get_local $i11)
                         )
-                        (br $do-once$2)
+                        (br $do-once0)
                       )
                       (call $_abort)
                     )
@@ -536,7 +536,7 @@
                       (get_local $i12)
                     )
                   )
-                  (block $do-once$4
+                  (block $do-once2
                     (if
                       (i32.ne
                         (get_local $i15)
@@ -579,7 +579,7 @@
                                 (i32.const 184)
                               )
                             )
-                            (br $do-once$4)
+                            (br $do-once2)
                           )
                           (call $_abort)
                         )
@@ -918,8 +918,8 @@
                   (set_local $i7
                     (get_local $i10)
                   )
-                  (loop $while-in$7
-                    (block $while-out$6
+                  (loop $while-in
+                    (block $while-out
                       (set_local $i10
                         (i32.load
                           (i32.add
@@ -952,7 +952,7 @@
                               (set_local $i22
                                 (get_local $i7)
                               )
-                              (br $while-out$6)
+                              (br $while-out)
                             )
                             (set_local $i23
                               (get_local $i15)
@@ -1000,7 +1000,7 @@
                           (get_local $i7)
                         )
                       )
-                      (br $while-in$7)
+                      (br $while-in)
                     )
                   )
                   (set_local $i7
@@ -1044,7 +1044,7 @@
                       )
                     )
                   )
-                  (block $do-once$8
+                  (block $do-once4
                     (if
                       (i32.eq
                         (get_local $i12)
@@ -1086,7 +1086,7 @@
                                 (set_local $i24
                                   (i32.const 0)
                                 )
-                                (br $do-once$8)
+                                (br $do-once4)
                               )
                               (block
                                 (set_local $i25
@@ -1107,8 +1107,8 @@
                             )
                           )
                         )
-                        (loop $while-in$11
-                          (block $while-out$10
+                        (loop $while-in7
+                          (block $while-out6
                             (set_local $i14
                               (i32.add
                                 (get_local $i25)
@@ -1129,7 +1129,7 @@
                                 (set_local $i26
                                   (get_local $i14)
                                 )
-                                (br $while-in$11)
+                                (br $while-in7)
                               )
                             )
                             (set_local $i14
@@ -1154,7 +1154,7 @@
                                 (set_local $i28
                                   (get_local $i26)
                                 )
-                                (br $while-out$10)
+                                (br $while-out6)
                               )
                               (block
                                 (set_local $i25
@@ -1165,7 +1165,7 @@
                                 )
                               )
                             )
-                            (br $while-in$11)
+                            (br $while-in7)
                           )
                         )
                         (if
@@ -1182,7 +1182,7 @@
                             (set_local $i24
                               (get_local $i27)
                             )
-                            (br $do-once$8)
+                            (br $do-once4)
                           )
                         )
                       )
@@ -1242,14 +1242,14 @@
                             (set_local $i24
                               (get_local $i12)
                             )
-                            (br $do-once$8)
+                            (br $do-once4)
                           )
                           (call $_abort)
                         )
                       )
                     )
                   )
-                  (block $do-once$12
+                  (block $do-once8
                     (if
                       (get_local $i5)
                       (block
@@ -1302,7 +1302,7 @@
                                     )
                                   )
                                 )
-                                (br $do-once$12)
+                                (br $do-once8)
                               )
                             )
                           )
@@ -1345,7 +1345,7 @@
                               (i32.eqz
                                 (get_local $i24)
                               )
-                              (br $do-once$12)
+                              (br $do-once8)
                             )
                           )
                         )
@@ -1376,7 +1376,7 @@
                             )
                           )
                         )
-                        (block $do-once$14
+                        (block $do-once10
                           (if
                             (get_local $i7)
                             (if
@@ -1400,7 +1400,7 @@
                                   )
                                   (get_local $i24)
                                 )
-                                (br $do-once$14)
+                                (br $do-once10)
                               )
                             )
                           )
@@ -1438,7 +1438,7 @@
                                 )
                                 (get_local $i24)
                               )
-                              (br $do-once$12)
+                              (br $do-once8)
                             )
                           )
                         )
@@ -1871,8 +1871,8 @@
                       (set_local $i8
                         (i32.const 0)
                       )
-                      (loop $while-in$18
-                        (block $while-out$17
+                      (loop $while-in14
+                        (block $while-out13
                           (set_local $i16
                             (i32.and
                               (i32.load
@@ -1995,7 +1995,7 @@
                               (set_local $i36
                                 (i32.const 86)
                               )
-                              (br $while-out$17)
+                              (br $while-out13)
                             )
                             (block
                               (set_local $i12
@@ -2021,7 +2021,7 @@
                               )
                             )
                           )
-                          (br $while-in$18)
+                          (br $while-in14)
                         )
                       )
                     )
@@ -2071,7 +2071,7 @@
                             (set_local $i31
                               (get_local $i5)
                             )
-                            (br $do-once$0)
+                            (br $do-once)
                           )
                         )
                         (set_local $i4
@@ -2223,8 +2223,8 @@
                     (get_local $i36)
                     (i32.const 90)
                   )
-                  (loop $while-in$20
-                    (block $while-out$19
+                  (loop $while-in16
+                    (block $while-out15
                       (set_local $i36
                         (i32.const 0)
                       )
@@ -2285,7 +2285,7 @@
                           (set_local $i36
                             (i32.const 90)
                           )
-                          (br $while-in$20)
+                          (br $while-in16)
                         )
                       )
                       (set_local $i38
@@ -2307,7 +2307,7 @@
                           (set_local $i44
                             (get_local $i8)
                           )
-                          (br $while-out$19)
+                          (br $while-out15)
                         )
                         (block
                           (set_local $i37
@@ -2321,7 +2321,7 @@
                           )
                         )
                       )
-                      (br $while-in$20)
+                      (br $while-in16)
                     )
                   )
                 )
@@ -2384,7 +2384,7 @@
                         )
                       )
                     )
-                    (block $do-once$21
+                    (block $do-once17
                       (if
                         (i32.eq
                           (get_local $i7)
@@ -2426,7 +2426,7 @@
                                   (set_local $i45
                                     (i32.const 0)
                                   )
-                                  (br $do-once$21)
+                                  (br $do-once17)
                                 )
                                 (block
                                   (set_local $i46
@@ -2447,8 +2447,8 @@
                               )
                             )
                           )
-                          (loop $while-in$24
-                            (block $while-out$23
+                          (loop $while-in20
+                            (block $while-out19
                               (set_local $i2
                                 (i32.add
                                   (get_local $i46)
@@ -2469,7 +2469,7 @@
                                   (set_local $i47
                                     (get_local $i2)
                                   )
-                                  (br $while-in$24)
+                                  (br $while-in20)
                                 )
                               )
                               (set_local $i2
@@ -2494,7 +2494,7 @@
                                   (set_local $i49
                                     (get_local $i47)
                                   )
-                                  (br $while-out$23)
+                                  (br $while-out19)
                                 )
                                 (block
                                   (set_local $i46
@@ -2505,7 +2505,7 @@
                                   )
                                 )
                               )
-                              (br $while-in$24)
+                              (br $while-in20)
                             )
                           )
                           (if
@@ -2522,7 +2522,7 @@
                               (set_local $i45
                                 (get_local $i48)
                               )
-                              (br $do-once$21)
+                              (br $do-once17)
                             )
                           )
                         )
@@ -2582,14 +2582,14 @@
                               (set_local $i45
                                 (get_local $i7)
                               )
-                              (br $do-once$21)
+                              (br $do-once17)
                             )
                             (call $_abort)
                           )
                         )
                       )
                     )
-                    (block $do-once$25
+                    (block $do-once21
                       (if
                         (get_local $i3)
                         (block
@@ -2642,7 +2642,7 @@
                                       )
                                     )
                                   )
-                                  (br $do-once$25)
+                                  (br $do-once21)
                                 )
                               )
                             )
@@ -2685,7 +2685,7 @@
                                 (i32.eqz
                                   (get_local $i45)
                                 )
-                                (br $do-once$25)
+                                (br $do-once21)
                               )
                             )
                           )
@@ -2716,7 +2716,7 @@
                               )
                             )
                           )
-                          (block $do-once$27
+                          (block $do-once23
                             (if
                               (get_local $i15)
                               (if
@@ -2740,7 +2740,7 @@
                                     )
                                     (get_local $i45)
                                   )
-                                  (br $do-once$27)
+                                  (br $do-once23)
                                 )
                               )
                             )
@@ -2778,14 +2778,14 @@
                                   )
                                   (get_local $i45)
                                 )
-                                (br $do-once$25)
+                                (br $do-once21)
                               )
                             )
                           )
                         )
                       )
                     )
-                    (block $do-once$29
+                    (block $do-once25
                       (if
                         (i32.ge_u
                           (get_local $i43)
@@ -2933,7 +2933,7 @@
                                 )
                                 (get_local $i15)
                               )
-                              (br $do-once$29)
+                              (br $do-once25)
                             )
                           )
                           (set_local $i15
@@ -3130,7 +3130,7 @@
                                 )
                                 (get_local $i8)
                               )
-                              (br $do-once$29)
+                              (br $do-once25)
                             )
                           )
                           (set_local $i4
@@ -3157,8 +3157,8 @@
                               (get_local $i3)
                             )
                           )
-                          (loop $while-in$32
-                            (block $while-out$31
+                          (loop $while-in28
+                            (block $while-out27
                               (if
                                 (i32.eq
                                   (i32.and
@@ -3179,7 +3179,7 @@
                                   (set_local $i36
                                     (i32.const 148)
                                   )
-                                  (br $while-out$31)
+                                  (br $while-out27)
                                 )
                               )
                               (set_local $i3
@@ -3216,7 +3216,7 @@
                                   (set_local $i36
                                     (i32.const 145)
                                   )
-                                  (br $while-out$31)
+                                  (br $while-out27)
                                 )
                                 (block
                                   (set_local $i4
@@ -3230,7 +3230,7 @@
                                   )
                                 )
                               )
-                              (br $while-in$32)
+                              (br $while-in28)
                             )
                           )
                           (if
@@ -3272,7 +3272,7 @@
                                   )
                                   (get_local $i8)
                                 )
-                                (br $do-once$29)
+                                (br $do-once25)
                               )
                             )
                             (if
@@ -3341,7 +3341,7 @@
                                       )
                                       (i32.const 0)
                                     )
-                                    (br $do-once$29)
+                                    (br $do-once25)
                                   )
                                   (call $_abort)
                                 )
@@ -3600,7 +3600,7 @@
         )
       )
     )
-    (block $do-once$33
+    (block $do-once29
       (if
         (i32.eqz
           (i32.load
@@ -3660,7 +3660,7 @@
                   (i32.const 1431655768)
                 )
               )
-              (br $do-once$33)
+              (br $do-once29)
             )
             (call $_abort)
           )
@@ -3786,8 +3786,8 @@
                 (set_local $i50
                   (i32.const 624)
                 )
-                (loop $while-in$38
-                  (block $while-out$37
+                (loop $while-in34
+                  (block $while-out33
                     (set_local $i51
                       (i32.load
                         (get_local $i50)
@@ -3825,7 +3825,7 @@
                         (set_local $i57
                           (get_local $i45)
                         )
-                        (br $while-out$37)
+                        (br $while-out33)
                       )
                     )
                     (set_local $i50
@@ -3847,7 +3847,7 @@
                         (br $label$break$L259)
                       )
                     )
-                    (br $while-in$38)
+                    (br $while-in34)
                   )
                 )
                 (set_local $i50
@@ -3922,7 +3922,7 @@
               )
             )
           )
-          (block $do-once$39
+          (block $do-once35
             (if
               (if i32
                 (i32.eq
@@ -4032,7 +4032,7 @@
                         )
                         (i32.const 0)
                       )
-                      (br $do-once$39)
+                      (br $do-once35)
                     )
                     (set_local $i45
                       (call $_sbrk
@@ -4086,7 +4086,7 @@
                     (get_local $i61)
                   )
                 )
-                (block $do-once$42
+                (block $do-once38
                   (if
                     (if i32
                       (i32.and
@@ -4157,7 +4157,7 @@
                             (get_local $i61)
                           )
                         )
-                        (br $do-once$42)
+                        (br $do-once38)
                       )
                     )
                     (set_local $i63
@@ -4314,15 +4314,15 @@
             (i32.const 200)
           )
         )
-        (block $do-once$44
+        (block $do-once40
           (if
             (get_local $i60)
             (block
               (set_local $i63
                 (i32.const 624)
               )
-              (loop $do-in$47
-                (block $do-out$46
+              (loop $do-in
+                (block $do-out
                   (set_local $i43
                     (i32.load
                       (get_local $i63)
@@ -4363,7 +4363,7 @@
                       (set_local $i36
                         (i32.const 203)
                       )
-                      (br $do-out$46)
+                      (br $do-out)
                     )
                   )
                   (set_local $i63
@@ -4374,7 +4374,7 @@
                       )
                     )
                   )
-                  (br_if $do-in$47
+                  (br_if $do-in
                     (i32.ne
                       (get_local $i63)
                       (i32.const 0)
@@ -4499,7 +4499,7 @@
                       (i32.const 664)
                     )
                   )
-                  (br $do-once$44)
+                  (br $do-once40)
                 )
               )
               (set_local $i61
@@ -4534,8 +4534,8 @@
               (set_local $i63
                 (i32.const 624)
               )
-              (loop $while-in$49
-                (block $while-out$48
+              (loop $while-in43
+                (block $while-out42
                   (if
                     (i32.eq
                       (i32.load
@@ -4553,7 +4553,7 @@
                       (set_local $i36
                         (i32.const 211)
                       )
-                      (br $while-out$48)
+                      (br $while-out42)
                     )
                   )
                   (set_local $i63
@@ -4572,10 +4572,10 @@
                       (set_local $i71
                         (i32.const 624)
                       )
-                      (br $while-out$48)
+                      (br $while-out42)
                     )
                   )
-                  (br $while-in$49)
+                  (br $while-in43)
                 )
               )
               (if
@@ -4696,7 +4696,7 @@
                         (i32.const 3)
                       )
                     )
-                    (block $do-once$50
+                    (block $do-once44
                       (if
                         (i32.ne
                           (get_local $i43)
@@ -4744,7 +4744,7 @@
                                 )
                                 (get_local $i62)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $i62
@@ -4799,7 +4799,7 @@
                                         )
                                       )
                                     )
-                                    (block $do-once$53
+                                    (block $do-once47
                                       (if
                                         (i32.eq
                                           (get_local $i55)
@@ -4841,7 +4841,7 @@
                                                   (set_local $i72
                                                     (i32.const 0)
                                                   )
-                                                  (br $do-once$53)
+                                                  (br $do-once47)
                                                 )
                                                 (block
                                                   (set_local $i73
@@ -4862,8 +4862,8 @@
                                               )
                                             )
                                           )
-                                          (loop $while-in$56
-                                            (block $while-out$55
+                                          (loop $while-in50
+                                            (block $while-out49
                                               (set_local $i5
                                                 (i32.add
                                                   (get_local $i73)
@@ -4884,7 +4884,7 @@
                                                   (set_local $i74
                                                     (get_local $i5)
                                                   )
-                                                  (br $while-in$56)
+                                                  (br $while-in50)
                                                 )
                                               )
                                               (set_local $i5
@@ -4909,7 +4909,7 @@
                                                   (set_local $i76
                                                     (get_local $i74)
                                                   )
-                                                  (br $while-out$55)
+                                                  (br $while-out49)
                                                 )
                                                 (block
                                                   (set_local $i73
@@ -4920,7 +4920,7 @@
                                                   )
                                                 )
                                               )
-                                              (br $while-in$56)
+                                              (br $while-in50)
                                             )
                                           )
                                           (if
@@ -4937,7 +4937,7 @@
                                               (set_local $i72
                                                 (get_local $i75)
                                               )
-                                              (br $do-once$53)
+                                              (br $do-once47)
                                             )
                                           )
                                         )
@@ -4997,7 +4997,7 @@
                                               (set_local $i72
                                                 (get_local $i55)
                                               )
-                                              (br $do-once$53)
+                                              (br $do-once47)
                                             )
                                             (call $_abort)
                                           )
@@ -5027,7 +5027,7 @@
                                         )
                                       )
                                     )
-                                    (block $do-once$57
+                                    (block $do-once51
                                       (if
                                         (i32.ne
                                           (get_local $i43)
@@ -5084,7 +5084,7 @@
                                           )
                                           (if
                                             (get_local $i72)
-                                            (br $do-once$57)
+                                            (br $do-once51)
                                           )
                                           (i32.store
                                             (i32.const 180)
@@ -5135,7 +5135,7 @@
                                         (get_local $i5)
                                       )
                                     )
-                                    (block $do-once$59
+                                    (block $do-once53
                                       (if
                                         (get_local $i45)
                                         (if
@@ -5159,7 +5159,7 @@
                                               )
                                               (get_local $i72)
                                             )
-                                            (br $do-once$59)
+                                            (br $do-once53)
                                           )
                                         )
                                       )
@@ -5234,7 +5234,7 @@
                                         )
                                       )
                                     )
-                                    (block $do-once$61
+                                    (block $do-once55
                                       (if
                                         (i32.ne
                                           (get_local $i45)
@@ -5258,7 +5258,7 @@
                                               )
                                               (get_local $i43)
                                             )
-                                            (br $do-once$61)
+                                            (br $do-once55)
                                           )
                                           (call $_abort)
                                         )
@@ -5288,7 +5288,7 @@
                                         (br $label$break$L331)
                                       )
                                     )
-                                    (block $do-once$63
+                                    (block $do-once57
                                       (if
                                         (i32.eq
                                           (get_local $i55)
@@ -5325,7 +5325,7 @@
                                               (set_local $i77
                                                 (get_local $i5)
                                               )
-                                              (br $do-once$63)
+                                              (br $do-once57)
                                             )
                                           )
                                           (call $_abort)
@@ -5435,7 +5435,7 @@
                                   (get_local $i56)
                                 )
                               )
-                              (block $do-once$65
+                              (block $do-once59
                                 (if
                                   (i32.eqz
                                     (i32.and
@@ -5487,7 +5487,7 @@
                                         (set_local $i81
                                           (get_local $i52)
                                         )
-                                        (br $do-once$65)
+                                        (br $do-once59)
                                       )
                                     )
                                     (call $_abort)
@@ -5519,7 +5519,7 @@
                                 )
                                 (get_local $i62)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $i5
@@ -5528,7 +5528,7 @@
                               (i32.const 8)
                             )
                           )
-                          (block $do-once$67
+                          (block $do-once61
                             (if
                               (i32.eqz
                                 (get_local $i5)
@@ -5546,7 +5546,7 @@
                                     (set_local $i82
                                       (i32.const 31)
                                     )
-                                    (br $do-once$67)
+                                    (br $do-once61)
                                   )
                                 )
                                 (set_local $i54
@@ -5723,7 +5723,7 @@
                                 )
                                 (get_local $i63)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $i50
@@ -5750,8 +5750,8 @@
                               (get_local $i5)
                             )
                           )
-                          (loop $while-in$70
-                            (block $while-out$69
+                          (loop $while-in64
+                            (block $while-out63
                               (if
                                 (i32.eq
                                   (i32.and
@@ -5772,7 +5772,7 @@
                                   (set_local $i36
                                     (i32.const 281)
                                   )
-                                  (br $while-out$69)
+                                  (br $while-out63)
                                 )
                               )
                               (set_local $i5
@@ -5809,7 +5809,7 @@
                                   (set_local $i36
                                     (i32.const 278)
                                   )
-                                  (br $while-out$69)
+                                  (br $while-out63)
                                 )
                                 (block
                                   (set_local $i50
@@ -5823,7 +5823,7 @@
                                   )
                                 )
                               )
-                              (br $while-in$70)
+                              (br $while-in64)
                             )
                           )
                           (if
@@ -5865,7 +5865,7 @@
                                   )
                                   (get_local $i63)
                                 )
-                                (br $do-once$50)
+                                (br $do-once44)
                               )
                             )
                             (if
@@ -5934,7 +5934,7 @@
                                       )
                                       (i32.const 0)
                                     )
-                                    (br $do-once$50)
+                                    (br $do-once44)
                                   )
                                   (call $_abort)
                                 )
@@ -5987,8 +5987,8 @@
                   )
                 )
               )
-              (loop $while-in$72
-                (block $while-out$71
+              (loop $while-in66
+                (block $while-out65
                   (set_local $i63
                     (i32.load
                       (get_local $i71)
@@ -6023,7 +6023,7 @@
                       (set_local $i86
                         (get_local $i53)
                       )
-                      (br $while-out$71)
+                      (br $while-out65)
                     )
                   )
                   (set_local $i71
@@ -6034,7 +6034,7 @@
                       )
                     )
                   )
-                  (br $while-in$72)
+                  (br $while-in66)
                 )
               )
               (set_local $i44
@@ -6232,8 +6232,8 @@
                   (i32.const 24)
                 )
               )
-              (loop $do-in$74
-                (block $do-out$73
+              (loop $do-in68
+                (block $do-out67
                   (set_local $i63
                     (i32.add
                       (get_local $i63)
@@ -6244,7 +6244,7 @@
                     (get_local $i63)
                     (i32.const 7)
                   )
-                  (br_if $do-in$74
+                  (br_if $do-in68
                     (i32.lt_u
                       (i32.add
                         (get_local $i63)
@@ -6404,7 +6404,7 @@
                         )
                         (get_local $i61)
                       )
-                      (br $do-once$44)
+                      (br $do-once40)
                     )
                   )
                   (set_local $i61
@@ -6595,7 +6595,7 @@
                         )
                         (get_local $i60)
                       )
-                      (br $do-once$44)
+                      (br $do-once40)
                     )
                   )
                   (set_local $i5
@@ -6622,8 +6622,8 @@
                       (get_local $i43)
                     )
                   )
-                  (loop $while-in$76
-                    (block $while-out$75
+                  (loop $while-in70
+                    (block $while-out69
                       (if
                         (i32.eq
                           (i32.and
@@ -6644,7 +6644,7 @@
                           (set_local $i36
                             (i32.const 307)
                           )
-                          (br $while-out$75)
+                          (br $while-out69)
                         )
                       )
                       (set_local $i43
@@ -6681,7 +6681,7 @@
                           (set_local $i36
                             (i32.const 304)
                           )
-                          (br $while-out$75)
+                          (br $while-out69)
                         )
                         (block
                           (set_local $i5
@@ -6695,7 +6695,7 @@
                           )
                         )
                       )
-                      (br $while-in$76)
+                      (br $while-in70)
                     )
                   )
                   (if
@@ -6737,7 +6737,7 @@
                           )
                           (get_local $i60)
                         )
-                        (br $do-once$44)
+                        (br $do-once40)
                       )
                     )
                     (if
@@ -6806,7 +6806,7 @@
                               )
                               (i32.const 0)
                             )
-                            (br $do-once$44)
+                            (br $do-once40)
                           )
                           (call $_abort)
                         )
@@ -6863,8 +6863,8 @@
               (set_local $i5
                 (i32.const 0)
               )
-              (loop $do-in$78
-                (block $do-out$77
+              (loop $do-in72
+                (block $do-out71
                   (set_local $i62
                     (i32.add
                       (i32.const 216)
@@ -6897,7 +6897,7 @@
                       (i32.const 1)
                     )
                   )
-                  (br_if $do-in$78
+                  (br_if $do-in72
                     (i32.ne
                       (get_local $i5)
                       (i32.const 32)
@@ -7156,7 +7156,7 @@
         (get_local $i5)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.eqz
           (i32.and
@@ -7232,7 +7232,7 @@
                   (set_local $i13
                     (get_local $i9)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (i32.store
@@ -7360,7 +7360,7 @@
                   (set_local $i13
                     (get_local $i9)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (if
@@ -7419,7 +7419,7 @@
               (set_local $i13
                 (get_local $i9)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $i7
@@ -7438,7 +7438,7 @@
               )
             )
           )
-          (block $do-once$2
+          (block $do-once0
             (if
               (i32.eq
                 (get_local $i10)
@@ -7480,7 +7480,7 @@
                         (set_local $i18
                           (i32.const 0)
                         )
-                        (br $do-once$2)
+                        (br $do-once0)
                       )
                       (block
                         (set_local $i19
@@ -7501,8 +7501,8 @@
                     )
                   )
                 )
-                (loop $while-in$5
-                  (block $while-out$4
+                (loop $while-in
+                  (block $while-out
                     (set_local $i11
                       (i32.add
                         (get_local $i19)
@@ -7523,7 +7523,7 @@
                         (set_local $i20
                           (get_local $i11)
                         )
-                        (br $while-in$5)
+                        (br $while-in)
                       )
                     )
                     (set_local $i11
@@ -7548,7 +7548,7 @@
                         (set_local $i22
                           (get_local $i20)
                         )
-                        (br $while-out$4)
+                        (br $while-out)
                       )
                       (block
                         (set_local $i19
@@ -7559,7 +7559,7 @@
                         )
                       )
                     )
-                    (br $while-in$5)
+                    (br $while-in)
                   )
                 )
                 (if
@@ -7576,7 +7576,7 @@
                     (set_local $i18
                       (get_local $i21)
                     )
-                    (br $do-once$2)
+                    (br $do-once0)
                   )
                 )
               )
@@ -7636,7 +7636,7 @@
                     (set_local $i18
                       (get_local $i10)
                     )
-                    (br $do-once$2)
+                    (br $do-once0)
                   )
                   (call $_abort)
                 )
@@ -7701,7 +7701,7 @@
                       (set_local $i13
                         (get_local $i9)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -7751,7 +7751,7 @@
                       (set_local $i13
                         (get_local $i9)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -7786,7 +7786,7 @@
                   (get_local $i11)
                 )
               )
-              (block $do-once$6
+              (block $do-once2
                 (if
                   (get_local $i14)
                   (if
@@ -7810,7 +7810,7 @@
                         )
                         (get_local $i18)
                       )
-                      (br $do-once$6)
+                      (br $do-once2)
                     )
                   )
                 )
@@ -7854,7 +7854,7 @@
                     (set_local $i13
                       (get_local $i9)
                     )
-                    (br $do-once$0)
+                    (br $do-once)
                   )
                 )
                 (block
@@ -8035,7 +8035,7 @@
             (i32.const 3)
           )
         )
-        (block $do-once$8
+        (block $do-once4
           (if
             (i32.ge_u
               (get_local $i2)
@@ -8058,7 +8058,7 @@
                   )
                 )
               )
-              (block $do-once$10
+              (block $do-once6
                 (if
                   (i32.eq
                     (get_local $i22)
@@ -8100,7 +8100,7 @@
                             (set_local $i23
                               (i32.const 0)
                             )
-                            (br $do-once$10)
+                            (br $do-once6)
                           )
                           (block
                             (set_local $i24
@@ -8121,8 +8121,8 @@
                         )
                       )
                     )
-                    (loop $while-in$13
-                      (block $while-out$12
+                    (loop $while-in9
+                      (block $while-out8
                         (set_local $i19
                           (i32.add
                             (get_local $i24)
@@ -8143,7 +8143,7 @@
                             (set_local $i25
                               (get_local $i19)
                             )
-                            (br $while-in$13)
+                            (br $while-in9)
                           )
                         )
                         (set_local $i19
@@ -8168,7 +8168,7 @@
                             (set_local $i27
                               (get_local $i25)
                             )
-                            (br $while-out$12)
+                            (br $while-out8)
                           )
                           (block
                             (set_local $i24
@@ -8179,7 +8179,7 @@
                             )
                           )
                         )
-                        (br $while-in$13)
+                        (br $while-in9)
                       )
                     )
                     (if
@@ -8198,7 +8198,7 @@
                         (set_local $i23
                           (get_local $i26)
                         )
-                        (br $do-once$10)
+                        (br $do-once6)
                       )
                     )
                   )
@@ -8260,7 +8260,7 @@
                         (set_local $i23
                           (get_local $i22)
                         )
-                        (br $do-once$10)
+                        (br $do-once6)
                       )
                       (call $_abort)
                     )
@@ -8319,7 +8319,7 @@
                               )
                             )
                           )
-                          (br $do-once$8)
+                          (br $do-once4)
                         )
                       )
                     )
@@ -8362,7 +8362,7 @@
                         (i32.eqz
                           (get_local $i23)
                         )
-                        (br $do-once$8)
+                        (br $do-once4)
                       )
                     )
                   )
@@ -8396,7 +8396,7 @@
                       (get_local $i9)
                     )
                   )
-                  (block $do-once$14
+                  (block $do-once10
                     (if
                       (get_local $i8)
                       (if
@@ -8420,7 +8420,7 @@
                             )
                             (get_local $i23)
                           )
-                          (br $do-once$14)
+                          (br $do-once10)
                         )
                       )
                     )
@@ -8458,7 +8458,7 @@
                           )
                           (get_local $i23)
                         )
-                        (br $do-once$8)
+                        (br $do-once4)
                       )
                     )
                   )
@@ -8544,7 +8544,7 @@
                       )
                     )
                   )
-                  (br $do-once$8)
+                  (br $do-once4)
                 )
               )
               (if
@@ -8936,7 +8936,7 @@
         (get_local $i32)
       )
     )
-    (block $do-once$16
+    (block $do-once12
       (if
         (i32.and
           (get_local $i30)
@@ -8967,8 +8967,8 @@
               (get_local $i5)
             )
           )
-          (loop $while-in$19
-            (block $while-out$18
+          (loop $while-in15
+            (block $while-out14
               (if
                 (i32.eq
                   (i32.and
@@ -8989,7 +8989,7 @@
                   (set_local $i34
                     (i32.const 130)
                   )
-                  (br $while-out$18)
+                  (br $while-out14)
                 )
               )
               (set_local $i28
@@ -9026,7 +9026,7 @@
                   (set_local $i34
                     (i32.const 127)
                   )
-                  (br $while-out$18)
+                  (br $while-out14)
                 )
                 (block
                   (set_local $i31
@@ -9040,7 +9040,7 @@
                   )
                 )
               )
-              (br $while-in$19)
+              (br $while-in15)
             )
           )
           (if
@@ -9082,7 +9082,7 @@
                   )
                   (get_local $i12)
                 )
-                (br $do-once$16)
+                (br $do-once12)
               )
             )
             (if
@@ -9151,7 +9151,7 @@
                       )
                       (i32.const 0)
                     )
-                    (br $do-once$16)
+                    (br $do-once12)
                   )
                   (call $_abort)
                 )
@@ -9216,8 +9216,8 @@
       )
       (return)
     )
-    (loop $while-in$21
-      (block $while-out$20
+    (loop $while-in17
+      (block $while-out16
         (set_local $i12
           (i32.load
             (get_local $i37)
@@ -9227,7 +9227,7 @@
           (i32.eqz
             (get_local $i12)
           )
-          (br $while-out$20)
+          (br $while-out16)
           (set_local $i37
             (i32.add
               (get_local $i12)
@@ -9235,7 +9235,7 @@
             )
           )
         )
-        (br $while-in$21)
+        (br $while-in17)
       )
     )
     (i32.store
@@ -9364,8 +9364,8 @@
         (get_local $i3)
       )
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (if
           (i32.eqz
             (i32.load
@@ -9452,7 +9452,7 @@
             (set_local $i15
               (i32.const 6)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (if
@@ -9470,7 +9470,7 @@
             (set_local $i15
               (i32.const 8)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (set_local $i11
@@ -9605,7 +9605,7 @@
         (set_local $i13
           (get_local $i11)
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
     (if
@@ -9833,8 +9833,8 @@
                 (set_local $i4
                   (get_local $i2)
                 )
-                (loop $while-in$3
-                  (block $while-out$2
+                (loop $while-in
+                  (block $while-out
                     (if
                       (i32.eqz
                         (get_local $i4)
@@ -9875,13 +9875,13 @@
                         (set_local $i15
                           (get_local $i4)
                         )
-                        (br $while-out$2)
+                        (br $while-out)
                       )
                       (set_local $i4
                         (get_local $i14)
                       )
                     )
-                    (br $while-in$3)
+                    (br $while-in)
                   )
                 )
                 (if
@@ -9986,7 +9986,7 @@
     (local $i6 i32)
     (local $i7 i32)
     (local $i8 i32)
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $i1)
         (block
@@ -10006,7 +10006,7 @@
                   (get_local $i1)
                 )
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $i3
@@ -10077,8 +10077,8 @@
               (set_local $i4
                 (get_local $i5)
               )
-              (loop $while-in$3
-                (block $while-out$2
+              (loop $while-in
+                (block $while-out
                   (if
                     (i32.gt_s
                       (i32.load
@@ -10147,13 +10147,13 @@
                       (set_local $i6
                         (get_local $i8)
                       )
-                      (br $while-out$2)
+                      (br $while-out)
                     )
                     (set_local $i4
                       (get_local $i8)
                     )
                   )
-                  (br $while-in$3)
+                  (br $while-in)
                 )
               )
             )
@@ -10208,8 +10208,8 @@
           (set_local $i6
             (get_local $i2)
           )
-          (loop $while-in$2
-            (block $while-out$1
+          (loop $while-in
+            (block $while-out
               (if
                 (i32.eqz
                   (i32.load8_s
@@ -10246,13 +10246,13 @@
                   (set_local $i4
                     (i32.const 4)
                   )
-                  (br $while-out$1)
+                  (br $while-out)
                 )
                 (set_local $i5
                   (get_local $i8)
                 )
               )
-              (br $while-in$2)
+              (br $while-in)
             )
           )
         )
@@ -10267,8 +10267,8 @@
         (set_local $i4
           (get_local $i3)
         )
-        (loop $while-in$4
-          (block $while-out$3
+        (loop $while-in1
+          (block $while-out0
             (set_local $i3
               (i32.load
                 (get_local $i4)
@@ -10303,10 +10303,10 @@
                 (set_local $i10
                   (get_local $i4)
                 )
-                (br $while-out$3)
+                (br $while-out0)
               )
             )
-            (br $while-in$4)
+            (br $while-in1)
           )
         )
         (if
@@ -10329,8 +10329,8 @@
             (set_local $i9
               (get_local $i10)
             )
-            (loop $while-in$6
-              (block $while-out$5
+            (loop $while-in3
+              (block $while-out2
                 (set_local $i10
                   (i32.add
                     (get_local $i9)
@@ -10347,13 +10347,13 @@
                     (set_local $i11
                       (get_local $i10)
                     )
-                    (br $while-out$5)
+                    (br $while-out2)
                   )
                   (set_local $i9
                     (get_local $i10)
                   )
                 )
-                (br $while-in$6)
+                (br $while-in3)
               )
             )
           )
@@ -10446,7 +10446,7 @@
         )
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.eq
           (get_local $i9)
@@ -10504,7 +10504,7 @@
               (set_local $i10
                 (get_local $i11)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (if
@@ -10722,8 +10722,8 @@
         )
       )
       (block
-        (loop $while-in$1
-          (block $while-out$0
+        (loop $while-in
+          (block $while-out
             (if
               (i32.eqz
                 (i32.and
@@ -10731,7 +10731,7 @@
                   (i32.const 3)
                 )
               )
-              (br $while-out$0)
+              (br $while-out)
             )
             (block
               (if
@@ -10767,11 +10767,11 @@
                 )
               )
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
-        (loop $while-in$3
-          (block $while-out$2
+        (loop $while-in1
+          (block $while-out0
             (if
               (i32.eqz
                 (i32.ge_s
@@ -10779,7 +10779,7 @@
                   (i32.const 4)
                 )
               )
-              (br $while-out$2)
+              (br $while-out0)
             )
             (block
               (i32.store
@@ -10807,13 +10807,13 @@
                 )
               )
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
     )
-    (loop $while-in$5
-      (block $while-out$4
+    (loop $while-in3
+      (block $while-out2
         (if
           (i32.eqz
             (i32.gt_s
@@ -10821,7 +10821,7 @@
               (i32.const 0)
             )
           )
-          (br $while-out$4)
+          (br $while-out2)
         )
         (block
           (i32.store8
@@ -10849,7 +10849,7 @@
             )
           )
         )
-        (br $while-in$5)
+        (br $while-in3)
       )
     )
     (return
@@ -10930,8 +10930,8 @@
                 (get_local $i5)
               )
             )
-            (loop $while-in$1
-              (block $while-out$0
+            (loop $while-in
+              (block $while-out
                 (if
                   (i32.eqz
                     (i32.lt_s
@@ -10939,7 +10939,7 @@
                       (get_local $i5)
                     )
                   )
-                  (br $while-out$0)
+                  (br $while-out)
                 )
                 (block
                   (i32.store8
@@ -10953,13 +10953,13 @@
                     )
                   )
                 )
-                (br $while-in$1)
+                (br $while-in)
               )
             )
           )
         )
-        (loop $while-in$3
-          (block $while-out$2
+        (loop $while-in1
+          (block $while-out0
             (if
               (i32.eqz
                 (i32.lt_s
@@ -10967,7 +10967,7 @@
                   (get_local $i7)
                 )
               )
-              (br $while-out$2)
+              (br $while-out0)
             )
             (block
               (i32.store
@@ -10981,13 +10981,13 @@
                 )
               )
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
     )
-    (loop $while-in$5
-      (block $while-out$4
+    (loop $while-in3
+      (block $while-out2
         (if
           (i32.eqz
             (i32.lt_s
@@ -10995,7 +10995,7 @@
               (get_local $i4)
             )
           )
-          (br $while-out$4)
+          (br $while-out2)
         )
         (block
           (i32.store8
@@ -11009,7 +11009,7 @@
             )
           )
         )
-        (br $while-in$5)
+        (br $while-in3)
       )
     )
     (return
@@ -11049,7 +11049,7 @@
         (i32.const 0)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.lt_s
           (call $_fputs
@@ -11114,7 +11114,7 @@
               (set_local $i4
                 (i32.const 0)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $i4

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -293,11 +293,11 @@
         (i32.const 52)
       )
     )
-    (block $switch$0 f64
-      (block $switch-default$3
-        (block $switch-case$2
-          (block $switch-case$1
-            (br_table $switch-case$1 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-case$2 $switch-default$3
+    (block $switch f64
+      (block $switch-default
+        (block $switch-case0
+          (block $switch-case
+            (br_table $switch-case $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case0 $switch-default
               (i32.sub
                 (tee_local $2
                   (i32.and
@@ -336,11 +336,11 @@
               (i32.const 0)
             )
           )
-          (br $switch$0
+          (br $switch
             (get_local $0)
           )
         )
-        (br $switch$0
+        (br $switch
           (get_local $0)
         )
       )
@@ -387,7 +387,7 @@
     )
     (block $jumpthreading$outer$0
       (block $jumpthreading$inner$0
-        (loop $while-in$1
+        (loop $while-in
           (br_if $jumpthreading$inner$0
             (i32.eq
               (i32.and
@@ -399,7 +399,7 @@
               (get_local $0)
             )
           )
-          (br_if $while-in$1
+          (br_if $while-in
             (i32.ne
               (tee_local $1
                 (i32.add
@@ -447,8 +447,8 @@
         (get_local $4)
         (i32.const 5)
       )
-      (loop $while-in$3
-        (loop $while-in$5
+      (loop $while-in1
+        (loop $while-in3
           (set_local $0
             (i32.add
               (get_local $2)
@@ -463,7 +463,7 @@
               (set_local $2
                 (get_local $0)
               )
-              (br $while-in$5)
+              (br $while-in3)
             )
           )
         )
@@ -478,7 +478,7 @@
             (set_local $2
               (get_local $0)
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
           (set_local $5
             (get_local $0)
@@ -699,7 +699,7 @@
   (func $_fflush (param $0 i32) (result i32)
     (local $1 i32)
     (local $2 i32)
-    (block $do-once$0 i32
+    (block $do-once i32
       (if i32
         (get_local $0)
         (block i32
@@ -710,7 +710,7 @@
               )
               (i32.const -1)
             )
-            (br $do-once$0
+            (br $do-once
               (call $___fflush_unlocked
                 (get_local $0)
               )
@@ -762,7 +762,7 @@
                 (i32.const 40)
               )
             )
-            (loop $while-in$3
+            (loop $while-in
               (set_local $2
                 (if i32
                   (i32.gt_s
@@ -802,7 +802,7 @@
                   (get_local $1)
                 )
               )
-              (br_if $while-in$3
+              (br_if $while-in
                 (tee_local $1
                   (i32.load offset=56
                     (get_local $1)
@@ -972,7 +972,7 @@
       (block $jumpthreading$outer$1 i32
         (block $jumpthreading$inner$1
           (block $jumpthreading$inner$0
-            (loop $while-in$1
+            (loop $while-in
               (br_if $jumpthreading$inner$0
                 (i32.eq
                   (get_local $11)
@@ -1148,7 +1148,7 @@
                 (set_local $1
                   (get_local $3)
                 )
-                (br $while-in$1)
+                (br $while-in)
               )
             )
           )
@@ -1277,12 +1277,12 @@
         (i32.const 40)
       )
     )
-    (loop $do-in$1
+    (loop $do-in
       (i32.store
         (get_local $4)
         (i32.const 0)
       )
-      (br_if $do-in$1
+      (br_if $do-in
         (i32.lt_s
           (tee_local $4
             (i32.add
@@ -1607,7 +1607,7 @@
                 (set_local $3
                   (get_local $1)
                 )
-                (loop $while-in$3
+                (loop $while-in
                   (if
                     (i32.eqz
                       (get_local $3)
@@ -1640,7 +1640,7 @@
                       (set_local $3
                         (get_local $4)
                       )
-                      (br $while-in$3)
+                      (br $while-in)
                     )
                   )
                 )
@@ -1792,7 +1792,7 @@
     )
   )
   (func $_wcrtomb (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-    (block $do-once$0 i32
+    (block $do-once i32
       (if i32
         (get_local $0)
         (block i32
@@ -1809,7 +1809,7 @@
                   (i32.const 255)
                 )
               )
-              (br $do-once$0
+              (br $do-once
                 (i32.const 1)
               )
             )
@@ -1846,7 +1846,7 @@
                   (i32.const 255)
                 )
               )
-              (br $do-once$0
+              (br $do-once
                 (i32.const 2)
               )
             )
@@ -1908,7 +1908,7 @@
                   (i32.const 255)
                 )
               )
-              (br $do-once$0
+              (br $do-once
                 (i32.const 3)
               )
             )
@@ -2042,7 +2042,7 @@
                   (i32.const 255)
                 )
               )
-              (loop $while-in$2
+              (loop $while-in
                 (br_if $jumpthreading$inner$2
                   (i32.eq
                     (i32.load8_s
@@ -2057,7 +2057,7 @@
                     )
                   )
                 )
-                (br_if $while-in$2
+                (br_if $while-in
                   (i32.and
                     (tee_local $3
                       (i32.ne
@@ -2132,8 +2132,8 @@
                   (get_local $2)
                   (i32.const 3)
                 )
-                (loop $while-in$6
-                  (block $while-out$5
+                (loop $while-in3
+                  (block $while-out2
                     (if
                       (i32.and
                         (i32.xor
@@ -2159,7 +2159,7 @@
                         (set_local $1
                           (get_local $2)
                         )
-                        (br $while-out$5)
+                        (br $while-out2)
                       )
                     )
                     (set_local $0
@@ -2183,7 +2183,7 @@
                       (set_local $2
                         (get_local $1)
                       )
-                      (br $while-in$6)
+                      (br $while-in3)
                     )
                   )
                 )
@@ -2208,7 +2208,7 @@
               )
             )
           )
-          (loop $while-in$8
+          (loop $while-in5
             (br_if $label$break$L8
               (i32.eq
                 (i32.load8_s
@@ -2229,7 +2229,7 @@
                 (i32.const 1)
               )
             )
-            (br_if $while-in$8
+            (br_if $while-in5
               (tee_local $1
                 (i32.add
                   (get_local $1)
@@ -2659,10 +2659,10 @@
             )
             (loop $label$continue$L9
               (block $label$break$L9
-                (block $switch-default$5
-                  (block $switch-case$4
-                    (block $switch-case$3
-                      (br_table $switch-case$4 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-case$3 $switch-default$5
+                (block $switch-default
+                  (block $switch-case0
+                    (block $switch-case
+                      (br_table $switch-case0 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case $switch-default
                         (i32.sub
                           (i32.shr_s
                             (i32.shl
@@ -2713,7 +2713,7 @@
                   (get_local $28)
                   (i32.const 9)
                 )
-                (loop $while-in$8
+                (loop $while-in
                   (set_local $28
                     (i32.const 0)
                   )
@@ -2759,7 +2759,7 @@
                       (set_local $43
                         (get_local $35)
                       )
-                      (br $while-in$8)
+                      (br $while-in)
                     )
                   )
                 )
@@ -2902,7 +2902,7 @@
                   (set_local $8
                     (i32.const 0)
                   )
-                  (loop $while-in$11
+                  (loop $while-in4
                     (if
                       (i32.eqz
                         (i32.and
@@ -2941,7 +2941,7 @@
                         (get_local $8)
                       )
                     )
-                    (br_if $while-in$11
+                    (br_if $while-in4
                       (i32.eq
                         (i32.and
                           (tee_local $5
@@ -2982,7 +2982,7 @@
                 )
               )
             )
-            (block $do-once$12
+            (block $do-once5
               (if
                 (i32.eq
                   (i32.shr_s
@@ -3092,7 +3092,7 @@
                           (set_local $17
                             (i32.const 0)
                           )
-                          (br $do-once$12)
+                          (br $do-once5)
                         )
                       )
                       (set_local $7
@@ -3170,7 +3170,7 @@
                     (set_local $8
                       (i32.const 0)
                     )
-                    (loop $while-in$15
+                    (loop $while-in8
                       (set_local $13
                         (i32.add
                           (i32.mul
@@ -3204,7 +3204,7 @@
                           (set_local $13
                             (get_local $9)
                           )
-                          (br $while-in$15)
+                          (br $while-in8)
                         )
                         (set_local $9
                           (get_local $13)
@@ -3308,7 +3308,7 @@
                             )
                           )
                         )
-                        (loop $while-in$18
+                        (loop $while-in11
                           (set_local $7
                             (i32.add
                               (i32.mul
@@ -3342,7 +3342,7 @@
                               (set_local $7
                                 (get_local $9)
                               )
-                              (br $while-in$18)
+                              (br $while-in11)
                             )
                             (br $label$break$L46
                               (get_local $5)
@@ -3470,7 +3470,7 @@
             (set_local $11
               (i32.const 0)
             )
-            (loop $while-in$20
+            (loop $while-in13
               (if
                 (i32.gt_u
                   (tee_local $5
@@ -3529,7 +3529,7 @@
                   (set_local $11
                     (get_local $5)
                   )
-                  (br $while-in$20)
+                  (br $while-in13)
                 )
                 (block
                   (set_local $16
@@ -3692,20 +3692,20 @@
                     (block $jumpthreading$inner$4
                       (block $jumpthreading$inner$3
                         (block $jumpthreading$inner$2
-                          (block $switch-default$127
-                            (block $switch-case$49
-                              (block $switch-case$48
-                                (block $switch-case$47
-                                  (block $switch-case$46
-                                    (block $switch-case$45
-                                      (block $switch-case$44
-                                        (block $switch-case$43
-                                          (block $switch-case$41
-                                            (block $switch-case$40
-                                              (block $switch-case$36
-                                                (block $switch-case$35
-                                                  (block $switch-case$34
-                                                    (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$49 $switch-case$49 $switch-case$49 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$49 $switch-default$127 $switch-case$44 $switch-case$41 $switch-case$49 $switch-case$49 $switch-case$49 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127
+                          (block $switch-default120
+                            (block $switch-case42
+                              (block $switch-case41
+                                (block $switch-case40
+                                  (block $switch-case39
+                                    (block $switch-case38
+                                      (block $switch-case37
+                                        (block $switch-case36
+                                          (block $switch-case34
+                                            (block $switch-case33
+                                              (block $switch-case29
+                                                (block $switch-case28
+                                                  (block $switch-case27
+                                                    (br_table $switch-case42 $switch-default120 $switch-case40 $switch-default120 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case29 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case42 $switch-default120 $switch-case37 $switch-case34 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-case34 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case29 $switch-default120
                                                       (i32.sub
                                                         (tee_local $16
                                                           (select
@@ -3737,15 +3737,15 @@
                                                       )
                                                     )
                                                   )
-                                                  (block $switch-default$33
-                                                    (block $switch-case$32
-                                                      (block $switch-case$31
-                                                        (block $switch-case$30
-                                                          (block $switch-case$29
-                                                            (block $switch-case$28
-                                                              (block $switch-case$27
-                                                                (block $switch-case$26
-                                                                  (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
+                                                  (block $switch-default26
+                                                    (block $switch-case25
+                                                      (block $switch-case24
+                                                        (block $switch-case23
+                                                          (block $switch-case22
+                                                            (block $switch-case21
+                                                              (block $switch-case20
+                                                                (block $switch-case19
+                                                                  (br_table $switch-case19 $switch-case20 $switch-case21 $switch-case22 $switch-case23 $switch-default26 $switch-case24 $switch-case25 $switch-default26
                                                                     (i32.sub
                                                                       (get_local $11)
                                                                       (i32.const 0)
@@ -3952,7 +3952,7 @@
                                                 (set_local $8
                                                   (get_local $23)
                                                 )
-                                                (loop $while-in$39
+                                                (loop $while-in32
                                                   (i32.store8
                                                     (tee_local $8
                                                       (i32.add
@@ -3971,7 +3971,7 @@
                                                       (i32.const 255)
                                                     )
                                                   )
-                                                  (br_if $while-in$39
+                                                  (br_if $while-in32
                                                     (i32.eqz
                                                       (i32.and
                                                         (i32.eqz
@@ -4319,7 +4319,7 @@
                               (get_local $5)
                             )
                             (set_local $5
-                              (block $do-once$56 i32
+                              (block $do-once49 i32
                                 (if i32
                                   (i32.or
                                     (i32.lt_u
@@ -4420,14 +4420,14 @@
                                               (set_local $14
                                                 (f64.const 8)
                                               )
-                                              (loop $while-in$61
+                                              (loop $while-in54
                                                 (set_local $14
                                                   (f64.mul
                                                     (get_local $14)
                                                     (f64.const 16)
                                                   )
                                                 )
-                                                (br_if $while-in$61
+                                                (br_if $while-in54
                                                   (tee_local $5
                                                     (i32.add
                                                       (get_local $5)
@@ -4562,7 +4562,7 @@
                                         (set_local $5
                                           (get_local $24)
                                         )
-                                        (loop $while-in$63
+                                        (loop $while-in56
                                           (i32.store8
                                             (get_local $5)
                                             (i32.and
@@ -4597,7 +4597,7 @@
                                             )
                                           )
                                           (set_local $5
-                                            (block $do-once$64 i32
+                                            (block $do-once57 i32
                                               (if i32
                                                 (i32.eq
                                                   (i32.sub
@@ -4613,7 +4613,7 @@
                                                 )
                                                 (block i32
                                                   (drop
-                                                    (br_if $do-once$64
+                                                    (br_if $do-once57
                                                       (get_local $6)
                                                       (i32.and
                                                         (get_local $16)
@@ -4640,7 +4640,7 @@
                                               )
                                             )
                                           )
-                                          (br_if $while-in$63
+                                          (br_if $while-in56
                                             (f64.ne
                                               (get_local $14)
                                               (f64.const 0)
@@ -4784,7 +4784,7 @@
                                             (i32.const 8192)
                                           )
                                         )
-                                        (br $do-once$56
+                                        (br $do-once49
                                           (select
                                             (get_local $17)
                                             (get_local $6)
@@ -4851,7 +4851,7 @@
                                     (set_local $6
                                       (get_local $8)
                                     )
-                                    (loop $while-in$67
+                                    (loop $while-in60
                                       (i32.store
                                         (get_local $6)
                                         (tee_local $5
@@ -4866,7 +4866,7 @@
                                           (i32.const 4)
                                         )
                                       )
-                                      (br_if $while-in$67
+                                      (br_if $while-in60
                                         (f64.ne
                                           (tee_local $14
                                             (f64.mul
@@ -4896,7 +4896,7 @@
                                         (set_local $9
                                           (get_local $8)
                                         )
-                                        (loop $while-in$69
+                                        (loop $while-in62
                                           (set_local $21
                                             (select
                                               (i32.const 29)
@@ -4908,7 +4908,7 @@
                                             )
                                           )
                                           (set_local $9
-                                            (block $do-once$70 i32
+                                            (block $do-once63 i32
                                               (if i32
                                                 (i32.lt_u
                                                   (tee_local $7
@@ -4924,7 +4924,7 @@
                                                   (set_local $5
                                                     (i32.const 0)
                                                   )
-                                                  (loop $while-in$73
+                                                  (loop $while-in66
                                                     (set_local $12
                                                       (call $___uremdi3
                                                         (tee_local $5
@@ -4960,7 +4960,7 @@
                                                         (i32.const 0)
                                                       )
                                                     )
-                                                    (br_if $while-in$73
+                                                    (br_if $while-in66
                                                       (i32.ge_u
                                                         (tee_local $7
                                                           (i32.add
@@ -4973,7 +4973,7 @@
                                                     )
                                                   )
                                                   (drop
-                                                    (br_if $do-once$70
+                                                    (br_if $do-once63
                                                       (get_local $9)
                                                       (i32.eqz
                                                         (get_local $5)
@@ -4997,8 +4997,8 @@
                                           (set_local $5
                                             (get_local $6)
                                           )
-                                          (loop $while-in$75
-                                            (block $while-out$74
+                                          (loop $while-in68
+                                            (block $while-out67
                                               (if
                                                 (i32.le_u
                                                   (get_local $5)
@@ -5008,7 +5008,7 @@
                                                   (set_local $6
                                                     (get_local $5)
                                                   )
-                                                  (br $while-out$74)
+                                                  (br $while-out67)
                                                 )
                                               )
                                               (if
@@ -5027,7 +5027,7 @@
                                                   (set_local $5
                                                     (get_local $6)
                                                   )
-                                                  (br $while-in$75)
+                                                  (br $while-in68)
                                                 )
                                               )
                                             )
@@ -5043,7 +5043,7 @@
                                               )
                                             )
                                           )
-                                          (br_if $while-in$69
+                                          (br_if $while-in62
                                             (i32.gt_s
                                               (get_local $7)
                                               (i32.const 0)
@@ -5085,7 +5085,7 @@
                                             (i32.const 102)
                                           )
                                         )
-                                        (loop $while-in$77
+                                        (loop $while-in70
                                           (set_local $26
                                             (select
                                               (i32.const 9)
@@ -5108,7 +5108,7 @@
                                                   (select
                                                     (get_local $8)
                                                     (tee_local $5
-                                                      (block $do-once$78 i32
+                                                      (block $do-once71 i32
                                                         (if i32
                                                           (i32.lt_u
                                                             (get_local $5)
@@ -5136,7 +5136,7 @@
                                                             (set_local $7
                                                               (get_local $5)
                                                             )
-                                                            (loop $while-in$81
+                                                            (loop $while-in74
                                                               (i32.store
                                                                 (get_local $7)
                                                                 (i32.add
@@ -5160,7 +5160,7 @@
                                                                   (get_local $31)
                                                                 )
                                                               )
-                                                              (br_if $while-in$81
+                                                              (br_if $while-in74
                                                                 (i32.lt_u
                                                                   (tee_local $7
                                                                     (i32.add
@@ -5185,7 +5185,7 @@
                                                               )
                                                             )
                                                             (drop
-                                                              (br_if $do-once$78
+                                                              (br_if $do-once71
                                                                 (get_local $5)
                                                                 (i32.eqz
                                                                   (get_local $9)
@@ -5249,7 +5249,7 @@
                                               )
                                             )
                                           )
-                                          (br_if $while-in$77
+                                          (br_if $while-in70
                                             (i32.lt_s
                                               (get_local $7)
                                               (i32.const 0)
@@ -5264,7 +5264,7 @@
                                         (get_local $6)
                                       )
                                     )
-                                    (block $do-once$82
+                                    (block $do-once75
                                       (if
                                         (i32.lt_u
                                           (get_local $5)
@@ -5283,7 +5283,7 @@
                                               (i32.const 9)
                                             )
                                           )
-                                          (br_if $do-once$82
+                                          (br_if $do-once75
                                             (i32.lt_u
                                               (tee_local $11
                                                 (i32.load
@@ -5296,14 +5296,14 @@
                                           (set_local $7
                                             (i32.const 10)
                                           )
-                                          (loop $while-in$85
+                                          (loop $while-in78
                                             (set_local $6
                                               (i32.add
                                                 (get_local $6)
                                                 (i32.const 1)
                                               )
                                             )
-                                            (br_if $while-in$85
+                                            (br_if $while-in78
                                               (i32.ge_u
                                                 (get_local $11)
                                                 (tee_local $7
@@ -5420,14 +5420,14 @@
                                               (set_local $12
                                                 (i32.const 10)
                                               )
-                                              (loop $while-in$87
+                                              (loop $while-in80
                                                 (set_local $12
                                                   (i32.mul
                                                     (get_local $12)
                                                     (i32.const 10)
                                                   )
                                                 )
-                                                (br_if $while-in$87
+                                                (br_if $while-in80
                                                   (i32.ne
                                                     (tee_local $11
                                                       (i32.add
@@ -5444,7 +5444,7 @@
                                               (i32.const 10)
                                             )
                                           )
-                                          (block $do-once$88
+                                          (block $do-once81
                                             (if
                                               (i32.eqz
                                                 (i32.and
@@ -5520,12 +5520,12 @@
                                                   )
                                                 )
                                                 (set_local $22
-                                                  (block $do-once$90 f64
+                                                  (block $do-once83 f64
                                                     (if f64
                                                       (get_local $30)
                                                       (block f64
                                                         (drop
-                                                          (br_if $do-once$90
+                                                          (br_if $do-once83
                                                             (get_local $22)
                                                             (i32.ne
                                                               (i32.load8_s
@@ -5557,7 +5557,7 @@
                                                     )
                                                   )
                                                 )
-                                                (br_if $do-once$88
+                                                (br_if $do-once81
                                                   (f64.eq
                                                     (f64.add
                                                       (get_local $22)
@@ -5580,7 +5580,7 @@
                                                     (get_local $6)
                                                     (i32.const 999999999)
                                                   )
-                                                  (loop $while-in$93
+                                                  (loop $while-in86
                                                     (i32.store
                                                       (get_local $7)
                                                       (i32.const 0)
@@ -5622,7 +5622,7 @@
                                                         )
                                                       )
                                                     )
-                                                    (br_if $while-in$93
+                                                    (br_if $while-in86
                                                       (i32.gt_u
                                                         (get_local $6)
                                                         (i32.const 999999999)
@@ -5642,7 +5642,7 @@
                                                     (i32.const 9)
                                                   )
                                                 )
-                                                (br_if $do-once$88
+                                                (br_if $do-once81
                                                   (i32.lt_u
                                                     (tee_local $12
                                                       (i32.load
@@ -5655,14 +5655,14 @@
                                                 (set_local $11
                                                   (i32.const 10)
                                                 )
-                                                (loop $while-in$95
+                                                (loop $while-in88
                                                   (set_local $6
                                                     (i32.add
                                                       (get_local $6)
                                                       (i32.const 1)
                                                     )
                                                   )
-                                                  (br_if $while-in$95
+                                                  (br_if $while-in88
                                                     (i32.ge_u
                                                       (get_local $12)
                                                       (tee_local $11
@@ -5714,8 +5714,8 @@
                                     (set_local $5
                                       (get_local $9)
                                     )
-                                    (loop $while-in$97
-                                      (block $while-out$96
+                                    (loop $while-in90
+                                      (block $while-out89
                                         (if
                                           (i32.le_u
                                             (get_local $5)
@@ -5728,7 +5728,7 @@
                                             (set_local $9
                                               (get_local $5)
                                             )
-                                            (br $while-out$96)
+                                            (br $while-out89)
                                           )
                                         )
                                         (if
@@ -5752,13 +5752,13 @@
                                             (set_local $5
                                               (get_local $6)
                                             )
-                                            (br $while-in$97)
+                                            (br $while-in90)
                                           )
                                         )
                                       )
                                     )
                                     (set_local $19
-                                      (block $do-once$98 i32
+                                      (block $do-once91 i32
                                         (if i32
                                           (get_local $21)
                                           (block i32
@@ -5825,12 +5825,12 @@
                                                 (set_local $5
                                                   (get_local $16)
                                                 )
-                                                (br $do-once$98
+                                                (br $do-once91
                                                   (get_local $7)
                                                 )
                                               )
                                             )
-                                            (block $do-once$100
+                                            (block $do-once93
                                               (if
                                                 (get_local $26)
                                                 (block
@@ -5849,7 +5849,7 @@
                                                       (set_local $5
                                                         (i32.const 9)
                                                       )
-                                                      (br $do-once$100)
+                                                      (br $do-once93)
                                                     )
                                                   )
                                                   (if
@@ -5864,7 +5864,7 @@
                                                       (set_local $5
                                                         (i32.const 0)
                                                       )
-                                                      (br $do-once$100)
+                                                      (br $do-once93)
                                                     )
                                                     (block
                                                       (set_local $7
@@ -5875,14 +5875,14 @@
                                                       )
                                                     )
                                                   )
-                                                  (loop $while-in$103
+                                                  (loop $while-in96
                                                     (set_local $5
                                                       (i32.add
                                                         (get_local $5)
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (br_if $while-in$103
+                                                    (br_if $while-in96
                                                       (i32.eqz
                                                         (i32.and
                                                           (call $i32u-rem
@@ -6073,7 +6073,7 @@
                                               )
                                               (i32.const 2)
                                             )
-                                            (loop $while-in$105
+                                            (loop $while-in98
                                               (i32.store8
                                                 (tee_local $7
                                                   (i32.add
@@ -6083,7 +6083,7 @@
                                                 )
                                                 (i32.const 48)
                                               )
-                                              (br_if $while-in$105
+                                              (br_if $while-in98
                                                 (i32.lt_s
                                                   (i32.sub
                                                     (get_local $32)
@@ -6183,7 +6183,7 @@
                                         (i32.const 65536)
                                       )
                                     )
-                                    (block $do-once$106
+                                    (block $do-once99
                                       (if
                                         (get_local $21)
                                         (block
@@ -6199,7 +6199,7 @@
                                               )
                                             )
                                           )
-                                          (loop $while-in$109
+                                          (loop $while-in102
                                             (set_local $6
                                               (call $_fmt_u
                                                 (i32.load
@@ -6209,14 +6209,14 @@
                                                 (get_local $34)
                                               )
                                             )
-                                            (block $do-once$110
+                                            (block $do-once103
                                               (if
                                                 (i32.eq
                                                   (get_local $7)
                                                   (get_local $12)
                                                 )
                                                 (block
-                                                  (br_if $do-once$110
+                                                  (br_if $do-once103
                                                     (i32.ne
                                                       (get_local $6)
                                                       (get_local $34)
@@ -6231,13 +6231,13 @@
                                                   )
                                                 )
                                                 (block
-                                                  (br_if $do-once$110
+                                                  (br_if $do-once103
                                                     (i32.le_u
                                                       (get_local $6)
                                                       (get_local $24)
                                                     )
                                                   )
-                                                  (loop $while-in$113
+                                                  (loop $while-in106
                                                     (i32.store8
                                                       (tee_local $6
                                                         (i32.add
@@ -6247,7 +6247,7 @@
                                                       )
                                                       (i32.const 48)
                                                     )
-                                                    (br_if $while-in$113
+                                                    (br_if $while-in106
                                                       (i32.gt_u
                                                         (get_local $6)
                                                         (get_local $24)
@@ -6291,15 +6291,15 @@
                                                 (set_local $7
                                                   (get_local $6)
                                                 )
-                                                (br $while-in$109)
+                                                (br $while-in102)
                                               )
                                             )
                                           )
-                                          (block $do-once$114
+                                          (block $do-once107
                                             (if
                                               (get_local $16)
                                               (block
-                                                (br_if $do-once$114
+                                                (br_if $do-once107
                                                   (i32.and
                                                     (i32.load
                                                       (get_local $0)
@@ -6332,7 +6332,7 @@
                                               (set_local $7
                                                 (get_local $5)
                                               )
-                                              (loop $while-in$117
+                                              (loop $while-in110
                                                 (if
                                                   (i32.gt_u
                                                     (tee_local $5
@@ -6346,7 +6346,7 @@
                                                     )
                                                     (get_local $24)
                                                   )
-                                                  (loop $while-in$119
+                                                  (loop $while-in112
                                                     (i32.store8
                                                       (tee_local $5
                                                         (i32.add
@@ -6356,7 +6356,7 @@
                                                       )
                                                       (i32.const 48)
                                                     )
-                                                    (br_if $while-in$119
+                                                    (br_if $while-in112
                                                       (i32.gt_u
                                                         (get_local $5)
                                                         (get_local $24)
@@ -6414,7 +6414,7 @@
                                                     (set_local $7
                                                       (get_local $5)
                                                     )
-                                                    (br $while-in$117)
+                                                    (br $while-in110)
                                                   )
                                                 )
                                               )
@@ -6459,7 +6459,7 @@
                                               (set_local $7
                                                 (get_local $5)
                                               )
-                                              (loop $while-in$121
+                                              (loop $while-in114
                                                 (set_local $8
                                                   (if i32
                                                     (i32.eq
@@ -6484,7 +6484,7 @@
                                                     (get_local $5)
                                                   )
                                                 )
-                                                (block $do-once$122
+                                                (block $do-once115
                                                   (if
                                                     (i32.eq
                                                       (get_local $6)
@@ -6514,7 +6514,7 @@
                                                           )
                                                         )
                                                       )
-                                                      (br_if $do-once$122
+                                                      (br_if $do-once115
                                                         (i32.and
                                                           (get_local $9)
                                                           (i32.lt_s
@@ -6523,7 +6523,7 @@
                                                           )
                                                         )
                                                       )
-                                                      (br_if $do-once$122
+                                                      (br_if $do-once115
                                                         (i32.and
                                                           (i32.load
                                                             (get_local $0)
@@ -6552,10 +6552,10 @@
                                                           (set_local $5
                                                             (get_local $8)
                                                           )
-                                                          (br $do-once$122)
+                                                          (br $do-once115)
                                                         )
                                                       )
-                                                      (loop $while-in$125
+                                                      (loop $while-in118
                                                         (i32.store8
                                                           (tee_local $5
                                                             (i32.add
@@ -6565,7 +6565,7 @@
                                                           )
                                                           (i32.const 48)
                                                         )
-                                                        (br_if $while-in$125
+                                                        (br_if $while-in118
                                                           (i32.gt_u
                                                             (get_local $5)
                                                             (get_local $24)
@@ -6630,7 +6630,7 @@
                                                     (set_local $7
                                                       (get_local $5)
                                                     )
-                                                    (br $while-in$121)
+                                                    (br $while-in114)
                                                   )
                                                 )
                                               )
@@ -6646,7 +6646,7 @@
                                             (i32.const 18)
                                             (i32.const 0)
                                           )
-                                          (br_if $do-once$106
+                                          (br_if $do-once99
                                             (i32.and
                                               (i32.load
                                                 (get_local $0)
@@ -6856,7 +6856,7 @@
                             (set_local $8
                               (get_local $23)
                             )
-                            (loop $while-in$130
+                            (loop $while-in123
                               (i32.store8
                                 (tee_local $8
                                   (i32.add
@@ -6883,7 +6883,7 @@
                                   (i32.const 255)
                                 )
                               )
-                              (br_if $while-in$130
+                              (br_if $while-in123
                                 (i32.eqz
                                   (i32.and
                                     (i32.eqz
@@ -7030,9 +7030,9 @@
                       (get_local $18)
                     )
                   )
-                  (loop $while-in$132
-                    (block $while-out$131
-                      (br_if $while-out$131
+                  (loop $while-in125
+                    (block $while-out124
+                      (br_if $while-out124
                         (i32.eqz
                           (tee_local $9
                             (i32.load
@@ -7041,7 +7041,7 @@
                           )
                         )
                       )
-                      (br_if $while-out$131
+                      (br_if $while-out124
                         (i32.or
                           (i32.lt_s
                             (tee_local $6
@@ -7067,7 +7067,7 @@
                           (i32.const 4)
                         )
                       )
-                      (br_if $while-in$132
+                      (br_if $while-in125
                         (i32.gt_u
                           (get_local $8)
                           (tee_local $1
@@ -7110,7 +7110,7 @@
                           (get_local $18)
                         )
                       )
-                      (loop $while-in$134
+                      (loop $while-in127
                         (if
                           (i32.eqz
                             (tee_local $8
@@ -7171,7 +7171,7 @@
                             )
                           )
                         )
-                        (br_if $while-in$134
+                        (br_if $while-in127
                           (i32.lt_u
                             (get_local $6)
                             (get_local $1)
@@ -7423,9 +7423,9 @@
             (set_local $0
               (i32.const 1)
             )
-            (loop $while-in$137
-              (block $while-out$136
-                (br_if $while-out$136
+            (loop $while-in130
+              (block $while-out129
+                (br_if $while-out129
                   (i32.eqz
                     (tee_local $1
                       (i32.load
@@ -7451,7 +7451,7 @@
                   (get_local $1)
                   (get_local $2)
                 )
-                (br_if $while-in$137
+                (br_if $while-in130
                   (i32.lt_s
                     (tee_local $0
                       (i32.add
@@ -7475,7 +7475,7 @@
                 (get_local $0)
                 (i32.const 10)
               )
-              (loop $while-in$139
+              (loop $while-in132
                 (set_local $1
                   (i32.add
                     (get_local $0)
@@ -7508,7 +7508,7 @@
                     (set_local $0
                       (get_local $1)
                     )
-                    (br $while-in$139)
+                    (br $while-in132)
                   )
                   (set_local $15
                     (i32.const 1)
@@ -7541,18 +7541,18 @@
           (get_local $1)
           (i32.const 20)
         )
-        (block $switch-default$14
-          (block $switch-case$13
-            (block $switch-case$12
-              (block $switch-case$11
-                (block $switch-case$10
-                  (block $switch-case$9
-                    (block $switch-case$8
-                      (block $switch-case$7
-                        (block $switch-case$6
-                          (block $switch-case$5
-                            (block $switch-case$4
-                              (br_table $switch-case$4 $switch-case$5 $switch-case$6 $switch-case$7 $switch-case$8 $switch-case$9 $switch-case$10 $switch-case$11 $switch-case$12 $switch-case$13 $switch-default$14
+        (block $switch-default
+          (block $switch-case9
+            (block $switch-case8
+              (block $switch-case7
+                (block $switch-case6
+                  (block $switch-case5
+                    (block $switch-case4
+                      (block $switch-case3
+                        (block $switch-case2
+                          (block $switch-case1
+                            (block $switch-case
+                              (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $switch-default
                                 (i32.sub
                                   (get_local $1)
                                   (i32.const 9)
@@ -7952,7 +7952,7 @@
           )
         )
         (block i32
-          (loop $while-in$1
+          (loop $while-in
             (set_local $3
               (call $___uremdi3
                 (get_local $0)
@@ -8011,7 +8011,7 @@
                 (set_local $1
                   (get_local $4)
                 )
-                (br $while-in$1)
+                (br $while-in)
               )
               (set_local $0
                 (get_local $3)
@@ -8025,7 +8025,7 @@
     )
     (if
       (get_local $0)
-      (loop $while-in$3
+      (loop $while-in1
         (i32.store8
           (tee_local $1
             (i32.add
@@ -8068,7 +8068,7 @@
             (set_local $0
               (get_local $2)
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
@@ -8102,7 +8102,7 @@
     (set_local $5
       (get_local $6)
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.and
           (i32.gt_s
@@ -8166,7 +8166,7 @@
               (set_local $3
                 (get_local $7)
               )
-              (loop $while-in$3
+              (loop $while-in
                 (set_local $3
                   (i32.eqz
                     (i32.and
@@ -8192,7 +8192,7 @@
                     )
                   )
                 )
-                (br_if $while-in$3
+                (br_if $while-in
                   (i32.gt_u
                     (tee_local $2
                       (i32.add
@@ -8210,7 +8210,7 @@
                   (i32.const 255)
                 )
               )
-              (br_if $do-once$0
+              (br_if $do-once
                 (i32.eqz
                   (get_local $3)
                 )
@@ -8221,7 +8221,7 @@
               (set_local $1
                 (get_local $4)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (drop
@@ -8263,7 +8263,7 @@
     (local $22 i32)
     (local $23 i32)
     (local $24 i32)
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.lt_u
           (get_local $0)
@@ -8919,8 +8919,8 @@
                   (set_local $2
                     (get_local $1)
                   )
-                  (loop $while-in$7
-                    (block $while-out$6
+                  (loop $while-in
+                    (block $while-out
                       (if
                         (i32.eqz
                           (tee_local $0
@@ -8941,7 +8941,7 @@
                             (set_local $2
                               (get_local $1)
                             )
-                            (br $while-out$6)
+                            (br $while-out)
                           )
                         )
                       )
@@ -8978,7 +8978,7 @@
                           (get_local $6)
                         )
                       )
-                      (br $while-in$7)
+                      (br $while-in)
                     )
                   )
                   (if
@@ -9009,7 +9009,7 @@
                       (get_local $2)
                     )
                   )
-                  (block $do-once$8
+                  (block $do-once4
                     (if
                       (i32.eq
                         (tee_local $0
@@ -9050,11 +9050,11 @@
                               (set_local $5
                                 (i32.const 0)
                               )
-                              (br $do-once$8)
+                              (br $do-once4)
                             )
                           )
                         )
-                        (loop $while-in$11
+                        (loop $while-in7
                           (if
                             (tee_local $8
                               (i32.load
@@ -9073,7 +9073,7 @@
                               (set_local $0
                                 (get_local $6)
                               )
-                              (br $while-in$11)
+                              (br $while-in7)
                             )
                           )
                           (if
@@ -9094,7 +9094,7 @@
                               (set_local $0
                                 (get_local $6)
                               )
-                              (br $while-in$11)
+                              (br $while-in7)
                             )
                           )
                         )
@@ -9171,7 +9171,7 @@
                       )
                     )
                   )
-                  (block $do-once$12
+                  (block $do-once8
                     (if
                       (get_local $11)
                       (block
@@ -9219,7 +9219,7 @@
                                     )
                                   )
                                 )
-                                (br $do-once$12)
+                                (br $do-once8)
                               )
                             )
                           )
@@ -9254,7 +9254,7 @@
                                 (get_local $5)
                               )
                             )
-                            (br_if $do-once$12
+                            (br_if $do-once8
                               (i32.eqz
                                 (get_local $5)
                               )
@@ -9692,7 +9692,7 @@
                         (set_local $2
                           (i32.const 0)
                         )
-                        (loop $while-in$18
+                        (loop $while-in14
                           (if
                             (i32.lt_u
                               (tee_local $8
@@ -9809,7 +9809,7 @@
                               (set_local $0
                                 (get_local $14)
                               )
-                              (br $while-in$18)
+                              (br $while-in14)
                             )
                           )
                         )
@@ -9862,7 +9862,7 @@
                               (set_local $0
                                 (get_local $9)
                               )
-                              (br $do-once$0)
+                              (br $do-once)
                             )
                           )
                           (set_local $12
@@ -9994,7 +9994,7 @@
                     (get_local $19)
                     (i32.const 90)
                   )
-                  (loop $while-in$20
+                  (loop $while-in16
                     (set_local $2
                       (i32.lt_u
                         (tee_local $0
@@ -10035,10 +10035,10 @@
                         (set_local $3
                           (get_local $0)
                         )
-                        (br $while-in$20)
+                        (br $while-in16)
                       )
                     )
-                    (br_if $while-in$20
+                    (br_if $while-in16
                       (tee_local $3
                         (i32.load offset=20
                           (get_local $3)
@@ -10096,7 +10096,7 @@
                           (get_local $6)
                         )
                       )
-                      (block $do-once$21
+                      (block $do-once17
                         (if
                           (i32.eq
                             (tee_local $0
@@ -10137,11 +10137,11 @@
                                   (set_local $10
                                     (i32.const 0)
                                   )
-                                  (br $do-once$21)
+                                  (br $do-once17)
                                 )
                               )
                             )
-                            (loop $while-in$24
+                            (loop $while-in20
                               (if
                                 (tee_local $3
                                   (i32.load
@@ -10160,7 +10160,7 @@
                                   (set_local $0
                                     (get_local $2)
                                   )
-                                  (br $while-in$24)
+                                  (br $while-in20)
                                 )
                               )
                               (if
@@ -10181,7 +10181,7 @@
                                   (set_local $0
                                     (get_local $2)
                                   )
-                                  (br $while-in$24)
+                                  (br $while-in20)
                                 )
                               )
                             )
@@ -10258,7 +10258,7 @@
                           )
                         )
                       )
-                      (block $do-once$25
+                      (block $do-once21
                         (if
                           (get_local $5)
                           (block
@@ -10306,7 +10306,7 @@
                                         )
                                       )
                                     )
-                                    (br $do-once$25)
+                                    (br $do-once21)
                                   )
                                 )
                               )
@@ -10341,7 +10341,7 @@
                                     (get_local $10)
                                   )
                                 )
-                                (br_if $do-once$25
+                                (br_if $do-once21
                                   (i32.eqz
                                     (get_local $10)
                                   )
@@ -10416,7 +10416,7 @@
                           )
                         )
                       )
-                      (block $do-once$29
+                      (block $do-once25
                         (if
                           (i32.lt_u
                             (get_local $7)
@@ -10574,7 +10574,7 @@
                                   (get_local $4)
                                   (get_local $0)
                                 )
-                                (br $do-once$29)
+                                (br $do-once25)
                               )
                             )
                             (set_local $1
@@ -10739,7 +10739,7 @@
                                   (get_local $4)
                                   (get_local $4)
                                 )
-                                (br $do-once$29)
+                                (br $do-once25)
                               )
                             )
                             (set_local $2
@@ -10769,7 +10769,7 @@
                             (block $jumpthreading$outer$1
                               (block $jumpthreading$inner$1
                                 (block $jumpthreading$inner$0
-                                  (loop $while-in$32
+                                  (loop $while-in28
                                     (br_if $jumpthreading$inner$1
                                       (i32.eq
                                         (i32.and
@@ -10814,7 +10814,7 @@
                                         (set_local $0
                                           (get_local $3)
                                         )
-                                        (br $while-in$32)
+                                        (br $while-in28)
                                       )
                                       (block
                                         (set_local $1
@@ -10853,7 +10853,7 @@
                                       (get_local $4)
                                       (get_local $4)
                                     )
-                                    (br $do-once$29)
+                                    (br $do-once25)
                                   )
                                 )
                                 (br $jumpthreading$outer$1)
@@ -11248,8 +11248,8 @@
                   (set_local $1
                     (i32.const 624)
                   )
-                  (loop $while-in$38
-                    (block $while-out$37
+                  (loop $while-in34
+                    (block $while-out33
                       (if
                         (i32.le_u
                           (tee_local $3
@@ -11278,11 +11278,11 @@
                             (set_local $4
                               (get_local $1)
                             )
-                            (br $while-out$37)
+                            (br $while-out33)
                           )
                         )
                       )
-                      (br_if $while-in$38
+                      (br_if $while-in34
                         (tee_local $1
                           (i32.load offset=8
                             (get_local $1)
@@ -11601,7 +11601,7 @@
           (get_local $3)
         )
       )
-      (block $do-once$44
+      (block $do-once40
         (if
           (tee_local $7
             (i32.load
@@ -11614,7 +11614,7 @@
             )
             (block $jumpthreading$outer$9
               (block $jumpthreading$inner$9
-                (loop $while-in$49
+                (loop $while-in45
                   (br_if $jumpthreading$inner$9
                     (i32.eq
                       (get_local $2)
@@ -11637,7 +11637,7 @@
                       )
                     )
                   )
-                  (br_if $while-in$49
+                  (br_if $while-in45
                     (tee_local $3
                       (i32.load offset=8
                         (get_local $3)
@@ -11740,7 +11740,7 @@
                         (i32.const 664)
                       )
                     )
-                    (br $do-once$44)
+                    (br $do-once40)
                   )
                 )
               )
@@ -11776,7 +11776,7 @@
             )
             (block $jumpthreading$outer$10
               (block $jumpthreading$inner$10
-                (loop $while-in$51
+                (loop $while-in47
                   (if
                     (i32.eq
                       (i32.load
@@ -11791,7 +11791,7 @@
                       (br $jumpthreading$inner$10)
                     )
                   )
-                  (br_if $while-in$51
+                  (br_if $while-in47
                     (tee_local $3
                       (i32.load offset=8
                         (get_local $3)
@@ -11901,7 +11901,7 @@
                       (i32.const 3)
                     )
                   )
-                  (block $do-once$52
+                  (block $do-once48
                     (if
                       (i32.eq
                         (get_local $8)
@@ -11969,7 +11969,7 @@
                               )
                               (get_local $0)
                             )
-                            (br $do-once$52)
+                            (br $do-once48)
                           )
                         )
                         (i32.store
@@ -12012,7 +12012,7 @@
                                             (get_local $8)
                                           )
                                         )
-                                        (block $do-once$55
+                                        (block $do-once51
                                           (if
                                             (i32.ne
                                               (tee_local $4
@@ -12041,7 +12041,7 @@
                                                 )
                                                 (call $_abort)
                                               )
-                                              (br_if $do-once$55
+                                              (br_if $do-once51
                                                 (i32.eq
                                                   (i32.load offset=12
                                                     (get_local $4)
@@ -12077,7 +12077,7 @@
                                             (br $label$break$L331)
                                           )
                                         )
-                                        (block $do-once$57
+                                        (block $do-once53
                                           (if
                                             (i32.eq
                                               (get_local $3)
@@ -12113,7 +12113,7 @@
                                                   (set_local $21
                                                     (get_local $0)
                                                   )
-                                                  (br $do-once$57)
+                                                  (br $do-once53)
                                                 )
                                               )
                                               (call $_abort)
@@ -12135,7 +12135,7 @@
                                             (get_local $8)
                                           )
                                         )
-                                        (block $do-once$59
+                                        (block $do-once55
                                           (if
                                             (i32.eq
                                               (tee_local $0
@@ -12177,11 +12177,11 @@
                                                     (set_local $11
                                                       (i32.const 0)
                                                     )
-                                                    (br $do-once$59)
+                                                    (br $do-once55)
                                                   )
                                                 )
                                               )
-                                              (loop $while-in$62
+                                              (loop $while-in58
                                                 (if
                                                   (tee_local $4
                                                     (i32.load
@@ -12200,7 +12200,7 @@
                                                     (set_local $0
                                                       (get_local $3)
                                                     )
-                                                    (br $while-in$62)
+                                                    (br $while-in58)
                                                   )
                                                 )
                                                 (if
@@ -12221,7 +12221,7 @@
                                                     (set_local $0
                                                       (get_local $3)
                                                     )
-                                                    (br $while-in$62)
+                                                    (br $while-in58)
                                                   )
                                                 )
                                               )
@@ -12303,7 +12303,7 @@
                                             (get_local $7)
                                           )
                                         )
-                                        (block $do-once$63
+                                        (block $do-once59
                                           (if
                                             (i32.eq
                                               (get_local $8)
@@ -12328,7 +12328,7 @@
                                                 (get_local $0)
                                                 (get_local $11)
                                               )
-                                              (br_if $do-once$63
+                                              (br_if $do-once59
                                                 (get_local $11)
                                               )
                                               (i32.store
@@ -12523,7 +12523,7 @@
                                 )
                               )
                             )
-                            (block $do-once$67
+                            (block $do-once63
                               (if
                                 (i32.and
                                   (tee_local $2
@@ -12562,7 +12562,7 @@
                                       (set_local $17
                                         (get_local $1)
                                       )
-                                      (br $do-once$67)
+                                      (br $do-once63)
                                     )
                                   )
                                   (call $_abort)
@@ -12603,7 +12603,7 @@
                               (get_local $6)
                               (get_local $0)
                             )
-                            (br $do-once$52)
+                            (br $do-once48)
                           )
                         )
                         (set_local $1
@@ -12611,7 +12611,7 @@
                             (i32.const 480)
                             (i32.shl
                               (tee_local $3
-                                (block $do-once$69 i32
+                                (block $do-once65 i32
                                   (if i32
                                     (tee_local $0
                                       (i32.shr_u
@@ -12621,7 +12621,7 @@
                                     )
                                     (block i32
                                       (drop
-                                        (br_if $do-once$69
+                                        (br_if $do-once65
                                           (i32.const 31)
                                           (i32.gt_u
                                             (get_local $2)
@@ -12774,7 +12774,7 @@
                               (get_local $6)
                               (get_local $6)
                             )
-                            (br $do-once$52)
+                            (br $do-once48)
                           )
                         )
                         (set_local $3
@@ -12804,7 +12804,7 @@
                         (block $jumpthreading$outer$6
                           (block $jumpthreading$inner$6
                             (block $jumpthreading$inner$5
-                              (loop $while-in$72
+                              (loop $while-in68
                                 (br_if $jumpthreading$inner$6
                                   (i32.eq
                                     (i32.and
@@ -12849,7 +12849,7 @@
                                     (set_local $0
                                       (get_local $4)
                                     )
-                                    (br $while-in$72)
+                                    (br $while-in68)
                                   )
                                   (block
                                     (set_local $1
@@ -12888,7 +12888,7 @@
                                   (get_local $6)
                                   (get_local $6)
                                 )
-                                (br $do-once$52)
+                                (br $do-once48)
                               )
                             )
                             (br $jumpthreading$outer$6)
@@ -12954,8 +12954,8 @@
                 )
               )
             )
-            (loop $while-in$74
-              (block $while-out$73
+            (loop $while-in70
+              (block $while-out69
                 (if
                   (i32.le_u
                     (tee_local $3
@@ -12965,7 +12965,7 @@
                     )
                     (get_local $7)
                   )
-                  (br_if $while-out$73
+                  (br_if $while-out69
                     (i32.gt_u
                       (tee_local $3
                         (i32.add
@@ -12984,7 +12984,7 @@
                     (get_local $4)
                   )
                 )
-                (br $while-in$74)
+                (br $while-in70)
               )
             )
             (set_local $5
@@ -13152,7 +13152,7 @@
                 (i32.const 24)
               )
             )
-            (loop $while-in$76
+            (loop $while-in72
               (i32.store
                 (tee_local $1
                   (i32.add
@@ -13162,7 +13162,7 @@
                 )
                 (i32.const 7)
               )
-              (br_if $while-in$76
+              (br_if $while-in72
                 (i32.lt_u
                   (i32.add
                     (get_local $1)
@@ -13302,7 +13302,7 @@
                       (get_local $7)
                       (get_local $1)
                     )
-                    (br $do-once$44)
+                    (br $do-once40)
                   )
                 )
                 (set_local $2
@@ -13462,7 +13462,7 @@
                       (get_local $7)
                       (get_local $7)
                     )
-                    (br $do-once$44)
+                    (br $do-once40)
                   )
                 )
                 (set_local $3
@@ -13492,7 +13492,7 @@
                 (block $jumpthreading$outer$8
                   (block $jumpthreading$inner$8
                     (block $jumpthreading$inner$7
-                      (loop $while-in$78
+                      (loop $while-in74
                         (br_if $jumpthreading$inner$8
                           (i32.eq
                             (i32.and
@@ -13537,7 +13537,7 @@
                             (set_local $1
                               (get_local $4)
                             )
-                            (br $while-in$78)
+                            (br $while-in74)
                           )
                           (block
                             (set_local $2
@@ -13576,7 +13576,7 @@
                           (get_local $7)
                           (get_local $7)
                         )
-                        (br $do-once$44)
+                        (br $do-once40)
                       )
                     )
                     (br $jumpthreading$outer$8)
@@ -13678,7 +13678,7 @@
             (set_local $3
               (i32.const 0)
             )
-            (loop $while-in$47
+            (loop $while-in43
               (i32.store offset=12
                 (tee_local $4
                   (i32.add
@@ -13698,7 +13698,7 @@
                 (get_local $4)
                 (get_local $4)
               )
-              (br_if $while-in$47
+              (br_if $while-in43
                 (i32.ne
                   (tee_local $3
                     (i32.add
@@ -13903,7 +13903,7 @@
         )
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.and
           (get_local $3)
@@ -13982,7 +13982,7 @@
                   (set_local $1
                     (get_local $3)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (i32.store
@@ -14096,7 +14096,7 @@
                   (set_local $1
                     (get_local $3)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (if
@@ -14151,7 +14151,7 @@
               (set_local $1
                 (get_local $3)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $12
@@ -14159,7 +14159,7 @@
               (get_local $0)
             )
           )
-          (block $do-once$2
+          (block $do-once0
             (if
               (i32.eq
                 (tee_local $2
@@ -14201,11 +14201,11 @@
                       (set_local $7
                         (i32.const 0)
                       )
-                      (br $do-once$2)
+                      (br $do-once0)
                     )
                   )
                 )
-                (loop $while-in$5
+                (loop $while-in
                   (if
                     (tee_local $8
                       (i32.load
@@ -14224,7 +14224,7 @@
                       (set_local $5
                         (get_local $10)
                       )
-                      (br $while-in$5)
+                      (br $while-in)
                     )
                   )
                   (if
@@ -14245,7 +14245,7 @@
                       (set_local $5
                         (get_local $10)
                       )
-                      (br $while-in$5)
+                      (br $while-in)
                     )
                   )
                 )
@@ -14375,7 +14375,7 @@
                       (set_local $1
                         (get_local $3)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -14421,7 +14421,7 @@
                       (set_local $1
                         (get_local $3)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -14682,7 +14682,7 @@
             (i32.const 3)
           )
         )
-        (block $do-once$8
+        (block $do-once4
           (if
             (i32.lt_u
               (get_local $0)
@@ -14756,7 +14756,7 @@
                       )
                     )
                   )
-                  (br $do-once$8)
+                  (br $do-once4)
                 )
               )
               (if
@@ -14814,7 +14814,7 @@
                   (get_local $6)
                 )
               )
-              (block $do-once$10
+              (block $do-once6
                 (if
                   (i32.eq
                     (tee_local $0
@@ -14856,11 +14856,11 @@
                           (set_local $9
                             (i32.const 0)
                           )
-                          (br $do-once$10)
+                          (br $do-once6)
                         )
                       )
                     )
-                    (loop $while-in$13
+                    (loop $while-in9
                       (if
                         (tee_local $3
                           (i32.load
@@ -14879,7 +14879,7 @@
                           (set_local $1
                             (get_local $5)
                           )
-                          (br $while-in$13)
+                          (br $while-in9)
                         )
                       )
                       (if
@@ -14900,7 +14900,7 @@
                           (set_local $1
                             (get_local $5)
                           )
-                          (br $while-in$13)
+                          (br $while-in9)
                         )
                       )
                     )
@@ -15028,7 +15028,7 @@
                               )
                             )
                           )
-                          (br $do-once$8)
+                          (br $do-once4)
                         )
                       )
                     )
@@ -15063,7 +15063,7 @@
                           (get_local $9)
                         )
                       )
-                      (br_if $do-once$8
+                      (br_if $do-once4
                         (i32.eqz
                           (get_local $9)
                         )
@@ -15398,7 +15398,7 @@
       (get_local $4)
       (i32.const 0)
     )
-    (block $do-once$16
+    (block $do-once12
       (if
         (i32.and
           (tee_local $0
@@ -15441,7 +15441,7 @@
           (block $jumpthreading$outer$1
             (block $jumpthreading$inner$1
               (block $jumpthreading$inner$0
-                (loop $while-in$19
+                (loop $while-in15
                   (br_if $jumpthreading$inner$1
                     (i32.eq
                       (i32.and
@@ -15489,7 +15489,7 @@
                     (set_local $0
                       (get_local $3)
                     )
-                    (br $while-in$19)
+                    (br $while-in15)
                   )
                 )
               )
@@ -15518,7 +15518,7 @@
                     (get_local $4)
                     (get_local $4)
                   )
-                  (br $do-once$16)
+                  (br $do-once12)
                 )
               )
               (br $jumpthreading$outer$1)
@@ -15618,7 +15618,7 @@
         (i32.const 632)
       )
     )
-    (loop $while-in$21
+    (loop $while-in17
       (set_local $0
         (i32.add
           (tee_local $1
@@ -15629,7 +15629,7 @@
           (i32.const 8)
         )
       )
-      (br_if $while-in$21
+      (br_if $while-in17
         (get_local $1)
       )
     )
@@ -15745,7 +15745,7 @@
                 (get_local $3)
               )
             )
-            (loop $while-in$1
+            (loop $while-in
               (if
                 (i32.lt_s
                   (get_local $0)
@@ -15762,13 +15762,13 @@
                       (i32.const 1)
                     )
                   )
-                  (br $while-in$1)
+                  (br $while-in)
                 )
               )
             )
           )
         )
-        (loop $while-in$3
+        (loop $while-in1
           (if
             (i32.lt_s
               (get_local $0)
@@ -15785,13 +15785,13 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$3)
+              (br $while-in1)
             )
           )
         )
       )
     )
-    (loop $while-in$5
+    (loop $while-in3
       (if
         (i32.lt_s
           (get_local $0)
@@ -15808,7 +15808,7 @@
               (i32.const 1)
             )
           )
-          (br $while-in$5)
+          (br $while-in3)
         )
       )
     )
@@ -15953,9 +15953,9 @@
         )
       )
       (block
-        (loop $while-in$1
-          (block $while-out$0
-            (br_if $while-out$0
+        (loop $while-in
+          (block $while-out
+            (br_if $while-out
               (i32.eqz
                 (i32.and
                   (get_local $0)
@@ -15995,10 +15995,10 @@
                 (i32.const 1)
               )
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
-        (loop $while-in$3
+        (loop $while-in1
           (if
             (i32.ge_s
               (get_local $2)
@@ -16029,13 +16029,13 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$3)
+              (br $while-in1)
             )
           )
         )
       )
     )
-    (loop $while-in$5
+    (loop $while-in3
       (if
         (i32.gt_s
           (get_local $2)
@@ -16066,7 +16066,7 @@
               (i32.const 1)
             )
           )
-          (br $while-in$5)
+          (br $while-in3)
         )
       )
     )

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -286,11 +286,11 @@
         (i32.const 52)
       )
     )
-    (block $switch$0 f64
-      (block $switch-default$3
-        (block $switch-case$2
-          (block $switch-case$1
-            (br_table $switch-case$1 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-case$2 $switch-default$3
+    (block $switch f64
+      (block $switch-default
+        (block $switch-case0
+          (block $switch-case
+            (br_table $switch-case $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case0 $switch-default
               (i32.sub
                 (tee_local $2
                   (i32.and
@@ -329,11 +329,11 @@
               (i32.const 0)
             )
           )
-          (br $switch$0
+          (br $switch
             (get_local $0)
           )
         )
-        (br $switch$0
+        (br $switch
           (get_local $0)
         )
       )
@@ -380,7 +380,7 @@
     )
     (block $jumpthreading$outer$0
       (block $jumpthreading$inner$0
-        (loop $while-in$1
+        (loop $while-in
           (br_if $jumpthreading$inner$0
             (i32.eq
               (i32.and
@@ -392,7 +392,7 @@
               (get_local $0)
             )
           )
-          (br_if $while-in$1
+          (br_if $while-in
             (i32.ne
               (tee_local $1
                 (i32.add
@@ -440,8 +440,8 @@
         (get_local $4)
         (i32.const 5)
       )
-      (loop $while-in$3
-        (loop $while-in$5
+      (loop $while-in1
+        (loop $while-in3
           (set_local $0
             (i32.add
               (get_local $2)
@@ -456,7 +456,7 @@
               (set_local $2
                 (get_local $0)
               )
-              (br $while-in$5)
+              (br $while-in3)
             )
           )
         )
@@ -471,7 +471,7 @@
             (set_local $2
               (get_local $0)
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
           (set_local $5
             (get_local $0)
@@ -692,7 +692,7 @@
   (func $_fflush (param $0 i32) (result i32)
     (local $1 i32)
     (local $2 i32)
-    (block $do-once$0 i32
+    (block $do-once i32
       (if i32
         (get_local $0)
         (block i32
@@ -703,7 +703,7 @@
               )
               (i32.const -1)
             )
-            (br $do-once$0
+            (br $do-once
               (call $___fflush_unlocked
                 (get_local $0)
               )
@@ -755,7 +755,7 @@
                 (i32.const 40)
               )
             )
-            (loop $while-in$3
+            (loop $while-in
               (set_local $2
                 (if i32
                   (i32.gt_s
@@ -795,7 +795,7 @@
                   (get_local $1)
                 )
               )
-              (br_if $while-in$3
+              (br_if $while-in
                 (tee_local $1
                   (i32.load offset=56
                     (get_local $1)
@@ -965,7 +965,7 @@
       (block $jumpthreading$outer$1 i32
         (block $jumpthreading$inner$1
           (block $jumpthreading$inner$0
-            (loop $while-in$1
+            (loop $while-in
               (br_if $jumpthreading$inner$0
                 (i32.eq
                   (get_local $11)
@@ -1141,7 +1141,7 @@
                 (set_local $1
                   (get_local $3)
                 )
-                (br $while-in$1)
+                (br $while-in)
               )
             )
           )
@@ -1270,12 +1270,12 @@
         (i32.const 40)
       )
     )
-    (loop $do-in$1
+    (loop $do-in
       (i32.store
         (get_local $4)
         (i32.const 0)
       )
-      (br_if $do-in$1
+      (br_if $do-in
         (i32.lt_s
           (tee_local $4
             (i32.add
@@ -1600,7 +1600,7 @@
                 (set_local $3
                   (get_local $1)
                 )
-                (loop $while-in$3
+                (loop $while-in
                   (if
                     (i32.eqz
                       (get_local $3)
@@ -1633,7 +1633,7 @@
                       (set_local $3
                         (get_local $4)
                       )
-                      (br $while-in$3)
+                      (br $while-in)
                     )
                   )
                 )
@@ -1785,7 +1785,7 @@
     )
   )
   (func $_wcrtomb (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-    (block $do-once$0 i32
+    (block $do-once i32
       (if i32
         (get_local $0)
         (block i32
@@ -1802,7 +1802,7 @@
                   (i32.const 255)
                 )
               )
-              (br $do-once$0
+              (br $do-once
                 (i32.const 1)
               )
             )
@@ -1839,7 +1839,7 @@
                   (i32.const 255)
                 )
               )
-              (br $do-once$0
+              (br $do-once
                 (i32.const 2)
               )
             )
@@ -1901,7 +1901,7 @@
                   (i32.const 255)
                 )
               )
-              (br $do-once$0
+              (br $do-once
                 (i32.const 3)
               )
             )
@@ -2035,7 +2035,7 @@
                   (i32.const 255)
                 )
               )
-              (loop $while-in$2
+              (loop $while-in
                 (br_if $jumpthreading$inner$2
                   (i32.eq
                     (i32.load8_s
@@ -2050,7 +2050,7 @@
                     )
                   )
                 )
-                (br_if $while-in$2
+                (br_if $while-in
                   (i32.and
                     (tee_local $3
                       (i32.ne
@@ -2125,8 +2125,8 @@
                   (get_local $2)
                   (i32.const 3)
                 )
-                (loop $while-in$6
-                  (block $while-out$5
+                (loop $while-in3
+                  (block $while-out2
                     (if
                       (i32.and
                         (i32.xor
@@ -2152,7 +2152,7 @@
                         (set_local $1
                           (get_local $2)
                         )
-                        (br $while-out$5)
+                        (br $while-out2)
                       )
                     )
                     (set_local $0
@@ -2176,7 +2176,7 @@
                       (set_local $2
                         (get_local $1)
                       )
-                      (br $while-in$6)
+                      (br $while-in3)
                     )
                   )
                 )
@@ -2201,7 +2201,7 @@
               )
             )
           )
-          (loop $while-in$8
+          (loop $while-in5
             (br_if $label$break$L8
               (i32.eq
                 (i32.load8_s
@@ -2222,7 +2222,7 @@
                 (i32.const 1)
               )
             )
-            (br_if $while-in$8
+            (br_if $while-in5
               (tee_local $1
                 (i32.add
                   (get_local $1)
@@ -2652,10 +2652,10 @@
             )
             (loop $label$continue$L9
               (block $label$break$L9
-                (block $switch-default$5
-                  (block $switch-case$4
-                    (block $switch-case$3
-                      (br_table $switch-case$4 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-case$3 $switch-default$5
+                (block $switch-default
+                  (block $switch-case0
+                    (block $switch-case
+                      (br_table $switch-case0 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case $switch-default
                         (i32.sub
                           (i32.shr_s
                             (i32.shl
@@ -2706,7 +2706,7 @@
                   (get_local $28)
                   (i32.const 9)
                 )
-                (loop $while-in$8
+                (loop $while-in
                   (set_local $28
                     (i32.const 0)
                   )
@@ -2752,7 +2752,7 @@
                       (set_local $43
                         (get_local $35)
                       )
-                      (br $while-in$8)
+                      (br $while-in)
                     )
                   )
                 )
@@ -2895,7 +2895,7 @@
                   (set_local $8
                     (i32.const 0)
                   )
-                  (loop $while-in$11
+                  (loop $while-in4
                     (if
                       (i32.eqz
                         (i32.and
@@ -2934,7 +2934,7 @@
                         (get_local $8)
                       )
                     )
-                    (br_if $while-in$11
+                    (br_if $while-in4
                       (i32.eq
                         (i32.and
                           (tee_local $5
@@ -2975,7 +2975,7 @@
                 )
               )
             )
-            (block $do-once$12
+            (block $do-once5
               (if
                 (i32.eq
                   (i32.shr_s
@@ -3085,7 +3085,7 @@
                           (set_local $17
                             (i32.const 0)
                           )
-                          (br $do-once$12)
+                          (br $do-once5)
                         )
                       )
                       (set_local $7
@@ -3163,7 +3163,7 @@
                     (set_local $8
                       (i32.const 0)
                     )
-                    (loop $while-in$15
+                    (loop $while-in8
                       (set_local $13
                         (i32.add
                           (i32.mul
@@ -3197,7 +3197,7 @@
                           (set_local $13
                             (get_local $9)
                           )
-                          (br $while-in$15)
+                          (br $while-in8)
                         )
                         (set_local $9
                           (get_local $13)
@@ -3301,7 +3301,7 @@
                             )
                           )
                         )
-                        (loop $while-in$18
+                        (loop $while-in11
                           (set_local $7
                             (i32.add
                               (i32.mul
@@ -3335,7 +3335,7 @@
                               (set_local $7
                                 (get_local $9)
                               )
-                              (br $while-in$18)
+                              (br $while-in11)
                             )
                             (br $label$break$L46
                               (get_local $5)
@@ -3463,7 +3463,7 @@
             (set_local $11
               (i32.const 0)
             )
-            (loop $while-in$20
+            (loop $while-in13
               (if
                 (i32.gt_u
                   (tee_local $5
@@ -3522,7 +3522,7 @@
                   (set_local $11
                     (get_local $5)
                   )
-                  (br $while-in$20)
+                  (br $while-in13)
                 )
                 (block
                   (set_local $16
@@ -3685,20 +3685,20 @@
                     (block $jumpthreading$inner$4
                       (block $jumpthreading$inner$3
                         (block $jumpthreading$inner$2
-                          (block $switch-default$127
-                            (block $switch-case$49
-                              (block $switch-case$48
-                                (block $switch-case$47
-                                  (block $switch-case$46
-                                    (block $switch-case$45
-                                      (block $switch-case$44
-                                        (block $switch-case$43
-                                          (block $switch-case$41
-                                            (block $switch-case$40
-                                              (block $switch-case$36
-                                                (block $switch-case$35
-                                                  (block $switch-case$34
-                                                    (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$49 $switch-case$49 $switch-case$49 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$49 $switch-default$127 $switch-case$44 $switch-case$41 $switch-case$49 $switch-case$49 $switch-case$49 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127
+                          (block $switch-default120
+                            (block $switch-case42
+                              (block $switch-case41
+                                (block $switch-case40
+                                  (block $switch-case39
+                                    (block $switch-case38
+                                      (block $switch-case37
+                                        (block $switch-case36
+                                          (block $switch-case34
+                                            (block $switch-case33
+                                              (block $switch-case29
+                                                (block $switch-case28
+                                                  (block $switch-case27
+                                                    (br_table $switch-case42 $switch-default120 $switch-case40 $switch-default120 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case29 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case42 $switch-default120 $switch-case37 $switch-case34 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-case34 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case29 $switch-default120
                                                       (i32.sub
                                                         (tee_local $16
                                                           (select
@@ -3730,15 +3730,15 @@
                                                       )
                                                     )
                                                   )
-                                                  (block $switch-default$33
-                                                    (block $switch-case$32
-                                                      (block $switch-case$31
-                                                        (block $switch-case$30
-                                                          (block $switch-case$29
-                                                            (block $switch-case$28
-                                                              (block $switch-case$27
-                                                                (block $switch-case$26
-                                                                  (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
+                                                  (block $switch-default26
+                                                    (block $switch-case25
+                                                      (block $switch-case24
+                                                        (block $switch-case23
+                                                          (block $switch-case22
+                                                            (block $switch-case21
+                                                              (block $switch-case20
+                                                                (block $switch-case19
+                                                                  (br_table $switch-case19 $switch-case20 $switch-case21 $switch-case22 $switch-case23 $switch-default26 $switch-case24 $switch-case25 $switch-default26
                                                                     (i32.sub
                                                                       (get_local $11)
                                                                       (i32.const 0)
@@ -3945,7 +3945,7 @@
                                                 (set_local $8
                                                   (get_local $23)
                                                 )
-                                                (loop $while-in$39
+                                                (loop $while-in32
                                                   (i32.store8
                                                     (tee_local $8
                                                       (i32.add
@@ -3964,7 +3964,7 @@
                                                       (i32.const 255)
                                                     )
                                                   )
-                                                  (br_if $while-in$39
+                                                  (br_if $while-in32
                                                     (i32.eqz
                                                       (i32.and
                                                         (i32.eqz
@@ -4312,7 +4312,7 @@
                               (get_local $5)
                             )
                             (set_local $5
-                              (block $do-once$56 i32
+                              (block $do-once49 i32
                                 (if i32
                                   (i32.or
                                     (i32.lt_u
@@ -4413,14 +4413,14 @@
                                               (set_local $14
                                                 (f64.const 8)
                                               )
-                                              (loop $while-in$61
+                                              (loop $while-in54
                                                 (set_local $14
                                                   (f64.mul
                                                     (get_local $14)
                                                     (f64.const 16)
                                                   )
                                                 )
-                                                (br_if $while-in$61
+                                                (br_if $while-in54
                                                   (tee_local $5
                                                     (i32.add
                                                       (get_local $5)
@@ -4555,7 +4555,7 @@
                                         (set_local $5
                                           (get_local $24)
                                         )
-                                        (loop $while-in$63
+                                        (loop $while-in56
                                           (i32.store8
                                             (get_local $5)
                                             (i32.and
@@ -4590,7 +4590,7 @@
                                             )
                                           )
                                           (set_local $5
-                                            (block $do-once$64 i32
+                                            (block $do-once57 i32
                                               (if i32
                                                 (i32.eq
                                                   (i32.sub
@@ -4606,7 +4606,7 @@
                                                 )
                                                 (block i32
                                                   (drop
-                                                    (br_if $do-once$64
+                                                    (br_if $do-once57
                                                       (get_local $6)
                                                       (i32.and
                                                         (get_local $16)
@@ -4633,7 +4633,7 @@
                                               )
                                             )
                                           )
-                                          (br_if $while-in$63
+                                          (br_if $while-in56
                                             (f64.ne
                                               (get_local $14)
                                               (f64.const 0)
@@ -4777,7 +4777,7 @@
                                             (i32.const 8192)
                                           )
                                         )
-                                        (br $do-once$56
+                                        (br $do-once49
                                           (select
                                             (get_local $17)
                                             (get_local $6)
@@ -4844,7 +4844,7 @@
                                     (set_local $6
                                       (get_local $8)
                                     )
-                                    (loop $while-in$67
+                                    (loop $while-in60
                                       (i32.store
                                         (get_local $6)
                                         (tee_local $5
@@ -4859,7 +4859,7 @@
                                           (i32.const 4)
                                         )
                                       )
-                                      (br_if $while-in$67
+                                      (br_if $while-in60
                                         (f64.ne
                                           (tee_local $14
                                             (f64.mul
@@ -4889,7 +4889,7 @@
                                         (set_local $9
                                           (get_local $8)
                                         )
-                                        (loop $while-in$69
+                                        (loop $while-in62
                                           (set_local $21
                                             (select
                                               (i32.const 29)
@@ -4901,7 +4901,7 @@
                                             )
                                           )
                                           (set_local $9
-                                            (block $do-once$70 i32
+                                            (block $do-once63 i32
                                               (if i32
                                                 (i32.lt_u
                                                   (tee_local $7
@@ -4917,7 +4917,7 @@
                                                   (set_local $5
                                                     (i32.const 0)
                                                   )
-                                                  (loop $while-in$73
+                                                  (loop $while-in66
                                                     (set_local $12
                                                       (call $___uremdi3
                                                         (tee_local $5
@@ -4953,7 +4953,7 @@
                                                         (i32.const 0)
                                                       )
                                                     )
-                                                    (br_if $while-in$73
+                                                    (br_if $while-in66
                                                       (i32.ge_u
                                                         (tee_local $7
                                                           (i32.add
@@ -4966,7 +4966,7 @@
                                                     )
                                                   )
                                                   (drop
-                                                    (br_if $do-once$70
+                                                    (br_if $do-once63
                                                       (get_local $9)
                                                       (i32.eqz
                                                         (get_local $5)
@@ -4990,8 +4990,8 @@
                                           (set_local $5
                                             (get_local $6)
                                           )
-                                          (loop $while-in$75
-                                            (block $while-out$74
+                                          (loop $while-in68
+                                            (block $while-out67
                                               (if
                                                 (i32.le_u
                                                   (get_local $5)
@@ -5001,7 +5001,7 @@
                                                   (set_local $6
                                                     (get_local $5)
                                                   )
-                                                  (br $while-out$74)
+                                                  (br $while-out67)
                                                 )
                                               )
                                               (if
@@ -5020,7 +5020,7 @@
                                                   (set_local $5
                                                     (get_local $6)
                                                   )
-                                                  (br $while-in$75)
+                                                  (br $while-in68)
                                                 )
                                               )
                                             )
@@ -5036,7 +5036,7 @@
                                               )
                                             )
                                           )
-                                          (br_if $while-in$69
+                                          (br_if $while-in62
                                             (i32.gt_s
                                               (get_local $7)
                                               (i32.const 0)
@@ -5078,7 +5078,7 @@
                                             (i32.const 102)
                                           )
                                         )
-                                        (loop $while-in$77
+                                        (loop $while-in70
                                           (set_local $26
                                             (select
                                               (i32.const 9)
@@ -5101,7 +5101,7 @@
                                                   (select
                                                     (get_local $8)
                                                     (tee_local $5
-                                                      (block $do-once$78 i32
+                                                      (block $do-once71 i32
                                                         (if i32
                                                           (i32.lt_u
                                                             (get_local $5)
@@ -5129,7 +5129,7 @@
                                                             (set_local $7
                                                               (get_local $5)
                                                             )
-                                                            (loop $while-in$81
+                                                            (loop $while-in74
                                                               (i32.store
                                                                 (get_local $7)
                                                                 (i32.add
@@ -5153,7 +5153,7 @@
                                                                   (get_local $31)
                                                                 )
                                                               )
-                                                              (br_if $while-in$81
+                                                              (br_if $while-in74
                                                                 (i32.lt_u
                                                                   (tee_local $7
                                                                     (i32.add
@@ -5178,7 +5178,7 @@
                                                               )
                                                             )
                                                             (drop
-                                                              (br_if $do-once$78
+                                                              (br_if $do-once71
                                                                 (get_local $5)
                                                                 (i32.eqz
                                                                   (get_local $9)
@@ -5242,7 +5242,7 @@
                                               )
                                             )
                                           )
-                                          (br_if $while-in$77
+                                          (br_if $while-in70
                                             (i32.lt_s
                                               (get_local $7)
                                               (i32.const 0)
@@ -5257,7 +5257,7 @@
                                         (get_local $6)
                                       )
                                     )
-                                    (block $do-once$82
+                                    (block $do-once75
                                       (if
                                         (i32.lt_u
                                           (get_local $5)
@@ -5276,7 +5276,7 @@
                                               (i32.const 9)
                                             )
                                           )
-                                          (br_if $do-once$82
+                                          (br_if $do-once75
                                             (i32.lt_u
                                               (tee_local $11
                                                 (i32.load
@@ -5289,14 +5289,14 @@
                                           (set_local $7
                                             (i32.const 10)
                                           )
-                                          (loop $while-in$85
+                                          (loop $while-in78
                                             (set_local $6
                                               (i32.add
                                                 (get_local $6)
                                                 (i32.const 1)
                                               )
                                             )
-                                            (br_if $while-in$85
+                                            (br_if $while-in78
                                               (i32.ge_u
                                                 (get_local $11)
                                                 (tee_local $7
@@ -5413,14 +5413,14 @@
                                               (set_local $12
                                                 (i32.const 10)
                                               )
-                                              (loop $while-in$87
+                                              (loop $while-in80
                                                 (set_local $12
                                                   (i32.mul
                                                     (get_local $12)
                                                     (i32.const 10)
                                                   )
                                                 )
-                                                (br_if $while-in$87
+                                                (br_if $while-in80
                                                   (i32.ne
                                                     (tee_local $11
                                                       (i32.add
@@ -5437,7 +5437,7 @@
                                               (i32.const 10)
                                             )
                                           )
-                                          (block $do-once$88
+                                          (block $do-once81
                                             (if
                                               (i32.eqz
                                                 (i32.and
@@ -5513,12 +5513,12 @@
                                                   )
                                                 )
                                                 (set_local $22
-                                                  (block $do-once$90 f64
+                                                  (block $do-once83 f64
                                                     (if f64
                                                       (get_local $30)
                                                       (block f64
                                                         (drop
-                                                          (br_if $do-once$90
+                                                          (br_if $do-once83
                                                             (get_local $22)
                                                             (i32.ne
                                                               (i32.load8_s
@@ -5550,7 +5550,7 @@
                                                     )
                                                   )
                                                 )
-                                                (br_if $do-once$88
+                                                (br_if $do-once81
                                                   (f64.eq
                                                     (f64.add
                                                       (get_local $22)
@@ -5573,7 +5573,7 @@
                                                     (get_local $6)
                                                     (i32.const 999999999)
                                                   )
-                                                  (loop $while-in$93
+                                                  (loop $while-in86
                                                     (i32.store
                                                       (get_local $7)
                                                       (i32.const 0)
@@ -5615,7 +5615,7 @@
                                                         )
                                                       )
                                                     )
-                                                    (br_if $while-in$93
+                                                    (br_if $while-in86
                                                       (i32.gt_u
                                                         (get_local $6)
                                                         (i32.const 999999999)
@@ -5635,7 +5635,7 @@
                                                     (i32.const 9)
                                                   )
                                                 )
-                                                (br_if $do-once$88
+                                                (br_if $do-once81
                                                   (i32.lt_u
                                                     (tee_local $12
                                                       (i32.load
@@ -5648,14 +5648,14 @@
                                                 (set_local $11
                                                   (i32.const 10)
                                                 )
-                                                (loop $while-in$95
+                                                (loop $while-in88
                                                   (set_local $6
                                                     (i32.add
                                                       (get_local $6)
                                                       (i32.const 1)
                                                     )
                                                   )
-                                                  (br_if $while-in$95
+                                                  (br_if $while-in88
                                                     (i32.ge_u
                                                       (get_local $12)
                                                       (tee_local $11
@@ -5707,8 +5707,8 @@
                                     (set_local $5
                                       (get_local $9)
                                     )
-                                    (loop $while-in$97
-                                      (block $while-out$96
+                                    (loop $while-in90
+                                      (block $while-out89
                                         (if
                                           (i32.le_u
                                             (get_local $5)
@@ -5721,7 +5721,7 @@
                                             (set_local $9
                                               (get_local $5)
                                             )
-                                            (br $while-out$96)
+                                            (br $while-out89)
                                           )
                                         )
                                         (if
@@ -5745,13 +5745,13 @@
                                             (set_local $5
                                               (get_local $6)
                                             )
-                                            (br $while-in$97)
+                                            (br $while-in90)
                                           )
                                         )
                                       )
                                     )
                                     (set_local $19
-                                      (block $do-once$98 i32
+                                      (block $do-once91 i32
                                         (if i32
                                           (get_local $21)
                                           (block i32
@@ -5818,12 +5818,12 @@
                                                 (set_local $5
                                                   (get_local $16)
                                                 )
-                                                (br $do-once$98
+                                                (br $do-once91
                                                   (get_local $7)
                                                 )
                                               )
                                             )
-                                            (block $do-once$100
+                                            (block $do-once93
                                               (if
                                                 (get_local $26)
                                                 (block
@@ -5842,7 +5842,7 @@
                                                       (set_local $5
                                                         (i32.const 9)
                                                       )
-                                                      (br $do-once$100)
+                                                      (br $do-once93)
                                                     )
                                                   )
                                                   (if
@@ -5857,7 +5857,7 @@
                                                       (set_local $5
                                                         (i32.const 0)
                                                       )
-                                                      (br $do-once$100)
+                                                      (br $do-once93)
                                                     )
                                                     (block
                                                       (set_local $7
@@ -5868,14 +5868,14 @@
                                                       )
                                                     )
                                                   )
-                                                  (loop $while-in$103
+                                                  (loop $while-in96
                                                     (set_local $5
                                                       (i32.add
                                                         (get_local $5)
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (br_if $while-in$103
+                                                    (br_if $while-in96
                                                       (i32.eqz
                                                         (i32.and
                                                           (i32.rem_u
@@ -6066,7 +6066,7 @@
                                               )
                                               (i32.const 2)
                                             )
-                                            (loop $while-in$105
+                                            (loop $while-in98
                                               (i32.store8
                                                 (tee_local $7
                                                   (i32.add
@@ -6076,7 +6076,7 @@
                                                 )
                                                 (i32.const 48)
                                               )
-                                              (br_if $while-in$105
+                                              (br_if $while-in98
                                                 (i32.lt_s
                                                   (i32.sub
                                                     (get_local $32)
@@ -6176,7 +6176,7 @@
                                         (i32.const 65536)
                                       )
                                     )
-                                    (block $do-once$106
+                                    (block $do-once99
                                       (if
                                         (get_local $21)
                                         (block
@@ -6192,7 +6192,7 @@
                                               )
                                             )
                                           )
-                                          (loop $while-in$109
+                                          (loop $while-in102
                                             (set_local $6
                                               (call $_fmt_u
                                                 (i32.load
@@ -6202,14 +6202,14 @@
                                                 (get_local $34)
                                               )
                                             )
-                                            (block $do-once$110
+                                            (block $do-once103
                                               (if
                                                 (i32.eq
                                                   (get_local $7)
                                                   (get_local $12)
                                                 )
                                                 (block
-                                                  (br_if $do-once$110
+                                                  (br_if $do-once103
                                                     (i32.ne
                                                       (get_local $6)
                                                       (get_local $34)
@@ -6224,13 +6224,13 @@
                                                   )
                                                 )
                                                 (block
-                                                  (br_if $do-once$110
+                                                  (br_if $do-once103
                                                     (i32.le_u
                                                       (get_local $6)
                                                       (get_local $24)
                                                     )
                                                   )
-                                                  (loop $while-in$113
+                                                  (loop $while-in106
                                                     (i32.store8
                                                       (tee_local $6
                                                         (i32.add
@@ -6240,7 +6240,7 @@
                                                       )
                                                       (i32.const 48)
                                                     )
-                                                    (br_if $while-in$113
+                                                    (br_if $while-in106
                                                       (i32.gt_u
                                                         (get_local $6)
                                                         (get_local $24)
@@ -6284,15 +6284,15 @@
                                                 (set_local $7
                                                   (get_local $6)
                                                 )
-                                                (br $while-in$109)
+                                                (br $while-in102)
                                               )
                                             )
                                           )
-                                          (block $do-once$114
+                                          (block $do-once107
                                             (if
                                               (get_local $16)
                                               (block
-                                                (br_if $do-once$114
+                                                (br_if $do-once107
                                                   (i32.and
                                                     (i32.load
                                                       (get_local $0)
@@ -6325,7 +6325,7 @@
                                               (set_local $7
                                                 (get_local $5)
                                               )
-                                              (loop $while-in$117
+                                              (loop $while-in110
                                                 (if
                                                   (i32.gt_u
                                                     (tee_local $5
@@ -6339,7 +6339,7 @@
                                                     )
                                                     (get_local $24)
                                                   )
-                                                  (loop $while-in$119
+                                                  (loop $while-in112
                                                     (i32.store8
                                                       (tee_local $5
                                                         (i32.add
@@ -6349,7 +6349,7 @@
                                                       )
                                                       (i32.const 48)
                                                     )
-                                                    (br_if $while-in$119
+                                                    (br_if $while-in112
                                                       (i32.gt_u
                                                         (get_local $5)
                                                         (get_local $24)
@@ -6407,7 +6407,7 @@
                                                     (set_local $7
                                                       (get_local $5)
                                                     )
-                                                    (br $while-in$117)
+                                                    (br $while-in110)
                                                   )
                                                 )
                                               )
@@ -6452,7 +6452,7 @@
                                               (set_local $7
                                                 (get_local $5)
                                               )
-                                              (loop $while-in$121
+                                              (loop $while-in114
                                                 (set_local $8
                                                   (if i32
                                                     (i32.eq
@@ -6477,7 +6477,7 @@
                                                     (get_local $5)
                                                   )
                                                 )
-                                                (block $do-once$122
+                                                (block $do-once115
                                                   (if
                                                     (i32.eq
                                                       (get_local $6)
@@ -6507,7 +6507,7 @@
                                                           )
                                                         )
                                                       )
-                                                      (br_if $do-once$122
+                                                      (br_if $do-once115
                                                         (i32.and
                                                           (get_local $9)
                                                           (i32.lt_s
@@ -6516,7 +6516,7 @@
                                                           )
                                                         )
                                                       )
-                                                      (br_if $do-once$122
+                                                      (br_if $do-once115
                                                         (i32.and
                                                           (i32.load
                                                             (get_local $0)
@@ -6545,10 +6545,10 @@
                                                           (set_local $5
                                                             (get_local $8)
                                                           )
-                                                          (br $do-once$122)
+                                                          (br $do-once115)
                                                         )
                                                       )
-                                                      (loop $while-in$125
+                                                      (loop $while-in118
                                                         (i32.store8
                                                           (tee_local $5
                                                             (i32.add
@@ -6558,7 +6558,7 @@
                                                           )
                                                           (i32.const 48)
                                                         )
-                                                        (br_if $while-in$125
+                                                        (br_if $while-in118
                                                           (i32.gt_u
                                                             (get_local $5)
                                                             (get_local $24)
@@ -6623,7 +6623,7 @@
                                                     (set_local $7
                                                       (get_local $5)
                                                     )
-                                                    (br $while-in$121)
+                                                    (br $while-in114)
                                                   )
                                                 )
                                               )
@@ -6639,7 +6639,7 @@
                                             (i32.const 18)
                                             (i32.const 0)
                                           )
-                                          (br_if $do-once$106
+                                          (br_if $do-once99
                                             (i32.and
                                               (i32.load
                                                 (get_local $0)
@@ -6849,7 +6849,7 @@
                             (set_local $8
                               (get_local $23)
                             )
-                            (loop $while-in$130
+                            (loop $while-in123
                               (i32.store8
                                 (tee_local $8
                                   (i32.add
@@ -6876,7 +6876,7 @@
                                   (i32.const 255)
                                 )
                               )
-                              (br_if $while-in$130
+                              (br_if $while-in123
                                 (i32.eqz
                                   (i32.and
                                     (i32.eqz
@@ -7023,9 +7023,9 @@
                       (get_local $18)
                     )
                   )
-                  (loop $while-in$132
-                    (block $while-out$131
-                      (br_if $while-out$131
+                  (loop $while-in125
+                    (block $while-out124
+                      (br_if $while-out124
                         (i32.eqz
                           (tee_local $9
                             (i32.load
@@ -7034,7 +7034,7 @@
                           )
                         )
                       )
-                      (br_if $while-out$131
+                      (br_if $while-out124
                         (i32.or
                           (i32.lt_s
                             (tee_local $6
@@ -7060,7 +7060,7 @@
                           (i32.const 4)
                         )
                       )
-                      (br_if $while-in$132
+                      (br_if $while-in125
                         (i32.gt_u
                           (get_local $8)
                           (tee_local $1
@@ -7103,7 +7103,7 @@
                           (get_local $18)
                         )
                       )
-                      (loop $while-in$134
+                      (loop $while-in127
                         (if
                           (i32.eqz
                             (tee_local $8
@@ -7164,7 +7164,7 @@
                             )
                           )
                         )
-                        (br_if $while-in$134
+                        (br_if $while-in127
                           (i32.lt_u
                             (get_local $6)
                             (get_local $1)
@@ -7416,9 +7416,9 @@
             (set_local $0
               (i32.const 1)
             )
-            (loop $while-in$137
-              (block $while-out$136
-                (br_if $while-out$136
+            (loop $while-in130
+              (block $while-out129
+                (br_if $while-out129
                   (i32.eqz
                     (tee_local $1
                       (i32.load
@@ -7444,7 +7444,7 @@
                   (get_local $1)
                   (get_local $2)
                 )
-                (br_if $while-in$137
+                (br_if $while-in130
                   (i32.lt_s
                     (tee_local $0
                       (i32.add
@@ -7468,7 +7468,7 @@
                 (get_local $0)
                 (i32.const 10)
               )
-              (loop $while-in$139
+              (loop $while-in132
                 (set_local $1
                   (i32.add
                     (get_local $0)
@@ -7501,7 +7501,7 @@
                     (set_local $0
                       (get_local $1)
                     )
-                    (br $while-in$139)
+                    (br $while-in132)
                   )
                   (set_local $15
                     (i32.const 1)
@@ -7534,18 +7534,18 @@
           (get_local $1)
           (i32.const 20)
         )
-        (block $switch-default$14
-          (block $switch-case$13
-            (block $switch-case$12
-              (block $switch-case$11
-                (block $switch-case$10
-                  (block $switch-case$9
-                    (block $switch-case$8
-                      (block $switch-case$7
-                        (block $switch-case$6
-                          (block $switch-case$5
-                            (block $switch-case$4
-                              (br_table $switch-case$4 $switch-case$5 $switch-case$6 $switch-case$7 $switch-case$8 $switch-case$9 $switch-case$10 $switch-case$11 $switch-case$12 $switch-case$13 $switch-default$14
+        (block $switch-default
+          (block $switch-case9
+            (block $switch-case8
+              (block $switch-case7
+                (block $switch-case6
+                  (block $switch-case5
+                    (block $switch-case4
+                      (block $switch-case3
+                        (block $switch-case2
+                          (block $switch-case1
+                            (block $switch-case
+                              (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $switch-default
                                 (i32.sub
                                   (get_local $1)
                                   (i32.const 9)
@@ -7945,7 +7945,7 @@
           )
         )
         (block i32
-          (loop $while-in$1
+          (loop $while-in
             (set_local $3
               (call $___uremdi3
                 (get_local $0)
@@ -8004,7 +8004,7 @@
                 (set_local $1
                   (get_local $4)
                 )
-                (br $while-in$1)
+                (br $while-in)
               )
               (set_local $0
                 (get_local $3)
@@ -8018,7 +8018,7 @@
     )
     (if
       (get_local $0)
-      (loop $while-in$3
+      (loop $while-in1
         (i32.store8
           (tee_local $1
             (i32.add
@@ -8061,7 +8061,7 @@
             (set_local $0
               (get_local $2)
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
@@ -8095,7 +8095,7 @@
     (set_local $5
       (get_local $6)
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.and
           (i32.gt_s
@@ -8159,7 +8159,7 @@
               (set_local $3
                 (get_local $7)
               )
-              (loop $while-in$3
+              (loop $while-in
                 (set_local $3
                   (i32.eqz
                     (i32.and
@@ -8185,7 +8185,7 @@
                     )
                   )
                 )
-                (br_if $while-in$3
+                (br_if $while-in
                   (i32.gt_u
                     (tee_local $2
                       (i32.add
@@ -8203,7 +8203,7 @@
                   (i32.const 255)
                 )
               )
-              (br_if $do-once$0
+              (br_if $do-once
                 (i32.eqz
                   (get_local $3)
                 )
@@ -8214,7 +8214,7 @@
               (set_local $1
                 (get_local $4)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (drop
@@ -8256,7 +8256,7 @@
     (local $22 i32)
     (local $23 i32)
     (local $24 i32)
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.lt_u
           (get_local $0)
@@ -8912,8 +8912,8 @@
                   (set_local $2
                     (get_local $1)
                   )
-                  (loop $while-in$7
-                    (block $while-out$6
+                  (loop $while-in
+                    (block $while-out
                       (if
                         (i32.eqz
                           (tee_local $0
@@ -8934,7 +8934,7 @@
                             (set_local $2
                               (get_local $1)
                             )
-                            (br $while-out$6)
+                            (br $while-out)
                           )
                         )
                       )
@@ -8971,7 +8971,7 @@
                           (get_local $6)
                         )
                       )
-                      (br $while-in$7)
+                      (br $while-in)
                     )
                   )
                   (if
@@ -9002,7 +9002,7 @@
                       (get_local $2)
                     )
                   )
-                  (block $do-once$8
+                  (block $do-once4
                     (if
                       (i32.eq
                         (tee_local $0
@@ -9043,11 +9043,11 @@
                               (set_local $5
                                 (i32.const 0)
                               )
-                              (br $do-once$8)
+                              (br $do-once4)
                             )
                           )
                         )
-                        (loop $while-in$11
+                        (loop $while-in7
                           (if
                             (tee_local $8
                               (i32.load
@@ -9066,7 +9066,7 @@
                               (set_local $0
                                 (get_local $6)
                               )
-                              (br $while-in$11)
+                              (br $while-in7)
                             )
                           )
                           (if
@@ -9087,7 +9087,7 @@
                               (set_local $0
                                 (get_local $6)
                               )
-                              (br $while-in$11)
+                              (br $while-in7)
                             )
                           )
                         )
@@ -9164,7 +9164,7 @@
                       )
                     )
                   )
-                  (block $do-once$12
+                  (block $do-once8
                     (if
                       (get_local $11)
                       (block
@@ -9212,7 +9212,7 @@
                                     )
                                   )
                                 )
-                                (br $do-once$12)
+                                (br $do-once8)
                               )
                             )
                           )
@@ -9247,7 +9247,7 @@
                                 (get_local $5)
                               )
                             )
-                            (br_if $do-once$12
+                            (br_if $do-once8
                               (i32.eqz
                                 (get_local $5)
                               )
@@ -9685,7 +9685,7 @@
                         (set_local $2
                           (i32.const 0)
                         )
-                        (loop $while-in$18
+                        (loop $while-in14
                           (if
                             (i32.lt_u
                               (tee_local $8
@@ -9802,7 +9802,7 @@
                               (set_local $0
                                 (get_local $14)
                               )
-                              (br $while-in$18)
+                              (br $while-in14)
                             )
                           )
                         )
@@ -9855,7 +9855,7 @@
                               (set_local $0
                                 (get_local $9)
                               )
-                              (br $do-once$0)
+                              (br $do-once)
                             )
                           )
                           (set_local $12
@@ -9987,7 +9987,7 @@
                     (get_local $19)
                     (i32.const 90)
                   )
-                  (loop $while-in$20
+                  (loop $while-in16
                     (set_local $2
                       (i32.lt_u
                         (tee_local $0
@@ -10028,10 +10028,10 @@
                         (set_local $3
                           (get_local $0)
                         )
-                        (br $while-in$20)
+                        (br $while-in16)
                       )
                     )
-                    (br_if $while-in$20
+                    (br_if $while-in16
                       (tee_local $3
                         (i32.load offset=20
                           (get_local $3)
@@ -10089,7 +10089,7 @@
                           (get_local $6)
                         )
                       )
-                      (block $do-once$21
+                      (block $do-once17
                         (if
                           (i32.eq
                             (tee_local $0
@@ -10130,11 +10130,11 @@
                                   (set_local $10
                                     (i32.const 0)
                                   )
-                                  (br $do-once$21)
+                                  (br $do-once17)
                                 )
                               )
                             )
-                            (loop $while-in$24
+                            (loop $while-in20
                               (if
                                 (tee_local $3
                                   (i32.load
@@ -10153,7 +10153,7 @@
                                   (set_local $0
                                     (get_local $2)
                                   )
-                                  (br $while-in$24)
+                                  (br $while-in20)
                                 )
                               )
                               (if
@@ -10174,7 +10174,7 @@
                                   (set_local $0
                                     (get_local $2)
                                   )
-                                  (br $while-in$24)
+                                  (br $while-in20)
                                 )
                               )
                             )
@@ -10251,7 +10251,7 @@
                           )
                         )
                       )
-                      (block $do-once$25
+                      (block $do-once21
                         (if
                           (get_local $5)
                           (block
@@ -10299,7 +10299,7 @@
                                         )
                                       )
                                     )
-                                    (br $do-once$25)
+                                    (br $do-once21)
                                   )
                                 )
                               )
@@ -10334,7 +10334,7 @@
                                     (get_local $10)
                                   )
                                 )
-                                (br_if $do-once$25
+                                (br_if $do-once21
                                   (i32.eqz
                                     (get_local $10)
                                   )
@@ -10409,7 +10409,7 @@
                           )
                         )
                       )
-                      (block $do-once$29
+                      (block $do-once25
                         (if
                           (i32.lt_u
                             (get_local $7)
@@ -10567,7 +10567,7 @@
                                   (get_local $4)
                                   (get_local $0)
                                 )
-                                (br $do-once$29)
+                                (br $do-once25)
                               )
                             )
                             (set_local $1
@@ -10732,7 +10732,7 @@
                                   (get_local $4)
                                   (get_local $4)
                                 )
-                                (br $do-once$29)
+                                (br $do-once25)
                               )
                             )
                             (set_local $2
@@ -10762,7 +10762,7 @@
                             (block $jumpthreading$outer$1
                               (block $jumpthreading$inner$1
                                 (block $jumpthreading$inner$0
-                                  (loop $while-in$32
+                                  (loop $while-in28
                                     (br_if $jumpthreading$inner$1
                                       (i32.eq
                                         (i32.and
@@ -10807,7 +10807,7 @@
                                         (set_local $0
                                           (get_local $3)
                                         )
-                                        (br $while-in$32)
+                                        (br $while-in28)
                                       )
                                       (block
                                         (set_local $1
@@ -10846,7 +10846,7 @@
                                       (get_local $4)
                                       (get_local $4)
                                     )
-                                    (br $do-once$29)
+                                    (br $do-once25)
                                   )
                                 )
                                 (br $jumpthreading$outer$1)
@@ -11241,8 +11241,8 @@
                   (set_local $1
                     (i32.const 624)
                   )
-                  (loop $while-in$38
-                    (block $while-out$37
+                  (loop $while-in34
+                    (block $while-out33
                       (if
                         (i32.le_u
                           (tee_local $3
@@ -11271,11 +11271,11 @@
                             (set_local $4
                               (get_local $1)
                             )
-                            (br $while-out$37)
+                            (br $while-out33)
                           )
                         )
                       )
-                      (br_if $while-in$38
+                      (br_if $while-in34
                         (tee_local $1
                           (i32.load offset=8
                             (get_local $1)
@@ -11594,7 +11594,7 @@
           (get_local $3)
         )
       )
-      (block $do-once$44
+      (block $do-once40
         (if
           (tee_local $7
             (i32.load
@@ -11607,7 +11607,7 @@
             )
             (block $jumpthreading$outer$9
               (block $jumpthreading$inner$9
-                (loop $while-in$49
+                (loop $while-in45
                   (br_if $jumpthreading$inner$9
                     (i32.eq
                       (get_local $2)
@@ -11630,7 +11630,7 @@
                       )
                     )
                   )
-                  (br_if $while-in$49
+                  (br_if $while-in45
                     (tee_local $3
                       (i32.load offset=8
                         (get_local $3)
@@ -11733,7 +11733,7 @@
                         (i32.const 664)
                       )
                     )
-                    (br $do-once$44)
+                    (br $do-once40)
                   )
                 )
               )
@@ -11769,7 +11769,7 @@
             )
             (block $jumpthreading$outer$10
               (block $jumpthreading$inner$10
-                (loop $while-in$51
+                (loop $while-in47
                   (if
                     (i32.eq
                       (i32.load
@@ -11784,7 +11784,7 @@
                       (br $jumpthreading$inner$10)
                     )
                   )
-                  (br_if $while-in$51
+                  (br_if $while-in47
                     (tee_local $3
                       (i32.load offset=8
                         (get_local $3)
@@ -11894,7 +11894,7 @@
                       (i32.const 3)
                     )
                   )
-                  (block $do-once$52
+                  (block $do-once48
                     (if
                       (i32.eq
                         (get_local $8)
@@ -11962,7 +11962,7 @@
                               )
                               (get_local $0)
                             )
-                            (br $do-once$52)
+                            (br $do-once48)
                           )
                         )
                         (i32.store
@@ -12005,7 +12005,7 @@
                                             (get_local $8)
                                           )
                                         )
-                                        (block $do-once$55
+                                        (block $do-once51
                                           (if
                                             (i32.ne
                                               (tee_local $4
@@ -12034,7 +12034,7 @@
                                                 )
                                                 (call $_abort)
                                               )
-                                              (br_if $do-once$55
+                                              (br_if $do-once51
                                                 (i32.eq
                                                   (i32.load offset=12
                                                     (get_local $4)
@@ -12070,7 +12070,7 @@
                                             (br $label$break$L331)
                                           )
                                         )
-                                        (block $do-once$57
+                                        (block $do-once53
                                           (if
                                             (i32.eq
                                               (get_local $3)
@@ -12106,7 +12106,7 @@
                                                   (set_local $21
                                                     (get_local $0)
                                                   )
-                                                  (br $do-once$57)
+                                                  (br $do-once53)
                                                 )
                                               )
                                               (call $_abort)
@@ -12128,7 +12128,7 @@
                                             (get_local $8)
                                           )
                                         )
-                                        (block $do-once$59
+                                        (block $do-once55
                                           (if
                                             (i32.eq
                                               (tee_local $0
@@ -12170,11 +12170,11 @@
                                                     (set_local $11
                                                       (i32.const 0)
                                                     )
-                                                    (br $do-once$59)
+                                                    (br $do-once55)
                                                   )
                                                 )
                                               )
-                                              (loop $while-in$62
+                                              (loop $while-in58
                                                 (if
                                                   (tee_local $4
                                                     (i32.load
@@ -12193,7 +12193,7 @@
                                                     (set_local $0
                                                       (get_local $3)
                                                     )
-                                                    (br $while-in$62)
+                                                    (br $while-in58)
                                                   )
                                                 )
                                                 (if
@@ -12214,7 +12214,7 @@
                                                     (set_local $0
                                                       (get_local $3)
                                                     )
-                                                    (br $while-in$62)
+                                                    (br $while-in58)
                                                   )
                                                 )
                                               )
@@ -12296,7 +12296,7 @@
                                             (get_local $7)
                                           )
                                         )
-                                        (block $do-once$63
+                                        (block $do-once59
                                           (if
                                             (i32.eq
                                               (get_local $8)
@@ -12321,7 +12321,7 @@
                                                 (get_local $0)
                                                 (get_local $11)
                                               )
-                                              (br_if $do-once$63
+                                              (br_if $do-once59
                                                 (get_local $11)
                                               )
                                               (i32.store
@@ -12516,7 +12516,7 @@
                                 )
                               )
                             )
-                            (block $do-once$67
+                            (block $do-once63
                               (if
                                 (i32.and
                                   (tee_local $2
@@ -12555,7 +12555,7 @@
                                       (set_local $17
                                         (get_local $1)
                                       )
-                                      (br $do-once$67)
+                                      (br $do-once63)
                                     )
                                   )
                                   (call $_abort)
@@ -12596,7 +12596,7 @@
                               (get_local $6)
                               (get_local $0)
                             )
-                            (br $do-once$52)
+                            (br $do-once48)
                           )
                         )
                         (set_local $1
@@ -12604,7 +12604,7 @@
                             (i32.const 480)
                             (i32.shl
                               (tee_local $3
-                                (block $do-once$69 i32
+                                (block $do-once65 i32
                                   (if i32
                                     (tee_local $0
                                       (i32.shr_u
@@ -12614,7 +12614,7 @@
                                     )
                                     (block i32
                                       (drop
-                                        (br_if $do-once$69
+                                        (br_if $do-once65
                                           (i32.const 31)
                                           (i32.gt_u
                                             (get_local $2)
@@ -12767,7 +12767,7 @@
                               (get_local $6)
                               (get_local $6)
                             )
-                            (br $do-once$52)
+                            (br $do-once48)
                           )
                         )
                         (set_local $3
@@ -12797,7 +12797,7 @@
                         (block $jumpthreading$outer$6
                           (block $jumpthreading$inner$6
                             (block $jumpthreading$inner$5
-                              (loop $while-in$72
+                              (loop $while-in68
                                 (br_if $jumpthreading$inner$6
                                   (i32.eq
                                     (i32.and
@@ -12842,7 +12842,7 @@
                                     (set_local $0
                                       (get_local $4)
                                     )
-                                    (br $while-in$72)
+                                    (br $while-in68)
                                   )
                                   (block
                                     (set_local $1
@@ -12881,7 +12881,7 @@
                                   (get_local $6)
                                   (get_local $6)
                                 )
-                                (br $do-once$52)
+                                (br $do-once48)
                               )
                             )
                             (br $jumpthreading$outer$6)
@@ -12947,8 +12947,8 @@
                 )
               )
             )
-            (loop $while-in$74
-              (block $while-out$73
+            (loop $while-in70
+              (block $while-out69
                 (if
                   (i32.le_u
                     (tee_local $3
@@ -12958,7 +12958,7 @@
                     )
                     (get_local $7)
                   )
-                  (br_if $while-out$73
+                  (br_if $while-out69
                     (i32.gt_u
                       (tee_local $3
                         (i32.add
@@ -12977,7 +12977,7 @@
                     (get_local $4)
                   )
                 )
-                (br $while-in$74)
+                (br $while-in70)
               )
             )
             (set_local $5
@@ -13145,7 +13145,7 @@
                 (i32.const 24)
               )
             )
-            (loop $while-in$76
+            (loop $while-in72
               (i32.store
                 (tee_local $1
                   (i32.add
@@ -13155,7 +13155,7 @@
                 )
                 (i32.const 7)
               )
-              (br_if $while-in$76
+              (br_if $while-in72
                 (i32.lt_u
                   (i32.add
                     (get_local $1)
@@ -13295,7 +13295,7 @@
                       (get_local $7)
                       (get_local $1)
                     )
-                    (br $do-once$44)
+                    (br $do-once40)
                   )
                 )
                 (set_local $2
@@ -13455,7 +13455,7 @@
                       (get_local $7)
                       (get_local $7)
                     )
-                    (br $do-once$44)
+                    (br $do-once40)
                   )
                 )
                 (set_local $3
@@ -13485,7 +13485,7 @@
                 (block $jumpthreading$outer$8
                   (block $jumpthreading$inner$8
                     (block $jumpthreading$inner$7
-                      (loop $while-in$78
+                      (loop $while-in74
                         (br_if $jumpthreading$inner$8
                           (i32.eq
                             (i32.and
@@ -13530,7 +13530,7 @@
                             (set_local $1
                               (get_local $4)
                             )
-                            (br $while-in$78)
+                            (br $while-in74)
                           )
                           (block
                             (set_local $2
@@ -13569,7 +13569,7 @@
                           (get_local $7)
                           (get_local $7)
                         )
-                        (br $do-once$44)
+                        (br $do-once40)
                       )
                     )
                     (br $jumpthreading$outer$8)
@@ -13671,7 +13671,7 @@
             (set_local $3
               (i32.const 0)
             )
-            (loop $while-in$47
+            (loop $while-in43
               (i32.store offset=12
                 (tee_local $4
                   (i32.add
@@ -13691,7 +13691,7 @@
                 (get_local $4)
                 (get_local $4)
               )
-              (br_if $while-in$47
+              (br_if $while-in43
                 (i32.ne
                   (tee_local $3
                     (i32.add
@@ -13896,7 +13896,7 @@
         )
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.and
           (get_local $3)
@@ -13975,7 +13975,7 @@
                   (set_local $1
                     (get_local $3)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (i32.store
@@ -14089,7 +14089,7 @@
                   (set_local $1
                     (get_local $3)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (if
@@ -14144,7 +14144,7 @@
               (set_local $1
                 (get_local $3)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $12
@@ -14152,7 +14152,7 @@
               (get_local $0)
             )
           )
-          (block $do-once$2
+          (block $do-once0
             (if
               (i32.eq
                 (tee_local $2
@@ -14194,11 +14194,11 @@
                       (set_local $7
                         (i32.const 0)
                       )
-                      (br $do-once$2)
+                      (br $do-once0)
                     )
                   )
                 )
-                (loop $while-in$5
+                (loop $while-in
                   (if
                     (tee_local $8
                       (i32.load
@@ -14217,7 +14217,7 @@
                       (set_local $5
                         (get_local $10)
                       )
-                      (br $while-in$5)
+                      (br $while-in)
                     )
                   )
                   (if
@@ -14238,7 +14238,7 @@
                       (set_local $5
                         (get_local $10)
                       )
-                      (br $while-in$5)
+                      (br $while-in)
                     )
                   )
                 )
@@ -14368,7 +14368,7 @@
                       (set_local $1
                         (get_local $3)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -14414,7 +14414,7 @@
                       (set_local $1
                         (get_local $3)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -14675,7 +14675,7 @@
             (i32.const 3)
           )
         )
-        (block $do-once$8
+        (block $do-once4
           (if
             (i32.lt_u
               (get_local $0)
@@ -14749,7 +14749,7 @@
                       )
                     )
                   )
-                  (br $do-once$8)
+                  (br $do-once4)
                 )
               )
               (if
@@ -14807,7 +14807,7 @@
                   (get_local $6)
                 )
               )
-              (block $do-once$10
+              (block $do-once6
                 (if
                   (i32.eq
                     (tee_local $0
@@ -14849,11 +14849,11 @@
                           (set_local $9
                             (i32.const 0)
                           )
-                          (br $do-once$10)
+                          (br $do-once6)
                         )
                       )
                     )
-                    (loop $while-in$13
+                    (loop $while-in9
                       (if
                         (tee_local $3
                           (i32.load
@@ -14872,7 +14872,7 @@
                           (set_local $1
                             (get_local $5)
                           )
-                          (br $while-in$13)
+                          (br $while-in9)
                         )
                       )
                       (if
@@ -14893,7 +14893,7 @@
                           (set_local $1
                             (get_local $5)
                           )
-                          (br $while-in$13)
+                          (br $while-in9)
                         )
                       )
                     )
@@ -15021,7 +15021,7 @@
                               )
                             )
                           )
-                          (br $do-once$8)
+                          (br $do-once4)
                         )
                       )
                     )
@@ -15056,7 +15056,7 @@
                           (get_local $9)
                         )
                       )
-                      (br_if $do-once$8
+                      (br_if $do-once4
                         (i32.eqz
                           (get_local $9)
                         )
@@ -15391,7 +15391,7 @@
       (get_local $4)
       (i32.const 0)
     )
-    (block $do-once$16
+    (block $do-once12
       (if
         (i32.and
           (tee_local $0
@@ -15434,7 +15434,7 @@
           (block $jumpthreading$outer$1
             (block $jumpthreading$inner$1
               (block $jumpthreading$inner$0
-                (loop $while-in$19
+                (loop $while-in15
                   (br_if $jumpthreading$inner$1
                     (i32.eq
                       (i32.and
@@ -15482,7 +15482,7 @@
                     (set_local $0
                       (get_local $3)
                     )
-                    (br $while-in$19)
+                    (br $while-in15)
                   )
                 )
               )
@@ -15511,7 +15511,7 @@
                     (get_local $4)
                     (get_local $4)
                   )
-                  (br $do-once$16)
+                  (br $do-once12)
                 )
               )
               (br $jumpthreading$outer$1)
@@ -15611,7 +15611,7 @@
         (i32.const 632)
       )
     )
-    (loop $while-in$21
+    (loop $while-in17
       (set_local $0
         (i32.add
           (tee_local $1
@@ -15622,7 +15622,7 @@
           (i32.const 8)
         )
       )
-      (br_if $while-in$21
+      (br_if $while-in17
         (get_local $1)
       )
     )
@@ -15738,7 +15738,7 @@
                 (get_local $3)
               )
             )
-            (loop $while-in$1
+            (loop $while-in
               (if
                 (i32.lt_s
                   (get_local $0)
@@ -15755,13 +15755,13 @@
                       (i32.const 1)
                     )
                   )
-                  (br $while-in$1)
+                  (br $while-in)
                 )
               )
             )
           )
         )
-        (loop $while-in$3
+        (loop $while-in1
           (if
             (i32.lt_s
               (get_local $0)
@@ -15778,13 +15778,13 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$3)
+              (br $while-in1)
             )
           )
         )
       )
     )
-    (loop $while-in$5
+    (loop $while-in3
       (if
         (i32.lt_s
           (get_local $0)
@@ -15801,7 +15801,7 @@
               (i32.const 1)
             )
           )
-          (br $while-in$5)
+          (br $while-in3)
         )
       )
     )
@@ -15946,9 +15946,9 @@
         )
       )
       (block
-        (loop $while-in$1
-          (block $while-out$0
-            (br_if $while-out$0
+        (loop $while-in
+          (block $while-out
+            (br_if $while-out
               (i32.eqz
                 (i32.and
                   (get_local $0)
@@ -15988,10 +15988,10 @@
                 (i32.const 1)
               )
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
-        (loop $while-in$3
+        (loop $while-in1
           (if
             (i32.ge_s
               (get_local $2)
@@ -16022,13 +16022,13 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$3)
+              (br $while-in1)
             )
           )
         )
       )
     )
-    (loop $while-in$5
+    (loop $while-in3
       (if
         (i32.gt_s
           (get_local $2)
@@ -16059,7 +16059,7 @@
               (i32.const 1)
             )
           )
-          (br $while-in$5)
+          (br $while-in3)
         )
       )
     )

--- a/test/emcc_hello_world.fromasm.imprecise.no-opts
+++ b/test/emcc_hello_world.fromasm.imprecise.no-opts
@@ -397,11 +397,11 @@
         (i32.const 2047)
       )
     )
-    (block $switch$0
-      (block $switch-default$3
-        (block $switch-case$2
-          (block $switch-case$1
-            (br_table $switch-case$1 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-case$2 $switch-default$3
+    (block $switch
+      (block $switch-default
+        (block $switch-case0
+          (block $switch-case
+            (br_table $switch-case $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case0 $switch-default
               (i32.sub
                 (get_local $$conv)
                 (i32.const 0)
@@ -464,14 +464,14 @@
             (set_local $$retval$0
               (get_local $$x$addr$0)
             )
-            (br $switch$0)
+            (br $switch)
           )
         )
         (block
           (set_local $$retval$0
             (get_local $$x)
           )
-          (br $switch$0)
+          (br $switch)
         )
       )
       (block
@@ -567,8 +567,8 @@
     (set_local $$i$012
       (i32.const 0)
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (set_local $$arrayidx
           (i32.add
             (i32.const 687)
@@ -601,7 +601,7 @@
             (set_local $label
               (i32.const 2)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (set_local $$inc
@@ -628,13 +628,13 @@
             (set_local $label
               (i32.const 5)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
           (set_local $$i$012
             (get_local $$inc)
           )
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
     (if
@@ -673,16 +673,16 @@
         (get_local $label)
         (i32.const 5)
       )
-      (loop $while-in$3
-        (block $while-out$2
+      (loop $while-in1
+        (block $while-out0
           (set_local $label
             (i32.const 0)
           )
           (set_local $$s$1
             (get_local $$s$010)
           )
-          (loop $while-in$5
-            (block $while-out$4
+          (loop $while-in3
+            (block $while-out2
               (set_local $$1
                 (i32.load8_s
                   (get_local $$s$1)
@@ -712,13 +712,13 @@
                   (set_local $$incdec$ptr$lcssa
                     (get_local $$incdec$ptr)
                   )
-                  (br $while-out$4)
+                  (br $while-out2)
                 )
                 (set_local $$s$1
                   (get_local $$incdec$ptr)
                 )
               )
-              (br $while-in$5)
+              (br $while-in3)
             )
           )
           (set_local $$dec
@@ -739,7 +739,7 @@
               (set_local $$s$0$lcssa
                 (get_local $$incdec$ptr$lcssa)
               )
-              (br $while-out$2)
+              (br $while-out0)
             )
             (block
               (set_local $$i$111
@@ -753,7 +753,7 @@
               )
             )
           )
-          (br $while-in$3)
+          (br $while-in1)
         )
       )
     )
@@ -1215,7 +1215,7 @@
         (i32.const 0)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $$tobool)
         (block
@@ -1277,8 +1277,8 @@
               (set_local $$r$021
                 (get_local $$cond10)
               )
-              (loop $while-in$3
-                (block $while-out$2
+              (loop $while-in
+                (block $while-out
                   (set_local $$lock13
                     (i32.add
                       (get_local $$f$addr$022)
@@ -1399,7 +1399,7 @@
                       (set_local $$r$0$lcssa
                         (get_local $$r$1)
                       )
-                      (br $while-out$2)
+                      (br $while-out)
                     )
                     (block
                       (set_local $$f$addr$022
@@ -1410,7 +1410,7 @@
                       )
                     )
                   )
-                  (br $while-in$3)
+                  (br $while-in)
                 )
               )
             )
@@ -1453,7 +1453,7 @@
               (set_local $$retval$0
                 (get_local $$call1$18)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $$call
@@ -1751,8 +1751,8 @@
     (set_local $$rem$0
       (get_local $$add)
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (set_local $$2
           (i32.load
             (i32.const 16)
@@ -1876,7 +1876,7 @@
             (set_local $label
               (i32.const 6)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (set_local $$cmp17
@@ -1897,7 +1897,7 @@
             (set_local $label
               (i32.const 8)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (set_local $$sub26
@@ -2076,7 +2076,7 @@
         (set_local $$rem$0
           (get_local $$sub26)
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
     (if
@@ -2309,8 +2309,8 @@
         (i32.const 40)
       )
     )
-    (loop $do-in$1
-      (block $do-out$0
+    (loop $do-in
+      (block $do-out
         (i32.store
           (get_local $dest)
           (i32.const 0)
@@ -2321,7 +2321,7 @@
             (i32.const 4)
           )
         )
-        (br_if $do-in$1
+        (br_if $do-in
           (i32.lt_s
             (get_local $dest)
             (get_local $stop)
@@ -2888,8 +2888,8 @@
                 (set_local $$i$0
                   (get_local $$l)
                 )
-                (loop $while-in$3
-                  (block $while-out$2
+                (loop $while-in
+                  (block $while-out
                     (set_local $$tobool9
                       (i32.eq
                         (get_local $$i$0)
@@ -2949,13 +2949,13 @@
                         (set_local $$i$0$lcssa36
                           (get_local $$i$0)
                         )
-                        (br $while-out$2)
+                        (br $while-out)
                       )
                       (set_local $$i$0
                         (get_local $$sub)
                       )
                     )
-                    (br $while-in$3)
+                    (br $while-in)
                   )
                 )
                 (set_local $$write15
@@ -3337,7 +3337,7 @@
         (i32.const 0)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $$tobool)
         (set_local $$retval$0
@@ -3366,7 +3366,7 @@
               (set_local $$retval$0
                 (i32.const 1)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $$cmp2
@@ -3431,7 +3431,7 @@
               (set_local $$retval$0
                 (i32.const 2)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $$cmp9
@@ -3548,7 +3548,7 @@
               (set_local $$retval$0
                 (i32.const 3)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $$sub27
@@ -3687,7 +3687,7 @@
               (set_local $$retval$0
                 (i32.const 4)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
             (block
               (set_local $$call
@@ -3700,7 +3700,7 @@
               (set_local $$retval$0
                 (i32.const -1)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
         )
@@ -3858,8 +3858,8 @@
           (set_local $$s$044
             (get_local $$src)
           )
-          (loop $while-in$2
-            (block $while-out$1
+          (loop $while-in
+            (block $while-out
               (set_local $$2
                 (i32.load8_s
                   (get_local $$s$044)
@@ -3960,10 +3960,10 @@
                   (set_local $label
                     (i32.const 5)
                   )
-                  (br $while-out$1)
+                  (br $while-out)
                 )
               )
-              (br $while-in$2)
+              (br $while-in)
             )
           )
         )
@@ -4080,8 +4080,8 @@
                     (set_local $$w$034
                       (get_local $$s$0$lcssa60)
                     )
-                    (loop $while-in$6
-                      (block $while-out$5
+                    (loop $while-in3
+                      (block $while-out2
                         (set_local $$6
                           (i32.load
                             (get_local $$w$034)
@@ -4134,7 +4134,7 @@
                             (set_local $$w$034$lcssa
                               (get_local $$w$034)
                             )
-                            (br $while-out$5)
+                            (br $while-out2)
                           )
                         )
                         (set_local $$incdec$ptr21
@@ -4178,7 +4178,7 @@
                             (br $label$break$L11)
                           )
                         )
-                        (br $while-in$6)
+                        (br $while-in3)
                       )
                     )
                     (set_local $$n$addr$227
@@ -4235,8 +4235,8 @@
                   )
                 )
               )
-              (loop $while-in$8
-                (block $while-out$7
+              (loop $while-in5
+                (block $while-out4
                   (set_local $$7
                     (i32.load8_s
                       (get_local $$s$128)
@@ -4299,7 +4299,7 @@
                       (set_local $$s$2
                         (get_local $$incdec$ptr33)
                       )
-                      (br $while-out$7)
+                      (br $while-out4)
                     )
                     (block
                       (set_local $$n$addr$227
@@ -4310,7 +4310,7 @@
                       )
                     )
                   )
-                  (br $while-in$8)
+                  (br $while-in5)
                 )
               )
             )
@@ -5862,7 +5862,7 @@
             (i32.const -1)
           )
         )
-        (block $do-once$0
+        (block $do-once
           (if
             (get_local $$cmp)
             (block
@@ -5891,7 +5891,7 @@
                   (set_local $$cnt$1
                     (i32.const -1)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
                 (block
                   (set_local $$add
@@ -5903,7 +5903,7 @@
                   (set_local $$cnt$1
                     (get_local $$add)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
             )
@@ -5954,11 +5954,11 @@
         )
         (loop $label$continue$L9
           (block $label$break$L9
-            (block $switch$2
-              (block $switch-default$5
-                (block $switch-case$4
-                  (block $switch-case$3
-                    (br_table $switch-case$4 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-case$3 $switch-default$5
+            (block $switch
+              (block $switch-default
+                (block $switch-case0
+                  (block $switch-case
+                    (br_table $switch-case0 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case $switch-default
                       (i32.sub
                         (i32.shr_s
                           (i32.shl
@@ -5982,7 +5982,7 @@
                       (i32.const 9)
                     )
                     (br $label$break$L9)
-                    (br $switch$2)
+                    (br $switch)
                   )
                 )
                 (block
@@ -5993,7 +5993,7 @@
                     (get_local $$incdec$ptr169274)
                   )
                   (br $label$break$L9)
-                  (br $switch$2)
+                  (br $switch)
                 )
               )
               (nop)
@@ -6024,8 +6024,8 @@
               (get_local $label)
               (i32.const 9)
             )
-            (loop $while-in$8
-              (block $while-out$7
+            (loop $while-in
+              (block $while-out
                 (set_local $label
                   (i32.const 0)
                 )
@@ -6115,10 +6115,10 @@
                     (set_local $$z$0$lcssa
                       (get_local $$incdec$ptr23)
                     )
-                    (br $while-out$7)
+                    (br $while-out)
                   )
                 )
-                (br $while-in$8)
+                (br $while-in)
               )
             )
           )
@@ -6351,8 +6351,8 @@
               (set_local $$storemerge$186309
                 (get_local $$storemerge)
               )
-              (loop $while-in$11
-                (block $while-out$10
+              (loop $while-in4
+                (block $while-out3
                   (set_local $$sub54
                     (i32.add
                       (get_local $$conv48311)
@@ -6477,10 +6477,10 @@
                       (set_local $$storemerge$186282
                         (get_local $$incdec$ptr62)
                       )
-                      (br $while-out$10)
+                      (br $while-out3)
                     )
                   )
-                  (br $while-in$11)
+                  (br $while-in4)
                 )
               )
             )
@@ -6509,7 +6509,7 @@
             (i32.const 42)
           )
         )
-        (block $do-once$12
+        (block $do-once5
           (if
             (get_local $$cmp65)
             (block
@@ -6709,7 +6709,7 @@
                       (set_local $$w$1
                         (i32.const 0)
                       )
-                      (br $do-once$12)
+                      (br $do-once5)
                     )
                   )
                   (set_local $$arglist_current
@@ -6881,8 +6881,8 @@
                   (set_local $$isdigittmp8$i
                     (get_local $$isdigittmp$5$i)
                   )
-                  (loop $while-in$15
-                    (block $while-out$14
+                  (loop $while-in8
+                    (block $while-out7
                       (set_local $$mul$i
                         (i32.mul
                           (get_local $$i$07$i)
@@ -6947,10 +6947,10 @@
                           (set_local $$incdec$ptr$i$lcssa
                             (get_local $$incdec$ptr$i)
                           )
-                          (br $while-out$14)
+                          (br $while-out7)
                         )
                       )
-                      (br $while-in$15)
+                      (br $while-in8)
                     )
                   )
                   (set_local $$cmp105
@@ -7094,8 +7094,8 @@
                       (br $label$break$L46)
                     )
                   )
-                  (loop $while-in$18
-                    (block $while-out$17
+                  (loop $while-in11
+                    (block $while-out10
                       (set_local $$mul$i$202
                         (i32.mul
                           (get_local $$i$07$i$201)
@@ -7163,7 +7163,7 @@
                           (br $label$break$L46)
                         )
                       )
-                      (br $while-in$18)
+                      (br $while-in11)
                     )
                   )
                 )
@@ -7440,8 +7440,8 @@
         (set_local $$st$0
           (i32.const 0)
         )
-        (loop $while-in$20
-          (block $while-out$19
+        (loop $while-in13
+          (block $while-out12
             (set_local $$51
               (i32.load8_s
                 (get_local $$incdec$ptr169271)
@@ -7544,10 +7544,10 @@
                 (set_local $$st$0$lcssa415
                   (get_local $$st$0)
                 )
-                (br $while-out$19)
+                (br $while-out12)
               )
             )
-            (br $while-in$20)
+            (br $while-in13)
           )
         )
         (set_local $$tobool178
@@ -7589,7 +7589,7 @@
             (i32.const -1)
           )
         )
-        (block $do-once$21
+        (block $do-once14
           (if
             (get_local $$cmp181)
             (if
@@ -7681,7 +7681,7 @@
                   (set_local $label
                     (i32.const 52)
                   )
-                  (br $do-once$21)
+                  (br $do-once14)
                 )
               )
               (if
@@ -7811,30 +7811,30 @@
           )
         )
         (block $label$break$L75
-          (block $switch$24
-            (block $switch-default$127
-              (block $switch-case$126
-                (block $switch-case$55
-                  (block $switch-case$54
-                    (block $switch-case$53
-                      (block $switch-case$52
-                        (block $switch-case$51
-                          (block $switch-case$50
-                            (block $switch-case$49
-                              (block $switch-case$48
-                                (block $switch-case$47
-                                  (block $switch-case$46
-                                    (block $switch-case$45
-                                      (block $switch-case$44
-                                        (block $switch-case$43
-                                          (block $switch-case$42
-                                            (block $switch-case$41
-                                              (block $switch-case$40
-                                                (block $switch-case$37
-                                                  (block $switch-case$36
-                                                    (block $switch-case$35
-                                                      (block $switch-case$34
-                                                        (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$52 $switch-case$51 $switch-case$50 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$53 $switch-default$127 $switch-case$44 $switch-case$42 $switch-case$126 $switch-case$55 $switch-case$54 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$37 $switch-default$127
+          (block $switch17
+            (block $switch-default120
+              (block $switch-case119
+                (block $switch-case48
+                  (block $switch-case47
+                    (block $switch-case46
+                      (block $switch-case45
+                        (block $switch-case44
+                          (block $switch-case43
+                            (block $switch-case42
+                              (block $switch-case41
+                                (block $switch-case40
+                                  (block $switch-case39
+                                    (block $switch-case38
+                                      (block $switch-case37
+                                        (block $switch-case36
+                                          (block $switch-case35
+                                            (block $switch-case34
+                                              (block $switch-case33
+                                                (block $switch-case30
+                                                  (block $switch-case29
+                                                    (block $switch-case28
+                                                      (block $switch-case27
+                                                        (br_table $switch-case42 $switch-default120 $switch-case40 $switch-default120 $switch-case45 $switch-case44 $switch-case43 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case29 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case46 $switch-default120 $switch-case37 $switch-case35 $switch-case119 $switch-case48 $switch-case47 $switch-default120 $switch-case34 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case30 $switch-default120
                                                           (i32.sub
                                                             (get_local $$t$0)
                                                             (i32.const 65)
@@ -7842,16 +7842,16 @@
                                                         )
                                                       )
                                                       (block
-                                                        (block $switch$25
-                                                          (block $switch-default$33
-                                                            (block $switch-case$32
-                                                              (block $switch-case$31
-                                                                (block $switch-case$30
-                                                                  (block $switch-case$29
-                                                                    (block $switch-case$28
-                                                                      (block $switch-case$27
-                                                                        (block $switch-case$26
-                                                                          (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
+                                                        (block $switch18
+                                                          (block $switch-default26
+                                                            (block $switch-case25
+                                                              (block $switch-case24
+                                                                (block $switch-case23
+                                                                  (block $switch-case22
+                                                                    (block $switch-case21
+                                                                      (block $switch-case20
+                                                                        (block $switch-case19
+                                                                          (br_table $switch-case19 $switch-case20 $switch-case21 $switch-case22 $switch-case23 $switch-default26 $switch-case24 $switch-case25 $switch-default26
                                                                             (i32.sub
                                                                               (get_local $$st$0$lcssa415)
                                                                               (i32.const 0)
@@ -7881,7 +7881,7 @@
                                                                             (get_local $$l10n$3)
                                                                           )
                                                                           (br $label$continue$L1)
-                                                                          (br $switch$25)
+                                                                          (br $switch18)
                                                                         )
                                                                       )
                                                                       (block
@@ -7907,7 +7907,7 @@
                                                                           (get_local $$l10n$3)
                                                                         )
                                                                         (br $label$continue$L1)
-                                                                        (br $switch$25)
+                                                                        (br $switch18)
                                                                       )
                                                                     )
                                                                     (block
@@ -7967,7 +7967,7 @@
                                                                         (get_local $$l10n$3)
                                                                       )
                                                                       (br $label$continue$L1)
-                                                                      (br $switch$25)
+                                                                      (br $switch18)
                                                                     )
                                                                   )
                                                                   (block
@@ -7999,7 +7999,7 @@
                                                                       (get_local $$l10n$3)
                                                                     )
                                                                     (br $label$continue$L1)
-                                                                    (br $switch$25)
+                                                                    (br $switch18)
                                                                   )
                                                                 )
                                                                 (block
@@ -8031,7 +8031,7 @@
                                                                     (get_local $$l10n$3)
                                                                   )
                                                                   (br $label$continue$L1)
-                                                                  (br $switch$25)
+                                                                  (br $switch18)
                                                                 )
                                                               )
                                                               (block
@@ -8057,7 +8057,7 @@
                                                                   (get_local $$l10n$3)
                                                                 )
                                                                 (br $label$continue$L1)
-                                                                (br $switch$25)
+                                                                (br $switch18)
                                                               )
                                                             )
                                                             (block
@@ -8117,7 +8117,7 @@
                                                                 (get_local $$l10n$3)
                                                               )
                                                               (br $label$continue$L1)
-                                                              (br $switch$25)
+                                                              (br $switch18)
                                                             )
                                                           )
                                                           (block
@@ -8136,7 +8136,7 @@
                                                             (br $label$continue$L1)
                                                           )
                                                         )
-                                                        (br $switch$24)
+                                                        (br $switch17)
                                                       )
                                                     )
                                                     (block
@@ -8171,7 +8171,7 @@
                                                       (set_local $label
                                                         (i32.const 64)
                                                       )
-                                                      (br $switch$24)
+                                                      (br $switch17)
                                                     )
                                                   )
                                                   (nop)
@@ -8189,7 +8189,7 @@
                                                   (set_local $label
                                                     (i32.const 64)
                                                   )
-                                                  (br $switch$24)
+                                                  (br $switch17)
                                                 )
                                               )
                                               (block
@@ -8251,8 +8251,8 @@
                                                     (set_local $$s$addr$06$i$221
                                                       (get_local $$add$ptr205)
                                                     )
-                                                    (loop $while-in$39
-                                                      (block $while-out$38
+                                                    (loop $while-in32
+                                                      (block $while-out31
                                                         (set_local $$125
                                                           (i32.and
                                                             (get_local $$126)
@@ -8315,7 +8315,7 @@
                                                             (set_local $$s$addr$0$lcssa$i$229
                                                               (get_local $$incdec$ptr$i$225)
                                                             )
-                                                            (br $while-out$38)
+                                                            (br $while-out31)
                                                           )
                                                           (block
                                                             (set_local $$126
@@ -8329,7 +8329,7 @@
                                                             )
                                                           )
                                                         )
-                                                        (br $while-in$39)
+                                                        (br $while-in32)
                                                       )
                                                     )
                                                   )
@@ -8417,7 +8417,7 @@
                                                     )
                                                   )
                                                 )
-                                                (br $switch$24)
+                                                (br $switch17)
                                               )
                                             )
                                             (nop)
@@ -8577,7 +8577,7 @@
                                                 )
                                               )
                                             )
-                                            (br $switch$24)
+                                            (br $switch17)
                                           )
                                         )
                                         (block
@@ -8621,7 +8621,7 @@
                                           (set_local $label
                                             (i32.const 76)
                                           )
-                                          (br $switch$24)
+                                          (br $switch17)
                                         )
                                       )
                                       (block
@@ -8678,7 +8678,7 @@
                                         (set_local $$z$2
                                           (get_local $$add$ptr205)
                                         )
-                                        (br $switch$24)
+                                        (br $switch17)
                                       )
                                     )
                                     (block
@@ -8701,7 +8701,7 @@
                                       (set_local $label
                                         (i32.const 82)
                                       )
-                                      (br $switch$24)
+                                      (br $switch17)
                                     )
                                   )
                                   (block
@@ -8729,7 +8729,7 @@
                                     (set_local $label
                                       (i32.const 82)
                                     )
-                                    (br $switch$24)
+                                    (br $switch17)
                                   )
                                 )
                                 (block
@@ -8776,7 +8776,7 @@
                                   (set_local $label
                                     (i32.const 86)
                                   )
-                                  (br $switch$24)
+                                  (br $switch17)
                                 )
                               )
                               (block
@@ -8812,7 +8812,7 @@
                                     )
                                   )
                                 )
-                                (br $switch$24)
+                                (br $switch17)
                               )
                             )
                             (nop)
@@ -8992,7 +8992,7 @@
                     (get_local $$191)
                   )
                 )
-                (block $do-once$56
+                (block $do-once49
                   (if
                     (get_local $$192)
                     (block
@@ -9104,7 +9104,7 @@
                               (get_local $$tobool76552$i)
                             )
                           )
-                          (block $do-once$58
+                          (block $do-once51
                             (if
                               (get_local $$tobool76$i)
                               (set_local $$y$addr$1$i
@@ -9117,8 +9117,8 @@
                                 (set_local $$round$0481$i
                                   (f64.const 8)
                                 )
-                                (loop $while-in$61
-                                  (block $while-out$60
+                                (loop $while-in54
+                                  (block $while-out53
                                     (set_local $$dec78$i
                                       (i32.add
                                         (get_local $$re$1482$i)
@@ -9143,7 +9143,7 @@
                                         (set_local $$mul80$i$lcssa
                                           (get_local $$mul80$i)
                                         )
-                                        (br $while-out$60)
+                                        (br $while-out53)
                                       )
                                       (block
                                         (set_local $$re$1482$i
@@ -9154,7 +9154,7 @@
                                         )
                                       )
                                     )
-                                    (br $while-in$61)
+                                    (br $while-in54)
                                   )
                                 )
                                 (set_local $$197
@@ -9202,7 +9202,7 @@
                                     (set_local $$y$addr$1$i
                                       (get_local $$sub88$i)
                                     )
-                                    (br $do-once$58)
+                                    (br $do-once51)
                                   )
                                   (block
                                     (set_local $$add90$i
@@ -9220,7 +9220,7 @@
                                     (set_local $$y$addr$1$i
                                       (get_local $$sub91$i)
                                     )
-                                    (br $do-once$58)
+                                    (br $do-once51)
                                   )
                                 )
                               )
@@ -9373,8 +9373,8 @@
                           (set_local $$y$addr$2$i
                             (get_local $$y$addr$1$i)
                           )
-                          (loop $while-in$63
-                            (block $while-out$62
+                          (loop $while-in56
+                            (block $while-out55
                               (set_local $$conv116$i
                                 (i32.trunc_s/f64
                                   (get_local $$y$addr$2$i)
@@ -9451,7 +9451,7 @@
                                   (i32.const 1)
                                 )
                               )
-                              (block $do-once$64
+                              (block $do-once57
                                 (if
                                   (get_local $$cmp127$i)
                                   (block
@@ -9479,7 +9479,7 @@
                                         (set_local $$s$1$i
                                           (get_local $$incdec$ptr122$i)
                                         )
-                                        (br $do-once$64)
+                                        (br $do-once57)
                                       )
                                     )
                                     (set_local $$incdec$ptr137$i
@@ -9521,10 +9521,10 @@
                                   (set_local $$s$1$i$lcssa
                                     (get_local $$s$1$i)
                                   )
-                                  (br $while-out$62)
+                                  (br $while-out55)
                                 )
                               )
-                              (br $while-in$63)
+                              (br $while-in56)
                             )
                           )
                           (set_local $$tobool140$i
@@ -9761,7 +9761,7 @@
                           (set_local $$retval$0$i
                             (get_local $$w$add165$i)
                           )
-                          (br $do-once$56)
+                          (br $do-once49)
                         )
                       )
                       (set_local $$cmp196$i
@@ -9844,8 +9844,8 @@
                       (set_local $$z$0$i
                         (get_local $$arraydecay208$add$ptr213$i)
                       )
-                      (loop $while-in$67
-                        (block $while-out$66
+                      (loop $while-in60
+                        (block $while-out59
                           (set_local $$conv216$i
                             (i32.trunc_s/f64
                               (get_local $$y$addr$4$i)
@@ -9898,10 +9898,10 @@
                               (set_local $$incdec$ptr217$i$lcssa
                                 (get_local $$incdec$ptr217$i)
                               )
-                              (br $while-out$66)
+                              (br $while-out59)
                             )
                           )
-                          (br $while-in$67)
+                          (br $while-in60)
                         )
                       )
                       (set_local $$$pr$i
@@ -9927,8 +9927,8 @@
                           (set_local $$z$1548$i
                             (get_local $$incdec$ptr217$i$lcssa)
                           )
-                          (loop $while-in$69
-                            (block $while-out$68
+                          (loop $while-in62
+                            (block $while-out61
                               (set_local $$cmp228$i
                                 (i32.gt_s
                                   (get_local $$211)
@@ -9954,7 +9954,7 @@
                                   (get_local $$a$1549$i)
                                 )
                               )
-                              (block $do-once$70
+                              (block $do-once63
                                 (if
                                   (get_local $$cmp235$543$i)
                                   (set_local $$a$2$ph$i
@@ -9967,8 +9967,8 @@
                                     (set_local $$d$0545$i
                                       (get_local $$d$0$542$i)
                                     )
-                                    (loop $while-in$73
-                                      (block $while-out$72
+                                    (loop $while-in66
+                                      (block $while-out65
                                         (set_local $$212
                                           (i32.load
                                             (get_local $$d$0545$i)
@@ -10039,7 +10039,7 @@
                                             (set_local $$conv242$i$lcssa
                                               (get_local $$219)
                                             )
-                                            (br $while-out$72)
+                                            (br $while-out65)
                                           )
                                           (block
                                             (set_local $$carry$0544$i
@@ -10050,7 +10050,7 @@
                                             )
                                           )
                                         )
-                                        (br $while-in$73)
+                                        (br $while-in66)
                                       )
                                     )
                                     (set_local $$tobool244$i
@@ -10065,7 +10065,7 @@
                                         (set_local $$a$2$ph$i
                                           (get_local $$a$1549$i)
                                         )
-                                        (br $do-once$70)
+                                        (br $do-once63)
                                       )
                                     )
                                     (set_local $$incdec$ptr246$i
@@ -10087,8 +10087,8 @@
                               (set_local $$z$2$i
                                 (get_local $$z$1548$i)
                               )
-                              (loop $while-in$75
-                                (block $while-out$74
+                              (loop $while-in68
+                                (block $while-out67
                                   (set_local $$cmp249$i
                                     (i32.gt_u
                                       (get_local $$z$2$i)
@@ -10103,7 +10103,7 @@
                                       (set_local $$z$2$i$lcssa
                                         (get_local $$z$2$i)
                                       )
-                                      (br $while-out$74)
+                                      (br $while-out67)
                                     )
                                   )
                                   (set_local $$arrayidx251$i
@@ -10132,10 +10132,10 @@
                                       (set_local $$z$2$i$lcssa
                                         (get_local $$z$2$i)
                                       )
-                                      (br $while-out$74)
+                                      (br $while-out67)
                                     )
                                   )
-                                  (br $while-in$75)
+                                  (br $while-in68)
                                 )
                               )
                               (set_local $$222
@@ -10182,10 +10182,10 @@
                                   (set_local $$z$1$lcssa$i
                                     (get_local $$z$2$i$lcssa)
                                   )
-                                  (br $while-out$68)
+                                  (br $while-out61)
                                 )
                               )
-                              (br $while-in$69)
+                              (br $while-in62)
                             )
                           )
                         )
@@ -10246,8 +10246,8 @@
                           (set_local $$z$3538$i
                             (get_local $$z$1$lcssa$i)
                           )
-                          (loop $while-in$77
-                            (block $while-out$76
+                          (loop $while-in70
+                            (block $while-out69
                               (set_local $$sub264$i
                                 (i32.sub
                                   (i32.const 0)
@@ -10273,7 +10273,7 @@
                                   (get_local $$z$3538$i)
                                 )
                               )
-                              (block $do-once$78
+                              (block $do-once71
                                 (if
                                   (get_local $$cmp277$533$i)
                                   (block
@@ -10301,8 +10301,8 @@
                                     (set_local $$d$1534$i
                                       (get_local $$a$3539$i)
                                     )
-                                    (loop $while-in$81
-                                      (block $while-out$80
+                                    (loop $while-in74
+                                      (block $while-out73
                                         (set_local $$225
                                           (i32.load
                                             (get_local $$d$1534$i)
@@ -10362,10 +10362,10 @@
                                             (set_local $$mul286$i$lcssa
                                               (get_local $$mul286$i)
                                             )
-                                            (br $while-out$80)
+                                            (br $while-out73)
                                           )
                                         )
-                                        (br $while-in$81)
+                                        (br $while-in74)
                                       )
                                     )
                                     (set_local $$226
@@ -10407,7 +10407,7 @@
                                         (set_local $$z$4$i
                                           (get_local $$z$3538$i)
                                         )
-                                        (br $do-once$78)
+                                        (br $do-once71)
                                       )
                                     )
                                     (set_local $$incdec$ptr296$i
@@ -10549,10 +10549,10 @@
                                   (set_local $$z$3$lcssa$i
                                     (get_local $$add$ptr311$z$4$i)
                                   )
-                                  (br $while-out$76)
+                                  (br $while-out69)
                                 )
                               )
-                              (br $while-in$77)
+                              (br $while-in70)
                             )
                           )
                         )
@@ -10571,7 +10571,7 @@
                           (get_local $$z$3$lcssa$i)
                         )
                       )
-                      (block $do-once$82
+                      (block $do-once75
                         (if
                           (get_local $$cmp315$i)
                           (block
@@ -10613,7 +10613,7 @@
                                 (set_local $$e$1$i
                                   (get_local $$mul322$i)
                                 )
-                                (br $do-once$82)
+                                (br $do-once75)
                               )
                               (block
                                 (set_local $$e$0531$i
@@ -10624,8 +10624,8 @@
                                 )
                               )
                             )
-                            (loop $while-in$85
-                              (block $while-out$84
+                            (loop $while-in78
+                              (block $while-out77
                                 (set_local $$mul328$i
                                   (i32.mul
                                     (get_local $$i$0530$i)
@@ -10650,7 +10650,7 @@
                                     (set_local $$e$1$i
                                       (get_local $$inc$i)
                                     )
-                                    (br $while-out$84)
+                                    (br $while-out77)
                                   )
                                   (block
                                     (set_local $$e$0531$i
@@ -10661,7 +10661,7 @@
                                     )
                                   )
                                 )
-                                (br $while-in$85)
+                                (br $while-in78)
                               )
                             )
                           )
@@ -10824,8 +10824,8 @@
                               (set_local $$j$0527$i
                                 (get_local $$j$0$524$i)
                               )
-                              (loop $while-in$87
-                                (block $while-out$86
+                              (loop $while-in80
+                                (block $while-out79
                                   (set_local $$mul367$i
                                     (i32.mul
                                       (get_local $$i$1526$i)
@@ -10850,7 +10850,7 @@
                                       (set_local $$i$1$lcssa$i
                                         (get_local $$mul367$i)
                                       )
-                                      (br $while-out$86)
+                                      (br $while-out79)
                                     )
                                     (block
                                       (set_local $$i$1526$i
@@ -10861,7 +10861,7 @@
                                       )
                                     )
                                   )
-                                  (br $while-in$87)
+                                  (br $while-in80)
                                 )
                               )
                             )
@@ -10907,7 +10907,7 @@
                               (get_local $$tobool371$i)
                             )
                           )
-                          (block $do-once$88
+                          (block $do-once81
                             (if
                               (get_local $$or$cond395$i)
                               (block
@@ -11001,7 +11001,7 @@
                                     (i32.const 0)
                                   )
                                 )
-                                (block $do-once$90
+                                (block $do-once83
                                   (if
                                     (get_local $$tobool400$i)
                                     (block
@@ -11041,7 +11041,7 @@
                                           (set_local $$small$1$i
                                             (get_local $$small$0$i)
                                           )
-                                          (br $do-once$90)
+                                          (br $do-once83)
                                         )
                                       )
                                       (set_local $$mul406$i
@@ -11099,7 +11099,7 @@
                                     (set_local $$e$4$i
                                       (get_local $$e$1$i)
                                     )
-                                    (br $do-once$88)
+                                    (br $do-once81)
                                   )
                                 )
                                 (set_local $$add414$i
@@ -11127,8 +11127,8 @@
                                     (set_local $$d$2520$i
                                       (get_local $$add$ptr358$i)
                                     )
-                                    (loop $while-in$93
-                                      (block $while-out$92
+                                    (loop $while-in86
+                                      (block $while-out85
                                         (set_local $$incdec$ptr419$i
                                           (i32.add
                                             (get_local $$d$2520$i)
@@ -11204,10 +11204,10 @@
                                             (set_local $$d$2$lcssa$i
                                               (get_local $$incdec$ptr419$i)
                                             )
-                                            (br $while-out$92)
+                                            (br $while-out85)
                                           )
                                         )
-                                        (br $while-in$93)
+                                        (br $while-in86)
                                       )
                                     )
                                   )
@@ -11264,7 +11264,7 @@
                                     (set_local $$e$4$i
                                       (get_local $$mul431$i)
                                     )
-                                    (br $do-once$88)
+                                    (br $do-once81)
                                   )
                                   (block
                                     (set_local $$e$2517$i
@@ -11275,8 +11275,8 @@
                                     )
                                   )
                                 )
-                                (loop $while-in$95
-                                  (block $while-out$94
+                                (loop $while-in88
+                                  (block $while-out87
                                     (set_local $$mul437$i
                                       (i32.mul
                                         (get_local $$i$2516$i)
@@ -11307,7 +11307,7 @@
                                         (set_local $$e$4$i
                                           (get_local $$inc438$i)
                                         )
-                                        (br $while-out$94)
+                                        (br $while-out87)
                                       )
                                       (block
                                         (set_local $$e$2517$i
@@ -11318,7 +11318,7 @@
                                         )
                                       )
                                     )
-                                    (br $while-in$95)
+                                    (br $while-in88)
                                   )
                                 )
                               )
@@ -11374,8 +11374,8 @@
                       (set_local $$z$7$i
                         (get_local $$z$7$ph$i)
                       )
-                      (loop $while-in$97
-                        (block $while-out$96
+                      (loop $while-in90
+                        (block $while-out89
                           (set_local $$cmp450$i
                             (i32.gt_u
                               (get_local $$z$7$i)
@@ -11393,7 +11393,7 @@
                               (set_local $$z$7$i$lcssa
                                 (get_local $$z$7$i)
                               )
-                              (br $while-out$96)
+                              (br $while-out89)
                             )
                           )
                           (set_local $$arrayidx453$i
@@ -11425,13 +11425,13 @@
                               (set_local $$z$7$i$lcssa
                                 (get_local $$z$7$i)
                               )
-                              (br $while-out$96)
+                              (br $while-out89)
                             )
                           )
-                          (br $while-in$97)
+                          (br $while-in90)
                         )
                       )
-                      (block $do-once$98
+                      (block $do-once91
                         (if
                           (get_local $$cmp338$i)
                           (block
@@ -11546,10 +11546,10 @@
                                 (set_local $$t$addr$1$i
                                   (get_local $$t$addr$0$i)
                                 )
-                                (br $do-once$98)
+                                (br $do-once91)
                               )
                             )
-                            (block $do-once$100
+                            (block $do-once93
                               (if
                                 (get_local $$cmp450$lcssa$i)
                                 (block
@@ -11576,7 +11576,7 @@
                                       (set_local $$j$2$i
                                         (i32.const 9)
                                       )
-                                      (br $do-once$100)
+                                      (br $do-once93)
                                     )
                                   )
                                   (set_local $$rem494$510$i
@@ -11608,11 +11608,11 @@
                                       (set_local $$j$2$i
                                         (i32.const 0)
                                       )
-                                      (br $do-once$100)
+                                      (br $do-once93)
                                     )
                                   )
-                                  (loop $while-in$103
-                                    (block $while-out$102
+                                  (loop $while-in96
+                                    (block $while-out95
                                       (set_local $$mul499$i
                                         (i32.mul
                                           (get_local $$i$3512$i)
@@ -11654,10 +11654,10 @@
                                           (set_local $$j$2$i
                                             (get_local $$inc500$i)
                                           )
-                                          (br $while-out$102)
+                                          (br $while-out95)
                                         )
                                       )
-                                      (br $while-in$103)
+                                      (br $while-in96)
                                     )
                                   )
                                 )
@@ -11749,7 +11749,7 @@
                                 (set_local $$t$addr$1$i
                                   (get_local $$t$addr$0$i)
                                 )
-                                (br $do-once$98)
+                                (br $do-once91)
                               )
                               (block
                                 (set_local $$add561$i
@@ -11799,7 +11799,7 @@
                                 (set_local $$t$addr$1$i
                                   (get_local $$t$addr$0$i)
                                 )
-                                (br $do-once$98)
+                                (br $do-once91)
                               )
                             )
                           )
@@ -11932,8 +11932,8 @@
                               (set_local $$estr$1507$i
                                 (get_local $$243)
                               )
-                              (loop $while-in$105
-                                (block $while-out$104
+                              (loop $while-in98
+                                (block $while-out97
                                   (set_local $$incdec$ptr639$i
                                     (i32.add
                                       (get_local $$estr$1507$i)
@@ -11968,10 +11968,10 @@
                                       (set_local $$estr$1$lcssa$i
                                         (get_local $$incdec$ptr639$i)
                                       )
-                                      (br $while-out$104)
+                                      (br $while-out97)
                                     )
                                   )
-                                  (br $while-in$105)
+                                  (br $while-in98)
                                 )
                               )
                             )
@@ -12117,7 +12117,7 @@
                         (get_local $$add653$i)
                         (get_local $$xor655$i)
                       )
-                      (block $do-once$106
+                      (block $do-once99
                         (if
                           (get_local $$cmp614$i)
                           (block
@@ -12137,8 +12137,8 @@
                             (set_local $$d$5494$i
                               (get_local $$r$0$a$9$i)
                             )
-                            (loop $while-in$109
-                              (block $while-out$108
+                            (loop $while-in102
+                              (block $while-out101
                                 (set_local $$248
                                   (i32.load
                                     (get_local $$d$5494$i)
@@ -12157,7 +12157,7 @@
                                     (get_local $$r$0$a$9$i)
                                   )
                                 )
-                                (block $do-once$110
+                                (block $do-once103
                                   (if
                                     (get_local $$cmp673$i)
                                     (block
@@ -12175,7 +12175,7 @@
                                           (set_local $$s668$1$i
                                             (get_local $$249)
                                           )
-                                          (br $do-once$110)
+                                          (br $do-once103)
                                         )
                                       )
                                       (i32.store8
@@ -12202,11 +12202,11 @@
                                           (set_local $$s668$1$i
                                             (get_local $$249)
                                           )
-                                          (br $do-once$110)
+                                          (br $do-once103)
                                         )
                                       )
-                                      (loop $while-in$113
-                                        (block $while-out$112
+                                      (loop $while-in106
+                                        (block $while-out105
                                           (set_local $$incdec$ptr681$i
                                             (i32.add
                                               (get_local $$s668$0492$i)
@@ -12232,10 +12232,10 @@
                                               (set_local $$s668$1$i
                                                 (get_local $$incdec$ptr681$i)
                                               )
-                                              (br $while-out$112)
+                                              (br $while-out105)
                                             )
                                           )
-                                          (br $while-in$113)
+                                          (br $while-in106)
                                         )
                                       )
                                     )
@@ -12297,13 +12297,13 @@
                                     (set_local $$incdec$ptr698$i$lcssa
                                       (get_local $$incdec$ptr698$i)
                                     )
-                                    (br $while-out$108)
+                                    (br $while-out101)
                                   )
                                   (set_local $$d$5494$i
                                     (get_local $$incdec$ptr698$i)
                                   )
                                 )
-                                (br $while-in$109)
+                                (br $while-in102)
                               )
                             )
                             (set_local $$251
@@ -12312,7 +12312,7 @@
                                 (i32.const 0)
                               )
                             )
-                            (block $do-once$114
+                            (block $do-once107
                               (if
                                 (i32.eqz
                                   (get_local $$251)
@@ -12339,7 +12339,7 @@
                                     (i32.eqz
                                       (get_local $$tobool$i$449$i)
                                     )
-                                    (br $do-once$114)
+                                    (br $do-once107)
                                   )
                                   (drop
                                     (call $___fwritex
@@ -12378,8 +12378,8 @@
                                 (set_local $$p$addr$4489$i
                                   (get_local $$p$addr$3$i)
                                 )
-                                (loop $while-in$117
-                                  (block $while-out$116
+                                (loop $while-in110
+                                  (block $while-out109
                                     (set_local $$254
                                       (i32.load
                                         (get_local $$d$6488$i)
@@ -12404,8 +12404,8 @@
                                         (set_local $$s715$0484$i
                                           (get_local $$255)
                                         )
-                                        (loop $while-in$119
-                                          (block $while-out$118
+                                        (loop $while-in112
+                                          (block $while-out111
                                             (set_local $$incdec$ptr725$i
                                               (i32.add
                                                 (get_local $$s715$0484$i)
@@ -12431,10 +12431,10 @@
                                                 (set_local $$s715$0$lcssa$i
                                                   (get_local $$incdec$ptr725$i)
                                                 )
-                                                (br $while-out$118)
+                                                (br $while-out111)
                                               )
                                             )
-                                            (br $while-in$119)
+                                            (br $while-in112)
                                           )
                                         )
                                       )
@@ -12528,10 +12528,10 @@
                                         (set_local $$p$addr$4$lcssa$i
                                           (get_local $$sub735$i)
                                         )
-                                        (br $while-out$116)
+                                        (br $while-out109)
                                       )
                                     )
-                                    (br $while-in$117)
+                                    (br $while-in110)
                                   )
                                 )
                               )
@@ -12588,8 +12588,8 @@
                                 (set_local $$p$addr$5501$i
                                   (get_local $$p$addr$3$i)
                                 )
-                                (loop $while-in$121
-                                  (block $while-out$120
+                                (loop $while-in114
+                                  (block $while-out113
                                     (set_local $$258
                                       (i32.load
                                         (get_local $$d$7500$i)
@@ -12629,7 +12629,7 @@
                                         (get_local $$a$9$ph$i)
                                       )
                                     )
-                                    (block $do-once$122
+                                    (block $do-once115
                                       (if
                                         (get_local $$cmp765$i)
                                         (block
@@ -12684,7 +12684,7 @@
                                               (set_local $$s753$2$i
                                                 (get_local $$incdec$ptr776$i)
                                               )
-                                              (br $do-once$122)
+                                              (br $do-once115)
                                             )
                                           )
                                           (set_local $$261
@@ -12712,7 +12712,7 @@
                                               (set_local $$s753$2$i
                                                 (get_local $$incdec$ptr776$i)
                                               )
-                                              (br $do-once$122)
+                                              (br $do-once115)
                                             )
                                           )
                                           (drop
@@ -12742,11 +12742,11 @@
                                               (set_local $$s753$2$i
                                                 (get_local $$s753$0$i)
                                               )
-                                              (br $do-once$122)
+                                              (br $do-once115)
                                             )
                                           )
-                                          (loop $while-in$125
-                                            (block $while-out$124
+                                          (loop $while-in118
+                                            (block $while-out117
                                               (set_local $$incdec$ptr773$i
                                                 (i32.add
                                                   (get_local $$s753$1496$i)
@@ -12772,10 +12772,10 @@
                                                   (set_local $$s753$2$i
                                                     (get_local $$incdec$ptr773$i)
                                                   )
-                                                  (br $while-out$124)
+                                                  (br $while-out117)
                                                 )
                                               )
-                                              (br $while-in$125)
+                                              (br $while-in118)
                                             )
                                           )
                                         )
@@ -12876,10 +12876,10 @@
                                         (set_local $$p$addr$5$lcssa$i
                                           (get_local $$sub806$i)
                                         )
-                                        (br $while-out$120)
+                                        (br $while-out113)
                                       )
                                     )
-                                    (br $while-in$121)
+                                    (br $while-in114)
                                   )
                                 )
                               )
@@ -12921,7 +12921,7 @@
                               (i32.eqz
                                 (get_local $$tobool$i$i)
                               )
-                              (br $do-once$106)
+                              (br $do-once99)
                             )
                             (set_local $$sub$ptr$rhs$cast812$i
                               (get_local $$estr$2$i)
@@ -13145,7 +13145,7 @@
                   (get_local $$l10n$3)
                 )
                 (br $label$continue$L1)
-                (br $switch$24)
+                (br $switch17)
               )
             )
             (block
@@ -13261,8 +13261,8 @@
                   (set_local $$s$addr$06$i
                     (get_local $$add$ptr205)
                   )
-                  (loop $while-in$130
-                    (block $while-out$129
+                  (loop $while-in123
+                    (block $while-out122
                       (set_local $$idxprom$i
                         (i32.and
                           (get_local $$99)
@@ -13342,7 +13342,7 @@
                           (set_local $$incdec$ptr$i$212$lcssa
                             (get_local $$incdec$ptr$i$212)
                           )
-                          (br $while-out$129)
+                          (br $while-out122)
                         )
                         (block
                           (set_local $$101
@@ -13356,7 +13356,7 @@
                           )
                         )
                       )
-                      (br $while-in$130)
+                      (br $while-in123)
                     )
                   )
                   (set_local $$107
@@ -13609,8 +13609,8 @@
                     (set_local $$ws$0317
                       (get_local $$176)
                     )
-                    (loop $while-in$132
-                      (block $while-out$131
+                    (loop $while-in125
+                      (block $while-out124
                         (set_local $$177
                           (i32.load
                             (get_local $$ws$0317)
@@ -13631,7 +13631,7 @@
                             (set_local $$l$2
                               (get_local $$l$1315)
                             )
-                            (br $while-out$131)
+                            (br $while-out124)
                           )
                         )
                         (set_local $$call384
@@ -13673,7 +13673,7 @@
                             (set_local $$l$2
                               (get_local $$call384)
                             )
-                            (br $while-out$131)
+                            (br $while-out124)
                           )
                         )
                         (set_local $$incdec$ptr383
@@ -13714,10 +13714,10 @@
                             (set_local $$l$2
                               (get_local $$call384)
                             )
-                            (br $while-out$131)
+                            (br $while-out124)
                           )
                         )
-                        (br $while-in$132)
+                        (br $while-in125)
                       )
                     )
                     (set_local $$cmp397
@@ -13770,8 +13770,8 @@
                         (set_local $$ws$1326
                           (get_local $$178)
                         )
-                        (loop $while-in$134
-                          (block $while-out$133
+                        (loop $while-in127
+                          (block $while-out126
                             (set_local $$179
                               (i32.load
                                 (get_local $$ws$1326)
@@ -13881,10 +13881,10 @@
                                 (set_local $label
                                   (i32.const 98)
                                 )
-                                (br $while-out$133)
+                                (br $while-out126)
                               )
                             )
-                            (br $while-in$134)
+                            (br $while-in127)
                           )
                         )
                       )
@@ -14297,8 +14297,8 @@
                   (set_local $$i$2299
                     (i32.const 1)
                   )
-                  (loop $while-in$137
-                    (block $while-out$136
+                  (loop $while-in130
+                    (block $while-out129
                       (set_local $$arrayidx469
                         (i32.add
                           (get_local $$nl_type)
@@ -14325,7 +14325,7 @@
                           (set_local $$i$2299$lcssa
                             (get_local $$i$2299)
                           )
-                          (br $while-out$136)
+                          (br $while-out129)
                         )
                       )
                       (set_local $$add$ptr473
@@ -14366,7 +14366,7 @@
                           (br $label$break$L343)
                         )
                       )
-                      (br $while-in$137)
+                      (br $while-in130)
                     )
                   )
                   (set_local $$cmp478$295
@@ -14381,8 +14381,8 @@
                       (set_local $$i$3296
                         (get_local $$i$2299$lcssa)
                       )
-                      (loop $while-in$139
-                        (block $while-out$138
+                      (loop $while-in132
+                        (block $while-out131
                           (set_local $$arrayidx481
                             (i32.add
                               (get_local $$nl_type)
@@ -14435,10 +14435,10 @@
                               (set_local $$retval$0
                                 (i32.const 1)
                               )
-                              (br $while-out$138)
+                              (br $while-out131)
                             )
                           )
-                          (br $while-in$139)
+                          (br $while-in132)
                         )
                       )
                     )
@@ -14666,20 +14666,20 @@
         (i32.eqz
           (get_local $$cmp)
         )
-        (block $do-once$1
-          (block $switch$3
-            (block $switch-default$14
-              (block $switch-case$13
-                (block $switch-case$12
-                  (block $switch-case$11
-                    (block $switch-case$10
-                      (block $switch-case$9
-                        (block $switch-case$8
-                          (block $switch-case$7
-                            (block $switch-case$6
-                              (block $switch-case$5
-                                (block $switch-case$4
-                                  (br_table $switch-case$4 $switch-case$5 $switch-case$6 $switch-case$7 $switch-case$8 $switch-case$9 $switch-case$10 $switch-case$11 $switch-case$12 $switch-case$13 $switch-default$14
+        (block $do-once
+          (block $switch
+            (block $switch-default
+              (block $switch-case9
+                (block $switch-case8
+                  (block $switch-case7
+                    (block $switch-case6
+                      (block $switch-case5
+                        (block $switch-case4
+                          (block $switch-case3
+                            (block $switch-case2
+                              (block $switch-case1
+                                (block $switch-case
+                                  (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $switch-default
                                     (i32.sub
                                       (get_local $$type)
                                       (i32.const 9)
@@ -14766,7 +14766,7 @@
                                     (get_local $$6)
                                   )
                                   (br $label$break$L1)
-                                  (br $switch$3)
+                                  (br $switch)
                                 )
                               )
                               (block
@@ -14883,7 +14883,7 @@
                                   (get_local $$15)
                                 )
                                 (br $label$break$L1)
-                                (br $switch$3)
+                                (br $switch)
                               )
                             )
                             (block
@@ -14985,7 +14985,7 @@
                                 (i32.const 0)
                               )
                               (br $label$break$L1)
-                              (br $switch$3)
+                              (br $switch)
                             )
                           )
                           (block
@@ -15107,7 +15107,7 @@
                               (get_local $$42)
                             )
                             (br $label$break$L1)
-                            (br $switch$3)
+                            (br $switch)
                           )
                         )
                         (block
@@ -15239,7 +15239,7 @@
                             (get_local $$56)
                           )
                           (br $label$break$L1)
-                          (br $switch$3)
+                          (br $switch)
                         )
                       )
                       (block
@@ -15347,7 +15347,7 @@
                           (i32.const 0)
                         )
                         (br $label$break$L1)
-                        (br $switch$3)
+                        (br $switch)
                       )
                     )
                     (block
@@ -15479,7 +15479,7 @@
                         (get_local $$81)
                       )
                       (br $label$break$L1)
-                      (br $switch$3)
+                      (br $switch)
                     )
                   )
                   (block
@@ -15587,7 +15587,7 @@
                       (i32.const 0)
                     )
                     (br $label$break$L1)
-                    (br $switch$3)
+                    (br $switch)
                   )
                 )
                 (block
@@ -15670,7 +15670,7 @@
                     (get_local $$103)
                   )
                   (br $label$break$L1)
-                  (br $switch$3)
+                  (br $switch)
                 )
               )
               (block
@@ -15753,7 +15753,7 @@
                   (get_local $$110)
                 )
                 (br $label$break$L1)
-                (br $switch$3)
+                (br $switch)
               )
             )
             (br $label$break$L1)
@@ -15846,8 +15846,8 @@
         (set_local $$s$addr$013
           (get_local $$s)
         )
-        (loop $while-in$1
-          (block $while-out$0
+        (loop $while-in
+          (block $while-out
             (set_local $$9
               (call $___uremdi3
                 (get_local $$7)
@@ -15945,10 +15945,10 @@
                 (set_local $$incdec$ptr$lcssa
                   (get_local $$incdec$ptr)
                 )
-                (br $while-out$0)
+                (br $while-out)
               )
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
         (set_local $$s$addr$0$lcssa
@@ -15985,8 +15985,8 @@
         (set_local $$y$010
           (get_local $$x$addr$0$lcssa$off0)
         )
-        (loop $while-in$3
-          (block $while-out$2
+        (loop $while-in1
+          (block $while-out0
             (set_local $$rem4
               (i32.and
                 (i32.rem_u
@@ -16039,7 +16039,7 @@
                 (set_local $$s$addr$1$lcssa
                   (get_local $$incdec$ptr7)
                 )
-                (br $while-out$2)
+                (br $while-out0)
               )
               (block
                 (set_local $$s$addr$19
@@ -16050,7 +16050,7 @@
                 )
               )
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
@@ -16129,7 +16129,7 @@
         (get_local $$tobool)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $$or$cond)
         (block
@@ -16200,8 +16200,8 @@
               (set_local $$tobool$i18
                 (get_local $$tobool$i$16)
               )
-              (loop $while-in$3
-                (block $while-out$2
+              (loop $while-in
+                (block $while-out
                   (if
                     (get_local $$tobool$i18)
                     (block
@@ -16262,9 +16262,9 @@
                         (get_local $$tobool$i)
                       )
                     )
-                    (br $while-out$2)
+                    (br $while-out)
                   )
-                  (br $while-in$3)
+                  (br $while-in)
                 )
               )
               (set_local $$3
@@ -16278,7 +16278,7 @@
                 (set_local $$l$addr$0$lcssa21
                   (get_local $$3)
                 )
-                (br $do-once$0)
+                (br $do-once)
               )
             )
             (if
@@ -16286,7 +16286,7 @@
               (set_local $$l$addr$0$lcssa21
                 (get_local $$sub)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (drop
@@ -17503,7 +17503,7 @@
         (i32.const 245)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $$cmp)
         (block
@@ -17627,7 +17627,7 @@
                   (get_local $$3)
                 )
               )
-              (block $do-once$2
+              (block $do-once0
                 (if
                   (get_local $$cmp10)
                   (block
@@ -17698,7 +17698,7 @@
                           (get_local $$1)
                           (get_local $$3)
                         )
-                        (br $do-once$2)
+                        (br $do-once0)
                       )
                       (call $_abort)
                     )
@@ -17998,7 +17998,7 @@
                       (get_local $$10)
                     )
                   )
-                  (block $do-once$4
+                  (block $do-once2
                     (if
                       (get_local $$cmp70)
                       (block
@@ -18080,7 +18080,7 @@
                             (set_local $$13
                               (get_local $$$pre)
                             )
-                            (br $do-once$4)
+                            (br $do-once2)
                           )
                           (call $_abort)
                         )
@@ -18523,8 +18523,8 @@
                   (set_local $$v$0$i
                     (get_local $$20)
                   )
-                  (loop $while-in$7
-                    (block $while-out$6
+                  (loop $while-in
+                    (block $while-out
                       (set_local $$arrayidx23$i
                         (i32.add
                           (get_local $$t$0$i)
@@ -18571,7 +18571,7 @@
                               (set_local $$v$0$i$lcssa
                                 (get_local $$v$0$i)
                               )
-                              (br $while-out$6)
+                              (br $while-out)
                             )
                             (set_local $$cond4$i
                               (get_local $$23)
@@ -18634,7 +18634,7 @@
                       (set_local $$v$0$i
                         (get_local $$cond$v$0$i)
                       )
-                      (br $while-in$7)
+                      (br $while-in)
                     )
                   )
                   (set_local $$25
@@ -18698,7 +18698,7 @@
                       (get_local $$v$0$i$lcssa)
                     )
                   )
-                  (block $do-once$8
+                  (block $do-once4
                     (if
                       (get_local $$cmp40$i)
                       (block
@@ -18745,7 +18745,7 @@
                                 (set_local $$R$3$i
                                   (i32.const 0)
                                 )
-                                (br $do-once$8)
+                                (br $do-once4)
                               )
                               (block
                                 (set_local $$R$1$i
@@ -18766,8 +18766,8 @@
                             )
                           )
                         )
-                        (loop $while-in$11
-                          (block $while-out$10
+                        (loop $while-in7
+                          (block $while-out6
                             (set_local $$arrayidx71$i
                               (i32.add
                                 (get_local $$R$1$i)
@@ -18796,7 +18796,7 @@
                                 (set_local $$RP$1$i
                                   (get_local $$arrayidx71$i)
                                 )
-                                (br $while-in$11)
+                                (br $while-in7)
                               )
                             )
                             (set_local $$arrayidx75$i
@@ -18825,7 +18825,7 @@
                                 (set_local $$RP$1$i$lcssa
                                   (get_local $$RP$1$i)
                                 )
-                                (br $while-out$10)
+                                (br $while-out6)
                               )
                               (block
                                 (set_local $$R$1$i
@@ -18836,7 +18836,7 @@
                                 )
                               )
                             )
-                            (br $while-in$11)
+                            (br $while-in7)
                           )
                         )
                         (set_local $$cmp81$i
@@ -18856,7 +18856,7 @@
                             (set_local $$R$3$i
                               (get_local $$R$1$i$lcssa)
                             )
-                            (br $do-once$8)
+                            (br $do-once4)
                           )
                         )
                       )
@@ -18936,7 +18936,7 @@
                             (set_local $$R$3$i
                               (get_local $$27)
                             )
-                            (br $do-once$8)
+                            (br $do-once4)
                           )
                           (call $_abort)
                         )
@@ -18949,7 +18949,7 @@
                       (i32.const 0)
                     )
                   )
-                  (block $do-once$12
+                  (block $do-once8
                     (if
                       (i32.eqz
                         (get_local $$cmp90$i)
@@ -19029,7 +19029,7 @@
                                   (i32.const 180)
                                   (get_local $$and103$i)
                                 )
-                                (br $do-once$12)
+                                (br $do-once8)
                               )
                             )
                           )
@@ -19093,7 +19093,7 @@
                             )
                             (if
                               (get_local $$cmp126$i)
-                              (br $do-once$12)
+                              (br $do-once8)
                             )
                           )
                         )
@@ -19139,7 +19139,7 @@
                             (i32.const 0)
                           )
                         )
-                        (block $do-once$14
+                        (block $do-once10
                           (if
                             (i32.eqz
                               (get_local $$cmp138$i)
@@ -19175,7 +19175,7 @@
                                     (get_local $$parent149$i)
                                     (get_local $$R$3$i)
                                   )
-                                  (br $do-once$14)
+                                  (br $do-once10)
                                 )
                               )
                             )
@@ -19238,7 +19238,7 @@
                                   (get_local $$parent166$i)
                                   (get_local $$R$3$i)
                                 )
-                                (br $do-once$12)
+                                (br $do-once8)
                               )
                             )
                           )
@@ -19843,8 +19843,8 @@
                         (set_local $$v$0$i$153
                           (i32.const 0)
                         )
-                        (loop $while-in$18
-                          (block $while-out$17
+                        (loop $while-in14
+                          (block $while-out13
                             (set_local $$head$i$154
                               (i32.add
                                 (get_local $$t$0$i$151)
@@ -20017,7 +20017,7 @@
                                 (set_local $label
                                   (i32.const 86)
                                 )
-                                (br $while-out$17)
+                                (br $while-out13)
                               )
                               (block
                                 (set_local $$rsize$0$i$152
@@ -20037,7 +20037,7 @@
                                 )
                               )
                             )
-                            (br $while-in$18)
+                            (br $while-in14)
                           )
                         )
                       )
@@ -20106,7 +20106,7 @@
                               (set_local $$nb$0
                                 (get_local $$and145)
                               )
-                              (br $do-once$0)
+                              (br $do-once)
                             )
                           )
                           (set_local $$sub67$i
@@ -20307,8 +20307,8 @@
                       (get_local $label)
                       (i32.const 90)
                     )
-                    (loop $while-in$20
-                      (block $while-out$19
+                    (loop $while-in16
+                      (block $while-out15
                         (set_local $label
                           (i32.const 0)
                         )
@@ -20389,7 +20389,7 @@
                             (set_local $label
                               (i32.const 90)
                             )
-                            (br $while-in$20)
+                            (br $while-in16)
                           )
                         )
                         (set_local $$arrayidx113$i$159
@@ -20418,7 +20418,7 @@
                             (set_local $$v$4$lcssa$i
                               (get_local $$t$4$v$4$i)
                             )
-                            (br $while-out$19)
+                            (br $while-out15)
                           )
                           (block
                             (set_local $$rsize$49$i
@@ -20435,7 +20435,7 @@
                             )
                           )
                         )
-                        (br $while-in$20)
+                        (br $while-in16)
                       )
                     )
                   )
@@ -20532,7 +20532,7 @@
                               (get_local $$v$4$lcssa$i)
                             )
                           )
-                          (block $do-once$21
+                          (block $do-once17
                             (if
                               (get_local $$cmp128$i)
                               (block
@@ -20579,7 +20579,7 @@
                                         (set_local $$R$3$i$171
                                           (i32.const 0)
                                         )
-                                        (br $do-once$21)
+                                        (br $do-once17)
                                       )
                                       (block
                                         (set_local $$R$1$i$168
@@ -20600,8 +20600,8 @@
                                     )
                                   )
                                 )
-                                (loop $while-in$24
-                                  (block $while-out$23
+                                (loop $while-in20
+                                  (block $while-out19
                                     (set_local $$arrayidx161$i
                                       (i32.add
                                         (get_local $$R$1$i$168)
@@ -20630,7 +20630,7 @@
                                         (set_local $$RP$1$i$167
                                           (get_local $$arrayidx161$i)
                                         )
-                                        (br $while-in$24)
+                                        (br $while-in20)
                                       )
                                     )
                                     (set_local $$arrayidx165$i$169
@@ -20659,7 +20659,7 @@
                                         (set_local $$RP$1$i$167$lcssa
                                           (get_local $$RP$1$i$167)
                                         )
-                                        (br $while-out$23)
+                                        (br $while-out19)
                                       )
                                       (block
                                         (set_local $$R$1$i$168
@@ -20670,7 +20670,7 @@
                                         )
                                       )
                                     )
-                                    (br $while-in$24)
+                                    (br $while-in20)
                                   )
                                 )
                                 (set_local $$cmp171$i
@@ -20690,7 +20690,7 @@
                                     (set_local $$R$3$i$171
                                       (get_local $$R$1$i$168$lcssa)
                                     )
-                                    (br $do-once$21)
+                                    (br $do-once17)
                                   )
                                 )
                               )
@@ -20770,7 +20770,7 @@
                                     (set_local $$R$3$i$171
                                       (get_local $$64)
                                     )
-                                    (br $do-once$21)
+                                    (br $do-once17)
                                   )
                                   (call $_abort)
                                 )
@@ -20783,7 +20783,7 @@
                               (i32.const 0)
                             )
                           )
-                          (block $do-once$25
+                          (block $do-once21
                             (if
                               (i32.eqz
                                 (get_local $$cmp180$i)
@@ -20863,7 +20863,7 @@
                                           (i32.const 180)
                                           (get_local $$and194$i)
                                         )
-                                        (br $do-once$25)
+                                        (br $do-once21)
                                       )
                                     )
                                   )
@@ -20927,7 +20927,7 @@
                                     )
                                     (if
                                       (get_local $$cmp217$i)
-                                      (br $do-once$25)
+                                      (br $do-once21)
                                     )
                                   )
                                 )
@@ -20973,7 +20973,7 @@
                                     (i32.const 0)
                                   )
                                 )
-                                (block $do-once$27
+                                (block $do-once23
                                   (if
                                     (i32.eqz
                                       (get_local $$cmp229$i)
@@ -21009,7 +21009,7 @@
                                             (get_local $$parent240$i)
                                             (get_local $$R$3$i$171)
                                           )
-                                          (br $do-once$27)
+                                          (br $do-once23)
                                         )
                                       )
                                     )
@@ -21072,7 +21072,7 @@
                                           (get_local $$parent257$i)
                                           (get_local $$R$3$i$171)
                                         )
-                                        (br $do-once$25)
+                                        (br $do-once21)
                                       )
                                     )
                                   )
@@ -21086,7 +21086,7 @@
                               (i32.const 16)
                             )
                           )
-                          (block $do-once$29
+                          (block $do-once25
                             (if
                               (get_local $$cmp265$i)
                               (block
@@ -21333,7 +21333,7 @@
                                       (get_local $$bk313$i)
                                       (get_local $$arrayidx289$i)
                                     )
-                                    (br $do-once$29)
+                                    (br $do-once25)
                                   )
                                 )
                                 (set_local $$shr318$i
@@ -21614,7 +21614,7 @@
                                       (get_local $$fd371$i)
                                       (get_local $$add$ptr$i$161)
                                     )
-                                    (br $do-once$29)
+                                    (br $do-once25)
                                   )
                                 )
                                 (set_local $$87
@@ -21659,8 +21659,8 @@
                                 (set_local $$T$0$i
                                   (get_local $$87)
                                 )
-                                (loop $while-in$32
-                                  (block $while-out$31
+                                (loop $while-in28
+                                  (block $while-out27
                                     (set_local $$head386$i
                                       (i32.add
                                         (get_local $$T$0$i)
@@ -21693,7 +21693,7 @@
                                         (set_local $label
                                           (i32.const 148)
                                         )
-                                        (br $while-out$31)
+                                        (br $while-out27)
                                       )
                                     )
                                     (set_local $$shr391$i
@@ -21743,7 +21743,7 @@
                                         (set_local $label
                                           (i32.const 145)
                                         )
-                                        (br $while-out$31)
+                                        (br $while-out27)
                                       )
                                       (block
                                         (set_local $$K373$0$i
@@ -21754,7 +21754,7 @@
                                         )
                                       )
                                     )
-                                    (br $while-in$32)
+                                    (br $while-in28)
                                   )
                                 )
                                 (if
@@ -21812,7 +21812,7 @@
                                           (get_local $$fd408$i)
                                           (get_local $$add$ptr$i$161)
                                         )
-                                        (br $do-once$29)
+                                        (br $do-once25)
                                       )
                                     )
                                   )
@@ -21903,7 +21903,7 @@
                                             (get_local $$parent433$i)
                                             (i32.const 0)
                                           )
-                                          (br $do-once$29)
+                                          (br $do-once25)
                                         )
                                         (call $_abort)
                                       )
@@ -22196,7 +22196,7 @@
         (i32.const 0)
       )
     )
-    (block $do-once$33
+    (block $do-once29
       (if
         (get_local $$cmp$i$179)
         (block
@@ -22271,7 +22271,7 @@
                 (i32.const 648)
                 (get_local $$and7$i$i)
               )
-              (br $do-once$33)
+              (br $do-once29)
             )
             (call $_abort)
           )
@@ -22432,8 +22432,8 @@
                 (set_local $$sp$0$i$i
                   (i32.const 624)
                 )
-                (loop $while-in$38
-                  (block $while-out$37
+                (loop $while-in34
+                  (block $while-out33
                     (set_local $$105
                       (i32.load
                         (get_local $$sp$0$i$i)
@@ -22482,7 +22482,7 @@
                             (set_local $$size$i$i$lcssa
                               (get_local $$size$i$i)
                             )
-                            (br $while-out$37)
+                            (br $while-out33)
                           )
                         )
                       )
@@ -22516,7 +22516,7 @@
                         (get_local $$107)
                       )
                     )
-                    (br $while-in$38)
+                    (br $while-in34)
                   )
                 )
                 (set_local $$112
@@ -22616,7 +22616,7 @@
               )
             )
           )
-          (block $do-once$39
+          (block $do-once35
             (if
               (i32.eq
                 (get_local $label)
@@ -22774,7 +22774,7 @@
                             )
                             (if
                               (get_local $$or$cond2$i)
-                              (br $do-once$39)
+                              (br $do-once35)
                             )
                           )
                         )
@@ -22865,7 +22865,7 @@
                     (get_local $$or$cond5$i)
                   )
                 )
-                (block $do-once$42
+                (block $do-once38
                   (if
                     (get_local $$or$cond3$i)
                     (block
@@ -22938,7 +22938,7 @@
                               (set_local $$ssize$5$i
                                 (get_local $$add110$i)
                               )
-                              (br $do-once$42)
+                              (br $do-once38)
                             )
                           )
                         )
@@ -23154,7 +23154,7 @@
             (i32.const 0)
           )
         )
-        (block $do-once$44
+        (block $do-once40
           (if
             (get_local $$cmp157$i)
             (block
@@ -23216,8 +23216,8 @@
               (set_local $$i$01$i$i
                 (i32.const 0)
               )
-              (loop $while-in$47
-                (block $while-out$46
+              (loop $while-in43
+                (block $while-out42
                   (set_local $$shl$i$i
                     (i32.shl
                       (get_local $$i$01$i$i)
@@ -23267,12 +23267,12 @@
                   )
                   (if
                     (get_local $$exitcond$i$i)
-                    (br $while-out$46)
+                    (br $while-out42)
                     (set_local $$i$01$i$i
                       (get_local $$inc$i$i)
                     )
                   )
-                  (br $while-in$47)
+                  (br $while-in43)
                 )
               )
               (set_local $$sub172$i
@@ -23387,8 +23387,8 @@
               (set_local $$sp$0108$i
                 (i32.const 624)
               )
-              (loop $while-in$49
-                (block $while-out$48
+              (loop $while-in45
+                (block $while-out44
                   (set_local $$127
                     (i32.load
                       (get_local $$sp$0108$i)
@@ -23435,7 +23435,7 @@
                       (set_local $label
                         (i32.const 203)
                       )
-                      (br $while-out$48)
+                      (br $while-out44)
                     )
                   )
                   (set_local $$next$i
@@ -23457,12 +23457,12 @@
                   )
                   (if
                     (get_local $$cmp186$i)
-                    (br $while-out$48)
+                    (br $while-out44)
                     (set_local $$sp$0108$i
                       (get_local $$129)
                     )
                   )
-                  (br $while-in$49)
+                  (br $while-in45)
                 )
               )
               (if
@@ -23640,7 +23640,7 @@
                             (i32.const 204)
                             (get_local $$134)
                           )
-                          (br $do-once$44)
+                          (br $do-once40)
                         )
                       )
                     )
@@ -23682,8 +23682,8 @@
               (set_local $$sp$1107$i
                 (i32.const 624)
               )
-              (loop $while-in$51
-                (block $while-out$50
+              (loop $while-in47
+                (block $while-out46
                   (set_local $$136
                     (i32.load
                       (get_local $$sp$1107$i)
@@ -23707,7 +23707,7 @@
                       (set_local $label
                         (i32.const 211)
                       )
-                      (br $while-out$50)
+                      (br $while-out46)
                     )
                   )
                   (set_local $$next231$i
@@ -23733,13 +23733,13 @@
                       (set_local $$sp$0$i$i$i
                         (i32.const 624)
                       )
-                      (br $while-out$50)
+                      (br $while-out46)
                     )
                     (set_local $$sp$1107$i
                       (get_local $$137)
                     )
                   )
-                  (br $while-in$51)
+                  (br $while-in47)
                 )
               )
               (if
@@ -23937,7 +23937,7 @@
                           (get_local $$119)
                         )
                       )
-                      (block $do-once$52
+                      (block $do-once48
                         (if
                           (get_local $$cmp20$i$i)
                           (block
@@ -24037,7 +24037,7 @@
                                   (get_local $$add$ptr30$i$i)
                                   (get_local $$add26$i$i)
                                 )
-                                (br $do-once$52)
+                                (br $do-once48)
                               )
                             )
                             (set_local $$head32$i$i
@@ -24131,7 +24131,7 @@
                                           (get_local $$arrayidx$i$48$i)
                                         )
                                       )
-                                      (block $do-once$55
+                                      (block $do-once51
                                         (if
                                           (i32.eqz
                                             (get_local $$cmp41$i$i)
@@ -24166,7 +24166,7 @@
                                             )
                                             (if
                                               (get_local $$cmp44$i$i)
-                                              (br $do-once$55)
+                                              (br $do-once51)
                                             )
                                             (call $_abort)
                                           )
@@ -24217,7 +24217,7 @@
                                           (get_local $$arrayidx$i$48$i)
                                         )
                                       )
-                                      (block $do-once$57
+                                      (block $do-once53
                                         (if
                                           (get_local $$cmp54$i$i)
                                           (block
@@ -24265,7 +24265,7 @@
                                                 (set_local $$fd68$pre$phi$i$iZ2D
                                                   (get_local $$fd59$i$i)
                                                 )
-                                                (br $do-once$57)
+                                                (br $do-once53)
                                               )
                                             )
                                             (call $_abort)
@@ -24316,7 +24316,7 @@
                                           (get_local $$add$ptr16$i$i)
                                         )
                                       )
-                                      (block $do-once$59
+                                      (block $do-once55
                                         (if
                                           (get_local $$cmp75$i$i)
                                           (block
@@ -24363,7 +24363,7 @@
                                                     (set_local $$R$3$i$i
                                                       (i32.const 0)
                                                     )
-                                                    (br $do-once$59)
+                                                    (br $do-once55)
                                                   )
                                                   (block
                                                     (set_local $$R$1$i$i
@@ -24384,8 +24384,8 @@
                                                 )
                                               )
                                             )
-                                            (loop $while-in$62
-                                              (block $while-out$61
+                                            (loop $while-in58
+                                              (block $while-out57
                                                 (set_local $$arrayidx103$i$i
                                                   (i32.add
                                                     (get_local $$R$1$i$i)
@@ -24414,7 +24414,7 @@
                                                     (set_local $$RP$1$i$i
                                                       (get_local $$arrayidx103$i$i)
                                                     )
-                                                    (br $while-in$62)
+                                                    (br $while-in58)
                                                   )
                                                 )
                                                 (set_local $$arrayidx107$i$i
@@ -24443,7 +24443,7 @@
                                                     (set_local $$RP$1$i$i$lcssa
                                                       (get_local $$RP$1$i$i)
                                                     )
-                                                    (br $while-out$61)
+                                                    (br $while-out57)
                                                   )
                                                   (block
                                                     (set_local $$R$1$i$i
@@ -24454,7 +24454,7 @@
                                                     )
                                                   )
                                                 )
-                                                (br $while-in$62)
+                                                (br $while-in58)
                                               )
                                             )
                                             (set_local $$cmp112$i$i
@@ -24474,7 +24474,7 @@
                                                 (set_local $$R$3$i$i
                                                   (get_local $$R$1$i$i$lcssa)
                                                 )
-                                                (br $do-once$59)
+                                                (br $do-once55)
                                               )
                                             )
                                           )
@@ -24554,7 +24554,7 @@
                                                 (set_local $$R$3$i$i
                                                   (get_local $$155)
                                                 )
-                                                (br $do-once$59)
+                                                (br $do-once55)
                                               )
                                               (call $_abort)
                                             )
@@ -24602,7 +24602,7 @@
                                           (get_local $$164)
                                         )
                                       )
-                                      (block $do-once$63
+                                      (block $do-once59
                                         (if
                                           (get_local $$cmp124$i$i)
                                           (block
@@ -24620,7 +24620,7 @@
                                               (i32.eqz
                                                 (get_local $$cond2$i$i)
                                               )
-                                              (br $do-once$63)
+                                              (br $do-once59)
                                             )
                                             (set_local $$shl131$i$i
                                               (i32.shl
@@ -24758,7 +24758,7 @@
                                           (i32.const 0)
                                         )
                                       )
-                                      (block $do-once$65
+                                      (block $do-once61
                                         (if
                                           (i32.eqz
                                             (get_local $$cmp168$i$i)
@@ -24794,7 +24794,7 @@
                                                   (get_local $$parent179$i$i)
                                                   (get_local $$R$3$i$i)
                                                 )
-                                                (br $do-once$65)
+                                                (br $do-once61)
                                               )
                                             )
                                           )
@@ -24990,7 +24990,7 @@
                                     (i32.const 0)
                                   )
                                 )
-                                (block $do-once$67
+                                (block $do-once63
                                   (if
                                     (get_local $$tobool228$i$i)
                                     (block
@@ -25051,7 +25051,7 @@
                                           (set_local $$F224$0$i$i
                                             (get_local $$175)
                                           )
-                                          (br $do-once$67)
+                                          (br $do-once63)
                                         )
                                       )
                                       (call $_abort)
@@ -25092,7 +25092,7 @@
                                   (get_local $$bk248$i$i)
                                   (get_local $$arrayidx223$i$i)
                                 )
-                                (br $do-once$52)
+                                (br $do-once48)
                               )
                             )
                             (set_local $$shr253$i$i
@@ -25107,7 +25107,7 @@
                                 (i32.const 0)
                               )
                             )
-                            (block $do-once$69
+                            (block $do-once65
                               (if
                                 (get_local $$cmp254$i$i)
                                 (set_local $$I252$0$i$i
@@ -25126,7 +25126,7 @@
                                       (set_local $$I252$0$i$i
                                         (i32.const 31)
                                       )
-                                      (br $do-once$69)
+                                      (br $do-once65)
                                     )
                                   )
                                   (set_local $$sub262$i$i
@@ -25376,7 +25376,7 @@
                                   (get_local $$fd303$i$i)
                                   (get_local $$add$ptr17$i$i)
                                 )
-                                (br $do-once$52)
+                                (br $do-once48)
                               )
                             )
                             (set_local $$178
@@ -25421,8 +25421,8 @@
                             (set_local $$T$0$i$58$i
                               (get_local $$178)
                             )
-                            (loop $while-in$72
-                              (block $while-out$71
+                            (loop $while-in68
+                              (block $while-out67
                                 (set_local $$head317$i$i
                                   (i32.add
                                     (get_local $$T$0$i$58$i)
@@ -25455,7 +25455,7 @@
                                     (set_local $label
                                       (i32.const 281)
                                     )
-                                    (br $while-out$71)
+                                    (br $while-out67)
                                   )
                                 )
                                 (set_local $$shr322$i$i
@@ -25505,7 +25505,7 @@
                                     (set_local $label
                                       (i32.const 278)
                                     )
-                                    (br $while-out$71)
+                                    (br $while-out67)
                                   )
                                   (block
                                     (set_local $$K305$0$i$i
@@ -25516,7 +25516,7 @@
                                     )
                                   )
                                 )
-                                (br $while-in$72)
+                                (br $while-in68)
                               )
                             )
                             (if
@@ -25574,7 +25574,7 @@
                                       (get_local $$fd339$i$i)
                                       (get_local $$add$ptr17$i$i)
                                     )
-                                    (br $do-once$52)
+                                    (br $do-once48)
                                   )
                                 )
                               )
@@ -25665,7 +25665,7 @@
                                         (get_local $$parent361$i$i)
                                         (i32.const 0)
                                       )
-                                      (br $do-once$52)
+                                      (br $do-once48)
                                     )
                                     (call $_abort)
                                   )
@@ -25694,8 +25694,8 @@
                   )
                 )
               )
-              (loop $while-in$74
-                (block $while-out$73
+              (loop $while-in70
+                (block $while-out69
                   (set_local $$185
                     (i32.load
                       (get_local $$sp$0$i$i$i)
@@ -25741,7 +25741,7 @@
                           (set_local $$add$ptr$i$i$i$lcssa
                             (get_local $$add$ptr$i$i$i)
                           )
-                          (br $while-out$73)
+                          (br $while-out69)
                         )
                       )
                     )
@@ -25760,7 +25760,7 @@
                   (set_local $$sp$0$i$i$i
                     (get_local $$187)
                   )
-                  (br $while-in$74)
+                  (br $while-in70)
                 )
               )
               (set_local $$add$ptr2$i$i
@@ -26024,8 +26024,8 @@
               (set_local $$p$0$i$i
                 (get_local $$add$ptr15$i$i)
               )
-              (loop $while-in$76
-                (block $while-out$75
+              (loop $while-in72
+                (block $while-out71
                   (set_local $$add$ptr24$i$i
                     (i32.add
                       (get_local $$p$0$i$i)
@@ -26053,9 +26053,9 @@
                     (set_local $$p$0$i$i
                       (get_local $$add$ptr24$i$i)
                     )
-                    (br $while-out$75)
+                    (br $while-out71)
                   )
-                  (br $while-in$76)
+                  (br $while-in72)
                 )
               )
               (set_local $$cmp28$i$i
@@ -26266,7 +26266,7 @@
                         (get_local $$bk55$i$i)
                         (get_local $$arrayidx$i$20$i)
                       )
-                      (br $do-once$44)
+                      (br $do-once40)
                     )
                   )
                   (set_local $$shr58$i$i
@@ -26541,7 +26541,7 @@
                         (get_local $$fd103$i$i)
                         (get_local $$119)
                       )
-                      (br $do-once$44)
+                      (br $do-once40)
                     )
                   )
                   (set_local $$200
@@ -26586,8 +26586,8 @@
                   (set_local $$T$0$i$i
                     (get_local $$200)
                   )
-                  (loop $while-in$78
-                    (block $while-out$77
+                  (loop $while-in74
+                    (block $while-out73
                       (set_local $$head118$i$i
                         (i32.add
                           (get_local $$T$0$i$i)
@@ -26620,7 +26620,7 @@
                           (set_local $label
                             (i32.const 307)
                           )
-                          (br $while-out$77)
+                          (br $while-out73)
                         )
                       )
                       (set_local $$shr123$i$i
@@ -26670,7 +26670,7 @@
                           (set_local $label
                             (i32.const 304)
                           )
-                          (br $while-out$77)
+                          (br $while-out73)
                         )
                         (block
                           (set_local $$K105$0$i$i
@@ -26681,7 +26681,7 @@
                           )
                         )
                       )
-                      (br $while-in$78)
+                      (br $while-in74)
                     )
                   )
                   (if
@@ -26739,7 +26739,7 @@
                             (get_local $$fd140$i$i)
                             (get_local $$119)
                           )
-                          (br $do-once$44)
+                          (br $do-once40)
                         )
                       )
                     )
@@ -26830,7 +26830,7 @@
                               (get_local $$parent162$i$i)
                               (i32.const 0)
                             )
-                            (br $do-once$44)
+                            (br $do-once40)
                           )
                           (call $_abort)
                         )
@@ -27382,7 +27382,7 @@
         (i32.const 0)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $$tobool9)
         (block
@@ -27477,7 +27477,7 @@
                   (set_local $$psize$1
                     (get_local $$add17)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (i32.store
@@ -27663,7 +27663,7 @@
                   (set_local $$psize$1
                     (get_local $$add17)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (set_local $$cmp50
@@ -27742,7 +27742,7 @@
               (set_local $$psize$1
                 (get_local $$add17)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $$parent
@@ -27773,7 +27773,7 @@
               (get_local $$add$ptr16)
             )
           )
-          (block $do-once$2
+          (block $do-once0
             (if
               (get_local $$cmp74)
               (block
@@ -27820,7 +27820,7 @@
                         (set_local $$R$3
                           (i32.const 0)
                         )
-                        (br $do-once$2)
+                        (br $do-once0)
                       )
                       (block
                         (set_local $$R$1
@@ -27841,8 +27841,8 @@
                     )
                   )
                 )
-                (loop $while-in$5
-                  (block $while-out$4
+                (loop $while-in
+                  (block $while-out
                     (set_local $$arrayidx108
                       (i32.add
                         (get_local $$R$1)
@@ -27871,7 +27871,7 @@
                         (set_local $$RP$1
                           (get_local $$arrayidx108)
                         )
-                        (br $while-in$5)
+                        (br $while-in)
                       )
                     )
                     (set_local $$arrayidx113
@@ -27900,7 +27900,7 @@
                         (set_local $$RP$1$lcssa
                           (get_local $$RP$1)
                         )
-                        (br $while-out$4)
+                        (br $while-out)
                       )
                       (block
                         (set_local $$R$1
@@ -27911,7 +27911,7 @@
                         )
                       )
                     )
-                    (br $while-in$5)
+                    (br $while-in)
                   )
                 )
                 (set_local $$cmp118
@@ -27931,7 +27931,7 @@
                     (set_local $$R$3
                       (get_local $$R$1$lcssa)
                     )
-                    (br $do-once$2)
+                    (br $do-once0)
                   )
                 )
               )
@@ -28011,7 +28011,7 @@
                     (set_local $$R$3
                       (get_local $$10)
                     )
-                    (br $do-once$2)
+                    (br $do-once0)
                   )
                   (call $_abort)
                 )
@@ -28115,7 +28115,7 @@
                       (set_local $$psize$1
                         (get_local $$add17)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -28186,7 +28186,7 @@
                       (set_local $$psize$1
                         (get_local $$add17)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -28233,7 +28233,7 @@
                   (i32.const 0)
                 )
               )
-              (block $do-once$6
+              (block $do-once2
                 (if
                   (i32.eqz
                     (get_local $$cmp173)
@@ -28269,7 +28269,7 @@
                           (get_local $$parent183)
                           (get_local $$R$3)
                         )
-                        (br $do-once$6)
+                        (br $do-once2)
                       )
                     )
                   )
@@ -28344,7 +28344,7 @@
                       (set_local $$psize$1
                         (get_local $$add17)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -28579,7 +28579,7 @@
             (i32.const 256)
           )
         )
-        (block $do-once$8
+        (block $do-once4
           (if
             (get_local $$cmp269)
             (block
@@ -28707,7 +28707,7 @@
                     (i32.const 176)
                     (get_local $$and301)
                   )
-                  (br $do-once$8)
+                  (br $do-once4)
                 )
               )
               (set_local $$cmp305
@@ -28815,7 +28815,7 @@
                   (get_local $$add$ptr6)
                 )
               )
-              (block $do-once$10
+              (block $do-once6
                 (if
                   (get_local $$cmp334)
                   (block
@@ -28862,7 +28862,7 @@
                             (set_local $$R332$3
                               (i32.const 0)
                             )
-                            (br $do-once$10)
+                            (br $do-once6)
                           )
                           (block
                             (set_local $$R332$1
@@ -28883,8 +28883,8 @@
                         )
                       )
                     )
-                    (loop $while-in$13
-                      (block $while-out$12
+                    (loop $while-in9
+                      (block $while-out8
                         (set_local $$arrayidx374
                           (i32.add
                             (get_local $$R332$1)
@@ -28913,7 +28913,7 @@
                             (set_local $$RP360$1
                               (get_local $$arrayidx374)
                             )
-                            (br $while-in$13)
+                            (br $while-in9)
                           )
                         )
                         (set_local $$arrayidx379
@@ -28942,7 +28942,7 @@
                             (set_local $$RP360$1$lcssa
                               (get_local $$RP360$1)
                             )
-                            (br $while-out$12)
+                            (br $while-out8)
                           )
                           (block
                             (set_local $$R332$1
@@ -28953,7 +28953,7 @@
                             )
                           )
                         )
-                        (br $while-in$13)
+                        (br $while-in9)
                       )
                     )
                     (set_local $$51
@@ -28978,7 +28978,7 @@
                         (set_local $$R332$3
                           (get_local $$R332$1$lcssa)
                         )
-                        (br $do-once$10)
+                        (br $do-once6)
                       )
                     )
                   )
@@ -29063,7 +29063,7 @@
                         (set_local $$R332$3
                           (get_local $$42)
                         )
-                        (br $do-once$10)
+                        (br $do-once6)
                       )
                       (call $_abort)
                     )
@@ -29155,7 +29155,7 @@
                             (i32.const 180)
                             (get_local $$and410)
                           )
-                          (br $do-once$8)
+                          (br $do-once4)
                         )
                       )
                     )
@@ -29219,7 +29219,7 @@
                       )
                       (if
                         (get_local $$cmp432)
-                        (br $do-once$8)
+                        (br $do-once4)
                       )
                     )
                   )
@@ -29265,7 +29265,7 @@
                       (i32.const 0)
                     )
                   )
-                  (block $do-once$14
+                  (block $do-once10
                     (if
                       (i32.eqz
                         (get_local $$cmp445)
@@ -29301,7 +29301,7 @@
                               (get_local $$parent455)
                               (get_local $$R332$3)
                             )
-                            (br $do-once$14)
+                            (br $do-once10)
                           )
                         )
                       )
@@ -29364,7 +29364,7 @@
                             (get_local $$parent471)
                             (get_local $$R332$3)
                           )
-                          (br $do-once$8)
+                          (br $do-once4)
                         )
                       )
                     )
@@ -29851,7 +29851,7 @@
         (i32.const 0)
       )
     )
-    (block $do-once$16
+    (block $do-once12
       (if
         (get_local $$tobool575)
         (block
@@ -29943,8 +29943,8 @@
           (set_local $$T$0
             (get_local $$67)
           )
-          (loop $while-in$19
-            (block $while-out$18
+          (loop $while-in15
+            (block $while-out14
               (set_local $$head591
                 (i32.add
                   (get_local $$T$0)
@@ -29977,7 +29977,7 @@
                   (set_local $label
                     (i32.const 130)
                   )
-                  (br $while-out$18)
+                  (br $while-out14)
                 )
               )
               (set_local $$shr596
@@ -30027,7 +30027,7 @@
                   (set_local $label
                     (i32.const 127)
                   )
-                  (br $while-out$18)
+                  (br $while-out14)
                 )
                 (block
                   (set_local $$K583$0
@@ -30038,7 +30038,7 @@
                   )
                 )
               )
-              (br $while-in$19)
+              (br $while-in15)
             )
           )
           (if
@@ -30096,7 +30096,7 @@
                     (get_local $$fd612)
                     (get_local $$p$1)
                   )
-                  (br $do-once$16)
+                  (br $do-once12)
                 )
               )
             )
@@ -30187,7 +30187,7 @@
                       (get_local $$parent635)
                       (i32.const 0)
                     )
-                    (br $do-once$16)
+                    (br $do-once12)
                   )
                   (call $_abort)
                 )
@@ -30225,8 +30225,8 @@
       )
       (return)
     )
-    (loop $while-in$21
-      (block $while-out$20
+    (loop $while-in17
+      (block $while-out16
         (set_local $$sp$0$i
           (i32.load
             (get_local $$sp$0$in$i)
@@ -30246,12 +30246,12 @@
         )
         (if
           (get_local $$cmp$i)
-          (br $while-out$20)
+          (br $while-out16)
           (set_local $$sp$0$in$i
             (get_local $$next4$i)
           )
         )
-        (br $while-in$21)
+        (br $while-in17)
       )
     )
     (i32.store
@@ -30410,8 +30410,8 @@
                 (get_local $unaligned)
               )
             )
-            (loop $while-in$1
-              (block $while-out$0
+            (loop $while-in
+              (block $while-out
                 (if
                   (i32.eqz
                     (i32.lt_s
@@ -30419,7 +30419,7 @@
                       (get_local $unaligned)
                     )
                   )
-                  (br $while-out$0)
+                  (br $while-out)
                 )
                 (block
                   (i32.store8
@@ -30433,13 +30433,13 @@
                     )
                   )
                 )
-                (br $while-in$1)
+                (br $while-in)
               )
             )
           )
         )
-        (loop $while-in$3
-          (block $while-out$2
+        (loop $while-in1
+          (block $while-out0
             (if
               (i32.eqz
                 (i32.lt_s
@@ -30447,7 +30447,7 @@
                   (get_local $stop4)
                 )
               )
-              (br $while-out$2)
+              (br $while-out0)
             )
             (block
               (i32.store
@@ -30461,13 +30461,13 @@
                 )
               )
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
     )
-    (loop $while-in$5
-      (block $while-out$4
+    (loop $while-in3
+      (block $while-out2
         (if
           (i32.eqz
             (i32.lt_s
@@ -30475,7 +30475,7 @@
               (get_local $stop)
             )
           )
-          (br $while-out$4)
+          (br $while-out2)
         )
         (block
           (i32.store8
@@ -30489,7 +30489,7 @@
             )
           )
         )
-        (br $while-in$5)
+        (br $while-in3)
       )
     )
     (return
@@ -30647,8 +30647,8 @@
         )
       )
       (block
-        (loop $while-in$1
-          (block $while-out$0
+        (loop $while-in
+          (block $while-out
             (if
               (i32.eqz
                 (i32.and
@@ -30656,7 +30656,7 @@
                   (i32.const 3)
                 )
               )
-              (br $while-out$0)
+              (br $while-out)
             )
             (block
               (if
@@ -30693,11 +30693,11 @@
                 )
               )
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
-        (loop $while-in$3
-          (block $while-out$2
+        (loop $while-in1
+          (block $while-out0
             (if
               (i32.eqz
                 (i32.ge_s
@@ -30705,7 +30705,7 @@
                   (i32.const 4)
                 )
               )
-              (br $while-out$2)
+              (br $while-out0)
             )
             (block
               (i32.store
@@ -30733,13 +30733,13 @@
                 )
               )
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
     )
-    (loop $while-in$5
-      (block $while-out$4
+    (loop $while-in3
+      (block $while-out2
         (if
           (i32.eqz
             (i32.gt_s
@@ -30747,7 +30747,7 @@
               (i32.const 0)
             )
           )
-          (br $while-out$4)
+          (br $while-out2)
         )
         (block
           (i32.store8
@@ -30775,7 +30775,7 @@
             )
           )
         )
-        (br $while-in$5)
+        (br $while-in3)
       )
     )
     (return

--- a/test/emcc_hello_world.fromasm.no-opts
+++ b/test/emcc_hello_world.fromasm.no-opts
@@ -403,11 +403,11 @@
         (i32.const 2047)
       )
     )
-    (block $switch$0
-      (block $switch-default$3
-        (block $switch-case$2
-          (block $switch-case$1
-            (br_table $switch-case$1 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-case$2 $switch-default$3
+    (block $switch
+      (block $switch-default
+        (block $switch-case0
+          (block $switch-case
+            (br_table $switch-case $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case0 $switch-default
               (i32.sub
                 (get_local $$conv)
                 (i32.const 0)
@@ -470,14 +470,14 @@
             (set_local $$retval$0
               (get_local $$x$addr$0)
             )
-            (br $switch$0)
+            (br $switch)
           )
         )
         (block
           (set_local $$retval$0
             (get_local $$x)
           )
-          (br $switch$0)
+          (br $switch)
         )
       )
       (block
@@ -573,8 +573,8 @@
     (set_local $$i$012
       (i32.const 0)
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (set_local $$arrayidx
           (i32.add
             (i32.const 687)
@@ -607,7 +607,7 @@
             (set_local $label
               (i32.const 2)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (set_local $$inc
@@ -634,13 +634,13 @@
             (set_local $label
               (i32.const 5)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
           (set_local $$i$012
             (get_local $$inc)
           )
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
     (if
@@ -679,16 +679,16 @@
         (get_local $label)
         (i32.const 5)
       )
-      (loop $while-in$3
-        (block $while-out$2
+      (loop $while-in1
+        (block $while-out0
           (set_local $label
             (i32.const 0)
           )
           (set_local $$s$1
             (get_local $$s$010)
           )
-          (loop $while-in$5
-            (block $while-out$4
+          (loop $while-in3
+            (block $while-out2
               (set_local $$1
                 (i32.load8_s
                   (get_local $$s$1)
@@ -718,13 +718,13 @@
                   (set_local $$incdec$ptr$lcssa
                     (get_local $$incdec$ptr)
                   )
-                  (br $while-out$4)
+                  (br $while-out2)
                 )
                 (set_local $$s$1
                   (get_local $$incdec$ptr)
                 )
               )
-              (br $while-in$5)
+              (br $while-in3)
             )
           )
           (set_local $$dec
@@ -745,7 +745,7 @@
               (set_local $$s$0$lcssa
                 (get_local $$incdec$ptr$lcssa)
               )
-              (br $while-out$2)
+              (br $while-out0)
             )
             (block
               (set_local $$i$111
@@ -759,7 +759,7 @@
               )
             )
           )
-          (br $while-in$3)
+          (br $while-in1)
         )
       )
     )
@@ -1221,7 +1221,7 @@
         (i32.const 0)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $$tobool)
         (block
@@ -1283,8 +1283,8 @@
               (set_local $$r$021
                 (get_local $$cond10)
               )
-              (loop $while-in$3
-                (block $while-out$2
+              (loop $while-in
+                (block $while-out
                   (set_local $$lock13
                     (i32.add
                       (get_local $$f$addr$022)
@@ -1405,7 +1405,7 @@
                       (set_local $$r$0$lcssa
                         (get_local $$r$1)
                       )
-                      (br $while-out$2)
+                      (br $while-out)
                     )
                     (block
                       (set_local $$f$addr$022
@@ -1416,7 +1416,7 @@
                       )
                     )
                   )
-                  (br $while-in$3)
+                  (br $while-in)
                 )
               )
             )
@@ -1459,7 +1459,7 @@
               (set_local $$retval$0
                 (get_local $$call1$18)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $$call
@@ -1757,8 +1757,8 @@
     (set_local $$rem$0
       (get_local $$add)
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (set_local $$2
           (i32.load
             (i32.const 16)
@@ -1882,7 +1882,7 @@
             (set_local $label
               (i32.const 6)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (set_local $$cmp17
@@ -1903,7 +1903,7 @@
             (set_local $label
               (i32.const 8)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (set_local $$sub26
@@ -2082,7 +2082,7 @@
         (set_local $$rem$0
           (get_local $$sub26)
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
     (if
@@ -2315,8 +2315,8 @@
         (i32.const 40)
       )
     )
-    (loop $do-in$1
-      (block $do-out$0
+    (loop $do-in
+      (block $do-out
         (i32.store
           (get_local $dest)
           (i32.const 0)
@@ -2327,7 +2327,7 @@
             (i32.const 4)
           )
         )
-        (br_if $do-in$1
+        (br_if $do-in
           (i32.lt_s
             (get_local $dest)
             (get_local $stop)
@@ -2894,8 +2894,8 @@
                 (set_local $$i$0
                   (get_local $$l)
                 )
-                (loop $while-in$3
-                  (block $while-out$2
+                (loop $while-in
+                  (block $while-out
                     (set_local $$tobool9
                       (i32.eq
                         (get_local $$i$0)
@@ -2955,13 +2955,13 @@
                         (set_local $$i$0$lcssa36
                           (get_local $$i$0)
                         )
-                        (br $while-out$2)
+                        (br $while-out)
                       )
                       (set_local $$i$0
                         (get_local $$sub)
                       )
                     )
-                    (br $while-in$3)
+                    (br $while-in)
                   )
                 )
                 (set_local $$write15
@@ -3343,7 +3343,7 @@
         (i32.const 0)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $$tobool)
         (set_local $$retval$0
@@ -3372,7 +3372,7 @@
               (set_local $$retval$0
                 (i32.const 1)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $$cmp2
@@ -3437,7 +3437,7 @@
               (set_local $$retval$0
                 (i32.const 2)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $$cmp9
@@ -3554,7 +3554,7 @@
               (set_local $$retval$0
                 (i32.const 3)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $$sub27
@@ -3693,7 +3693,7 @@
               (set_local $$retval$0
                 (i32.const 4)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
             (block
               (set_local $$call
@@ -3706,7 +3706,7 @@
               (set_local $$retval$0
                 (i32.const -1)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
         )
@@ -3864,8 +3864,8 @@
           (set_local $$s$044
             (get_local $$src)
           )
-          (loop $while-in$2
-            (block $while-out$1
+          (loop $while-in
+            (block $while-out
               (set_local $$2
                 (i32.load8_s
                   (get_local $$s$044)
@@ -3966,10 +3966,10 @@
                   (set_local $label
                     (i32.const 5)
                   )
-                  (br $while-out$1)
+                  (br $while-out)
                 )
               )
-              (br $while-in$2)
+              (br $while-in)
             )
           )
         )
@@ -4086,8 +4086,8 @@
                     (set_local $$w$034
                       (get_local $$s$0$lcssa60)
                     )
-                    (loop $while-in$6
-                      (block $while-out$5
+                    (loop $while-in3
+                      (block $while-out2
                         (set_local $$6
                           (i32.load
                             (get_local $$w$034)
@@ -4140,7 +4140,7 @@
                             (set_local $$w$034$lcssa
                               (get_local $$w$034)
                             )
-                            (br $while-out$5)
+                            (br $while-out2)
                           )
                         )
                         (set_local $$incdec$ptr21
@@ -4184,7 +4184,7 @@
                             (br $label$break$L11)
                           )
                         )
-                        (br $while-in$6)
+                        (br $while-in3)
                       )
                     )
                     (set_local $$n$addr$227
@@ -4241,8 +4241,8 @@
                   )
                 )
               )
-              (loop $while-in$8
-                (block $while-out$7
+              (loop $while-in5
+                (block $while-out4
                   (set_local $$7
                     (i32.load8_s
                       (get_local $$s$128)
@@ -4305,7 +4305,7 @@
                       (set_local $$s$2
                         (get_local $$incdec$ptr33)
                       )
-                      (br $while-out$7)
+                      (br $while-out4)
                     )
                     (block
                       (set_local $$n$addr$227
@@ -4316,7 +4316,7 @@
                       )
                     )
                   )
-                  (br $while-in$8)
+                  (br $while-in5)
                 )
               )
             )
@@ -5868,7 +5868,7 @@
             (i32.const -1)
           )
         )
-        (block $do-once$0
+        (block $do-once
           (if
             (get_local $$cmp)
             (block
@@ -5897,7 +5897,7 @@
                   (set_local $$cnt$1
                     (i32.const -1)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
                 (block
                   (set_local $$add
@@ -5909,7 +5909,7 @@
                   (set_local $$cnt$1
                     (get_local $$add)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
             )
@@ -5960,11 +5960,11 @@
         )
         (loop $label$continue$L9
           (block $label$break$L9
-            (block $switch$2
-              (block $switch-default$5
-                (block $switch-case$4
-                  (block $switch-case$3
-                    (br_table $switch-case$4 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-default$5 $switch-case$3 $switch-default$5
+            (block $switch
+              (block $switch-default
+                (block $switch-case0
+                  (block $switch-case
+                    (br_table $switch-case0 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case $switch-default
                       (i32.sub
                         (i32.shr_s
                           (i32.shl
@@ -5988,7 +5988,7 @@
                       (i32.const 9)
                     )
                     (br $label$break$L9)
-                    (br $switch$2)
+                    (br $switch)
                   )
                 )
                 (block
@@ -5999,7 +5999,7 @@
                     (get_local $$incdec$ptr169274)
                   )
                   (br $label$break$L9)
-                  (br $switch$2)
+                  (br $switch)
                 )
               )
               (nop)
@@ -6030,8 +6030,8 @@
               (get_local $label)
               (i32.const 9)
             )
-            (loop $while-in$8
-              (block $while-out$7
+            (loop $while-in
+              (block $while-out
                 (set_local $label
                   (i32.const 0)
                 )
@@ -6121,10 +6121,10 @@
                     (set_local $$z$0$lcssa
                       (get_local $$incdec$ptr23)
                     )
-                    (br $while-out$7)
+                    (br $while-out)
                   )
                 )
-                (br $while-in$8)
+                (br $while-in)
               )
             )
           )
@@ -6357,8 +6357,8 @@
               (set_local $$storemerge$186309
                 (get_local $$storemerge)
               )
-              (loop $while-in$11
-                (block $while-out$10
+              (loop $while-in4
+                (block $while-out3
                   (set_local $$sub54
                     (i32.add
                       (get_local $$conv48311)
@@ -6483,10 +6483,10 @@
                       (set_local $$storemerge$186282
                         (get_local $$incdec$ptr62)
                       )
-                      (br $while-out$10)
+                      (br $while-out3)
                     )
                   )
-                  (br $while-in$11)
+                  (br $while-in4)
                 )
               )
             )
@@ -6515,7 +6515,7 @@
             (i32.const 42)
           )
         )
-        (block $do-once$12
+        (block $do-once5
           (if
             (get_local $$cmp65)
             (block
@@ -6715,7 +6715,7 @@
                       (set_local $$w$1
                         (i32.const 0)
                       )
-                      (br $do-once$12)
+                      (br $do-once5)
                     )
                   )
                   (set_local $$arglist_current
@@ -6887,8 +6887,8 @@
                   (set_local $$isdigittmp8$i
                     (get_local $$isdigittmp$5$i)
                   )
-                  (loop $while-in$15
-                    (block $while-out$14
+                  (loop $while-in8
+                    (block $while-out7
                       (set_local $$mul$i
                         (i32.mul
                           (get_local $$i$07$i)
@@ -6953,10 +6953,10 @@
                           (set_local $$incdec$ptr$i$lcssa
                             (get_local $$incdec$ptr$i)
                           )
-                          (br $while-out$14)
+                          (br $while-out7)
                         )
                       )
-                      (br $while-in$15)
+                      (br $while-in8)
                     )
                   )
                   (set_local $$cmp105
@@ -7100,8 +7100,8 @@
                       (br $label$break$L46)
                     )
                   )
-                  (loop $while-in$18
-                    (block $while-out$17
+                  (loop $while-in11
+                    (block $while-out10
                       (set_local $$mul$i$202
                         (i32.mul
                           (get_local $$i$07$i$201)
@@ -7169,7 +7169,7 @@
                           (br $label$break$L46)
                         )
                       )
-                      (br $while-in$18)
+                      (br $while-in11)
                     )
                   )
                 )
@@ -7446,8 +7446,8 @@
         (set_local $$st$0
           (i32.const 0)
         )
-        (loop $while-in$20
-          (block $while-out$19
+        (loop $while-in13
+          (block $while-out12
             (set_local $$51
               (i32.load8_s
                 (get_local $$incdec$ptr169271)
@@ -7550,10 +7550,10 @@
                 (set_local $$st$0$lcssa415
                   (get_local $$st$0)
                 )
-                (br $while-out$19)
+                (br $while-out12)
               )
             )
-            (br $while-in$20)
+            (br $while-in13)
           )
         )
         (set_local $$tobool178
@@ -7595,7 +7595,7 @@
             (i32.const -1)
           )
         )
-        (block $do-once$21
+        (block $do-once14
           (if
             (get_local $$cmp181)
             (if
@@ -7687,7 +7687,7 @@
                   (set_local $label
                     (i32.const 52)
                   )
-                  (br $do-once$21)
+                  (br $do-once14)
                 )
               )
               (if
@@ -7817,30 +7817,30 @@
           )
         )
         (block $label$break$L75
-          (block $switch$24
-            (block $switch-default$127
-              (block $switch-case$126
-                (block $switch-case$55
-                  (block $switch-case$54
-                    (block $switch-case$53
-                      (block $switch-case$52
-                        (block $switch-case$51
-                          (block $switch-case$50
-                            (block $switch-case$49
-                              (block $switch-case$48
-                                (block $switch-case$47
-                                  (block $switch-case$46
-                                    (block $switch-case$45
-                                      (block $switch-case$44
-                                        (block $switch-case$43
-                                          (block $switch-case$42
-                                            (block $switch-case$41
-                                              (block $switch-case$40
-                                                (block $switch-case$37
-                                                  (block $switch-case$36
-                                                    (block $switch-case$35
-                                                      (block $switch-case$34
-                                                        (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$52 $switch-case$51 $switch-case$50 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$53 $switch-default$127 $switch-case$44 $switch-case$42 $switch-case$126 $switch-case$55 $switch-case$54 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$37 $switch-default$127
+          (block $switch17
+            (block $switch-default120
+              (block $switch-case119
+                (block $switch-case48
+                  (block $switch-case47
+                    (block $switch-case46
+                      (block $switch-case45
+                        (block $switch-case44
+                          (block $switch-case43
+                            (block $switch-case42
+                              (block $switch-case41
+                                (block $switch-case40
+                                  (block $switch-case39
+                                    (block $switch-case38
+                                      (block $switch-case37
+                                        (block $switch-case36
+                                          (block $switch-case35
+                                            (block $switch-case34
+                                              (block $switch-case33
+                                                (block $switch-case30
+                                                  (block $switch-case29
+                                                    (block $switch-case28
+                                                      (block $switch-case27
+                                                        (br_table $switch-case42 $switch-default120 $switch-case40 $switch-default120 $switch-case45 $switch-case44 $switch-case43 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case29 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case46 $switch-default120 $switch-case37 $switch-case35 $switch-case119 $switch-case48 $switch-case47 $switch-default120 $switch-case34 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case30 $switch-default120
                                                           (i32.sub
                                                             (get_local $$t$0)
                                                             (i32.const 65)
@@ -7848,16 +7848,16 @@
                                                         )
                                                       )
                                                       (block
-                                                        (block $switch$25
-                                                          (block $switch-default$33
-                                                            (block $switch-case$32
-                                                              (block $switch-case$31
-                                                                (block $switch-case$30
-                                                                  (block $switch-case$29
-                                                                    (block $switch-case$28
-                                                                      (block $switch-case$27
-                                                                        (block $switch-case$26
-                                                                          (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
+                                                        (block $switch18
+                                                          (block $switch-default26
+                                                            (block $switch-case25
+                                                              (block $switch-case24
+                                                                (block $switch-case23
+                                                                  (block $switch-case22
+                                                                    (block $switch-case21
+                                                                      (block $switch-case20
+                                                                        (block $switch-case19
+                                                                          (br_table $switch-case19 $switch-case20 $switch-case21 $switch-case22 $switch-case23 $switch-default26 $switch-case24 $switch-case25 $switch-default26
                                                                             (i32.sub
                                                                               (get_local $$st$0$lcssa415)
                                                                               (i32.const 0)
@@ -7887,7 +7887,7 @@
                                                                             (get_local $$l10n$3)
                                                                           )
                                                                           (br $label$continue$L1)
-                                                                          (br $switch$25)
+                                                                          (br $switch18)
                                                                         )
                                                                       )
                                                                       (block
@@ -7913,7 +7913,7 @@
                                                                           (get_local $$l10n$3)
                                                                         )
                                                                         (br $label$continue$L1)
-                                                                        (br $switch$25)
+                                                                        (br $switch18)
                                                                       )
                                                                     )
                                                                     (block
@@ -7973,7 +7973,7 @@
                                                                         (get_local $$l10n$3)
                                                                       )
                                                                       (br $label$continue$L1)
-                                                                      (br $switch$25)
+                                                                      (br $switch18)
                                                                     )
                                                                   )
                                                                   (block
@@ -8005,7 +8005,7 @@
                                                                       (get_local $$l10n$3)
                                                                     )
                                                                     (br $label$continue$L1)
-                                                                    (br $switch$25)
+                                                                    (br $switch18)
                                                                   )
                                                                 )
                                                                 (block
@@ -8037,7 +8037,7 @@
                                                                     (get_local $$l10n$3)
                                                                   )
                                                                   (br $label$continue$L1)
-                                                                  (br $switch$25)
+                                                                  (br $switch18)
                                                                 )
                                                               )
                                                               (block
@@ -8063,7 +8063,7 @@
                                                                   (get_local $$l10n$3)
                                                                 )
                                                                 (br $label$continue$L1)
-                                                                (br $switch$25)
+                                                                (br $switch18)
                                                               )
                                                             )
                                                             (block
@@ -8123,7 +8123,7 @@
                                                                 (get_local $$l10n$3)
                                                               )
                                                               (br $label$continue$L1)
-                                                              (br $switch$25)
+                                                              (br $switch18)
                                                             )
                                                           )
                                                           (block
@@ -8142,7 +8142,7 @@
                                                             (br $label$continue$L1)
                                                           )
                                                         )
-                                                        (br $switch$24)
+                                                        (br $switch17)
                                                       )
                                                     )
                                                     (block
@@ -8177,7 +8177,7 @@
                                                       (set_local $label
                                                         (i32.const 64)
                                                       )
-                                                      (br $switch$24)
+                                                      (br $switch17)
                                                     )
                                                   )
                                                   (nop)
@@ -8195,7 +8195,7 @@
                                                   (set_local $label
                                                     (i32.const 64)
                                                   )
-                                                  (br $switch$24)
+                                                  (br $switch17)
                                                 )
                                               )
                                               (block
@@ -8257,8 +8257,8 @@
                                                     (set_local $$s$addr$06$i$221
                                                       (get_local $$add$ptr205)
                                                     )
-                                                    (loop $while-in$39
-                                                      (block $while-out$38
+                                                    (loop $while-in32
+                                                      (block $while-out31
                                                         (set_local $$125
                                                           (i32.and
                                                             (get_local $$126)
@@ -8321,7 +8321,7 @@
                                                             (set_local $$s$addr$0$lcssa$i$229
                                                               (get_local $$incdec$ptr$i$225)
                                                             )
-                                                            (br $while-out$38)
+                                                            (br $while-out31)
                                                           )
                                                           (block
                                                             (set_local $$126
@@ -8335,7 +8335,7 @@
                                                             )
                                                           )
                                                         )
-                                                        (br $while-in$39)
+                                                        (br $while-in32)
                                                       )
                                                     )
                                                   )
@@ -8423,7 +8423,7 @@
                                                     )
                                                   )
                                                 )
-                                                (br $switch$24)
+                                                (br $switch17)
                                               )
                                             )
                                             (nop)
@@ -8583,7 +8583,7 @@
                                                 )
                                               )
                                             )
-                                            (br $switch$24)
+                                            (br $switch17)
                                           )
                                         )
                                         (block
@@ -8627,7 +8627,7 @@
                                           (set_local $label
                                             (i32.const 76)
                                           )
-                                          (br $switch$24)
+                                          (br $switch17)
                                         )
                                       )
                                       (block
@@ -8684,7 +8684,7 @@
                                         (set_local $$z$2
                                           (get_local $$add$ptr205)
                                         )
-                                        (br $switch$24)
+                                        (br $switch17)
                                       )
                                     )
                                     (block
@@ -8707,7 +8707,7 @@
                                       (set_local $label
                                         (i32.const 82)
                                       )
-                                      (br $switch$24)
+                                      (br $switch17)
                                     )
                                   )
                                   (block
@@ -8735,7 +8735,7 @@
                                     (set_local $label
                                       (i32.const 82)
                                     )
-                                    (br $switch$24)
+                                    (br $switch17)
                                   )
                                 )
                                 (block
@@ -8782,7 +8782,7 @@
                                   (set_local $label
                                     (i32.const 86)
                                   )
-                                  (br $switch$24)
+                                  (br $switch17)
                                 )
                               )
                               (block
@@ -8818,7 +8818,7 @@
                                     )
                                   )
                                 )
-                                (br $switch$24)
+                                (br $switch17)
                               )
                             )
                             (nop)
@@ -8998,7 +8998,7 @@
                     (get_local $$191)
                   )
                 )
-                (block $do-once$56
+                (block $do-once49
                   (if
                     (get_local $$192)
                     (block
@@ -9110,7 +9110,7 @@
                               (get_local $$tobool76552$i)
                             )
                           )
-                          (block $do-once$58
+                          (block $do-once51
                             (if
                               (get_local $$tobool76$i)
                               (set_local $$y$addr$1$i
@@ -9123,8 +9123,8 @@
                                 (set_local $$round$0481$i
                                   (f64.const 8)
                                 )
-                                (loop $while-in$61
-                                  (block $while-out$60
+                                (loop $while-in54
+                                  (block $while-out53
                                     (set_local $$dec78$i
                                       (i32.add
                                         (get_local $$re$1482$i)
@@ -9149,7 +9149,7 @@
                                         (set_local $$mul80$i$lcssa
                                           (get_local $$mul80$i)
                                         )
-                                        (br $while-out$60)
+                                        (br $while-out53)
                                       )
                                       (block
                                         (set_local $$re$1482$i
@@ -9160,7 +9160,7 @@
                                         )
                                       )
                                     )
-                                    (br $while-in$61)
+                                    (br $while-in54)
                                   )
                                 )
                                 (set_local $$197
@@ -9208,7 +9208,7 @@
                                     (set_local $$y$addr$1$i
                                       (get_local $$sub88$i)
                                     )
-                                    (br $do-once$58)
+                                    (br $do-once51)
                                   )
                                   (block
                                     (set_local $$add90$i
@@ -9226,7 +9226,7 @@
                                     (set_local $$y$addr$1$i
                                       (get_local $$sub91$i)
                                     )
-                                    (br $do-once$58)
+                                    (br $do-once51)
                                   )
                                 )
                               )
@@ -9379,8 +9379,8 @@
                           (set_local $$y$addr$2$i
                             (get_local $$y$addr$1$i)
                           )
-                          (loop $while-in$63
-                            (block $while-out$62
+                          (loop $while-in56
+                            (block $while-out55
                               (set_local $$conv116$i
                                 (call $f64-to-int
                                   (get_local $$y$addr$2$i)
@@ -9457,7 +9457,7 @@
                                   (i32.const 1)
                                 )
                               )
-                              (block $do-once$64
+                              (block $do-once57
                                 (if
                                   (get_local $$cmp127$i)
                                   (block
@@ -9485,7 +9485,7 @@
                                         (set_local $$s$1$i
                                           (get_local $$incdec$ptr122$i)
                                         )
-                                        (br $do-once$64)
+                                        (br $do-once57)
                                       )
                                     )
                                     (set_local $$incdec$ptr137$i
@@ -9527,10 +9527,10 @@
                                   (set_local $$s$1$i$lcssa
                                     (get_local $$s$1$i)
                                   )
-                                  (br $while-out$62)
+                                  (br $while-out55)
                                 )
                               )
-                              (br $while-in$63)
+                              (br $while-in56)
                             )
                           )
                           (set_local $$tobool140$i
@@ -9767,7 +9767,7 @@
                           (set_local $$retval$0$i
                             (get_local $$w$add165$i)
                           )
-                          (br $do-once$56)
+                          (br $do-once49)
                         )
                       )
                       (set_local $$cmp196$i
@@ -9850,8 +9850,8 @@
                       (set_local $$z$0$i
                         (get_local $$arraydecay208$add$ptr213$i)
                       )
-                      (loop $while-in$67
-                        (block $while-out$66
+                      (loop $while-in60
+                        (block $while-out59
                           (set_local $$conv216$i
                             (call $f64-to-int
                               (get_local $$y$addr$4$i)
@@ -9904,10 +9904,10 @@
                               (set_local $$incdec$ptr217$i$lcssa
                                 (get_local $$incdec$ptr217$i)
                               )
-                              (br $while-out$66)
+                              (br $while-out59)
                             )
                           )
-                          (br $while-in$67)
+                          (br $while-in60)
                         )
                       )
                       (set_local $$$pr$i
@@ -9933,8 +9933,8 @@
                           (set_local $$z$1548$i
                             (get_local $$incdec$ptr217$i$lcssa)
                           )
-                          (loop $while-in$69
-                            (block $while-out$68
+                          (loop $while-in62
+                            (block $while-out61
                               (set_local $$cmp228$i
                                 (i32.gt_s
                                   (get_local $$211)
@@ -9960,7 +9960,7 @@
                                   (get_local $$a$1549$i)
                                 )
                               )
-                              (block $do-once$70
+                              (block $do-once63
                                 (if
                                   (get_local $$cmp235$543$i)
                                   (set_local $$a$2$ph$i
@@ -9973,8 +9973,8 @@
                                     (set_local $$d$0545$i
                                       (get_local $$d$0$542$i)
                                     )
-                                    (loop $while-in$73
-                                      (block $while-out$72
+                                    (loop $while-in66
+                                      (block $while-out65
                                         (set_local $$212
                                           (i32.load
                                             (get_local $$d$0545$i)
@@ -10045,7 +10045,7 @@
                                             (set_local $$conv242$i$lcssa
                                               (get_local $$219)
                                             )
-                                            (br $while-out$72)
+                                            (br $while-out65)
                                           )
                                           (block
                                             (set_local $$carry$0544$i
@@ -10056,7 +10056,7 @@
                                             )
                                           )
                                         )
-                                        (br $while-in$73)
+                                        (br $while-in66)
                                       )
                                     )
                                     (set_local $$tobool244$i
@@ -10071,7 +10071,7 @@
                                         (set_local $$a$2$ph$i
                                           (get_local $$a$1549$i)
                                         )
-                                        (br $do-once$70)
+                                        (br $do-once63)
                                       )
                                     )
                                     (set_local $$incdec$ptr246$i
@@ -10093,8 +10093,8 @@
                               (set_local $$z$2$i
                                 (get_local $$z$1548$i)
                               )
-                              (loop $while-in$75
-                                (block $while-out$74
+                              (loop $while-in68
+                                (block $while-out67
                                   (set_local $$cmp249$i
                                     (i32.gt_u
                                       (get_local $$z$2$i)
@@ -10109,7 +10109,7 @@
                                       (set_local $$z$2$i$lcssa
                                         (get_local $$z$2$i)
                                       )
-                                      (br $while-out$74)
+                                      (br $while-out67)
                                     )
                                   )
                                   (set_local $$arrayidx251$i
@@ -10138,10 +10138,10 @@
                                       (set_local $$z$2$i$lcssa
                                         (get_local $$z$2$i)
                                       )
-                                      (br $while-out$74)
+                                      (br $while-out67)
                                     )
                                   )
-                                  (br $while-in$75)
+                                  (br $while-in68)
                                 )
                               )
                               (set_local $$222
@@ -10188,10 +10188,10 @@
                                   (set_local $$z$1$lcssa$i
                                     (get_local $$z$2$i$lcssa)
                                   )
-                                  (br $while-out$68)
+                                  (br $while-out61)
                                 )
                               )
-                              (br $while-in$69)
+                              (br $while-in62)
                             )
                           )
                         )
@@ -10252,8 +10252,8 @@
                           (set_local $$z$3538$i
                             (get_local $$z$1$lcssa$i)
                           )
-                          (loop $while-in$77
-                            (block $while-out$76
+                          (loop $while-in70
+                            (block $while-out69
                               (set_local $$sub264$i
                                 (i32.sub
                                   (i32.const 0)
@@ -10279,7 +10279,7 @@
                                   (get_local $$z$3538$i)
                                 )
                               )
-                              (block $do-once$78
+                              (block $do-once71
                                 (if
                                   (get_local $$cmp277$533$i)
                                   (block
@@ -10307,8 +10307,8 @@
                                     (set_local $$d$1534$i
                                       (get_local $$a$3539$i)
                                     )
-                                    (loop $while-in$81
-                                      (block $while-out$80
+                                    (loop $while-in74
+                                      (block $while-out73
                                         (set_local $$225
                                           (i32.load
                                             (get_local $$d$1534$i)
@@ -10368,10 +10368,10 @@
                                             (set_local $$mul286$i$lcssa
                                               (get_local $$mul286$i)
                                             )
-                                            (br $while-out$80)
+                                            (br $while-out73)
                                           )
                                         )
-                                        (br $while-in$81)
+                                        (br $while-in74)
                                       )
                                     )
                                     (set_local $$226
@@ -10413,7 +10413,7 @@
                                         (set_local $$z$4$i
                                           (get_local $$z$3538$i)
                                         )
-                                        (br $do-once$78)
+                                        (br $do-once71)
                                       )
                                     )
                                     (set_local $$incdec$ptr296$i
@@ -10555,10 +10555,10 @@
                                   (set_local $$z$3$lcssa$i
                                     (get_local $$add$ptr311$z$4$i)
                                   )
-                                  (br $while-out$76)
+                                  (br $while-out69)
                                 )
                               )
-                              (br $while-in$77)
+                              (br $while-in70)
                             )
                           )
                         )
@@ -10577,7 +10577,7 @@
                           (get_local $$z$3$lcssa$i)
                         )
                       )
-                      (block $do-once$82
+                      (block $do-once75
                         (if
                           (get_local $$cmp315$i)
                           (block
@@ -10619,7 +10619,7 @@
                                 (set_local $$e$1$i
                                   (get_local $$mul322$i)
                                 )
-                                (br $do-once$82)
+                                (br $do-once75)
                               )
                               (block
                                 (set_local $$e$0531$i
@@ -10630,8 +10630,8 @@
                                 )
                               )
                             )
-                            (loop $while-in$85
-                              (block $while-out$84
+                            (loop $while-in78
+                              (block $while-out77
                                 (set_local $$mul328$i
                                   (i32.mul
                                     (get_local $$i$0530$i)
@@ -10656,7 +10656,7 @@
                                     (set_local $$e$1$i
                                       (get_local $$inc$i)
                                     )
-                                    (br $while-out$84)
+                                    (br $while-out77)
                                   )
                                   (block
                                     (set_local $$e$0531$i
@@ -10667,7 +10667,7 @@
                                     )
                                   )
                                 )
-                                (br $while-in$85)
+                                (br $while-in78)
                               )
                             )
                           )
@@ -10830,8 +10830,8 @@
                               (set_local $$j$0527$i
                                 (get_local $$j$0$524$i)
                               )
-                              (loop $while-in$87
-                                (block $while-out$86
+                              (loop $while-in80
+                                (block $while-out79
                                   (set_local $$mul367$i
                                     (i32.mul
                                       (get_local $$i$1526$i)
@@ -10856,7 +10856,7 @@
                                       (set_local $$i$1$lcssa$i
                                         (get_local $$mul367$i)
                                       )
-                                      (br $while-out$86)
+                                      (br $while-out79)
                                     )
                                     (block
                                       (set_local $$i$1526$i
@@ -10867,7 +10867,7 @@
                                       )
                                     )
                                   )
-                                  (br $while-in$87)
+                                  (br $while-in80)
                                 )
                               )
                             )
@@ -10913,7 +10913,7 @@
                               (get_local $$tobool371$i)
                             )
                           )
-                          (block $do-once$88
+                          (block $do-once81
                             (if
                               (get_local $$or$cond395$i)
                               (block
@@ -11007,7 +11007,7 @@
                                     (i32.const 0)
                                   )
                                 )
-                                (block $do-once$90
+                                (block $do-once83
                                   (if
                                     (get_local $$tobool400$i)
                                     (block
@@ -11047,7 +11047,7 @@
                                           (set_local $$small$1$i
                                             (get_local $$small$0$i)
                                           )
-                                          (br $do-once$90)
+                                          (br $do-once83)
                                         )
                                       )
                                       (set_local $$mul406$i
@@ -11105,7 +11105,7 @@
                                     (set_local $$e$4$i
                                       (get_local $$e$1$i)
                                     )
-                                    (br $do-once$88)
+                                    (br $do-once81)
                                   )
                                 )
                                 (set_local $$add414$i
@@ -11133,8 +11133,8 @@
                                     (set_local $$d$2520$i
                                       (get_local $$add$ptr358$i)
                                     )
-                                    (loop $while-in$93
-                                      (block $while-out$92
+                                    (loop $while-in86
+                                      (block $while-out85
                                         (set_local $$incdec$ptr419$i
                                           (i32.add
                                             (get_local $$d$2520$i)
@@ -11210,10 +11210,10 @@
                                             (set_local $$d$2$lcssa$i
                                               (get_local $$incdec$ptr419$i)
                                             )
-                                            (br $while-out$92)
+                                            (br $while-out85)
                                           )
                                         )
-                                        (br $while-in$93)
+                                        (br $while-in86)
                                       )
                                     )
                                   )
@@ -11270,7 +11270,7 @@
                                     (set_local $$e$4$i
                                       (get_local $$mul431$i)
                                     )
-                                    (br $do-once$88)
+                                    (br $do-once81)
                                   )
                                   (block
                                     (set_local $$e$2517$i
@@ -11281,8 +11281,8 @@
                                     )
                                   )
                                 )
-                                (loop $while-in$95
-                                  (block $while-out$94
+                                (loop $while-in88
+                                  (block $while-out87
                                     (set_local $$mul437$i
                                       (i32.mul
                                         (get_local $$i$2516$i)
@@ -11313,7 +11313,7 @@
                                         (set_local $$e$4$i
                                           (get_local $$inc438$i)
                                         )
-                                        (br $while-out$94)
+                                        (br $while-out87)
                                       )
                                       (block
                                         (set_local $$e$2517$i
@@ -11324,7 +11324,7 @@
                                         )
                                       )
                                     )
-                                    (br $while-in$95)
+                                    (br $while-in88)
                                   )
                                 )
                               )
@@ -11380,8 +11380,8 @@
                       (set_local $$z$7$i
                         (get_local $$z$7$ph$i)
                       )
-                      (loop $while-in$97
-                        (block $while-out$96
+                      (loop $while-in90
+                        (block $while-out89
                           (set_local $$cmp450$i
                             (i32.gt_u
                               (get_local $$z$7$i)
@@ -11399,7 +11399,7 @@
                               (set_local $$z$7$i$lcssa
                                 (get_local $$z$7$i)
                               )
-                              (br $while-out$96)
+                              (br $while-out89)
                             )
                           )
                           (set_local $$arrayidx453$i
@@ -11431,13 +11431,13 @@
                               (set_local $$z$7$i$lcssa
                                 (get_local $$z$7$i)
                               )
-                              (br $while-out$96)
+                              (br $while-out89)
                             )
                           )
-                          (br $while-in$97)
+                          (br $while-in90)
                         )
                       )
-                      (block $do-once$98
+                      (block $do-once91
                         (if
                           (get_local $$cmp338$i)
                           (block
@@ -11552,10 +11552,10 @@
                                 (set_local $$t$addr$1$i
                                   (get_local $$t$addr$0$i)
                                 )
-                                (br $do-once$98)
+                                (br $do-once91)
                               )
                             )
-                            (block $do-once$100
+                            (block $do-once93
                               (if
                                 (get_local $$cmp450$lcssa$i)
                                 (block
@@ -11582,7 +11582,7 @@
                                       (set_local $$j$2$i
                                         (i32.const 9)
                                       )
-                                      (br $do-once$100)
+                                      (br $do-once93)
                                     )
                                   )
                                   (set_local $$rem494$510$i
@@ -11614,11 +11614,11 @@
                                       (set_local $$j$2$i
                                         (i32.const 0)
                                       )
-                                      (br $do-once$100)
+                                      (br $do-once93)
                                     )
                                   )
-                                  (loop $while-in$103
-                                    (block $while-out$102
+                                  (loop $while-in96
+                                    (block $while-out95
                                       (set_local $$mul499$i
                                         (i32.mul
                                           (get_local $$i$3512$i)
@@ -11660,10 +11660,10 @@
                                           (set_local $$j$2$i
                                             (get_local $$inc500$i)
                                           )
-                                          (br $while-out$102)
+                                          (br $while-out95)
                                         )
                                       )
-                                      (br $while-in$103)
+                                      (br $while-in96)
                                     )
                                   )
                                 )
@@ -11755,7 +11755,7 @@
                                 (set_local $$t$addr$1$i
                                   (get_local $$t$addr$0$i)
                                 )
-                                (br $do-once$98)
+                                (br $do-once91)
                               )
                               (block
                                 (set_local $$add561$i
@@ -11805,7 +11805,7 @@
                                 (set_local $$t$addr$1$i
                                   (get_local $$t$addr$0$i)
                                 )
-                                (br $do-once$98)
+                                (br $do-once91)
                               )
                             )
                           )
@@ -11938,8 +11938,8 @@
                               (set_local $$estr$1507$i
                                 (get_local $$243)
                               )
-                              (loop $while-in$105
-                                (block $while-out$104
+                              (loop $while-in98
+                                (block $while-out97
                                   (set_local $$incdec$ptr639$i
                                     (i32.add
                                       (get_local $$estr$1507$i)
@@ -11974,10 +11974,10 @@
                                       (set_local $$estr$1$lcssa$i
                                         (get_local $$incdec$ptr639$i)
                                       )
-                                      (br $while-out$104)
+                                      (br $while-out97)
                                     )
                                   )
-                                  (br $while-in$105)
+                                  (br $while-in98)
                                 )
                               )
                             )
@@ -12123,7 +12123,7 @@
                         (get_local $$add653$i)
                         (get_local $$xor655$i)
                       )
-                      (block $do-once$106
+                      (block $do-once99
                         (if
                           (get_local $$cmp614$i)
                           (block
@@ -12143,8 +12143,8 @@
                             (set_local $$d$5494$i
                               (get_local $$r$0$a$9$i)
                             )
-                            (loop $while-in$109
-                              (block $while-out$108
+                            (loop $while-in102
+                              (block $while-out101
                                 (set_local $$248
                                   (i32.load
                                     (get_local $$d$5494$i)
@@ -12163,7 +12163,7 @@
                                     (get_local $$r$0$a$9$i)
                                   )
                                 )
-                                (block $do-once$110
+                                (block $do-once103
                                   (if
                                     (get_local $$cmp673$i)
                                     (block
@@ -12181,7 +12181,7 @@
                                           (set_local $$s668$1$i
                                             (get_local $$249)
                                           )
-                                          (br $do-once$110)
+                                          (br $do-once103)
                                         )
                                       )
                                       (i32.store8
@@ -12208,11 +12208,11 @@
                                           (set_local $$s668$1$i
                                             (get_local $$249)
                                           )
-                                          (br $do-once$110)
+                                          (br $do-once103)
                                         )
                                       )
-                                      (loop $while-in$113
-                                        (block $while-out$112
+                                      (loop $while-in106
+                                        (block $while-out105
                                           (set_local $$incdec$ptr681$i
                                             (i32.add
                                               (get_local $$s668$0492$i)
@@ -12238,10 +12238,10 @@
                                               (set_local $$s668$1$i
                                                 (get_local $$incdec$ptr681$i)
                                               )
-                                              (br $while-out$112)
+                                              (br $while-out105)
                                             )
                                           )
-                                          (br $while-in$113)
+                                          (br $while-in106)
                                         )
                                       )
                                     )
@@ -12303,13 +12303,13 @@
                                     (set_local $$incdec$ptr698$i$lcssa
                                       (get_local $$incdec$ptr698$i)
                                     )
-                                    (br $while-out$108)
+                                    (br $while-out101)
                                   )
                                   (set_local $$d$5494$i
                                     (get_local $$incdec$ptr698$i)
                                   )
                                 )
-                                (br $while-in$109)
+                                (br $while-in102)
                               )
                             )
                             (set_local $$251
@@ -12318,7 +12318,7 @@
                                 (i32.const 0)
                               )
                             )
-                            (block $do-once$114
+                            (block $do-once107
                               (if
                                 (i32.eqz
                                   (get_local $$251)
@@ -12345,7 +12345,7 @@
                                     (i32.eqz
                                       (get_local $$tobool$i$449$i)
                                     )
-                                    (br $do-once$114)
+                                    (br $do-once107)
                                   )
                                   (drop
                                     (call $___fwritex
@@ -12384,8 +12384,8 @@
                                 (set_local $$p$addr$4489$i
                                   (get_local $$p$addr$3$i)
                                 )
-                                (loop $while-in$117
-                                  (block $while-out$116
+                                (loop $while-in110
+                                  (block $while-out109
                                     (set_local $$254
                                       (i32.load
                                         (get_local $$d$6488$i)
@@ -12410,8 +12410,8 @@
                                         (set_local $$s715$0484$i
                                           (get_local $$255)
                                         )
-                                        (loop $while-in$119
-                                          (block $while-out$118
+                                        (loop $while-in112
+                                          (block $while-out111
                                             (set_local $$incdec$ptr725$i
                                               (i32.add
                                                 (get_local $$s715$0484$i)
@@ -12437,10 +12437,10 @@
                                                 (set_local $$s715$0$lcssa$i
                                                   (get_local $$incdec$ptr725$i)
                                                 )
-                                                (br $while-out$118)
+                                                (br $while-out111)
                                               )
                                             )
-                                            (br $while-in$119)
+                                            (br $while-in112)
                                           )
                                         )
                                       )
@@ -12534,10 +12534,10 @@
                                         (set_local $$p$addr$4$lcssa$i
                                           (get_local $$sub735$i)
                                         )
-                                        (br $while-out$116)
+                                        (br $while-out109)
                                       )
                                     )
-                                    (br $while-in$117)
+                                    (br $while-in110)
                                   )
                                 )
                               )
@@ -12594,8 +12594,8 @@
                                 (set_local $$p$addr$5501$i
                                   (get_local $$p$addr$3$i)
                                 )
-                                (loop $while-in$121
-                                  (block $while-out$120
+                                (loop $while-in114
+                                  (block $while-out113
                                     (set_local $$258
                                       (i32.load
                                         (get_local $$d$7500$i)
@@ -12635,7 +12635,7 @@
                                         (get_local $$a$9$ph$i)
                                       )
                                     )
-                                    (block $do-once$122
+                                    (block $do-once115
                                       (if
                                         (get_local $$cmp765$i)
                                         (block
@@ -12690,7 +12690,7 @@
                                               (set_local $$s753$2$i
                                                 (get_local $$incdec$ptr776$i)
                                               )
-                                              (br $do-once$122)
+                                              (br $do-once115)
                                             )
                                           )
                                           (set_local $$261
@@ -12718,7 +12718,7 @@
                                               (set_local $$s753$2$i
                                                 (get_local $$incdec$ptr776$i)
                                               )
-                                              (br $do-once$122)
+                                              (br $do-once115)
                                             )
                                           )
                                           (drop
@@ -12748,11 +12748,11 @@
                                               (set_local $$s753$2$i
                                                 (get_local $$s753$0$i)
                                               )
-                                              (br $do-once$122)
+                                              (br $do-once115)
                                             )
                                           )
-                                          (loop $while-in$125
-                                            (block $while-out$124
+                                          (loop $while-in118
+                                            (block $while-out117
                                               (set_local $$incdec$ptr773$i
                                                 (i32.add
                                                   (get_local $$s753$1496$i)
@@ -12778,10 +12778,10 @@
                                                   (set_local $$s753$2$i
                                                     (get_local $$incdec$ptr773$i)
                                                   )
-                                                  (br $while-out$124)
+                                                  (br $while-out117)
                                                 )
                                               )
-                                              (br $while-in$125)
+                                              (br $while-in118)
                                             )
                                           )
                                         )
@@ -12882,10 +12882,10 @@
                                         (set_local $$p$addr$5$lcssa$i
                                           (get_local $$sub806$i)
                                         )
-                                        (br $while-out$120)
+                                        (br $while-out113)
                                       )
                                     )
-                                    (br $while-in$121)
+                                    (br $while-in114)
                                   )
                                 )
                               )
@@ -12927,7 +12927,7 @@
                               (i32.eqz
                                 (get_local $$tobool$i$i)
                               )
-                              (br $do-once$106)
+                              (br $do-once99)
                             )
                             (set_local $$sub$ptr$rhs$cast812$i
                               (get_local $$estr$2$i)
@@ -13151,7 +13151,7 @@
                   (get_local $$l10n$3)
                 )
                 (br $label$continue$L1)
-                (br $switch$24)
+                (br $switch17)
               )
             )
             (block
@@ -13267,8 +13267,8 @@
                   (set_local $$s$addr$06$i
                     (get_local $$add$ptr205)
                   )
-                  (loop $while-in$130
-                    (block $while-out$129
+                  (loop $while-in123
+                    (block $while-out122
                       (set_local $$idxprom$i
                         (i32.and
                           (get_local $$99)
@@ -13348,7 +13348,7 @@
                           (set_local $$incdec$ptr$i$212$lcssa
                             (get_local $$incdec$ptr$i$212)
                           )
-                          (br $while-out$129)
+                          (br $while-out122)
                         )
                         (block
                           (set_local $$101
@@ -13362,7 +13362,7 @@
                           )
                         )
                       )
-                      (br $while-in$130)
+                      (br $while-in123)
                     )
                   )
                   (set_local $$107
@@ -13615,8 +13615,8 @@
                     (set_local $$ws$0317
                       (get_local $$176)
                     )
-                    (loop $while-in$132
-                      (block $while-out$131
+                    (loop $while-in125
+                      (block $while-out124
                         (set_local $$177
                           (i32.load
                             (get_local $$ws$0317)
@@ -13637,7 +13637,7 @@
                             (set_local $$l$2
                               (get_local $$l$1315)
                             )
-                            (br $while-out$131)
+                            (br $while-out124)
                           )
                         )
                         (set_local $$call384
@@ -13679,7 +13679,7 @@
                             (set_local $$l$2
                               (get_local $$call384)
                             )
-                            (br $while-out$131)
+                            (br $while-out124)
                           )
                         )
                         (set_local $$incdec$ptr383
@@ -13720,10 +13720,10 @@
                             (set_local $$l$2
                               (get_local $$call384)
                             )
-                            (br $while-out$131)
+                            (br $while-out124)
                           )
                         )
-                        (br $while-in$132)
+                        (br $while-in125)
                       )
                     )
                     (set_local $$cmp397
@@ -13776,8 +13776,8 @@
                         (set_local $$ws$1326
                           (get_local $$178)
                         )
-                        (loop $while-in$134
-                          (block $while-out$133
+                        (loop $while-in127
+                          (block $while-out126
                             (set_local $$179
                               (i32.load
                                 (get_local $$ws$1326)
@@ -13887,10 +13887,10 @@
                                 (set_local $label
                                   (i32.const 98)
                                 )
-                                (br $while-out$133)
+                                (br $while-out126)
                               )
                             )
-                            (br $while-in$134)
+                            (br $while-in127)
                           )
                         )
                       )
@@ -14303,8 +14303,8 @@
                   (set_local $$i$2299
                     (i32.const 1)
                   )
-                  (loop $while-in$137
-                    (block $while-out$136
+                  (loop $while-in130
+                    (block $while-out129
                       (set_local $$arrayidx469
                         (i32.add
                           (get_local $$nl_type)
@@ -14331,7 +14331,7 @@
                           (set_local $$i$2299$lcssa
                             (get_local $$i$2299)
                           )
-                          (br $while-out$136)
+                          (br $while-out129)
                         )
                       )
                       (set_local $$add$ptr473
@@ -14372,7 +14372,7 @@
                           (br $label$break$L343)
                         )
                       )
-                      (br $while-in$137)
+                      (br $while-in130)
                     )
                   )
                   (set_local $$cmp478$295
@@ -14387,8 +14387,8 @@
                       (set_local $$i$3296
                         (get_local $$i$2299$lcssa)
                       )
-                      (loop $while-in$139
-                        (block $while-out$138
+                      (loop $while-in132
+                        (block $while-out131
                           (set_local $$arrayidx481
                             (i32.add
                               (get_local $$nl_type)
@@ -14441,10 +14441,10 @@
                               (set_local $$retval$0
                                 (i32.const 1)
                               )
-                              (br $while-out$138)
+                              (br $while-out131)
                             )
                           )
-                          (br $while-in$139)
+                          (br $while-in132)
                         )
                       )
                     )
@@ -14672,20 +14672,20 @@
         (i32.eqz
           (get_local $$cmp)
         )
-        (block $do-once$1
-          (block $switch$3
-            (block $switch-default$14
-              (block $switch-case$13
-                (block $switch-case$12
-                  (block $switch-case$11
-                    (block $switch-case$10
-                      (block $switch-case$9
-                        (block $switch-case$8
-                          (block $switch-case$7
-                            (block $switch-case$6
-                              (block $switch-case$5
-                                (block $switch-case$4
-                                  (br_table $switch-case$4 $switch-case$5 $switch-case$6 $switch-case$7 $switch-case$8 $switch-case$9 $switch-case$10 $switch-case$11 $switch-case$12 $switch-case$13 $switch-default$14
+        (block $do-once
+          (block $switch
+            (block $switch-default
+              (block $switch-case9
+                (block $switch-case8
+                  (block $switch-case7
+                    (block $switch-case6
+                      (block $switch-case5
+                        (block $switch-case4
+                          (block $switch-case3
+                            (block $switch-case2
+                              (block $switch-case1
+                                (block $switch-case
+                                  (br_table $switch-case $switch-case1 $switch-case2 $switch-case3 $switch-case4 $switch-case5 $switch-case6 $switch-case7 $switch-case8 $switch-case9 $switch-default
                                     (i32.sub
                                       (get_local $$type)
                                       (i32.const 9)
@@ -14772,7 +14772,7 @@
                                     (get_local $$6)
                                   )
                                   (br $label$break$L1)
-                                  (br $switch$3)
+                                  (br $switch)
                                 )
                               )
                               (block
@@ -14889,7 +14889,7 @@
                                   (get_local $$15)
                                 )
                                 (br $label$break$L1)
-                                (br $switch$3)
+                                (br $switch)
                               )
                             )
                             (block
@@ -14991,7 +14991,7 @@
                                 (i32.const 0)
                               )
                               (br $label$break$L1)
-                              (br $switch$3)
+                              (br $switch)
                             )
                           )
                           (block
@@ -15113,7 +15113,7 @@
                               (get_local $$42)
                             )
                             (br $label$break$L1)
-                            (br $switch$3)
+                            (br $switch)
                           )
                         )
                         (block
@@ -15245,7 +15245,7 @@
                             (get_local $$56)
                           )
                           (br $label$break$L1)
-                          (br $switch$3)
+                          (br $switch)
                         )
                       )
                       (block
@@ -15353,7 +15353,7 @@
                           (i32.const 0)
                         )
                         (br $label$break$L1)
-                        (br $switch$3)
+                        (br $switch)
                       )
                     )
                     (block
@@ -15485,7 +15485,7 @@
                         (get_local $$81)
                       )
                       (br $label$break$L1)
-                      (br $switch$3)
+                      (br $switch)
                     )
                   )
                   (block
@@ -15593,7 +15593,7 @@
                       (i32.const 0)
                     )
                     (br $label$break$L1)
-                    (br $switch$3)
+                    (br $switch)
                   )
                 )
                 (block
@@ -15676,7 +15676,7 @@
                     (get_local $$103)
                   )
                   (br $label$break$L1)
-                  (br $switch$3)
+                  (br $switch)
                 )
               )
               (block
@@ -15759,7 +15759,7 @@
                   (get_local $$110)
                 )
                 (br $label$break$L1)
-                (br $switch$3)
+                (br $switch)
               )
             )
             (br $label$break$L1)
@@ -15852,8 +15852,8 @@
         (set_local $$s$addr$013
           (get_local $$s)
         )
-        (loop $while-in$1
-          (block $while-out$0
+        (loop $while-in
+          (block $while-out
             (set_local $$9
               (call $___uremdi3
                 (get_local $$7)
@@ -15951,10 +15951,10 @@
                 (set_local $$incdec$ptr$lcssa
                   (get_local $$incdec$ptr)
                 )
-                (br $while-out$0)
+                (br $while-out)
               )
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
         (set_local $$s$addr$0$lcssa
@@ -15991,8 +15991,8 @@
         (set_local $$y$010
           (get_local $$x$addr$0$lcssa$off0)
         )
-        (loop $while-in$3
-          (block $while-out$2
+        (loop $while-in1
+          (block $while-out0
             (set_local $$rem4
               (i32.and
                 (call $i32u-rem
@@ -16045,7 +16045,7 @@
                 (set_local $$s$addr$1$lcssa
                   (get_local $$incdec$ptr7)
                 )
-                (br $while-out$2)
+                (br $while-out0)
               )
               (block
                 (set_local $$s$addr$19
@@ -16056,7 +16056,7 @@
                 )
               )
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
@@ -16135,7 +16135,7 @@
         (get_local $$tobool)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $$or$cond)
         (block
@@ -16206,8 +16206,8 @@
               (set_local $$tobool$i18
                 (get_local $$tobool$i$16)
               )
-              (loop $while-in$3
-                (block $while-out$2
+              (loop $while-in
+                (block $while-out
                   (if
                     (get_local $$tobool$i18)
                     (block
@@ -16268,9 +16268,9 @@
                         (get_local $$tobool$i)
                       )
                     )
-                    (br $while-out$2)
+                    (br $while-out)
                   )
-                  (br $while-in$3)
+                  (br $while-in)
                 )
               )
               (set_local $$3
@@ -16284,7 +16284,7 @@
                 (set_local $$l$addr$0$lcssa21
                   (get_local $$3)
                 )
-                (br $do-once$0)
+                (br $do-once)
               )
             )
             (if
@@ -16292,7 +16292,7 @@
               (set_local $$l$addr$0$lcssa21
                 (get_local $$sub)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (drop
@@ -17509,7 +17509,7 @@
         (i32.const 245)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $$cmp)
         (block
@@ -17633,7 +17633,7 @@
                   (get_local $$3)
                 )
               )
-              (block $do-once$2
+              (block $do-once0
                 (if
                   (get_local $$cmp10)
                   (block
@@ -17704,7 +17704,7 @@
                           (get_local $$1)
                           (get_local $$3)
                         )
-                        (br $do-once$2)
+                        (br $do-once0)
                       )
                       (call $_abort)
                     )
@@ -18004,7 +18004,7 @@
                       (get_local $$10)
                     )
                   )
-                  (block $do-once$4
+                  (block $do-once2
                     (if
                       (get_local $$cmp70)
                       (block
@@ -18086,7 +18086,7 @@
                             (set_local $$13
                               (get_local $$$pre)
                             )
-                            (br $do-once$4)
+                            (br $do-once2)
                           )
                           (call $_abort)
                         )
@@ -18529,8 +18529,8 @@
                   (set_local $$v$0$i
                     (get_local $$20)
                   )
-                  (loop $while-in$7
-                    (block $while-out$6
+                  (loop $while-in
+                    (block $while-out
                       (set_local $$arrayidx23$i
                         (i32.add
                           (get_local $$t$0$i)
@@ -18577,7 +18577,7 @@
                               (set_local $$v$0$i$lcssa
                                 (get_local $$v$0$i)
                               )
-                              (br $while-out$6)
+                              (br $while-out)
                             )
                             (set_local $$cond4$i
                               (get_local $$23)
@@ -18640,7 +18640,7 @@
                       (set_local $$v$0$i
                         (get_local $$cond$v$0$i)
                       )
-                      (br $while-in$7)
+                      (br $while-in)
                     )
                   )
                   (set_local $$25
@@ -18704,7 +18704,7 @@
                       (get_local $$v$0$i$lcssa)
                     )
                   )
-                  (block $do-once$8
+                  (block $do-once4
                     (if
                       (get_local $$cmp40$i)
                       (block
@@ -18751,7 +18751,7 @@
                                 (set_local $$R$3$i
                                   (i32.const 0)
                                 )
-                                (br $do-once$8)
+                                (br $do-once4)
                               )
                               (block
                                 (set_local $$R$1$i
@@ -18772,8 +18772,8 @@
                             )
                           )
                         )
-                        (loop $while-in$11
-                          (block $while-out$10
+                        (loop $while-in7
+                          (block $while-out6
                             (set_local $$arrayidx71$i
                               (i32.add
                                 (get_local $$R$1$i)
@@ -18802,7 +18802,7 @@
                                 (set_local $$RP$1$i
                                   (get_local $$arrayidx71$i)
                                 )
-                                (br $while-in$11)
+                                (br $while-in7)
                               )
                             )
                             (set_local $$arrayidx75$i
@@ -18831,7 +18831,7 @@
                                 (set_local $$RP$1$i$lcssa
                                   (get_local $$RP$1$i)
                                 )
-                                (br $while-out$10)
+                                (br $while-out6)
                               )
                               (block
                                 (set_local $$R$1$i
@@ -18842,7 +18842,7 @@
                                 )
                               )
                             )
-                            (br $while-in$11)
+                            (br $while-in7)
                           )
                         )
                         (set_local $$cmp81$i
@@ -18862,7 +18862,7 @@
                             (set_local $$R$3$i
                               (get_local $$R$1$i$lcssa)
                             )
-                            (br $do-once$8)
+                            (br $do-once4)
                           )
                         )
                       )
@@ -18942,7 +18942,7 @@
                             (set_local $$R$3$i
                               (get_local $$27)
                             )
-                            (br $do-once$8)
+                            (br $do-once4)
                           )
                           (call $_abort)
                         )
@@ -18955,7 +18955,7 @@
                       (i32.const 0)
                     )
                   )
-                  (block $do-once$12
+                  (block $do-once8
                     (if
                       (i32.eqz
                         (get_local $$cmp90$i)
@@ -19035,7 +19035,7 @@
                                   (i32.const 180)
                                   (get_local $$and103$i)
                                 )
-                                (br $do-once$12)
+                                (br $do-once8)
                               )
                             )
                           )
@@ -19099,7 +19099,7 @@
                             )
                             (if
                               (get_local $$cmp126$i)
-                              (br $do-once$12)
+                              (br $do-once8)
                             )
                           )
                         )
@@ -19145,7 +19145,7 @@
                             (i32.const 0)
                           )
                         )
-                        (block $do-once$14
+                        (block $do-once10
                           (if
                             (i32.eqz
                               (get_local $$cmp138$i)
@@ -19181,7 +19181,7 @@
                                     (get_local $$parent149$i)
                                     (get_local $$R$3$i)
                                   )
-                                  (br $do-once$14)
+                                  (br $do-once10)
                                 )
                               )
                             )
@@ -19244,7 +19244,7 @@
                                   (get_local $$parent166$i)
                                   (get_local $$R$3$i)
                                 )
-                                (br $do-once$12)
+                                (br $do-once8)
                               )
                             )
                           )
@@ -19849,8 +19849,8 @@
                         (set_local $$v$0$i$153
                           (i32.const 0)
                         )
-                        (loop $while-in$18
-                          (block $while-out$17
+                        (loop $while-in14
+                          (block $while-out13
                             (set_local $$head$i$154
                               (i32.add
                                 (get_local $$t$0$i$151)
@@ -20023,7 +20023,7 @@
                                 (set_local $label
                                   (i32.const 86)
                                 )
-                                (br $while-out$17)
+                                (br $while-out13)
                               )
                               (block
                                 (set_local $$rsize$0$i$152
@@ -20043,7 +20043,7 @@
                                 )
                               )
                             )
-                            (br $while-in$18)
+                            (br $while-in14)
                           )
                         )
                       )
@@ -20112,7 +20112,7 @@
                               (set_local $$nb$0
                                 (get_local $$and145)
                               )
-                              (br $do-once$0)
+                              (br $do-once)
                             )
                           )
                           (set_local $$sub67$i
@@ -20313,8 +20313,8 @@
                       (get_local $label)
                       (i32.const 90)
                     )
-                    (loop $while-in$20
-                      (block $while-out$19
+                    (loop $while-in16
+                      (block $while-out15
                         (set_local $label
                           (i32.const 0)
                         )
@@ -20395,7 +20395,7 @@
                             (set_local $label
                               (i32.const 90)
                             )
-                            (br $while-in$20)
+                            (br $while-in16)
                           )
                         )
                         (set_local $$arrayidx113$i$159
@@ -20424,7 +20424,7 @@
                             (set_local $$v$4$lcssa$i
                               (get_local $$t$4$v$4$i)
                             )
-                            (br $while-out$19)
+                            (br $while-out15)
                           )
                           (block
                             (set_local $$rsize$49$i
@@ -20441,7 +20441,7 @@
                             )
                           )
                         )
-                        (br $while-in$20)
+                        (br $while-in16)
                       )
                     )
                   )
@@ -20538,7 +20538,7 @@
                               (get_local $$v$4$lcssa$i)
                             )
                           )
-                          (block $do-once$21
+                          (block $do-once17
                             (if
                               (get_local $$cmp128$i)
                               (block
@@ -20585,7 +20585,7 @@
                                         (set_local $$R$3$i$171
                                           (i32.const 0)
                                         )
-                                        (br $do-once$21)
+                                        (br $do-once17)
                                       )
                                       (block
                                         (set_local $$R$1$i$168
@@ -20606,8 +20606,8 @@
                                     )
                                   )
                                 )
-                                (loop $while-in$24
-                                  (block $while-out$23
+                                (loop $while-in20
+                                  (block $while-out19
                                     (set_local $$arrayidx161$i
                                       (i32.add
                                         (get_local $$R$1$i$168)
@@ -20636,7 +20636,7 @@
                                         (set_local $$RP$1$i$167
                                           (get_local $$arrayidx161$i)
                                         )
-                                        (br $while-in$24)
+                                        (br $while-in20)
                                       )
                                     )
                                     (set_local $$arrayidx165$i$169
@@ -20665,7 +20665,7 @@
                                         (set_local $$RP$1$i$167$lcssa
                                           (get_local $$RP$1$i$167)
                                         )
-                                        (br $while-out$23)
+                                        (br $while-out19)
                                       )
                                       (block
                                         (set_local $$R$1$i$168
@@ -20676,7 +20676,7 @@
                                         )
                                       )
                                     )
-                                    (br $while-in$24)
+                                    (br $while-in20)
                                   )
                                 )
                                 (set_local $$cmp171$i
@@ -20696,7 +20696,7 @@
                                     (set_local $$R$3$i$171
                                       (get_local $$R$1$i$168$lcssa)
                                     )
-                                    (br $do-once$21)
+                                    (br $do-once17)
                                   )
                                 )
                               )
@@ -20776,7 +20776,7 @@
                                     (set_local $$R$3$i$171
                                       (get_local $$64)
                                     )
-                                    (br $do-once$21)
+                                    (br $do-once17)
                                   )
                                   (call $_abort)
                                 )
@@ -20789,7 +20789,7 @@
                               (i32.const 0)
                             )
                           )
-                          (block $do-once$25
+                          (block $do-once21
                             (if
                               (i32.eqz
                                 (get_local $$cmp180$i)
@@ -20869,7 +20869,7 @@
                                           (i32.const 180)
                                           (get_local $$and194$i)
                                         )
-                                        (br $do-once$25)
+                                        (br $do-once21)
                                       )
                                     )
                                   )
@@ -20933,7 +20933,7 @@
                                     )
                                     (if
                                       (get_local $$cmp217$i)
-                                      (br $do-once$25)
+                                      (br $do-once21)
                                     )
                                   )
                                 )
@@ -20979,7 +20979,7 @@
                                     (i32.const 0)
                                   )
                                 )
-                                (block $do-once$27
+                                (block $do-once23
                                   (if
                                     (i32.eqz
                                       (get_local $$cmp229$i)
@@ -21015,7 +21015,7 @@
                                             (get_local $$parent240$i)
                                             (get_local $$R$3$i$171)
                                           )
-                                          (br $do-once$27)
+                                          (br $do-once23)
                                         )
                                       )
                                     )
@@ -21078,7 +21078,7 @@
                                           (get_local $$parent257$i)
                                           (get_local $$R$3$i$171)
                                         )
-                                        (br $do-once$25)
+                                        (br $do-once21)
                                       )
                                     )
                                   )
@@ -21092,7 +21092,7 @@
                               (i32.const 16)
                             )
                           )
-                          (block $do-once$29
+                          (block $do-once25
                             (if
                               (get_local $$cmp265$i)
                               (block
@@ -21339,7 +21339,7 @@
                                       (get_local $$bk313$i)
                                       (get_local $$arrayidx289$i)
                                     )
-                                    (br $do-once$29)
+                                    (br $do-once25)
                                   )
                                 )
                                 (set_local $$shr318$i
@@ -21620,7 +21620,7 @@
                                       (get_local $$fd371$i)
                                       (get_local $$add$ptr$i$161)
                                     )
-                                    (br $do-once$29)
+                                    (br $do-once25)
                                   )
                                 )
                                 (set_local $$87
@@ -21665,8 +21665,8 @@
                                 (set_local $$T$0$i
                                   (get_local $$87)
                                 )
-                                (loop $while-in$32
-                                  (block $while-out$31
+                                (loop $while-in28
+                                  (block $while-out27
                                     (set_local $$head386$i
                                       (i32.add
                                         (get_local $$T$0$i)
@@ -21699,7 +21699,7 @@
                                         (set_local $label
                                           (i32.const 148)
                                         )
-                                        (br $while-out$31)
+                                        (br $while-out27)
                                       )
                                     )
                                     (set_local $$shr391$i
@@ -21749,7 +21749,7 @@
                                         (set_local $label
                                           (i32.const 145)
                                         )
-                                        (br $while-out$31)
+                                        (br $while-out27)
                                       )
                                       (block
                                         (set_local $$K373$0$i
@@ -21760,7 +21760,7 @@
                                         )
                                       )
                                     )
-                                    (br $while-in$32)
+                                    (br $while-in28)
                                   )
                                 )
                                 (if
@@ -21818,7 +21818,7 @@
                                           (get_local $$fd408$i)
                                           (get_local $$add$ptr$i$161)
                                         )
-                                        (br $do-once$29)
+                                        (br $do-once25)
                                       )
                                     )
                                   )
@@ -21909,7 +21909,7 @@
                                             (get_local $$parent433$i)
                                             (i32.const 0)
                                           )
-                                          (br $do-once$29)
+                                          (br $do-once25)
                                         )
                                         (call $_abort)
                                       )
@@ -22202,7 +22202,7 @@
         (i32.const 0)
       )
     )
-    (block $do-once$33
+    (block $do-once29
       (if
         (get_local $$cmp$i$179)
         (block
@@ -22277,7 +22277,7 @@
                 (i32.const 648)
                 (get_local $$and7$i$i)
               )
-              (br $do-once$33)
+              (br $do-once29)
             )
             (call $_abort)
           )
@@ -22438,8 +22438,8 @@
                 (set_local $$sp$0$i$i
                   (i32.const 624)
                 )
-                (loop $while-in$38
-                  (block $while-out$37
+                (loop $while-in34
+                  (block $while-out33
                     (set_local $$105
                       (i32.load
                         (get_local $$sp$0$i$i)
@@ -22488,7 +22488,7 @@
                             (set_local $$size$i$i$lcssa
                               (get_local $$size$i$i)
                             )
-                            (br $while-out$37)
+                            (br $while-out33)
                           )
                         )
                       )
@@ -22522,7 +22522,7 @@
                         (get_local $$107)
                       )
                     )
-                    (br $while-in$38)
+                    (br $while-in34)
                   )
                 )
                 (set_local $$112
@@ -22622,7 +22622,7 @@
               )
             )
           )
-          (block $do-once$39
+          (block $do-once35
             (if
               (i32.eq
                 (get_local $label)
@@ -22780,7 +22780,7 @@
                             )
                             (if
                               (get_local $$or$cond2$i)
-                              (br $do-once$39)
+                              (br $do-once35)
                             )
                           )
                         )
@@ -22871,7 +22871,7 @@
                     (get_local $$or$cond5$i)
                   )
                 )
-                (block $do-once$42
+                (block $do-once38
                   (if
                     (get_local $$or$cond3$i)
                     (block
@@ -22944,7 +22944,7 @@
                               (set_local $$ssize$5$i
                                 (get_local $$add110$i)
                               )
-                              (br $do-once$42)
+                              (br $do-once38)
                             )
                           )
                         )
@@ -23160,7 +23160,7 @@
             (i32.const 0)
           )
         )
-        (block $do-once$44
+        (block $do-once40
           (if
             (get_local $$cmp157$i)
             (block
@@ -23222,8 +23222,8 @@
               (set_local $$i$01$i$i
                 (i32.const 0)
               )
-              (loop $while-in$47
-                (block $while-out$46
+              (loop $while-in43
+                (block $while-out42
                   (set_local $$shl$i$i
                     (i32.shl
                       (get_local $$i$01$i$i)
@@ -23273,12 +23273,12 @@
                   )
                   (if
                     (get_local $$exitcond$i$i)
-                    (br $while-out$46)
+                    (br $while-out42)
                     (set_local $$i$01$i$i
                       (get_local $$inc$i$i)
                     )
                   )
-                  (br $while-in$47)
+                  (br $while-in43)
                 )
               )
               (set_local $$sub172$i
@@ -23393,8 +23393,8 @@
               (set_local $$sp$0108$i
                 (i32.const 624)
               )
-              (loop $while-in$49
-                (block $while-out$48
+              (loop $while-in45
+                (block $while-out44
                   (set_local $$127
                     (i32.load
                       (get_local $$sp$0108$i)
@@ -23441,7 +23441,7 @@
                       (set_local $label
                         (i32.const 203)
                       )
-                      (br $while-out$48)
+                      (br $while-out44)
                     )
                   )
                   (set_local $$next$i
@@ -23463,12 +23463,12 @@
                   )
                   (if
                     (get_local $$cmp186$i)
-                    (br $while-out$48)
+                    (br $while-out44)
                     (set_local $$sp$0108$i
                       (get_local $$129)
                     )
                   )
-                  (br $while-in$49)
+                  (br $while-in45)
                 )
               )
               (if
@@ -23646,7 +23646,7 @@
                             (i32.const 204)
                             (get_local $$134)
                           )
-                          (br $do-once$44)
+                          (br $do-once40)
                         )
                       )
                     )
@@ -23688,8 +23688,8 @@
               (set_local $$sp$1107$i
                 (i32.const 624)
               )
-              (loop $while-in$51
-                (block $while-out$50
+              (loop $while-in47
+                (block $while-out46
                   (set_local $$136
                     (i32.load
                       (get_local $$sp$1107$i)
@@ -23713,7 +23713,7 @@
                       (set_local $label
                         (i32.const 211)
                       )
-                      (br $while-out$50)
+                      (br $while-out46)
                     )
                   )
                   (set_local $$next231$i
@@ -23739,13 +23739,13 @@
                       (set_local $$sp$0$i$i$i
                         (i32.const 624)
                       )
-                      (br $while-out$50)
+                      (br $while-out46)
                     )
                     (set_local $$sp$1107$i
                       (get_local $$137)
                     )
                   )
-                  (br $while-in$51)
+                  (br $while-in47)
                 )
               )
               (if
@@ -23943,7 +23943,7 @@
                           (get_local $$119)
                         )
                       )
-                      (block $do-once$52
+                      (block $do-once48
                         (if
                           (get_local $$cmp20$i$i)
                           (block
@@ -24043,7 +24043,7 @@
                                   (get_local $$add$ptr30$i$i)
                                   (get_local $$add26$i$i)
                                 )
-                                (br $do-once$52)
+                                (br $do-once48)
                               )
                             )
                             (set_local $$head32$i$i
@@ -24137,7 +24137,7 @@
                                           (get_local $$arrayidx$i$48$i)
                                         )
                                       )
-                                      (block $do-once$55
+                                      (block $do-once51
                                         (if
                                           (i32.eqz
                                             (get_local $$cmp41$i$i)
@@ -24172,7 +24172,7 @@
                                             )
                                             (if
                                               (get_local $$cmp44$i$i)
-                                              (br $do-once$55)
+                                              (br $do-once51)
                                             )
                                             (call $_abort)
                                           )
@@ -24223,7 +24223,7 @@
                                           (get_local $$arrayidx$i$48$i)
                                         )
                                       )
-                                      (block $do-once$57
+                                      (block $do-once53
                                         (if
                                           (get_local $$cmp54$i$i)
                                           (block
@@ -24271,7 +24271,7 @@
                                                 (set_local $$fd68$pre$phi$i$iZ2D
                                                   (get_local $$fd59$i$i)
                                                 )
-                                                (br $do-once$57)
+                                                (br $do-once53)
                                               )
                                             )
                                             (call $_abort)
@@ -24322,7 +24322,7 @@
                                           (get_local $$add$ptr16$i$i)
                                         )
                                       )
-                                      (block $do-once$59
+                                      (block $do-once55
                                         (if
                                           (get_local $$cmp75$i$i)
                                           (block
@@ -24369,7 +24369,7 @@
                                                     (set_local $$R$3$i$i
                                                       (i32.const 0)
                                                     )
-                                                    (br $do-once$59)
+                                                    (br $do-once55)
                                                   )
                                                   (block
                                                     (set_local $$R$1$i$i
@@ -24390,8 +24390,8 @@
                                                 )
                                               )
                                             )
-                                            (loop $while-in$62
-                                              (block $while-out$61
+                                            (loop $while-in58
+                                              (block $while-out57
                                                 (set_local $$arrayidx103$i$i
                                                   (i32.add
                                                     (get_local $$R$1$i$i)
@@ -24420,7 +24420,7 @@
                                                     (set_local $$RP$1$i$i
                                                       (get_local $$arrayidx103$i$i)
                                                     )
-                                                    (br $while-in$62)
+                                                    (br $while-in58)
                                                   )
                                                 )
                                                 (set_local $$arrayidx107$i$i
@@ -24449,7 +24449,7 @@
                                                     (set_local $$RP$1$i$i$lcssa
                                                       (get_local $$RP$1$i$i)
                                                     )
-                                                    (br $while-out$61)
+                                                    (br $while-out57)
                                                   )
                                                   (block
                                                     (set_local $$R$1$i$i
@@ -24460,7 +24460,7 @@
                                                     )
                                                   )
                                                 )
-                                                (br $while-in$62)
+                                                (br $while-in58)
                                               )
                                             )
                                             (set_local $$cmp112$i$i
@@ -24480,7 +24480,7 @@
                                                 (set_local $$R$3$i$i
                                                   (get_local $$R$1$i$i$lcssa)
                                                 )
-                                                (br $do-once$59)
+                                                (br $do-once55)
                                               )
                                             )
                                           )
@@ -24560,7 +24560,7 @@
                                                 (set_local $$R$3$i$i
                                                   (get_local $$155)
                                                 )
-                                                (br $do-once$59)
+                                                (br $do-once55)
                                               )
                                               (call $_abort)
                                             )
@@ -24608,7 +24608,7 @@
                                           (get_local $$164)
                                         )
                                       )
-                                      (block $do-once$63
+                                      (block $do-once59
                                         (if
                                           (get_local $$cmp124$i$i)
                                           (block
@@ -24626,7 +24626,7 @@
                                               (i32.eqz
                                                 (get_local $$cond2$i$i)
                                               )
-                                              (br $do-once$63)
+                                              (br $do-once59)
                                             )
                                             (set_local $$shl131$i$i
                                               (i32.shl
@@ -24764,7 +24764,7 @@
                                           (i32.const 0)
                                         )
                                       )
-                                      (block $do-once$65
+                                      (block $do-once61
                                         (if
                                           (i32.eqz
                                             (get_local $$cmp168$i$i)
@@ -24800,7 +24800,7 @@
                                                   (get_local $$parent179$i$i)
                                                   (get_local $$R$3$i$i)
                                                 )
-                                                (br $do-once$65)
+                                                (br $do-once61)
                                               )
                                             )
                                           )
@@ -24996,7 +24996,7 @@
                                     (i32.const 0)
                                   )
                                 )
-                                (block $do-once$67
+                                (block $do-once63
                                   (if
                                     (get_local $$tobool228$i$i)
                                     (block
@@ -25057,7 +25057,7 @@
                                           (set_local $$F224$0$i$i
                                             (get_local $$175)
                                           )
-                                          (br $do-once$67)
+                                          (br $do-once63)
                                         )
                                       )
                                       (call $_abort)
@@ -25098,7 +25098,7 @@
                                   (get_local $$bk248$i$i)
                                   (get_local $$arrayidx223$i$i)
                                 )
-                                (br $do-once$52)
+                                (br $do-once48)
                               )
                             )
                             (set_local $$shr253$i$i
@@ -25113,7 +25113,7 @@
                                 (i32.const 0)
                               )
                             )
-                            (block $do-once$69
+                            (block $do-once65
                               (if
                                 (get_local $$cmp254$i$i)
                                 (set_local $$I252$0$i$i
@@ -25132,7 +25132,7 @@
                                       (set_local $$I252$0$i$i
                                         (i32.const 31)
                                       )
-                                      (br $do-once$69)
+                                      (br $do-once65)
                                     )
                                   )
                                   (set_local $$sub262$i$i
@@ -25382,7 +25382,7 @@
                                   (get_local $$fd303$i$i)
                                   (get_local $$add$ptr17$i$i)
                                 )
-                                (br $do-once$52)
+                                (br $do-once48)
                               )
                             )
                             (set_local $$178
@@ -25427,8 +25427,8 @@
                             (set_local $$T$0$i$58$i
                               (get_local $$178)
                             )
-                            (loop $while-in$72
-                              (block $while-out$71
+                            (loop $while-in68
+                              (block $while-out67
                                 (set_local $$head317$i$i
                                   (i32.add
                                     (get_local $$T$0$i$58$i)
@@ -25461,7 +25461,7 @@
                                     (set_local $label
                                       (i32.const 281)
                                     )
-                                    (br $while-out$71)
+                                    (br $while-out67)
                                   )
                                 )
                                 (set_local $$shr322$i$i
@@ -25511,7 +25511,7 @@
                                     (set_local $label
                                       (i32.const 278)
                                     )
-                                    (br $while-out$71)
+                                    (br $while-out67)
                                   )
                                   (block
                                     (set_local $$K305$0$i$i
@@ -25522,7 +25522,7 @@
                                     )
                                   )
                                 )
-                                (br $while-in$72)
+                                (br $while-in68)
                               )
                             )
                             (if
@@ -25580,7 +25580,7 @@
                                       (get_local $$fd339$i$i)
                                       (get_local $$add$ptr17$i$i)
                                     )
-                                    (br $do-once$52)
+                                    (br $do-once48)
                                   )
                                 )
                               )
@@ -25671,7 +25671,7 @@
                                         (get_local $$parent361$i$i)
                                         (i32.const 0)
                                       )
-                                      (br $do-once$52)
+                                      (br $do-once48)
                                     )
                                     (call $_abort)
                                   )
@@ -25700,8 +25700,8 @@
                   )
                 )
               )
-              (loop $while-in$74
-                (block $while-out$73
+              (loop $while-in70
+                (block $while-out69
                   (set_local $$185
                     (i32.load
                       (get_local $$sp$0$i$i$i)
@@ -25747,7 +25747,7 @@
                           (set_local $$add$ptr$i$i$i$lcssa
                             (get_local $$add$ptr$i$i$i)
                           )
-                          (br $while-out$73)
+                          (br $while-out69)
                         )
                       )
                     )
@@ -25766,7 +25766,7 @@
                   (set_local $$sp$0$i$i$i
                     (get_local $$187)
                   )
-                  (br $while-in$74)
+                  (br $while-in70)
                 )
               )
               (set_local $$add$ptr2$i$i
@@ -26030,8 +26030,8 @@
               (set_local $$p$0$i$i
                 (get_local $$add$ptr15$i$i)
               )
-              (loop $while-in$76
-                (block $while-out$75
+              (loop $while-in72
+                (block $while-out71
                   (set_local $$add$ptr24$i$i
                     (i32.add
                       (get_local $$p$0$i$i)
@@ -26059,9 +26059,9 @@
                     (set_local $$p$0$i$i
                       (get_local $$add$ptr24$i$i)
                     )
-                    (br $while-out$75)
+                    (br $while-out71)
                   )
-                  (br $while-in$76)
+                  (br $while-in72)
                 )
               )
               (set_local $$cmp28$i$i
@@ -26272,7 +26272,7 @@
                         (get_local $$bk55$i$i)
                         (get_local $$arrayidx$i$20$i)
                       )
-                      (br $do-once$44)
+                      (br $do-once40)
                     )
                   )
                   (set_local $$shr58$i$i
@@ -26547,7 +26547,7 @@
                         (get_local $$fd103$i$i)
                         (get_local $$119)
                       )
-                      (br $do-once$44)
+                      (br $do-once40)
                     )
                   )
                   (set_local $$200
@@ -26592,8 +26592,8 @@
                   (set_local $$T$0$i$i
                     (get_local $$200)
                   )
-                  (loop $while-in$78
-                    (block $while-out$77
+                  (loop $while-in74
+                    (block $while-out73
                       (set_local $$head118$i$i
                         (i32.add
                           (get_local $$T$0$i$i)
@@ -26626,7 +26626,7 @@
                           (set_local $label
                             (i32.const 307)
                           )
-                          (br $while-out$77)
+                          (br $while-out73)
                         )
                       )
                       (set_local $$shr123$i$i
@@ -26676,7 +26676,7 @@
                           (set_local $label
                             (i32.const 304)
                           )
-                          (br $while-out$77)
+                          (br $while-out73)
                         )
                         (block
                           (set_local $$K105$0$i$i
@@ -26687,7 +26687,7 @@
                           )
                         )
                       )
-                      (br $while-in$78)
+                      (br $while-in74)
                     )
                   )
                   (if
@@ -26745,7 +26745,7 @@
                             (get_local $$fd140$i$i)
                             (get_local $$119)
                           )
-                          (br $do-once$44)
+                          (br $do-once40)
                         )
                       )
                     )
@@ -26836,7 +26836,7 @@
                               (get_local $$parent162$i$i)
                               (i32.const 0)
                             )
-                            (br $do-once$44)
+                            (br $do-once40)
                           )
                           (call $_abort)
                         )
@@ -27388,7 +27388,7 @@
         (i32.const 0)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $$tobool9)
         (block
@@ -27483,7 +27483,7 @@
                   (set_local $$psize$1
                     (get_local $$add17)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (i32.store
@@ -27669,7 +27669,7 @@
                   (set_local $$psize$1
                     (get_local $$add17)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (set_local $$cmp50
@@ -27748,7 +27748,7 @@
               (set_local $$psize$1
                 (get_local $$add17)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $$parent
@@ -27779,7 +27779,7 @@
               (get_local $$add$ptr16)
             )
           )
-          (block $do-once$2
+          (block $do-once0
             (if
               (get_local $$cmp74)
               (block
@@ -27826,7 +27826,7 @@
                         (set_local $$R$3
                           (i32.const 0)
                         )
-                        (br $do-once$2)
+                        (br $do-once0)
                       )
                       (block
                         (set_local $$R$1
@@ -27847,8 +27847,8 @@
                     )
                   )
                 )
-                (loop $while-in$5
-                  (block $while-out$4
+                (loop $while-in
+                  (block $while-out
                     (set_local $$arrayidx108
                       (i32.add
                         (get_local $$R$1)
@@ -27877,7 +27877,7 @@
                         (set_local $$RP$1
                           (get_local $$arrayidx108)
                         )
-                        (br $while-in$5)
+                        (br $while-in)
                       )
                     )
                     (set_local $$arrayidx113
@@ -27906,7 +27906,7 @@
                         (set_local $$RP$1$lcssa
                           (get_local $$RP$1)
                         )
-                        (br $while-out$4)
+                        (br $while-out)
                       )
                       (block
                         (set_local $$R$1
@@ -27917,7 +27917,7 @@
                         )
                       )
                     )
-                    (br $while-in$5)
+                    (br $while-in)
                   )
                 )
                 (set_local $$cmp118
@@ -27937,7 +27937,7 @@
                     (set_local $$R$3
                       (get_local $$R$1$lcssa)
                     )
-                    (br $do-once$2)
+                    (br $do-once0)
                   )
                 )
               )
@@ -28017,7 +28017,7 @@
                     (set_local $$R$3
                       (get_local $$10)
                     )
-                    (br $do-once$2)
+                    (br $do-once0)
                   )
                   (call $_abort)
                 )
@@ -28121,7 +28121,7 @@
                       (set_local $$psize$1
                         (get_local $$add17)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -28192,7 +28192,7 @@
                       (set_local $$psize$1
                         (get_local $$add17)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -28239,7 +28239,7 @@
                   (i32.const 0)
                 )
               )
-              (block $do-once$6
+              (block $do-once2
                 (if
                   (i32.eqz
                     (get_local $$cmp173)
@@ -28275,7 +28275,7 @@
                           (get_local $$parent183)
                           (get_local $$R$3)
                         )
-                        (br $do-once$6)
+                        (br $do-once2)
                       )
                     )
                   )
@@ -28350,7 +28350,7 @@
                       (set_local $$psize$1
                         (get_local $$add17)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -28585,7 +28585,7 @@
             (i32.const 256)
           )
         )
-        (block $do-once$8
+        (block $do-once4
           (if
             (get_local $$cmp269)
             (block
@@ -28713,7 +28713,7 @@
                     (i32.const 176)
                     (get_local $$and301)
                   )
-                  (br $do-once$8)
+                  (br $do-once4)
                 )
               )
               (set_local $$cmp305
@@ -28821,7 +28821,7 @@
                   (get_local $$add$ptr6)
                 )
               )
-              (block $do-once$10
+              (block $do-once6
                 (if
                   (get_local $$cmp334)
                   (block
@@ -28868,7 +28868,7 @@
                             (set_local $$R332$3
                               (i32.const 0)
                             )
-                            (br $do-once$10)
+                            (br $do-once6)
                           )
                           (block
                             (set_local $$R332$1
@@ -28889,8 +28889,8 @@
                         )
                       )
                     )
-                    (loop $while-in$13
-                      (block $while-out$12
+                    (loop $while-in9
+                      (block $while-out8
                         (set_local $$arrayidx374
                           (i32.add
                             (get_local $$R332$1)
@@ -28919,7 +28919,7 @@
                             (set_local $$RP360$1
                               (get_local $$arrayidx374)
                             )
-                            (br $while-in$13)
+                            (br $while-in9)
                           )
                         )
                         (set_local $$arrayidx379
@@ -28948,7 +28948,7 @@
                             (set_local $$RP360$1$lcssa
                               (get_local $$RP360$1)
                             )
-                            (br $while-out$12)
+                            (br $while-out8)
                           )
                           (block
                             (set_local $$R332$1
@@ -28959,7 +28959,7 @@
                             )
                           )
                         )
-                        (br $while-in$13)
+                        (br $while-in9)
                       )
                     )
                     (set_local $$51
@@ -28984,7 +28984,7 @@
                         (set_local $$R332$3
                           (get_local $$R332$1$lcssa)
                         )
-                        (br $do-once$10)
+                        (br $do-once6)
                       )
                     )
                   )
@@ -29069,7 +29069,7 @@
                         (set_local $$R332$3
                           (get_local $$42)
                         )
-                        (br $do-once$10)
+                        (br $do-once6)
                       )
                       (call $_abort)
                     )
@@ -29161,7 +29161,7 @@
                             (i32.const 180)
                             (get_local $$and410)
                           )
-                          (br $do-once$8)
+                          (br $do-once4)
                         )
                       )
                     )
@@ -29225,7 +29225,7 @@
                       )
                       (if
                         (get_local $$cmp432)
-                        (br $do-once$8)
+                        (br $do-once4)
                       )
                     )
                   )
@@ -29271,7 +29271,7 @@
                       (i32.const 0)
                     )
                   )
-                  (block $do-once$14
+                  (block $do-once10
                     (if
                       (i32.eqz
                         (get_local $$cmp445)
@@ -29307,7 +29307,7 @@
                               (get_local $$parent455)
                               (get_local $$R332$3)
                             )
-                            (br $do-once$14)
+                            (br $do-once10)
                           )
                         )
                       )
@@ -29370,7 +29370,7 @@
                             (get_local $$parent471)
                             (get_local $$R332$3)
                           )
-                          (br $do-once$8)
+                          (br $do-once4)
                         )
                       )
                     )
@@ -29857,7 +29857,7 @@
         (i32.const 0)
       )
     )
-    (block $do-once$16
+    (block $do-once12
       (if
         (get_local $$tobool575)
         (block
@@ -29949,8 +29949,8 @@
           (set_local $$T$0
             (get_local $$67)
           )
-          (loop $while-in$19
-            (block $while-out$18
+          (loop $while-in15
+            (block $while-out14
               (set_local $$head591
                 (i32.add
                   (get_local $$T$0)
@@ -29983,7 +29983,7 @@
                   (set_local $label
                     (i32.const 130)
                   )
-                  (br $while-out$18)
+                  (br $while-out14)
                 )
               )
               (set_local $$shr596
@@ -30033,7 +30033,7 @@
                   (set_local $label
                     (i32.const 127)
                   )
-                  (br $while-out$18)
+                  (br $while-out14)
                 )
                 (block
                   (set_local $$K583$0
@@ -30044,7 +30044,7 @@
                   )
                 )
               )
-              (br $while-in$19)
+              (br $while-in15)
             )
           )
           (if
@@ -30102,7 +30102,7 @@
                     (get_local $$fd612)
                     (get_local $$p$1)
                   )
-                  (br $do-once$16)
+                  (br $do-once12)
                 )
               )
             )
@@ -30193,7 +30193,7 @@
                       (get_local $$parent635)
                       (i32.const 0)
                     )
-                    (br $do-once$16)
+                    (br $do-once12)
                   )
                   (call $_abort)
                 )
@@ -30231,8 +30231,8 @@
       )
       (return)
     )
-    (loop $while-in$21
-      (block $while-out$20
+    (loop $while-in17
+      (block $while-out16
         (set_local $$sp$0$i
           (i32.load
             (get_local $$sp$0$in$i)
@@ -30252,12 +30252,12 @@
         )
         (if
           (get_local $$cmp$i)
-          (br $while-out$20)
+          (br $while-out16)
           (set_local $$sp$0$in$i
             (get_local $$next4$i)
           )
         )
-        (br $while-in$21)
+        (br $while-in17)
       )
     )
     (i32.store
@@ -30416,8 +30416,8 @@
                 (get_local $unaligned)
               )
             )
-            (loop $while-in$1
-              (block $while-out$0
+            (loop $while-in
+              (block $while-out
                 (if
                   (i32.eqz
                     (i32.lt_s
@@ -30425,7 +30425,7 @@
                       (get_local $unaligned)
                     )
                   )
-                  (br $while-out$0)
+                  (br $while-out)
                 )
                 (block
                   (i32.store8
@@ -30439,13 +30439,13 @@
                     )
                   )
                 )
-                (br $while-in$1)
+                (br $while-in)
               )
             )
           )
         )
-        (loop $while-in$3
-          (block $while-out$2
+        (loop $while-in1
+          (block $while-out0
             (if
               (i32.eqz
                 (i32.lt_s
@@ -30453,7 +30453,7 @@
                   (get_local $stop4)
                 )
               )
-              (br $while-out$2)
+              (br $while-out0)
             )
             (block
               (i32.store
@@ -30467,13 +30467,13 @@
                 )
               )
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
     )
-    (loop $while-in$5
-      (block $while-out$4
+    (loop $while-in3
+      (block $while-out2
         (if
           (i32.eqz
             (i32.lt_s
@@ -30481,7 +30481,7 @@
               (get_local $stop)
             )
           )
-          (br $while-out$4)
+          (br $while-out2)
         )
         (block
           (i32.store8
@@ -30495,7 +30495,7 @@
             )
           )
         )
-        (br $while-in$5)
+        (br $while-in3)
       )
     )
     (return
@@ -30653,8 +30653,8 @@
         )
       )
       (block
-        (loop $while-in$1
-          (block $while-out$0
+        (loop $while-in
+          (block $while-out
             (if
               (i32.eqz
                 (i32.and
@@ -30662,7 +30662,7 @@
                   (i32.const 3)
                 )
               )
-              (br $while-out$0)
+              (br $while-out)
             )
             (block
               (if
@@ -30699,11 +30699,11 @@
                 )
               )
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
-        (loop $while-in$3
-          (block $while-out$2
+        (loop $while-in1
+          (block $while-out0
             (if
               (i32.eqz
                 (i32.ge_s
@@ -30711,7 +30711,7 @@
                   (i32.const 4)
                 )
               )
-              (br $while-out$2)
+              (br $while-out0)
             )
             (block
               (i32.store
@@ -30739,13 +30739,13 @@
                 )
               )
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
     )
-    (loop $while-in$5
-      (block $while-out$4
+    (loop $while-in3
+      (block $while-out2
         (if
           (i32.eqz
             (i32.gt_s
@@ -30753,7 +30753,7 @@
               (i32.const 0)
             )
           )
-          (br $while-out$4)
+          (br $while-out2)
         )
         (block
           (i32.store8
@@ -30781,7 +30781,7 @@
             )
           )
         )
-        (br $while-in$5)
+        (br $while-in3)
       )
     )
     (return

--- a/test/example/relooper-fuzz.txt
+++ b/test/example/relooper-fuzz.txt
@@ -196,7 +196,7 @@
         )
       )
       (loop $shape$3$continue
-        (block $block$5$break
+        (block $block$5$break0
           (if
             (i32.eq
               (get_local $1)

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -148,7 +148,7 @@
     (set_local $13
       (get_local $25)
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.lt_u
           (get_local $0)
@@ -816,8 +816,8 @@
                   (set_local $3
                     (get_local $4)
                   )
-                  (loop $while-in$7
-                    (block $while-out$6
+                  (loop $while-in
+                    (block $while-out
                       (if
                         (tee_local $4
                           (i32.load offset=16
@@ -843,7 +843,7 @@
                             (set_local $1
                               (get_local $3)
                             )
-                            (br $while-out$6)
+                            (br $while-out)
                           )
                         )
                       )
@@ -880,7 +880,7 @@
                           (get_local $6)
                         )
                       )
-                      (br $while-in$7)
+                      (br $while-in)
                     )
                   )
                   (if
@@ -911,7 +911,7 @@
                       (get_local $1)
                     )
                   )
-                  (block $do-once$8
+                  (block $do-once4
                     (if
                       (i32.eq
                         (tee_local $17
@@ -958,11 +958,11 @@
                               (set_local $23
                                 (i32.const 0)
                               )
-                              (br $do-once$8)
+                              (br $do-once4)
                             )
                           )
                         )
-                        (loop $while-in$11
+                        (loop $while-in7
                           (if
                             (tee_local $9
                               (i32.load
@@ -981,7 +981,7 @@
                               (set_local $6
                                 (get_local $10)
                               )
-                              (br $while-in$11)
+                              (br $while-in7)
                             )
                           )
                           (if
@@ -1002,7 +1002,7 @@
                               (set_local $6
                                 (get_local $10)
                               )
-                              (br $while-in$11)
+                              (br $while-in7)
                             )
                           )
                         )
@@ -1079,7 +1079,7 @@
                       )
                     )
                   )
-                  (block $do-once$12
+                  (block $do-once8
                     (if
                       (get_local $0)
                       (block
@@ -1127,7 +1127,7 @@
                                     )
                                   )
                                 )
-                                (br $do-once$12)
+                                (br $do-once8)
                               )
                             )
                           )
@@ -1162,7 +1162,7 @@
                                 (get_local $23)
                               )
                             )
-                            (br_if $do-once$12
+                            (br_if $do-once8
                               (i32.eqz
                                 (get_local $23)
                               )
@@ -1605,7 +1605,7 @@
                       (set_local $8
                         (i32.const 0)
                       )
-                      (loop $while-in$18
+                      (loop $while-in14
                         (if
                           (i32.lt_u
                             (tee_local $2
@@ -1724,7 +1724,7 @@
                                 )
                               )
                             )
-                            (br $while-in$18)
+                            (br $while-in14)
                           )
                         )
                       )
@@ -1786,7 +1786,7 @@
                               (set_local $6
                                 (get_local $0)
                               )
-                              (br $do-once$0)
+                              (br $do-once)
                             )
                           )
                           (set_local $6
@@ -1921,7 +1921,7 @@
                     (get_local $9)
                     (i32.const 90)
                   )
-                  (loop $while-in$20
+                  (loop $while-in16
                     (set_local $9
                       (i32.const 0)
                     )
@@ -1971,7 +1971,7 @@
                         (set_local $32
                           (get_local $8)
                         )
-                        (br $while-in$20)
+                        (br $while-in16)
                       )
                     )
                     (if
@@ -1987,7 +1987,7 @@
                         (set_local $32
                           (get_local $8)
                         )
-                        (br $while-in$20)
+                        (br $while-in16)
                       )
                       (block
                         (set_local $16
@@ -2041,7 +2041,7 @@
                           (get_local $11)
                         )
                       )
-                      (block $do-once$21
+                      (block $do-once17
                         (if
                           (i32.eq
                             (tee_local $3
@@ -2089,11 +2089,11 @@
                                   (set_local $22
                                     (i32.const 0)
                                   )
-                                  (br $do-once$21)
+                                  (br $do-once17)
                                 )
                               )
                             )
-                            (loop $while-in$24
+                            (loop $while-in20
                               (if
                                 (tee_local $6
                                   (i32.load
@@ -2112,7 +2112,7 @@
                                   (set_local $3
                                     (get_local $2)
                                   )
-                                  (br $while-in$24)
+                                  (br $while-in20)
                                 )
                               )
                               (if
@@ -2133,7 +2133,7 @@
                                   (set_local $3
                                     (get_local $2)
                                   )
-                                  (br $while-in$24)
+                                  (br $while-in20)
                                 )
                               )
                             )
@@ -2210,7 +2210,7 @@
                           )
                         )
                       )
-                      (block $do-once$25
+                      (block $do-once21
                         (if
                           (get_local $5)
                           (block
@@ -2258,7 +2258,7 @@
                                         )
                                       )
                                     )
-                                    (br $do-once$25)
+                                    (br $do-once21)
                                   )
                                 )
                               )
@@ -2293,7 +2293,7 @@
                                     (get_local $22)
                                   )
                                 )
-                                (br_if $do-once$25
+                                (br_if $do-once21
                                   (i32.eqz
                                     (get_local $22)
                                   )
@@ -2368,7 +2368,7 @@
                           )
                         )
                       )
-                      (block $do-once$29
+                      (block $do-once25
                         (if
                           (i32.lt_u
                             (get_local $16)
@@ -2526,7 +2526,7 @@
                                   (get_local $8)
                                   (get_local $5)
                                 )
-                                (br $do-once$29)
+                                (br $do-once25)
                               )
                             )
                             (set_local $15
@@ -2691,7 +2691,7 @@
                                   (get_local $8)
                                   (get_local $8)
                                 )
-                                (br $do-once$29)
+                                (br $do-once25)
                               )
                             )
                             (set_local $10
@@ -2718,8 +2718,8 @@
                                 (get_local $15)
                               )
                             )
-                            (loop $while-in$32
-                              (block $while-out$31
+                            (loop $while-in28
+                              (block $while-out27
                                 (if
                                   (i32.eq
                                     (i32.and
@@ -2737,7 +2737,7 @@
                                     (set_local $9
                                       (i32.const 148)
                                     )
-                                    (br $while-out$31)
+                                    (br $while-out27)
                                   )
                                 )
                                 (if
@@ -2770,7 +2770,7 @@
                                     (set_local $2
                                       (get_local $3)
                                     )
-                                    (br $while-in$32)
+                                    (br $while-in28)
                                   )
                                   (block
                                     (set_local $21
@@ -3220,8 +3220,8 @@
                       (set_local $7
                         (i32.const 1656)
                       )
-                      (loop $while-in$36
-                        (block $while-out$35
+                      (loop $while-in32
+                        (block $while-out31
                           (if
                             (i32.le_u
                               (tee_local $3
@@ -3253,11 +3253,11 @@
                                 (set_local $5
                                   (get_local $19)
                                 )
-                                (br $while-out$35)
+                                (br $while-out31)
                               )
                             )
                           )
-                          (br_if $while-in$36
+                          (br_if $while-in32
                             (tee_local $7
                               (i32.load offset=8
                                 (get_local $7)
@@ -3337,7 +3337,7 @@
                     )
                   )
                 )
-                (block $do-once$37
+                (block $do-once33
                   (if
                     (i32.eq
                       (get_local $9)
@@ -3417,7 +3417,7 @@
                                   (i32.const 1648)
                                 )
                               )
-                              (br_if $do-once$37
+                              (br_if $do-once33
                                 (i32.or
                                   (i32.le_u
                                     (get_local $0)
@@ -3674,7 +3674,7 @@
             (get_local $12)
           )
         )
-        (block $do-once$42
+        (block $do-once38
           (if
             (tee_local $12
               (i32.load
@@ -3685,8 +3685,8 @@
               (set_local $1
                 (i32.const 1656)
               )
-              (loop $do-in$47
-                (block $do-out$46
+              (loop $do-in41
+                (block $do-out40
                   (if
                     (i32.eq
                       (get_local $20)
@@ -3724,10 +3724,10 @@
                       (set_local $9
                         (i32.const 201)
                       )
-                      (br $do-out$46)
+                      (br $do-out40)
                     )
                   )
-                  (br_if $do-in$47
+                  (br_if $do-in41
                     (i32.ne
                       (tee_local $1
                         (i32.load offset=8
@@ -3837,7 +3837,7 @@
                           (i32.const 1696)
                         )
                       )
-                      (br $do-once$42)
+                      (br $do-once38)
                     )
                   )
                 )
@@ -3871,8 +3871,8 @@
               (set_local $1
                 (i32.const 1656)
               )
-              (loop $while-in$49
-                (block $while-out$48
+              (loop $while-in43
+                (block $while-out42
                   (if
                     (i32.eq
                       (i32.load
@@ -3890,10 +3890,10 @@
                       (set_local $9
                         (i32.const 209)
                       )
-                      (br $while-out$48)
+                      (br $while-out42)
                     )
                   )
-                  (br_if $while-in$49
+                  (br_if $while-in43
                     (tee_local $1
                       (i32.load offset=8
                         (get_local $1)
@@ -4009,7 +4009,7 @@
                         (i32.const 3)
                       )
                     )
-                    (block $do-once$50
+                    (block $do-once44
                       (if
                         (i32.eq
                           (get_local $4)
@@ -4077,7 +4077,7 @@
                                 )
                                 (get_local $2)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (i32.store
@@ -4120,7 +4120,7 @@
                                               (get_local $4)
                                             )
                                           )
-                                          (block $do-once$53
+                                          (block $do-once47
                                             (if
                                               (i32.ne
                                                 (tee_local $21
@@ -4149,7 +4149,7 @@
                                                   )
                                                   (call $qa)
                                                 )
-                                                (br_if $do-once$53
+                                                (br_if $do-once47
                                                   (i32.eq
                                                     (i32.load offset=12
                                                       (get_local $21)
@@ -4185,7 +4185,7 @@
                                               (br $label$break$e)
                                             )
                                           )
-                                          (block $do-once$55
+                                          (block $do-once49
                                             (if
                                               (i32.eq
                                                 (get_local $11)
@@ -4221,7 +4221,7 @@
                                                     (set_local $44
                                                       (get_local $0)
                                                     )
-                                                    (br $do-once$55)
+                                                    (br $do-once49)
                                                   )
                                                 )
                                                 (call $qa)
@@ -4243,7 +4243,7 @@
                                               (get_local $4)
                                             )
                                           )
-                                          (block $do-once$57
+                                          (block $do-once51
                                             (if
                                               (i32.eq
                                                 (tee_local $0
@@ -4291,11 +4291,11 @@
                                                       (set_local $24
                                                         (i32.const 0)
                                                       )
-                                                      (br $do-once$57)
+                                                      (br $do-once51)
                                                     )
                                                   )
                                                 )
-                                                (loop $while-in$60
+                                                (loop $while-in54
                                                   (if
                                                     (tee_local $3
                                                       (i32.load
@@ -4314,7 +4314,7 @@
                                                       (set_local $16
                                                         (get_local $7)
                                                       )
-                                                      (br $while-in$60)
+                                                      (br $while-in54)
                                                     )
                                                   )
                                                   (if
@@ -4335,7 +4335,7 @@
                                                       (set_local $16
                                                         (get_local $7)
                                                       )
-                                                      (br $while-in$60)
+                                                      (br $while-in54)
                                                     )
                                                   )
                                                 )
@@ -4417,7 +4417,7 @@
                                               (get_local $19)
                                             )
                                           )
-                                          (block $do-once$61
+                                          (block $do-once55
                                             (if
                                               (i32.eq
                                                 (get_local $4)
@@ -4442,7 +4442,7 @@
                                                   (get_local $21)
                                                   (get_local $24)
                                                 )
-                                                (br_if $do-once$61
+                                                (br_if $do-once55
                                                   (get_local $24)
                                                 )
                                                 (i32.store
@@ -4637,7 +4637,7 @@
                                   )
                                 )
                               )
-                              (block $do-once$65
+                              (block $do-once59
                                 (if
                                   (i32.and
                                     (tee_local $11
@@ -4676,7 +4676,7 @@
                                         (set_local $38
                                           (get_local $19)
                                         )
-                                        (br $do-once$65)
+                                        (br $do-once59)
                                       )
                                     )
                                     (call $qa)
@@ -4717,7 +4717,7 @@
                                 (get_local $1)
                                 (get_local $2)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $0
@@ -4725,7 +4725,7 @@
                               (i32.const 1512)
                               (i32.shl
                                 (tee_local $6
-                                  (block $do-once$67 i32
+                                  (block $do-once61 i32
                                     (if i32
                                       (tee_local $0
                                         (i32.shr_u
@@ -4735,7 +4735,7 @@
                                       )
                                       (block i32
                                         (drop
-                                          (br_if $do-once$67
+                                          (br_if $do-once61
                                             (i32.const 31)
                                             (i32.gt_u
                                               (get_local $14)
@@ -4888,7 +4888,7 @@
                                 (get_local $1)
                                 (get_local $1)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $7
@@ -4915,8 +4915,8 @@
                               (get_local $0)
                             )
                           )
-                          (loop $while-in$70
-                            (block $while-out$69
+                          (loop $while-in64
+                            (block $while-out63
                               (if
                                 (i32.eq
                                   (i32.and
@@ -4934,7 +4934,7 @@
                                   (set_local $9
                                     (i32.const 279)
                                   )
-                                  (br $while-out$69)
+                                  (br $while-out63)
                                 )
                               )
                               (if
@@ -4967,7 +4967,7 @@
                                   (set_local $2
                                     (get_local $5)
                                   )
-                                  (br $while-in$70)
+                                  (br $while-in64)
                                 )
                                 (block
                                   (set_local $46
@@ -5085,8 +5085,8 @@
                   )
                 )
               )
-              (loop $while-in$72
-                (block $while-out$71
+              (loop $while-in66
+                (block $while-out65
                   (if
                     (i32.le_u
                       (tee_local $1
@@ -5112,7 +5112,7 @@
                         (set_local $0
                           (get_local $14)
                         )
-                        (br $while-out$71)
+                        (br $while-out65)
                       )
                     )
                   )
@@ -5121,7 +5121,7 @@
                       (get_local $30)
                     )
                   )
-                  (br $while-in$72)
+                  (br $while-in66)
                 )
               )
               (set_local $14
@@ -5289,7 +5289,7 @@
                   (i32.const 24)
                 )
               )
-              (loop $do-in$74
+              (loop $do-in68
                 (i32.store
                   (tee_local $1
                     (i32.add
@@ -5299,7 +5299,7 @@
                   )
                   (i32.const 7)
                 )
-                (br_if $do-in$74
+                (br_if $do-in68
                   (i32.lt_u
                     (i32.add
                       (get_local $1)
@@ -5439,7 +5439,7 @@
                         (get_local $12)
                         (get_local $13)
                       )
-                      (br $do-once$42)
+                      (br $do-once38)
                     )
                   )
                   (set_local $0
@@ -5599,7 +5599,7 @@
                         (get_local $12)
                         (get_local $12)
                       )
-                      (br $do-once$42)
+                      (br $do-once38)
                     )
                   )
                   (set_local $4
@@ -5626,8 +5626,8 @@
                       (get_local $0)
                     )
                   )
-                  (loop $while-in$76
-                    (block $while-out$75
+                  (loop $while-in70
+                    (block $while-out69
                       (if
                         (i32.eq
                           (i32.and
@@ -5645,7 +5645,7 @@
                           (set_local $9
                             (i32.const 305)
                           )
-                          (br $while-out$75)
+                          (br $while-out69)
                         )
                       )
                       (if
@@ -5678,7 +5678,7 @@
                           (set_local $5
                             (get_local $2)
                           )
-                          (br $while-in$76)
+                          (br $while-in70)
                         )
                         (block
                           (set_local $48
@@ -5829,7 +5829,7 @@
               (set_local $4
                 (i32.const 0)
               )
-              (loop $do-in$45
+              (loop $do-in
                 (i32.store offset=12
                   (tee_local $13
                     (i32.add
@@ -5849,7 +5849,7 @@
                   (get_local $13)
                   (get_local $13)
                 )
-                (br_if $do-in$45
+                (br_if $do-in
                   (i32.ne
                     (tee_local $4
                       (i32.add
@@ -6065,7 +6065,7 @@
         )
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.and
           (get_local $3)
@@ -6144,7 +6144,7 @@
                   (set_local $7
                     (get_local $5)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (i32.store
@@ -6258,7 +6258,7 @@
                   (set_local $7
                     (get_local $5)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (if
@@ -6313,7 +6313,7 @@
               (set_local $7
                 (get_local $5)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $11
@@ -6321,7 +6321,7 @@
               (get_local $0)
             )
           )
-          (block $do-once$2
+          (block $do-once0
             (if
               (i32.eq
                 (tee_local $1
@@ -6368,11 +6368,11 @@
                       (set_local $4
                         (i32.const 0)
                       )
-                      (br $do-once$2)
+                      (br $do-once0)
                     )
                   )
                 )
-                (loop $while-in$5
+                (loop $while-in
                   (if
                     (tee_local $10
                       (i32.load
@@ -6391,7 +6391,7 @@
                       (set_local $3
                         (get_local $6)
                       )
-                      (br $while-in$5)
+                      (br $while-in)
                     )
                   )
                   (if
@@ -6412,7 +6412,7 @@
                       (set_local $3
                         (get_local $6)
                       )
-                      (br $while-in$5)
+                      (br $while-in)
                     )
                     (block
                       (set_local $6
@@ -6550,7 +6550,7 @@
                       (set_local $7
                         (get_local $5)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -6596,7 +6596,7 @@
                       (set_local $7
                         (get_local $5)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -6860,7 +6860,7 @@
             (i32.const 3)
           )
         )
-        (block $do-once$8
+        (block $do-once4
           (if
             (i32.lt_u
               (get_local $1)
@@ -6934,7 +6934,7 @@
                       )
                     )
                   )
-                  (br $do-once$8)
+                  (br $do-once4)
                 )
               )
               (if
@@ -6992,7 +6992,7 @@
                   (get_local $8)
                 )
               )
-              (block $do-once$10
+              (block $do-once6
                 (if
                   (i32.eq
                     (tee_local $9
@@ -7039,11 +7039,11 @@
                           (set_local $12
                             (i32.const 0)
                           )
-                          (br $do-once$10)
+                          (br $do-once6)
                         )
                       )
                     )
-                    (loop $while-in$13
+                    (loop $while-in9
                       (if
                         (tee_local $10
                           (i32.load
@@ -7062,7 +7062,7 @@
                           (set_local $3
                             (get_local $1)
                           )
-                          (br $while-in$13)
+                          (br $while-in9)
                         )
                       )
                       (if
@@ -7083,7 +7083,7 @@
                           (set_local $3
                             (get_local $1)
                           )
-                          (br $while-in$13)
+                          (br $while-in9)
                         )
                       )
                     )
@@ -7211,7 +7211,7 @@
                               )
                             )
                           )
-                          (br $do-once$8)
+                          (br $do-once4)
                         )
                       )
                     )
@@ -7246,7 +7246,7 @@
                           (get_local $12)
                         )
                       )
-                      (br_if $do-once$8
+                      (br_if $do-once4
                         (i32.eqz
                           (get_local $12)
                         )
@@ -7620,8 +7620,8 @@
             (get_local $4)
           )
         )
-        (loop $while-in$19
-          (block $while-out$18
+        (loop $while-in15
+          (block $while-out14
             (if
               (i32.eq
                 (i32.and
@@ -7639,7 +7639,7 @@
                 (set_local $0
                   (i32.const 130)
                 )
-                (br $while-out$18)
+                (br $while-out14)
               )
             )
             (if
@@ -7672,7 +7672,7 @@
                 (set_local $1
                   (get_local $12)
                 )
-                (br $while-in$19)
+                (br $while-in15)
               )
               (block
                 (set_local $18
@@ -7820,7 +7820,7 @@
         (i32.const 1664)
       )
     )
-    (loop $while-in$21
+    (loop $while-in17
       (if
         (tee_local $2
           (i32.load
@@ -7834,7 +7834,7 @@
               (i32.const 8)
             )
           )
-          (br $while-in$21)
+          (br $while-in17)
         )
       )
     )
@@ -7943,8 +7943,8 @@
         (get_local $2)
       )
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (if
           (i32.eq
             (get_local $3)
@@ -8014,7 +8014,7 @@
             (set_local $1
               (i32.const 6)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (if
@@ -8139,7 +8139,7 @@
             (set_local $3
               (get_local $9)
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
       )
@@ -8331,7 +8331,7 @@
                   (set_local $3
                     (get_local $1)
                   )
-                  (loop $while-in$3
+                  (loop $while-in
                     (if
                       (i32.eqz
                         (get_local $3)
@@ -8364,7 +8364,7 @@
                         (set_local $3
                           (get_local $6)
                         )
-                        (br $while-in$3)
+                        (br $while-in)
                       )
                     )
                   )
@@ -8466,7 +8466,7 @@
           (set_local $4
             (get_local $3)
           )
-          (loop $while-in$2
+          (loop $while-in
             (if
               (i32.eqz
                 (i32.load8_s
@@ -8480,7 +8480,7 @@
                 (br $label$break$a)
               )
             )
-            (br_if $while-in$2
+            (br_if $while-in
               (i32.and
                 (tee_local $4
                   (tee_local $0
@@ -8522,7 +8522,7 @@
         (set_local $2
           (get_local $1)
         )
-        (loop $while-in$4
+        (loop $while-in1
           (if
             (i32.and
               (i32.xor
@@ -8551,7 +8551,7 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$4)
+              (br $while-in1)
             )
           )
         )
@@ -8570,7 +8570,7 @@
             (set_local $1
               (get_local $0)
             )
-            (loop $while-in$6
+            (loop $while-in3
               (if
                 (i32.load8_s
                   (tee_local $0
@@ -8584,7 +8584,7 @@
                   (set_local $1
                     (get_local $0)
                   )
-                  (br $while-in$6)
+                  (br $while-in3)
                 )
               )
             )
@@ -8603,7 +8603,7 @@
   (func $_a (param $0 i32) (result i32)
     (local $1 i32)
     (local $2 i32)
-    (block $do-once$0 i32
+    (block $do-once i32
       (if i32
         (get_local $0)
         (block i32
@@ -8614,7 +8614,7 @@
               )
               (i32.const -1)
             )
-            (br $do-once$0
+            (br $do-once
               (call $$a
                 (get_local $0)
               )
@@ -8673,7 +8673,7 @@
               (set_local $2
                 (get_local $0)
               )
-              (loop $while-in$3
+              (loop $while-in
                 (set_local $0
                   (if i32
                     (i32.gt_s
@@ -8713,7 +8713,7 @@
                     (get_local $1)
                   )
                 )
-                (br_if $while-in$3
+                (br_if $while-in
                   (tee_local $1
                     (i32.load offset=56
                       (get_local $1)
@@ -8801,7 +8801,7 @@
         )
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.eq
           (get_local $8)
@@ -8846,7 +8846,7 @@
                   (get_local $2)
                   (get_local $9)
                 )
-                (br $do-once$0)
+                (br $do-once)
               )
             )
           )
@@ -9048,9 +9048,9 @@
         )
       )
       (block
-        (loop $while-in$1
-          (block $while-out$0
-            (br_if $while-out$0
+        (loop $while-in
+          (block $while-out
+            (br_if $while-out
               (i32.eqz
                 (i32.and
                   (get_local $0)
@@ -9090,10 +9090,10 @@
                 (i32.const 1)
               )
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
-        (loop $while-in$3
+        (loop $while-in1
           (if
             (i32.ge_s
               (get_local $2)
@@ -9124,13 +9124,13 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$3)
+              (br $while-in1)
             )
           )
         )
       )
     )
-    (loop $while-in$5
+    (loop $while-in3
       (if
         (i32.gt_s
           (get_local $2)
@@ -9161,7 +9161,7 @@
               (i32.const 1)
             )
           )
-          (br $while-in$5)
+          (br $while-in3)
         )
       )
     )
@@ -9236,7 +9236,7 @@
                 (get_local $3)
               )
             )
-            (loop $while-in$1
+            (loop $while-in
               (if
                 (i32.lt_s
                   (get_local $0)
@@ -9253,13 +9253,13 @@
                       (i32.const 1)
                     )
                   )
-                  (br $while-in$1)
+                  (br $while-in)
                 )
               )
             )
           )
         )
-        (loop $while-in$3
+        (loop $while-in1
           (if
             (i32.lt_s
               (get_local $0)
@@ -9276,13 +9276,13 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$3)
+              (br $while-in1)
             )
           )
         )
       )
     )
-    (loop $while-in$5
+    (loop $while-in3
       (if
         (i32.lt_s
           (get_local $0)
@@ -9299,7 +9299,7 @@
               (i32.const 1)
             )
           )
-          (br $while-in$5)
+          (br $while-in3)
         )
       )
     )
@@ -9331,7 +9331,7 @@
       )
     )
     (set_local $0
-      (block $do-once$0 i32
+      (block $do-once i32
         (if i32
           (i32.lt_s
             (call $cb
@@ -9377,7 +9377,7 @@
                     (get_local $2)
                     (i32.const 10)
                   )
-                  (br $do-once$0
+                  (br $do-once
                     (i32.const 0)
                   )
                 )

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -146,7 +146,7 @@
     (set_local $13
       (get_local $25)
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.lt_u
           (get_local $0)
@@ -814,8 +814,8 @@
                   (set_local $3
                     (get_local $4)
                   )
-                  (loop $while-in$7
-                    (block $while-out$6
+                  (loop $while-in
+                    (block $while-out
                       (if
                         (tee_local $4
                           (i32.load offset=16
@@ -841,7 +841,7 @@
                             (set_local $1
                               (get_local $3)
                             )
-                            (br $while-out$6)
+                            (br $while-out)
                           )
                         )
                       )
@@ -878,7 +878,7 @@
                           (get_local $6)
                         )
                       )
-                      (br $while-in$7)
+                      (br $while-in)
                     )
                   )
                   (if
@@ -909,7 +909,7 @@
                       (get_local $1)
                     )
                   )
-                  (block $do-once$8
+                  (block $do-once4
                     (if
                       (i32.eq
                         (tee_local $17
@@ -956,11 +956,11 @@
                               (set_local $23
                                 (i32.const 0)
                               )
-                              (br $do-once$8)
+                              (br $do-once4)
                             )
                           )
                         )
-                        (loop $while-in$11
+                        (loop $while-in7
                           (if
                             (tee_local $9
                               (i32.load
@@ -979,7 +979,7 @@
                               (set_local $6
                                 (get_local $10)
                               )
-                              (br $while-in$11)
+                              (br $while-in7)
                             )
                           )
                           (if
@@ -1000,7 +1000,7 @@
                               (set_local $6
                                 (get_local $10)
                               )
-                              (br $while-in$11)
+                              (br $while-in7)
                             )
                           )
                         )
@@ -1077,7 +1077,7 @@
                       )
                     )
                   )
-                  (block $do-once$12
+                  (block $do-once8
                     (if
                       (get_local $0)
                       (block
@@ -1125,7 +1125,7 @@
                                     )
                                   )
                                 )
-                                (br $do-once$12)
+                                (br $do-once8)
                               )
                             )
                           )
@@ -1160,7 +1160,7 @@
                                 (get_local $23)
                               )
                             )
-                            (br_if $do-once$12
+                            (br_if $do-once8
                               (i32.eqz
                                 (get_local $23)
                               )
@@ -1603,7 +1603,7 @@
                       (set_local $8
                         (i32.const 0)
                       )
-                      (loop $while-in$18
+                      (loop $while-in14
                         (if
                           (i32.lt_u
                             (tee_local $2
@@ -1722,7 +1722,7 @@
                                 )
                               )
                             )
-                            (br $while-in$18)
+                            (br $while-in14)
                           )
                         )
                       )
@@ -1784,7 +1784,7 @@
                               (set_local $6
                                 (get_local $0)
                               )
-                              (br $do-once$0)
+                              (br $do-once)
                             )
                           )
                           (set_local $6
@@ -1919,7 +1919,7 @@
                     (get_local $9)
                     (i32.const 90)
                   )
-                  (loop $while-in$20
+                  (loop $while-in16
                     (set_local $9
                       (i32.const 0)
                     )
@@ -1969,7 +1969,7 @@
                         (set_local $32
                           (get_local $8)
                         )
-                        (br $while-in$20)
+                        (br $while-in16)
                       )
                     )
                     (if
@@ -1985,7 +1985,7 @@
                         (set_local $32
                           (get_local $8)
                         )
-                        (br $while-in$20)
+                        (br $while-in16)
                       )
                       (block
                         (set_local $16
@@ -2039,7 +2039,7 @@
                           (get_local $11)
                         )
                       )
-                      (block $do-once$21
+                      (block $do-once17
                         (if
                           (i32.eq
                             (tee_local $3
@@ -2087,11 +2087,11 @@
                                   (set_local $22
                                     (i32.const 0)
                                   )
-                                  (br $do-once$21)
+                                  (br $do-once17)
                                 )
                               )
                             )
-                            (loop $while-in$24
+                            (loop $while-in20
                               (if
                                 (tee_local $6
                                   (i32.load
@@ -2110,7 +2110,7 @@
                                   (set_local $3
                                     (get_local $2)
                                   )
-                                  (br $while-in$24)
+                                  (br $while-in20)
                                 )
                               )
                               (if
@@ -2131,7 +2131,7 @@
                                   (set_local $3
                                     (get_local $2)
                                   )
-                                  (br $while-in$24)
+                                  (br $while-in20)
                                 )
                               )
                             )
@@ -2208,7 +2208,7 @@
                           )
                         )
                       )
-                      (block $do-once$25
+                      (block $do-once21
                         (if
                           (get_local $5)
                           (block
@@ -2256,7 +2256,7 @@
                                         )
                                       )
                                     )
-                                    (br $do-once$25)
+                                    (br $do-once21)
                                   )
                                 )
                               )
@@ -2291,7 +2291,7 @@
                                     (get_local $22)
                                   )
                                 )
-                                (br_if $do-once$25
+                                (br_if $do-once21
                                   (i32.eqz
                                     (get_local $22)
                                   )
@@ -2366,7 +2366,7 @@
                           )
                         )
                       )
-                      (block $do-once$29
+                      (block $do-once25
                         (if
                           (i32.lt_u
                             (get_local $16)
@@ -2524,7 +2524,7 @@
                                   (get_local $8)
                                   (get_local $5)
                                 )
-                                (br $do-once$29)
+                                (br $do-once25)
                               )
                             )
                             (set_local $15
@@ -2689,7 +2689,7 @@
                                   (get_local $8)
                                   (get_local $8)
                                 )
-                                (br $do-once$29)
+                                (br $do-once25)
                               )
                             )
                             (set_local $10
@@ -2716,8 +2716,8 @@
                                 (get_local $15)
                               )
                             )
-                            (loop $while-in$32
-                              (block $while-out$31
+                            (loop $while-in28
+                              (block $while-out27
                                 (if
                                   (i32.eq
                                     (i32.and
@@ -2735,7 +2735,7 @@
                                     (set_local $9
                                       (i32.const 148)
                                     )
-                                    (br $while-out$31)
+                                    (br $while-out27)
                                   )
                                 )
                                 (if
@@ -2768,7 +2768,7 @@
                                     (set_local $2
                                       (get_local $3)
                                     )
-                                    (br $while-in$32)
+                                    (br $while-in28)
                                   )
                                   (block
                                     (set_local $21
@@ -3218,8 +3218,8 @@
                       (set_local $7
                         (i32.const 1656)
                       )
-                      (loop $while-in$36
-                        (block $while-out$35
+                      (loop $while-in32
+                        (block $while-out31
                           (if
                             (i32.le_u
                               (tee_local $3
@@ -3251,11 +3251,11 @@
                                 (set_local $5
                                   (get_local $19)
                                 )
-                                (br $while-out$35)
+                                (br $while-out31)
                               )
                             )
                           )
-                          (br_if $while-in$36
+                          (br_if $while-in32
                             (tee_local $7
                               (i32.load offset=8
                                 (get_local $7)
@@ -3335,7 +3335,7 @@
                     )
                   )
                 )
-                (block $do-once$37
+                (block $do-once33
                   (if
                     (i32.eq
                       (get_local $9)
@@ -3415,7 +3415,7 @@
                                   (i32.const 1648)
                                 )
                               )
-                              (br_if $do-once$37
+                              (br_if $do-once33
                                 (i32.or
                                   (i32.le_u
                                     (get_local $0)
@@ -3672,7 +3672,7 @@
             (get_local $12)
           )
         )
-        (block $do-once$42
+        (block $do-once38
           (if
             (tee_local $12
               (i32.load
@@ -3683,8 +3683,8 @@
               (set_local $1
                 (i32.const 1656)
               )
-              (loop $do-in$47
-                (block $do-out$46
+              (loop $do-in41
+                (block $do-out40
                   (if
                     (i32.eq
                       (get_local $20)
@@ -3722,10 +3722,10 @@
                       (set_local $9
                         (i32.const 201)
                       )
-                      (br $do-out$46)
+                      (br $do-out40)
                     )
                   )
-                  (br_if $do-in$47
+                  (br_if $do-in41
                     (i32.ne
                       (tee_local $1
                         (i32.load offset=8
@@ -3835,7 +3835,7 @@
                           (i32.const 1696)
                         )
                       )
-                      (br $do-once$42)
+                      (br $do-once38)
                     )
                   )
                 )
@@ -3869,8 +3869,8 @@
               (set_local $1
                 (i32.const 1656)
               )
-              (loop $while-in$49
-                (block $while-out$48
+              (loop $while-in43
+                (block $while-out42
                   (if
                     (i32.eq
                       (i32.load
@@ -3888,10 +3888,10 @@
                       (set_local $9
                         (i32.const 209)
                       )
-                      (br $while-out$48)
+                      (br $while-out42)
                     )
                   )
-                  (br_if $while-in$49
+                  (br_if $while-in43
                     (tee_local $1
                       (i32.load offset=8
                         (get_local $1)
@@ -4007,7 +4007,7 @@
                         (i32.const 3)
                       )
                     )
-                    (block $do-once$50
+                    (block $do-once44
                       (if
                         (i32.eq
                           (get_local $4)
@@ -4075,7 +4075,7 @@
                                 )
                                 (get_local $2)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (i32.store
@@ -4118,7 +4118,7 @@
                                               (get_local $4)
                                             )
                                           )
-                                          (block $do-once$53
+                                          (block $do-once47
                                             (if
                                               (i32.ne
                                                 (tee_local $21
@@ -4147,7 +4147,7 @@
                                                   )
                                                   (call $qa)
                                                 )
-                                                (br_if $do-once$53
+                                                (br_if $do-once47
                                                   (i32.eq
                                                     (i32.load offset=12
                                                       (get_local $21)
@@ -4183,7 +4183,7 @@
                                               (br $label$break$e)
                                             )
                                           )
-                                          (block $do-once$55
+                                          (block $do-once49
                                             (if
                                               (i32.eq
                                                 (get_local $11)
@@ -4219,7 +4219,7 @@
                                                     (set_local $44
                                                       (get_local $0)
                                                     )
-                                                    (br $do-once$55)
+                                                    (br $do-once49)
                                                   )
                                                 )
                                                 (call $qa)
@@ -4241,7 +4241,7 @@
                                               (get_local $4)
                                             )
                                           )
-                                          (block $do-once$57
+                                          (block $do-once51
                                             (if
                                               (i32.eq
                                                 (tee_local $0
@@ -4289,11 +4289,11 @@
                                                       (set_local $24
                                                         (i32.const 0)
                                                       )
-                                                      (br $do-once$57)
+                                                      (br $do-once51)
                                                     )
                                                   )
                                                 )
-                                                (loop $while-in$60
+                                                (loop $while-in54
                                                   (if
                                                     (tee_local $3
                                                       (i32.load
@@ -4312,7 +4312,7 @@
                                                       (set_local $16
                                                         (get_local $7)
                                                       )
-                                                      (br $while-in$60)
+                                                      (br $while-in54)
                                                     )
                                                   )
                                                   (if
@@ -4333,7 +4333,7 @@
                                                       (set_local $16
                                                         (get_local $7)
                                                       )
-                                                      (br $while-in$60)
+                                                      (br $while-in54)
                                                     )
                                                   )
                                                 )
@@ -4415,7 +4415,7 @@
                                               (get_local $19)
                                             )
                                           )
-                                          (block $do-once$61
+                                          (block $do-once55
                                             (if
                                               (i32.eq
                                                 (get_local $4)
@@ -4440,7 +4440,7 @@
                                                   (get_local $21)
                                                   (get_local $24)
                                                 )
-                                                (br_if $do-once$61
+                                                (br_if $do-once55
                                                   (get_local $24)
                                                 )
                                                 (i32.store
@@ -4635,7 +4635,7 @@
                                   )
                                 )
                               )
-                              (block $do-once$65
+                              (block $do-once59
                                 (if
                                   (i32.and
                                     (tee_local $11
@@ -4674,7 +4674,7 @@
                                         (set_local $38
                                           (get_local $19)
                                         )
-                                        (br $do-once$65)
+                                        (br $do-once59)
                                       )
                                     )
                                     (call $qa)
@@ -4715,7 +4715,7 @@
                                 (get_local $1)
                                 (get_local $2)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $0
@@ -4723,7 +4723,7 @@
                               (i32.const 1512)
                               (i32.shl
                                 (tee_local $6
-                                  (block $do-once$67 i32
+                                  (block $do-once61 i32
                                     (if i32
                                       (tee_local $0
                                         (i32.shr_u
@@ -4733,7 +4733,7 @@
                                       )
                                       (block i32
                                         (drop
-                                          (br_if $do-once$67
+                                          (br_if $do-once61
                                             (i32.const 31)
                                             (i32.gt_u
                                               (get_local $14)
@@ -4886,7 +4886,7 @@
                                 (get_local $1)
                                 (get_local $1)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $7
@@ -4913,8 +4913,8 @@
                               (get_local $0)
                             )
                           )
-                          (loop $while-in$70
-                            (block $while-out$69
+                          (loop $while-in64
+                            (block $while-out63
                               (if
                                 (i32.eq
                                   (i32.and
@@ -4932,7 +4932,7 @@
                                   (set_local $9
                                     (i32.const 279)
                                   )
-                                  (br $while-out$69)
+                                  (br $while-out63)
                                 )
                               )
                               (if
@@ -4965,7 +4965,7 @@
                                   (set_local $2
                                     (get_local $5)
                                   )
-                                  (br $while-in$70)
+                                  (br $while-in64)
                                 )
                                 (block
                                   (set_local $46
@@ -5083,8 +5083,8 @@
                   )
                 )
               )
-              (loop $while-in$72
-                (block $while-out$71
+              (loop $while-in66
+                (block $while-out65
                   (if
                     (i32.le_u
                       (tee_local $1
@@ -5110,7 +5110,7 @@
                         (set_local $0
                           (get_local $14)
                         )
-                        (br $while-out$71)
+                        (br $while-out65)
                       )
                     )
                   )
@@ -5119,7 +5119,7 @@
                       (get_local $30)
                     )
                   )
-                  (br $while-in$72)
+                  (br $while-in66)
                 )
               )
               (set_local $14
@@ -5287,7 +5287,7 @@
                   (i32.const 24)
                 )
               )
-              (loop $do-in$74
+              (loop $do-in68
                 (i32.store
                   (tee_local $1
                     (i32.add
@@ -5297,7 +5297,7 @@
                   )
                   (i32.const 7)
                 )
-                (br_if $do-in$74
+                (br_if $do-in68
                   (i32.lt_u
                     (i32.add
                       (get_local $1)
@@ -5437,7 +5437,7 @@
                         (get_local $12)
                         (get_local $13)
                       )
-                      (br $do-once$42)
+                      (br $do-once38)
                     )
                   )
                   (set_local $0
@@ -5597,7 +5597,7 @@
                         (get_local $12)
                         (get_local $12)
                       )
-                      (br $do-once$42)
+                      (br $do-once38)
                     )
                   )
                   (set_local $4
@@ -5624,8 +5624,8 @@
                       (get_local $0)
                     )
                   )
-                  (loop $while-in$76
-                    (block $while-out$75
+                  (loop $while-in70
+                    (block $while-out69
                       (if
                         (i32.eq
                           (i32.and
@@ -5643,7 +5643,7 @@
                           (set_local $9
                             (i32.const 305)
                           )
-                          (br $while-out$75)
+                          (br $while-out69)
                         )
                       )
                       (if
@@ -5676,7 +5676,7 @@
                           (set_local $5
                             (get_local $2)
                           )
-                          (br $while-in$76)
+                          (br $while-in70)
                         )
                         (block
                           (set_local $48
@@ -5827,7 +5827,7 @@
               (set_local $4
                 (i32.const 0)
               )
-              (loop $do-in$45
+              (loop $do-in
                 (i32.store offset=12
                   (tee_local $13
                     (i32.add
@@ -5847,7 +5847,7 @@
                   (get_local $13)
                   (get_local $13)
                 )
-                (br_if $do-in$45
+                (br_if $do-in
                   (i32.ne
                     (tee_local $4
                       (i32.add
@@ -6063,7 +6063,7 @@
         )
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.and
           (get_local $3)
@@ -6142,7 +6142,7 @@
                   (set_local $7
                     (get_local $5)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (i32.store
@@ -6256,7 +6256,7 @@
                   (set_local $7
                     (get_local $5)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (if
@@ -6311,7 +6311,7 @@
               (set_local $7
                 (get_local $5)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $11
@@ -6319,7 +6319,7 @@
               (get_local $0)
             )
           )
-          (block $do-once$2
+          (block $do-once0
             (if
               (i32.eq
                 (tee_local $1
@@ -6366,11 +6366,11 @@
                       (set_local $4
                         (i32.const 0)
                       )
-                      (br $do-once$2)
+                      (br $do-once0)
                     )
                   )
                 )
-                (loop $while-in$5
+                (loop $while-in
                   (if
                     (tee_local $10
                       (i32.load
@@ -6389,7 +6389,7 @@
                       (set_local $3
                         (get_local $6)
                       )
-                      (br $while-in$5)
+                      (br $while-in)
                     )
                   )
                   (if
@@ -6410,7 +6410,7 @@
                       (set_local $3
                         (get_local $6)
                       )
-                      (br $while-in$5)
+                      (br $while-in)
                     )
                     (block
                       (set_local $6
@@ -6548,7 +6548,7 @@
                       (set_local $7
                         (get_local $5)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -6594,7 +6594,7 @@
                       (set_local $7
                         (get_local $5)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -6858,7 +6858,7 @@
             (i32.const 3)
           )
         )
-        (block $do-once$8
+        (block $do-once4
           (if
             (i32.lt_u
               (get_local $1)
@@ -6932,7 +6932,7 @@
                       )
                     )
                   )
-                  (br $do-once$8)
+                  (br $do-once4)
                 )
               )
               (if
@@ -6990,7 +6990,7 @@
                   (get_local $8)
                 )
               )
-              (block $do-once$10
+              (block $do-once6
                 (if
                   (i32.eq
                     (tee_local $9
@@ -7037,11 +7037,11 @@
                           (set_local $12
                             (i32.const 0)
                           )
-                          (br $do-once$10)
+                          (br $do-once6)
                         )
                       )
                     )
-                    (loop $while-in$13
+                    (loop $while-in9
                       (if
                         (tee_local $10
                           (i32.load
@@ -7060,7 +7060,7 @@
                           (set_local $3
                             (get_local $1)
                           )
-                          (br $while-in$13)
+                          (br $while-in9)
                         )
                       )
                       (if
@@ -7081,7 +7081,7 @@
                           (set_local $3
                             (get_local $1)
                           )
-                          (br $while-in$13)
+                          (br $while-in9)
                         )
                       )
                     )
@@ -7209,7 +7209,7 @@
                               )
                             )
                           )
-                          (br $do-once$8)
+                          (br $do-once4)
                         )
                       )
                     )
@@ -7244,7 +7244,7 @@
                           (get_local $12)
                         )
                       )
-                      (br_if $do-once$8
+                      (br_if $do-once4
                         (i32.eqz
                           (get_local $12)
                         )
@@ -7618,8 +7618,8 @@
             (get_local $4)
           )
         )
-        (loop $while-in$19
-          (block $while-out$18
+        (loop $while-in15
+          (block $while-out14
             (if
               (i32.eq
                 (i32.and
@@ -7637,7 +7637,7 @@
                 (set_local $0
                   (i32.const 130)
                 )
-                (br $while-out$18)
+                (br $while-out14)
               )
             )
             (if
@@ -7670,7 +7670,7 @@
                 (set_local $1
                   (get_local $12)
                 )
-                (br $while-in$19)
+                (br $while-in15)
               )
               (block
                 (set_local $18
@@ -7818,7 +7818,7 @@
         (i32.const 1664)
       )
     )
-    (loop $while-in$21
+    (loop $while-in17
       (if
         (tee_local $2
           (i32.load
@@ -7832,7 +7832,7 @@
               (i32.const 8)
             )
           )
-          (br $while-in$21)
+          (br $while-in17)
         )
       )
     )
@@ -7941,8 +7941,8 @@
         (get_local $2)
       )
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (if
           (i32.eq
             (get_local $3)
@@ -8012,7 +8012,7 @@
             (set_local $1
               (i32.const 6)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (if
@@ -8137,7 +8137,7 @@
             (set_local $3
               (get_local $9)
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
       )
@@ -8329,7 +8329,7 @@
                   (set_local $3
                     (get_local $1)
                   )
-                  (loop $while-in$3
+                  (loop $while-in
                     (if
                       (i32.eqz
                         (get_local $3)
@@ -8362,7 +8362,7 @@
                         (set_local $3
                           (get_local $6)
                         )
-                        (br $while-in$3)
+                        (br $while-in)
                       )
                     )
                   )
@@ -8464,7 +8464,7 @@
           (set_local $4
             (get_local $3)
           )
-          (loop $while-in$2
+          (loop $while-in
             (if
               (i32.eqz
                 (i32.load8_s
@@ -8478,7 +8478,7 @@
                 (br $label$break$a)
               )
             )
-            (br_if $while-in$2
+            (br_if $while-in
               (i32.and
                 (tee_local $4
                   (tee_local $0
@@ -8520,7 +8520,7 @@
         (set_local $2
           (get_local $1)
         )
-        (loop $while-in$4
+        (loop $while-in1
           (if
             (i32.and
               (i32.xor
@@ -8549,7 +8549,7 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$4)
+              (br $while-in1)
             )
           )
         )
@@ -8568,7 +8568,7 @@
             (set_local $1
               (get_local $0)
             )
-            (loop $while-in$6
+            (loop $while-in3
               (if
                 (i32.load8_s
                   (tee_local $0
@@ -8582,7 +8582,7 @@
                   (set_local $1
                     (get_local $0)
                   )
-                  (br $while-in$6)
+                  (br $while-in3)
                 )
               )
             )
@@ -8601,7 +8601,7 @@
   (func $_a (param $0 i32) (result i32)
     (local $1 i32)
     (local $2 i32)
-    (block $do-once$0 i32
+    (block $do-once i32
       (if i32
         (get_local $0)
         (block i32
@@ -8612,7 +8612,7 @@
               )
               (i32.const -1)
             )
-            (br $do-once$0
+            (br $do-once
               (call $$a
                 (get_local $0)
               )
@@ -8671,7 +8671,7 @@
               (set_local $2
                 (get_local $0)
               )
-              (loop $while-in$3
+              (loop $while-in
                 (set_local $0
                   (if i32
                     (i32.gt_s
@@ -8711,7 +8711,7 @@
                     (get_local $1)
                   )
                 )
-                (br_if $while-in$3
+                (br_if $while-in
                   (tee_local $1
                     (i32.load offset=56
                       (get_local $1)
@@ -8799,7 +8799,7 @@
         )
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.eq
           (get_local $8)
@@ -8844,7 +8844,7 @@
                   (get_local $2)
                   (get_local $9)
                 )
-                (br $do-once$0)
+                (br $do-once)
               )
             )
           )
@@ -9046,9 +9046,9 @@
         )
       )
       (block
-        (loop $while-in$1
-          (block $while-out$0
-            (br_if $while-out$0
+        (loop $while-in
+          (block $while-out
+            (br_if $while-out
               (i32.eqz
                 (i32.and
                   (get_local $0)
@@ -9088,10 +9088,10 @@
                 (i32.const 1)
               )
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
-        (loop $while-in$3
+        (loop $while-in1
           (if
             (i32.ge_s
               (get_local $2)
@@ -9122,13 +9122,13 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$3)
+              (br $while-in1)
             )
           )
         )
       )
     )
-    (loop $while-in$5
+    (loop $while-in3
       (if
         (i32.gt_s
           (get_local $2)
@@ -9159,7 +9159,7 @@
               (i32.const 1)
             )
           )
-          (br $while-in$5)
+          (br $while-in3)
         )
       )
     )
@@ -9234,7 +9234,7 @@
                 (get_local $3)
               )
             )
-            (loop $while-in$1
+            (loop $while-in
               (if
                 (i32.lt_s
                   (get_local $0)
@@ -9251,13 +9251,13 @@
                       (i32.const 1)
                     )
                   )
-                  (br $while-in$1)
+                  (br $while-in)
                 )
               )
             )
           )
         )
-        (loop $while-in$3
+        (loop $while-in1
           (if
             (i32.lt_s
               (get_local $0)
@@ -9274,13 +9274,13 @@
                   (i32.const 4)
                 )
               )
-              (br $while-in$3)
+              (br $while-in1)
             )
           )
         )
       )
     )
-    (loop $while-in$5
+    (loop $while-in3
       (if
         (i32.lt_s
           (get_local $0)
@@ -9297,7 +9297,7 @@
               (i32.const 1)
             )
           )
-          (br $while-in$5)
+          (br $while-in3)
         )
       )
     )
@@ -9329,7 +9329,7 @@
       )
     )
     (set_local $0
-      (block $do-once$0 i32
+      (block $do-once i32
         (if i32
           (i32.lt_s
             (call $cb
@@ -9375,7 +9375,7 @@
                     (get_local $2)
                     (i32.const 10)
                   )
-                  (br $do-once$0
+                  (br $do-once
                     (i32.const 0)
                   )
                 )

--- a/test/memorygrowth.fromasm.imprecise.no-opts
+++ b/test/memorygrowth.fromasm.imprecise.no-opts
@@ -184,7 +184,7 @@
     (set_local $c
       (get_local $b)
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.lt_u
           (get_local $a)
@@ -276,7 +276,7 @@
                   (get_local $m)
                 )
               )
-              (block $do-once$2
+              (block $do-once0
                 (if
                   (i32.eq
                     (get_local $i)
@@ -327,7 +327,7 @@
                           (get_local $j)
                           (get_local $n)
                         )
-                        (br $do-once$2)
+                        (br $do-once0)
                       )
                       (call $qa)
                     )
@@ -550,7 +550,7 @@
                       (get_local $o)
                     )
                   )
-                  (block $do-once$4
+                  (block $do-once2
                     (if
                       (i32.eq
                         (get_local $s)
@@ -611,7 +611,7 @@
                                 (i32.const 1216)
                               )
                             )
-                            (br $do-once$4)
+                            (br $do-once2)
                           )
                           (call $qa)
                         )
@@ -942,8 +942,8 @@
                   (set_local $s
                     (get_local $j)
                   )
-                  (loop $while-in$7
-                    (block $while-out$6
+                  (loop $while-in
+                    (block $while-out
                       (set_local $j
                         (i32.load
                           (i32.add
@@ -976,7 +976,7 @@
                               (set_local $A
                                 (get_local $s)
                               )
-                              (br $while-out$6)
+                              (br $while-out)
                             )
                             (set_local $B
                               (get_local $f)
@@ -1024,7 +1024,7 @@
                           (get_local $s)
                         )
                       )
-                      (br $while-in$7)
+                      (br $while-in)
                     )
                   )
                   (set_local $s
@@ -1068,7 +1068,7 @@
                       )
                     )
                   )
-                  (block $do-once$8
+                  (block $do-once4
                     (if
                       (i32.eq
                         (get_local $o)
@@ -1110,7 +1110,7 @@
                                 (set_local $C
                                   (i32.const 0)
                                 )
-                                (br $do-once$8)
+                                (br $do-once4)
                               )
                               (block
                                 (set_local $D
@@ -1131,8 +1131,8 @@
                             )
                           )
                         )
-                        (loop $while-in$11
-                          (block $while-out$10
+                        (loop $while-in7
+                          (block $while-out6
                             (set_local $q
                               (i32.add
                                 (get_local $D)
@@ -1153,7 +1153,7 @@
                                 (set_local $E
                                   (get_local $q)
                                 )
-                                (br $while-in$11)
+                                (br $while-in7)
                               )
                             )
                             (set_local $q
@@ -1178,7 +1178,7 @@
                                 (set_local $G
                                   (get_local $E)
                                 )
-                                (br $while-out$10)
+                                (br $while-out6)
                               )
                               (block
                                 (set_local $D
@@ -1189,7 +1189,7 @@
                                 )
                               )
                             )
-                            (br $while-in$11)
+                            (br $while-in7)
                           )
                         )
                         (if
@@ -1206,7 +1206,7 @@
                             (set_local $C
                               (get_local $F)
                             )
-                            (br $do-once$8)
+                            (br $do-once4)
                           )
                         )
                       )
@@ -1266,14 +1266,14 @@
                             (set_local $C
                               (get_local $o)
                             )
-                            (br $do-once$8)
+                            (br $do-once4)
                           )
                           (call $qa)
                         )
                       )
                     )
                   )
-                  (block $do-once$12
+                  (block $do-once8
                     (if
                       (get_local $e)
                       (block
@@ -1326,7 +1326,7 @@
                                     )
                                   )
                                 )
-                                (br $do-once$12)
+                                (br $do-once8)
                               )
                             )
                           )
@@ -1369,7 +1369,7 @@
                               (i32.eqz
                                 (get_local $C)
                               )
-                              (br $do-once$12)
+                              (br $do-once8)
                             )
                           )
                         )
@@ -1400,7 +1400,7 @@
                             )
                           )
                         )
-                        (block $do-once$14
+                        (block $do-once10
                           (if
                             (get_local $s)
                             (if
@@ -1424,7 +1424,7 @@
                                   )
                                   (get_local $C)
                                 )
-                                (br $do-once$14)
+                                (br $do-once10)
                               )
                             )
                           )
@@ -1462,7 +1462,7 @@
                                 )
                                 (get_local $C)
                               )
-                              (br $do-once$12)
+                              (br $do-once8)
                             )
                           )
                         )
@@ -1907,8 +1907,8 @@
                       (set_local $i
                         (i32.const 0)
                       )
-                      (loop $while-in$18
-                        (block $while-out$17
+                      (loop $while-in14
+                        (block $while-out13
                           (set_local $m
                             (i32.and
                               (i32.load
@@ -2031,7 +2031,7 @@
                               (set_local $N
                                 (i32.const 86)
                               )
-                              (br $while-out$17)
+                              (br $while-out13)
                             )
                             (block
                               (set_local $u
@@ -2057,7 +2057,7 @@
                               )
                             )
                           )
-                          (br $while-in$18)
+                          (br $while-in14)
                         )
                       )
                     )
@@ -2107,7 +2107,7 @@
                             (set_local $y
                               (get_local $e)
                             )
-                            (br $do-once$0)
+                            (br $do-once)
                           )
                         )
                         (set_local $t
@@ -2259,8 +2259,8 @@
                     (get_local $N)
                     (i32.const 90)
                   )
-                  (loop $while-in$20
-                    (block $while-out$19
+                  (loop $while-in16
+                    (block $while-out15
                       (set_local $N
                         (i32.const 0)
                       )
@@ -2321,7 +2321,7 @@
                           (set_local $N
                             (i32.const 90)
                           )
-                          (br $while-in$20)
+                          (br $while-in16)
                         )
                       )
                       (set_local $P
@@ -2343,7 +2343,7 @@
                           (set_local $V
                             (get_local $i)
                           )
-                          (br $while-out$19)
+                          (br $while-out15)
                         )
                         (block
                           (set_local $O
@@ -2357,7 +2357,7 @@
                           )
                         )
                       )
-                      (br $while-in$20)
+                      (br $while-in16)
                     )
                   )
                 )
@@ -2420,7 +2420,7 @@
                           )
                         )
                       )
-                      (block $do-once$21
+                      (block $do-once17
                         (if
                           (i32.eq
                             (get_local $s)
@@ -2462,7 +2462,7 @@
                                     (set_local $W
                                       (i32.const 0)
                                     )
-                                    (br $do-once$21)
+                                    (br $do-once17)
                                   )
                                   (block
                                     (set_local $X
@@ -2483,8 +2483,8 @@
                                 )
                               )
                             )
-                            (loop $while-in$24
-                              (block $while-out$23
+                            (loop $while-in20
+                              (block $while-out19
                                 (set_local $d
                                   (i32.add
                                     (get_local $X)
@@ -2505,7 +2505,7 @@
                                     (set_local $Y
                                       (get_local $d)
                                     )
-                                    (br $while-in$24)
+                                    (br $while-in20)
                                   )
                                 )
                                 (set_local $d
@@ -2530,7 +2530,7 @@
                                     (set_local $_
                                       (get_local $Y)
                                     )
-                                    (br $while-out$23)
+                                    (br $while-out19)
                                   )
                                   (block
                                     (set_local $X
@@ -2541,7 +2541,7 @@
                                     )
                                   )
                                 )
-                                (br $while-in$24)
+                                (br $while-in20)
                               )
                             )
                             (if
@@ -2558,7 +2558,7 @@
                                 (set_local $W
                                   (get_local $Z)
                                 )
-                                (br $do-once$21)
+                                (br $do-once17)
                               )
                             )
                           )
@@ -2618,14 +2618,14 @@
                                 (set_local $W
                                   (get_local $s)
                                 )
-                                (br $do-once$21)
+                                (br $do-once17)
                               )
                               (call $qa)
                             )
                           )
                         )
                       )
-                      (block $do-once$25
+                      (block $do-once21
                         (if
                           (get_local $g)
                           (block
@@ -2678,7 +2678,7 @@
                                         )
                                       )
                                     )
-                                    (br $do-once$25)
+                                    (br $do-once21)
                                   )
                                 )
                               )
@@ -2721,7 +2721,7 @@
                                   (i32.eqz
                                     (get_local $W)
                                   )
-                                  (br $do-once$25)
+                                  (br $do-once21)
                                 )
                               )
                             )
@@ -2752,7 +2752,7 @@
                                 )
                               )
                             )
-                            (block $do-once$27
+                            (block $do-once23
                               (if
                                 (get_local $q)
                                 (if
@@ -2776,7 +2776,7 @@
                                       )
                                       (get_local $W)
                                     )
-                                    (br $do-once$27)
+                                    (br $do-once23)
                                   )
                                 )
                               )
@@ -2814,14 +2814,14 @@
                                     )
                                     (get_local $W)
                                   )
-                                  (br $do-once$25)
+                                  (br $do-once21)
                                 )
                               )
                             )
                           )
                         )
                       )
-                      (block $do-once$29
+                      (block $do-once25
                         (if
                           (i32.lt_u
                             (get_local $U)
@@ -3007,7 +3007,7 @@
                                   )
                                   (get_local $g)
                                 )
-                                (br $do-once$29)
+                                (br $do-once25)
                               )
                             )
                             (set_local $g
@@ -3206,7 +3206,7 @@
                                   )
                                   (get_local $i)
                                 )
-                                (br $do-once$29)
+                                (br $do-once25)
                               )
                             )
                             (set_local $q
@@ -3233,8 +3233,8 @@
                                 (get_local $t)
                               )
                             )
-                            (loop $while-in$32
-                              (block $while-out$31
+                            (loop $while-in28
+                              (block $while-out27
                                 (if
                                   (i32.eq
                                     (i32.and
@@ -3255,7 +3255,7 @@
                                     (set_local $N
                                       (i32.const 148)
                                     )
-                                    (br $while-out$31)
+                                    (br $while-out27)
                                   )
                                 )
                                 (set_local $t
@@ -3292,7 +3292,7 @@
                                     (set_local $N
                                       (i32.const 145)
                                     )
-                                    (br $while-out$31)
+                                    (br $while-out27)
                                   )
                                   (block
                                     (set_local $q
@@ -3306,7 +3306,7 @@
                                     )
                                   )
                                 )
-                                (br $while-in$32)
+                                (br $while-in28)
                               )
                             )
                             (if
@@ -3348,7 +3348,7 @@
                                     )
                                     (get_local $i)
                                   )
-                                  (br $do-once$29)
+                                  (br $do-once25)
                                 )
                               )
                               (if
@@ -3417,7 +3417,7 @@
                                         )
                                         (i32.const 0)
                                       )
-                                      (br $do-once$29)
+                                      (br $do-once25)
                                     )
                                     (call $qa)
                                   )
@@ -3818,8 +3818,8 @@
                 (set_local $aa
                   (i32.const 1656)
                 )
-                (loop $while-in$36
-                  (block $while-out$35
+                (loop $while-in32
+                  (block $while-out31
                     (set_local $ba
                       (i32.load
                         (get_local $aa)
@@ -3854,7 +3854,7 @@
                             (set_local $ga
                               (get_local $$)
                             )
-                            (br $while-out$35)
+                            (br $while-out31)
                           )
                         )
                       )
@@ -3878,7 +3878,7 @@
                         (br $label$break$c)
                       )
                     )
-                    (br $while-in$36)
+                    (br $while-in32)
                   )
                 )
                 (set_local $aa
@@ -3950,7 +3950,7 @@
               )
             )
           )
-          (block $do-once$37
+          (block $do-once33
             (if
               (i32.eq
                 (get_local $N)
@@ -4052,7 +4052,7 @@
                                 (get_local $$)
                               )
                             )
-                            (br $do-once$37)
+                            (br $do-once33)
                           )
                         )
                         (set_local $$
@@ -4109,7 +4109,7 @@
                     (get_local $ka)
                   )
                 )
-                (block $do-once$40
+                (block $do-once36
                   (if
                     (i32.and
                       (i32.gt_u
@@ -4175,7 +4175,7 @@
                                 (get_local $ka)
                               )
                             )
-                            (br $do-once$40)
+                            (br $do-once36)
                           )
                         )
                         (set_local $ma
@@ -4332,7 +4332,7 @@
             (i32.const 1232)
           )
         )
-        (block $do-once$42
+        (block $do-once38
           (if
             (i32.eqz
               (get_local $ja)
@@ -4384,8 +4384,8 @@
               (set_local $ma
                 (i32.const 0)
               )
-              (loop $do-in$45
-                (block $do-out$44
+              (loop $do-in
+                (block $do-out
                   (set_local $c
                     (i32.add
                       (i32.const 1248)
@@ -4418,7 +4418,7 @@
                       (i32.const 1)
                     )
                   )
-                  (br_if $do-in$45
+                  (br_if $do-in
                     (i32.ne
                       (get_local $ma)
                       (i32.const 32)
@@ -4505,8 +4505,8 @@
               (set_local $ka
                 (i32.const 1656)
               )
-              (loop $do-in$47
-                (block $do-out$46
+              (loop $do-in41
+                (block $do-out40
                   (set_local $ma
                     (i32.load
                       (get_local $ka)
@@ -4547,7 +4547,7 @@
                       (set_local $N
                         (i32.const 201)
                       )
-                      (br $do-out$46)
+                      (br $do-out40)
                     )
                   )
                   (set_local $ka
@@ -4558,7 +4558,7 @@
                       )
                     )
                   )
-                  (br_if $do-in$47
+                  (br_if $do-in41
                     (i32.ne
                       (get_local $ka)
                       (i32.const 0)
@@ -4678,7 +4678,7 @@
                           (i32.const 1696)
                         )
                       )
-                      (br $do-once$42)
+                      (br $do-once38)
                     )
                   )
                 )
@@ -4715,8 +4715,8 @@
               (set_local $ka
                 (i32.const 1656)
               )
-              (loop $while-in$49
-                (block $while-out$48
+              (loop $while-in43
+                (block $while-out42
                   (if
                     (i32.eq
                       (i32.load
@@ -4734,7 +4734,7 @@
                       (set_local $N
                         (i32.const 209)
                       )
-                      (br $while-out$48)
+                      (br $while-out42)
                     )
                   )
                   (set_local $ka
@@ -4753,10 +4753,10 @@
                       (set_local $wa
                         (i32.const 1656)
                       )
-                      (br $while-out$48)
+                      (br $while-out42)
                     )
                   )
-                  (br $while-in$49)
+                  (br $while-in43)
                 )
               )
               (if
@@ -4877,7 +4877,7 @@
                         (i32.const 3)
                       )
                     )
-                    (block $do-once$50
+                    (block $do-once44
                       (if
                         (i32.eq
                           (get_local $ma)
@@ -4953,7 +4953,7 @@
                                 )
                                 (get_local $la)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $la
@@ -5020,7 +5020,7 @@
                                         )
                                       )
                                     )
-                                    (block $do-once$53
+                                    (block $do-once47
                                       (if
                                         (i32.ne
                                           (get_local $da)
@@ -5044,7 +5044,7 @@
                                               )
                                               (get_local $ma)
                                             )
-                                            (br $do-once$53)
+                                            (br $do-once47)
                                           )
                                           (call $qa)
                                         )
@@ -5074,7 +5074,7 @@
                                         (br $label$break$e)
                                       )
                                     )
-                                    (block $do-once$55
+                                    (block $do-once49
                                       (if
                                         (i32.eq
                                           (get_local $V)
@@ -5111,7 +5111,7 @@
                                               (set_local $xa
                                                 (get_local $e)
                                               )
-                                              (br $do-once$55)
+                                              (br $do-once49)
                                             )
                                           )
                                           (call $qa)
@@ -5147,7 +5147,7 @@
                                         )
                                       )
                                     )
-                                    (block $do-once$57
+                                    (block $do-once51
                                       (if
                                         (i32.eq
                                           (get_local $e)
@@ -5189,7 +5189,7 @@
                                                   (set_local $ya
                                                     (i32.const 0)
                                                   )
-                                                  (br $do-once$57)
+                                                  (br $do-once51)
                                                 )
                                                 (block
                                                   (set_local $za
@@ -5210,8 +5210,8 @@
                                               )
                                             )
                                           )
-                                          (loop $while-in$60
-                                            (block $while-out$59
+                                          (loop $while-in54
+                                            (block $while-out53
                                               (set_local $aa
                                                 (i32.add
                                                   (get_local $za)
@@ -5232,7 +5232,7 @@
                                                   (set_local $Aa
                                                     (get_local $aa)
                                                   )
-                                                  (br $while-in$60)
+                                                  (br $while-in54)
                                                 )
                                               )
                                               (set_local $aa
@@ -5257,7 +5257,7 @@
                                                   (set_local $Ca
                                                     (get_local $Aa)
                                                   )
-                                                  (br $while-out$59)
+                                                  (br $while-out53)
                                                 )
                                                 (block
                                                   (set_local $za
@@ -5268,7 +5268,7 @@
                                                   )
                                                 )
                                               )
-                                              (br $while-in$60)
+                                              (br $while-in54)
                                             )
                                           )
                                           (if
@@ -5285,7 +5285,7 @@
                                               (set_local $ya
                                                 (get_local $Ba)
                                               )
-                                              (br $do-once$57)
+                                              (br $do-once51)
                                             )
                                           )
                                         )
@@ -5345,7 +5345,7 @@
                                               (set_local $ya
                                                 (get_local $e)
                                               )
-                                              (br $do-once$57)
+                                              (br $do-once51)
                                             )
                                             (call $qa)
                                           )
@@ -5375,7 +5375,7 @@
                                         )
                                       )
                                     )
-                                    (block $do-once$61
+                                    (block $do-once55
                                       (if
                                         (i32.eq
                                           (get_local $ma)
@@ -5390,7 +5390,7 @@
                                           )
                                           (if
                                             (get_local $ya)
-                                            (br $do-once$61)
+                                            (br $do-once55)
                                           )
                                           (i32.store
                                             (i32.const 1212)
@@ -5483,7 +5483,7 @@
                                         (get_local $da)
                                       )
                                     )
-                                    (block $do-once$63
+                                    (block $do-once57
                                       (if
                                         (get_local $V)
                                         (if
@@ -5507,7 +5507,7 @@
                                               )
                                               (get_local $ya)
                                             )
-                                            (br $do-once$63)
+                                            (br $do-once57)
                                           )
                                         )
                                       )
@@ -5644,7 +5644,7 @@
                                   (get_local $fa)
                                 )
                               )
-                              (block $do-once$65
+                              (block $do-once59
                                 (if
                                   (i32.eqz
                                     (i32.and
@@ -5696,7 +5696,7 @@
                                         (set_local $Ga
                                           (get_local $$)
                                         )
-                                        (br $do-once$65)
+                                        (br $do-once59)
                                       )
                                     )
                                     (call $qa)
@@ -5728,7 +5728,7 @@
                                 )
                                 (get_local $la)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $e
@@ -5737,7 +5737,7 @@
                               (i32.const 8)
                             )
                           )
-                          (block $do-once$67
+                          (block $do-once61
                             (if
                               (i32.eqz
                                 (get_local $e)
@@ -5755,7 +5755,7 @@
                                     (set_local $Ha
                                       (i32.const 31)
                                     )
-                                    (br $do-once$67)
+                                    (br $do-once61)
                                   )
                                 )
                                 (set_local $V
@@ -5932,7 +5932,7 @@
                                 )
                                 (get_local $ka)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $aa
@@ -5959,8 +5959,8 @@
                               (get_local $e)
                             )
                           )
-                          (loop $while-in$70
-                            (block $while-out$69
+                          (loop $while-in64
+                            (block $while-out63
                               (if
                                 (i32.eq
                                   (i32.and
@@ -5981,7 +5981,7 @@
                                   (set_local $N
                                     (i32.const 279)
                                   )
-                                  (br $while-out$69)
+                                  (br $while-out63)
                                 )
                               )
                               (set_local $e
@@ -6018,7 +6018,7 @@
                                   (set_local $N
                                     (i32.const 276)
                                   )
-                                  (br $while-out$69)
+                                  (br $while-out63)
                                 )
                                 (block
                                   (set_local $aa
@@ -6032,7 +6032,7 @@
                                   )
                                 )
                               )
-                              (br $while-in$70)
+                              (br $while-in64)
                             )
                           )
                           (if
@@ -6074,7 +6074,7 @@
                                   )
                                   (get_local $ka)
                                 )
-                                (br $do-once$50)
+                                (br $do-once44)
                               )
                             )
                             (if
@@ -6143,7 +6143,7 @@
                                       )
                                       (i32.const 0)
                                     )
-                                    (br $do-once$50)
+                                    (br $do-once44)
                                   )
                                   (call $qa)
                                 )
@@ -6171,8 +6171,8 @@
                   )
                 )
               )
-              (loop $while-in$72
-                (block $while-out$71
+              (loop $while-in66
+                (block $while-out65
                   (set_local $ka
                     (i32.load
                       (get_local $wa)
@@ -6204,7 +6204,7 @@
                           (set_local $La
                             (get_local $ea)
                           )
-                          (br $while-out$71)
+                          (br $while-out65)
                         )
                       )
                     )
@@ -6217,7 +6217,7 @@
                       )
                     )
                   )
-                  (br $while-in$72)
+                  (br $while-in66)
                 )
               )
               (set_local $ca
@@ -6415,8 +6415,8 @@
                   (i32.const 24)
                 )
               )
-              (loop $do-in$74
-                (block $do-out$73
+              (loop $do-in68
+                (block $do-out67
                   (set_local $ka
                     (i32.add
                       (get_local $ka)
@@ -6427,7 +6427,7 @@
                     (get_local $ka)
                     (i32.const 7)
                   )
-                  (br_if $do-in$74
+                  (br_if $do-in68
                     (i32.lt_u
                       (i32.add
                         (get_local $ka)
@@ -6589,7 +6589,7 @@
                         )
                         (get_local $c)
                       )
-                      (br $do-once$42)
+                      (br $do-once38)
                     )
                   )
                   (set_local $c
@@ -6782,7 +6782,7 @@
                         )
                         (get_local $ja)
                       )
-                      (br $do-once$42)
+                      (br $do-once38)
                     )
                   )
                   (set_local $ma
@@ -6809,8 +6809,8 @@
                       (get_local $e)
                     )
                   )
-                  (loop $while-in$76
-                    (block $while-out$75
+                  (loop $while-in70
+                    (block $while-out69
                       (if
                         (i32.eq
                           (i32.and
@@ -6831,7 +6831,7 @@
                           (set_local $N
                             (i32.const 305)
                           )
-                          (br $while-out$75)
+                          (br $while-out69)
                         )
                       )
                       (set_local $e
@@ -6868,7 +6868,7 @@
                           (set_local $N
                             (i32.const 302)
                           )
-                          (br $while-out$75)
+                          (br $while-out69)
                         )
                         (block
                           (set_local $ma
@@ -6882,7 +6882,7 @@
                           )
                         )
                       )
-                      (br $while-in$76)
+                      (br $while-in70)
                     )
                   )
                   (if
@@ -6924,7 +6924,7 @@
                           )
                           (get_local $ja)
                         )
-                        (br $do-once$42)
+                        (br $do-once38)
                       )
                     )
                     (if
@@ -6993,7 +6993,7 @@
                               )
                               (i32.const 0)
                             )
-                            (br $do-once$42)
+                            (br $do-once38)
                           )
                           (call $qa)
                         )
@@ -7188,7 +7188,7 @@
         (get_local $e)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.eqz
           (i32.and
@@ -7264,7 +7264,7 @@
                   (set_local $n
                     (get_local $i)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (i32.store
@@ -7392,7 +7392,7 @@
                   (set_local $n
                     (get_local $i)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (if
@@ -7451,7 +7451,7 @@
               (set_local $n
                 (get_local $i)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $g
@@ -7470,7 +7470,7 @@
               )
             )
           )
-          (block $do-once$2
+          (block $do-once0
             (if
               (i32.eq
                 (get_local $j)
@@ -7512,7 +7512,7 @@
                         (set_local $s
                           (i32.const 0)
                         )
-                        (br $do-once$2)
+                        (br $do-once0)
                       )
                       (block
                         (set_local $t
@@ -7533,8 +7533,8 @@
                     )
                   )
                 )
-                (loop $while-in$5
-                  (block $while-out$4
+                (loop $while-in
+                  (block $while-out
                     (set_local $l
                       (i32.add
                         (get_local $t)
@@ -7555,7 +7555,7 @@
                         (set_local $u
                           (get_local $l)
                         )
-                        (br $while-in$5)
+                        (br $while-in)
                       )
                     )
                     (set_local $l
@@ -7580,7 +7580,7 @@
                         (set_local $w
                           (get_local $u)
                         )
-                        (br $while-out$4)
+                        (br $while-out)
                       )
                       (block
                         (set_local $t
@@ -7591,7 +7591,7 @@
                         )
                       )
                     )
-                    (br $while-in$5)
+                    (br $while-in)
                   )
                 )
                 (if
@@ -7608,7 +7608,7 @@
                     (set_local $s
                       (get_local $v)
                     )
-                    (br $do-once$2)
+                    (br $do-once0)
                   )
                 )
               )
@@ -7668,7 +7668,7 @@
                     (set_local $s
                       (get_local $j)
                     )
-                    (br $do-once$2)
+                    (br $do-once0)
                   )
                   (call $qa)
                 )
@@ -7743,7 +7743,7 @@
                       (set_local $n
                         (get_local $i)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -7793,7 +7793,7 @@
                       (set_local $n
                         (get_local $i)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -7828,7 +7828,7 @@
                   (get_local $l)
                 )
               )
-              (block $do-once$6
+              (block $do-once2
                 (if
                   (get_local $o)
                   (if
@@ -7852,7 +7852,7 @@
                         )
                         (get_local $s)
                       )
-                      (br $do-once$6)
+                      (br $do-once2)
                     )
                   )
                 )
@@ -7906,7 +7906,7 @@
                     (set_local $n
                       (get_local $i)
                     )
-                    (br $do-once$0)
+                    (br $do-once)
                   )
                 )
               )
@@ -8071,7 +8071,7 @@
             (i32.const 3)
           )
         )
-        (block $do-once$8
+        (block $do-once4
           (if
             (i32.lt_u
               (get_local $b)
@@ -8156,7 +8156,7 @@
                       )
                     )
                   )
-                  (br $do-once$8)
+                  (br $do-once4)
                 )
               )
               (if
@@ -8229,7 +8229,7 @@
                   )
                 )
               )
-              (block $do-once$10
+              (block $do-once6
                 (if
                   (i32.eq
                     (get_local $w)
@@ -8271,7 +8271,7 @@
                             (set_local $y
                               (i32.const 0)
                             )
-                            (br $do-once$10)
+                            (br $do-once6)
                           )
                           (block
                             (set_local $z
@@ -8292,8 +8292,8 @@
                         )
                       )
                     )
-                    (loop $while-in$13
-                      (block $while-out$12
+                    (loop $while-in9
+                      (block $while-out8
                         (set_local $t
                           (i32.add
                             (get_local $z)
@@ -8314,7 +8314,7 @@
                             (set_local $A
                               (get_local $t)
                             )
-                            (br $while-in$13)
+                            (br $while-in9)
                           )
                         )
                         (set_local $t
@@ -8339,7 +8339,7 @@
                             (set_local $C
                               (get_local $A)
                             )
-                            (br $while-out$12)
+                            (br $while-out8)
                           )
                           (block
                             (set_local $z
@@ -8350,7 +8350,7 @@
                             )
                           )
                         )
-                        (br $while-in$13)
+                        (br $while-in9)
                       )
                     )
                     (if
@@ -8369,7 +8369,7 @@
                         (set_local $y
                           (get_local $B)
                         )
-                        (br $do-once$10)
+                        (br $do-once6)
                       )
                     )
                   )
@@ -8431,7 +8431,7 @@
                         (set_local $y
                           (get_local $w)
                         )
-                        (br $do-once$10)
+                        (br $do-once6)
                       )
                       (call $qa)
                     )
@@ -8490,7 +8490,7 @@
                               )
                             )
                           )
-                          (br $do-once$8)
+                          (br $do-once4)
                         )
                       )
                     )
@@ -8533,7 +8533,7 @@
                         (i32.eqz
                           (get_local $y)
                         )
-                        (br $do-once$8)
+                        (br $do-once4)
                       )
                     )
                   )
@@ -8567,7 +8567,7 @@
                       (get_local $i)
                     )
                   )
-                  (block $do-once$14
+                  (block $do-once10
                     (if
                       (get_local $h)
                       (if
@@ -8591,7 +8591,7 @@
                             )
                             (get_local $y)
                           )
-                          (br $do-once$14)
+                          (br $do-once10)
                         )
                       )
                     )
@@ -8629,7 +8629,7 @@
                           )
                           (get_local $y)
                         )
-                        (br $do-once$8)
+                        (br $do-once4)
                       )
                     )
                   )
@@ -8976,7 +8976,7 @@
         (get_local $G)
       )
     )
-    (block $do-once$16
+    (block $do-once12
       (if
         (i32.eqz
           (i32.and
@@ -9043,8 +9043,8 @@
               (get_local $s)
             )
           )
-          (loop $while-in$19
-            (block $while-out$18
+          (loop $while-in15
+            (block $while-out14
               (if
                 (i32.eq
                   (i32.and
@@ -9065,7 +9065,7 @@
                   (set_local $I
                     (i32.const 130)
                   )
-                  (br $while-out$18)
+                  (br $while-out14)
                 )
               )
               (set_local $n
@@ -9102,7 +9102,7 @@
                   (set_local $I
                     (i32.const 127)
                   )
-                  (br $while-out$18)
+                  (br $while-out14)
                 )
                 (block
                   (set_local $F
@@ -9116,7 +9116,7 @@
                   )
                 )
               )
-              (br $while-in$19)
+              (br $while-in15)
             )
           )
           (if
@@ -9158,7 +9158,7 @@
                   )
                   (get_local $m)
                 )
-                (br $do-once$16)
+                (br $do-once12)
               )
             )
             (if
@@ -9227,7 +9227,7 @@
                       )
                       (i32.const 0)
                     )
-                    (br $do-once$16)
+                    (br $do-once12)
                   )
                   (call $qa)
                 )
@@ -9258,8 +9258,8 @@
       )
       (return)
     )
-    (loop $while-in$21
-      (block $while-out$20
+    (loop $while-in17
+      (block $while-out16
         (set_local $m
           (i32.load
             (get_local $L)
@@ -9269,7 +9269,7 @@
           (i32.eqz
             (get_local $m)
           )
-          (br $while-out$20)
+          (br $while-out16)
           (set_local $L
             (i32.add
               (get_local $m)
@@ -9277,7 +9277,7 @@
             )
           )
         )
-        (br $while-in$21)
+        (br $while-in17)
       )
     )
     (i32.store
@@ -9406,8 +9406,8 @@
         (get_local $c)
       )
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (if
           (i32.eqz
             (i32.load
@@ -9494,7 +9494,7 @@
             (set_local $p
               (i32.const 6)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (if
@@ -9512,7 +9512,7 @@
             (set_local $p
               (i32.const 8)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (set_local $l
@@ -9647,7 +9647,7 @@
         (set_local $n
           (get_local $l)
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
     (if
@@ -9875,8 +9875,8 @@
                 (set_local $d
                   (get_local $b)
                 )
-                (loop $while-in$3
-                  (block $while-out$2
+                (loop $while-in
+                  (block $while-out
                     (if
                       (i32.eqz
                         (get_local $d)
@@ -9917,13 +9917,13 @@
                         (set_local $q
                           (get_local $d)
                         )
-                        (br $while-out$2)
+                        (br $while-out)
                       )
                       (set_local $d
                         (get_local $p)
                       )
                     )
-                    (br $while-in$3)
+                    (br $while-in)
                   )
                 )
                 (if
@@ -10057,8 +10057,8 @@
           (set_local $f
             (get_local $b)
           )
-          (loop $while-in$2
-            (block $while-out$1
+          (loop $while-in
+            (block $while-out
               (if
                 (i32.eqz
                   (i32.load8_s
@@ -10095,13 +10095,13 @@
                   (set_local $d
                     (i32.const 4)
                   )
-                  (br $while-out$1)
+                  (br $while-out)
                 )
                 (set_local $e
                   (get_local $h)
                 )
               )
-              (br $while-in$2)
+              (br $while-in)
             )
           )
         )
@@ -10116,8 +10116,8 @@
         (set_local $d
           (get_local $c)
         )
-        (loop $while-in$4
-          (block $while-out$3
+        (loop $while-in1
+          (block $while-out0
             (set_local $c
               (i32.load
                 (get_local $d)
@@ -10152,10 +10152,10 @@
                 (set_local $l
                   (get_local $d)
                 )
-                (br $while-out$3)
+                (br $while-out0)
               )
             )
-            (br $while-in$4)
+            (br $while-in1)
           )
         )
         (if
@@ -10178,8 +10178,8 @@
             (set_local $j
               (get_local $l)
             )
-            (loop $while-in$6
-              (block $while-out$5
+            (loop $while-in3
+              (block $while-out2
                 (set_local $l
                   (i32.add
                     (get_local $j)
@@ -10196,13 +10196,13 @@
                     (set_local $m
                       (get_local $l)
                     )
-                    (br $while-out$5)
+                    (br $while-out2)
                   )
                   (set_local $j
                     (get_local $l)
                   )
                 )
-                (br $while-in$6)
+                (br $while-in3)
               )
             )
           )
@@ -10227,7 +10227,7 @@
     (local $f i32)
     (local $g i32)
     (local $h i32)
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.eqz
           (get_local $a)
@@ -10272,8 +10272,8 @@
               (set_local $c
                 (get_local $b)
               )
-              (loop $while-in$3
-                (block $while-out$2
+              (loop $while-in
+                (block $while-out
                   (if
                     (i32.gt_s
                       (i32.load
@@ -10342,13 +10342,13 @@
                       (set_local $d
                         (get_local $g)
                       )
-                      (br $while-out$2)
+                      (br $while-out)
                     )
                     (set_local $c
                       (get_local $g)
                     )
                   )
-                  (br $while-in$3)
+                  (br $while-in)
                 )
               )
             )
@@ -10377,7 +10377,7 @@
                   (get_local $a)
                 )
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $c
@@ -10490,7 +10490,7 @@
         )
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.eq
           (get_local $j)
@@ -10545,7 +10545,7 @@
                   (set_local $m
                     (get_local $n)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
             )
@@ -10775,8 +10775,8 @@
         )
       )
       (block
-        (loop $while-in$1
-          (block $while-out$0
+        (loop $while-in
+          (block $while-out
             (if
               (i32.eqz
                 (i32.and
@@ -10784,7 +10784,7 @@
                   (i32.const 3)
                 )
               )
-              (br $while-out$0)
+              (br $while-out)
             )
             (block
               (if
@@ -10820,11 +10820,11 @@
                 )
               )
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
-        (loop $while-in$3
-          (block $while-out$2
+        (loop $while-in1
+          (block $while-out0
             (if
               (i32.eqz
                 (i32.ge_s
@@ -10832,7 +10832,7 @@
                   (i32.const 4)
                 )
               )
-              (br $while-out$2)
+              (br $while-out0)
             )
             (block
               (i32.store
@@ -10860,13 +10860,13 @@
                 )
               )
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
     )
-    (loop $while-in$5
-      (block $while-out$4
+    (loop $while-in3
+      (block $while-out2
         (if
           (i32.eqz
             (i32.gt_s
@@ -10874,7 +10874,7 @@
               (i32.const 0)
             )
           )
-          (br $while-out$4)
+          (br $while-out2)
         )
         (block
           (i32.store8
@@ -10902,7 +10902,7 @@
             )
           )
         )
-        (br $while-in$5)
+        (br $while-in3)
       )
     )
     (return
@@ -10983,8 +10983,8 @@
                 (get_local $e)
               )
             )
-            (loop $while-in$1
-              (block $while-out$0
+            (loop $while-in
+              (block $while-out
                 (if
                   (i32.eqz
                     (i32.lt_s
@@ -10992,7 +10992,7 @@
                       (get_local $e)
                     )
                   )
-                  (br $while-out$0)
+                  (br $while-out)
                 )
                 (block
                   (i32.store8
@@ -11006,13 +11006,13 @@
                     )
                   )
                 )
-                (br $while-in$1)
+                (br $while-in)
               )
             )
           )
         )
-        (loop $while-in$3
-          (block $while-out$2
+        (loop $while-in1
+          (block $while-out0
             (if
               (i32.eqz
                 (i32.lt_s
@@ -11020,7 +11020,7 @@
                   (get_local $g)
                 )
               )
-              (br $while-out$2)
+              (br $while-out0)
             )
             (block
               (i32.store
@@ -11034,13 +11034,13 @@
                 )
               )
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
     )
-    (loop $while-in$5
-      (block $while-out$4
+    (loop $while-in3
+      (block $while-out2
         (if
           (i32.eqz
             (i32.lt_s
@@ -11048,7 +11048,7 @@
               (get_local $d)
             )
           )
-          (br $while-out$4)
+          (br $while-out2)
         )
         (block
           (i32.store8
@@ -11062,7 +11062,7 @@
             )
           )
         )
-        (br $while-in$5)
+        (br $while-in3)
       )
     )
     (return
@@ -11102,7 +11102,7 @@
         (i32.const 0)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.lt_s
           (call $cb
@@ -11162,7 +11162,7 @@
                   (set_local $d
                     (i32.const 0)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
             )

--- a/test/memorygrowth.fromasm.no-opts
+++ b/test/memorygrowth.fromasm.no-opts
@@ -185,7 +185,7 @@
     (set_local $c
       (get_local $b)
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.lt_u
           (get_local $a)
@@ -277,7 +277,7 @@
                   (get_local $m)
                 )
               )
-              (block $do-once$2
+              (block $do-once0
                 (if
                   (i32.eq
                     (get_local $i)
@@ -328,7 +328,7 @@
                           (get_local $j)
                           (get_local $n)
                         )
-                        (br $do-once$2)
+                        (br $do-once0)
                       )
                       (call $qa)
                     )
@@ -551,7 +551,7 @@
                       (get_local $o)
                     )
                   )
-                  (block $do-once$4
+                  (block $do-once2
                     (if
                       (i32.eq
                         (get_local $s)
@@ -612,7 +612,7 @@
                                 (i32.const 1216)
                               )
                             )
-                            (br $do-once$4)
+                            (br $do-once2)
                           )
                           (call $qa)
                         )
@@ -943,8 +943,8 @@
                   (set_local $s
                     (get_local $j)
                   )
-                  (loop $while-in$7
-                    (block $while-out$6
+                  (loop $while-in
+                    (block $while-out
                       (set_local $j
                         (i32.load
                           (i32.add
@@ -977,7 +977,7 @@
                               (set_local $A
                                 (get_local $s)
                               )
-                              (br $while-out$6)
+                              (br $while-out)
                             )
                             (set_local $B
                               (get_local $f)
@@ -1025,7 +1025,7 @@
                           (get_local $s)
                         )
                       )
-                      (br $while-in$7)
+                      (br $while-in)
                     )
                   )
                   (set_local $s
@@ -1069,7 +1069,7 @@
                       )
                     )
                   )
-                  (block $do-once$8
+                  (block $do-once4
                     (if
                       (i32.eq
                         (get_local $o)
@@ -1111,7 +1111,7 @@
                                 (set_local $C
                                   (i32.const 0)
                                 )
-                                (br $do-once$8)
+                                (br $do-once4)
                               )
                               (block
                                 (set_local $D
@@ -1132,8 +1132,8 @@
                             )
                           )
                         )
-                        (loop $while-in$11
-                          (block $while-out$10
+                        (loop $while-in7
+                          (block $while-out6
                             (set_local $q
                               (i32.add
                                 (get_local $D)
@@ -1154,7 +1154,7 @@
                                 (set_local $E
                                   (get_local $q)
                                 )
-                                (br $while-in$11)
+                                (br $while-in7)
                               )
                             )
                             (set_local $q
@@ -1179,7 +1179,7 @@
                                 (set_local $G
                                   (get_local $E)
                                 )
-                                (br $while-out$10)
+                                (br $while-out6)
                               )
                               (block
                                 (set_local $D
@@ -1190,7 +1190,7 @@
                                 )
                               )
                             )
-                            (br $while-in$11)
+                            (br $while-in7)
                           )
                         )
                         (if
@@ -1207,7 +1207,7 @@
                             (set_local $C
                               (get_local $F)
                             )
-                            (br $do-once$8)
+                            (br $do-once4)
                           )
                         )
                       )
@@ -1267,14 +1267,14 @@
                             (set_local $C
                               (get_local $o)
                             )
-                            (br $do-once$8)
+                            (br $do-once4)
                           )
                           (call $qa)
                         )
                       )
                     )
                   )
-                  (block $do-once$12
+                  (block $do-once8
                     (if
                       (get_local $e)
                       (block
@@ -1327,7 +1327,7 @@
                                     )
                                   )
                                 )
-                                (br $do-once$12)
+                                (br $do-once8)
                               )
                             )
                           )
@@ -1370,7 +1370,7 @@
                               (i32.eqz
                                 (get_local $C)
                               )
-                              (br $do-once$12)
+                              (br $do-once8)
                             )
                           )
                         )
@@ -1401,7 +1401,7 @@
                             )
                           )
                         )
-                        (block $do-once$14
+                        (block $do-once10
                           (if
                             (get_local $s)
                             (if
@@ -1425,7 +1425,7 @@
                                   )
                                   (get_local $C)
                                 )
-                                (br $do-once$14)
+                                (br $do-once10)
                               )
                             )
                           )
@@ -1463,7 +1463,7 @@
                                 )
                                 (get_local $C)
                               )
-                              (br $do-once$12)
+                              (br $do-once8)
                             )
                           )
                         )
@@ -1908,8 +1908,8 @@
                       (set_local $i
                         (i32.const 0)
                       )
-                      (loop $while-in$18
-                        (block $while-out$17
+                      (loop $while-in14
+                        (block $while-out13
                           (set_local $m
                             (i32.and
                               (i32.load
@@ -2032,7 +2032,7 @@
                               (set_local $N
                                 (i32.const 86)
                               )
-                              (br $while-out$17)
+                              (br $while-out13)
                             )
                             (block
                               (set_local $u
@@ -2058,7 +2058,7 @@
                               )
                             )
                           )
-                          (br $while-in$18)
+                          (br $while-in14)
                         )
                       )
                     )
@@ -2108,7 +2108,7 @@
                             (set_local $y
                               (get_local $e)
                             )
-                            (br $do-once$0)
+                            (br $do-once)
                           )
                         )
                         (set_local $t
@@ -2260,8 +2260,8 @@
                     (get_local $N)
                     (i32.const 90)
                   )
-                  (loop $while-in$20
-                    (block $while-out$19
+                  (loop $while-in16
+                    (block $while-out15
                       (set_local $N
                         (i32.const 0)
                       )
@@ -2322,7 +2322,7 @@
                           (set_local $N
                             (i32.const 90)
                           )
-                          (br $while-in$20)
+                          (br $while-in16)
                         )
                       )
                       (set_local $P
@@ -2344,7 +2344,7 @@
                           (set_local $V
                             (get_local $i)
                           )
-                          (br $while-out$19)
+                          (br $while-out15)
                         )
                         (block
                           (set_local $O
@@ -2358,7 +2358,7 @@
                           )
                         )
                       )
-                      (br $while-in$20)
+                      (br $while-in16)
                     )
                   )
                 )
@@ -2421,7 +2421,7 @@
                           )
                         )
                       )
-                      (block $do-once$21
+                      (block $do-once17
                         (if
                           (i32.eq
                             (get_local $s)
@@ -2463,7 +2463,7 @@
                                     (set_local $W
                                       (i32.const 0)
                                     )
-                                    (br $do-once$21)
+                                    (br $do-once17)
                                   )
                                   (block
                                     (set_local $X
@@ -2484,8 +2484,8 @@
                                 )
                               )
                             )
-                            (loop $while-in$24
-                              (block $while-out$23
+                            (loop $while-in20
+                              (block $while-out19
                                 (set_local $d
                                   (i32.add
                                     (get_local $X)
@@ -2506,7 +2506,7 @@
                                     (set_local $Y
                                       (get_local $d)
                                     )
-                                    (br $while-in$24)
+                                    (br $while-in20)
                                   )
                                 )
                                 (set_local $d
@@ -2531,7 +2531,7 @@
                                     (set_local $_
                                       (get_local $Y)
                                     )
-                                    (br $while-out$23)
+                                    (br $while-out19)
                                   )
                                   (block
                                     (set_local $X
@@ -2542,7 +2542,7 @@
                                     )
                                   )
                                 )
-                                (br $while-in$24)
+                                (br $while-in20)
                               )
                             )
                             (if
@@ -2559,7 +2559,7 @@
                                 (set_local $W
                                   (get_local $Z)
                                 )
-                                (br $do-once$21)
+                                (br $do-once17)
                               )
                             )
                           )
@@ -2619,14 +2619,14 @@
                                 (set_local $W
                                   (get_local $s)
                                 )
-                                (br $do-once$21)
+                                (br $do-once17)
                               )
                               (call $qa)
                             )
                           )
                         )
                       )
-                      (block $do-once$25
+                      (block $do-once21
                         (if
                           (get_local $g)
                           (block
@@ -2679,7 +2679,7 @@
                                         )
                                       )
                                     )
-                                    (br $do-once$25)
+                                    (br $do-once21)
                                   )
                                 )
                               )
@@ -2722,7 +2722,7 @@
                                   (i32.eqz
                                     (get_local $W)
                                   )
-                                  (br $do-once$25)
+                                  (br $do-once21)
                                 )
                               )
                             )
@@ -2753,7 +2753,7 @@
                                 )
                               )
                             )
-                            (block $do-once$27
+                            (block $do-once23
                               (if
                                 (get_local $q)
                                 (if
@@ -2777,7 +2777,7 @@
                                       )
                                       (get_local $W)
                                     )
-                                    (br $do-once$27)
+                                    (br $do-once23)
                                   )
                                 )
                               )
@@ -2815,14 +2815,14 @@
                                     )
                                     (get_local $W)
                                   )
-                                  (br $do-once$25)
+                                  (br $do-once21)
                                 )
                               )
                             )
                           )
                         )
                       )
-                      (block $do-once$29
+                      (block $do-once25
                         (if
                           (i32.lt_u
                             (get_local $U)
@@ -3008,7 +3008,7 @@
                                   )
                                   (get_local $g)
                                 )
-                                (br $do-once$29)
+                                (br $do-once25)
                               )
                             )
                             (set_local $g
@@ -3207,7 +3207,7 @@
                                   )
                                   (get_local $i)
                                 )
-                                (br $do-once$29)
+                                (br $do-once25)
                               )
                             )
                             (set_local $q
@@ -3234,8 +3234,8 @@
                                 (get_local $t)
                               )
                             )
-                            (loop $while-in$32
-                              (block $while-out$31
+                            (loop $while-in28
+                              (block $while-out27
                                 (if
                                   (i32.eq
                                     (i32.and
@@ -3256,7 +3256,7 @@
                                     (set_local $N
                                       (i32.const 148)
                                     )
-                                    (br $while-out$31)
+                                    (br $while-out27)
                                   )
                                 )
                                 (set_local $t
@@ -3293,7 +3293,7 @@
                                     (set_local $N
                                       (i32.const 145)
                                     )
-                                    (br $while-out$31)
+                                    (br $while-out27)
                                   )
                                   (block
                                     (set_local $q
@@ -3307,7 +3307,7 @@
                                     )
                                   )
                                 )
-                                (br $while-in$32)
+                                (br $while-in28)
                               )
                             )
                             (if
@@ -3349,7 +3349,7 @@
                                     )
                                     (get_local $i)
                                   )
-                                  (br $do-once$29)
+                                  (br $do-once25)
                                 )
                               )
                               (if
@@ -3418,7 +3418,7 @@
                                         )
                                         (i32.const 0)
                                       )
-                                      (br $do-once$29)
+                                      (br $do-once25)
                                     )
                                     (call $qa)
                                   )
@@ -3819,8 +3819,8 @@
                 (set_local $aa
                   (i32.const 1656)
                 )
-                (loop $while-in$36
-                  (block $while-out$35
+                (loop $while-in32
+                  (block $while-out31
                     (set_local $ba
                       (i32.load
                         (get_local $aa)
@@ -3855,7 +3855,7 @@
                             (set_local $ga
                               (get_local $$)
                             )
-                            (br $while-out$35)
+                            (br $while-out31)
                           )
                         )
                       )
@@ -3879,7 +3879,7 @@
                         (br $label$break$c)
                       )
                     )
-                    (br $while-in$36)
+                    (br $while-in32)
                   )
                 )
                 (set_local $aa
@@ -3951,7 +3951,7 @@
               )
             )
           )
-          (block $do-once$37
+          (block $do-once33
             (if
               (i32.eq
                 (get_local $N)
@@ -4053,7 +4053,7 @@
                                 (get_local $$)
                               )
                             )
-                            (br $do-once$37)
+                            (br $do-once33)
                           )
                         )
                         (set_local $$
@@ -4110,7 +4110,7 @@
                     (get_local $ka)
                   )
                 )
-                (block $do-once$40
+                (block $do-once36
                   (if
                     (i32.and
                       (i32.gt_u
@@ -4176,7 +4176,7 @@
                                 (get_local $ka)
                               )
                             )
-                            (br $do-once$40)
+                            (br $do-once36)
                           )
                         )
                         (set_local $ma
@@ -4333,7 +4333,7 @@
             (i32.const 1232)
           )
         )
-        (block $do-once$42
+        (block $do-once38
           (if
             (i32.eqz
               (get_local $ja)
@@ -4385,8 +4385,8 @@
               (set_local $ma
                 (i32.const 0)
               )
-              (loop $do-in$45
-                (block $do-out$44
+              (loop $do-in
+                (block $do-out
                   (set_local $c
                     (i32.add
                       (i32.const 1248)
@@ -4419,7 +4419,7 @@
                       (i32.const 1)
                     )
                   )
-                  (br_if $do-in$45
+                  (br_if $do-in
                     (i32.ne
                       (get_local $ma)
                       (i32.const 32)
@@ -4506,8 +4506,8 @@
               (set_local $ka
                 (i32.const 1656)
               )
-              (loop $do-in$47
-                (block $do-out$46
+              (loop $do-in41
+                (block $do-out40
                   (set_local $ma
                     (i32.load
                       (get_local $ka)
@@ -4548,7 +4548,7 @@
                       (set_local $N
                         (i32.const 201)
                       )
-                      (br $do-out$46)
+                      (br $do-out40)
                     )
                   )
                   (set_local $ka
@@ -4559,7 +4559,7 @@
                       )
                     )
                   )
-                  (br_if $do-in$47
+                  (br_if $do-in41
                     (i32.ne
                       (get_local $ka)
                       (i32.const 0)
@@ -4679,7 +4679,7 @@
                           (i32.const 1696)
                         )
                       )
-                      (br $do-once$42)
+                      (br $do-once38)
                     )
                   )
                 )
@@ -4716,8 +4716,8 @@
               (set_local $ka
                 (i32.const 1656)
               )
-              (loop $while-in$49
-                (block $while-out$48
+              (loop $while-in43
+                (block $while-out42
                   (if
                     (i32.eq
                       (i32.load
@@ -4735,7 +4735,7 @@
                       (set_local $N
                         (i32.const 209)
                       )
-                      (br $while-out$48)
+                      (br $while-out42)
                     )
                   )
                   (set_local $ka
@@ -4754,10 +4754,10 @@
                       (set_local $wa
                         (i32.const 1656)
                       )
-                      (br $while-out$48)
+                      (br $while-out42)
                     )
                   )
-                  (br $while-in$49)
+                  (br $while-in43)
                 )
               )
               (if
@@ -4878,7 +4878,7 @@
                         (i32.const 3)
                       )
                     )
-                    (block $do-once$50
+                    (block $do-once44
                       (if
                         (i32.eq
                           (get_local $ma)
@@ -4954,7 +4954,7 @@
                                 )
                                 (get_local $la)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $la
@@ -5021,7 +5021,7 @@
                                         )
                                       )
                                     )
-                                    (block $do-once$53
+                                    (block $do-once47
                                       (if
                                         (i32.ne
                                           (get_local $da)
@@ -5045,7 +5045,7 @@
                                               )
                                               (get_local $ma)
                                             )
-                                            (br $do-once$53)
+                                            (br $do-once47)
                                           )
                                           (call $qa)
                                         )
@@ -5075,7 +5075,7 @@
                                         (br $label$break$e)
                                       )
                                     )
-                                    (block $do-once$55
+                                    (block $do-once49
                                       (if
                                         (i32.eq
                                           (get_local $V)
@@ -5112,7 +5112,7 @@
                                               (set_local $xa
                                                 (get_local $e)
                                               )
-                                              (br $do-once$55)
+                                              (br $do-once49)
                                             )
                                           )
                                           (call $qa)
@@ -5148,7 +5148,7 @@
                                         )
                                       )
                                     )
-                                    (block $do-once$57
+                                    (block $do-once51
                                       (if
                                         (i32.eq
                                           (get_local $e)
@@ -5190,7 +5190,7 @@
                                                   (set_local $ya
                                                     (i32.const 0)
                                                   )
-                                                  (br $do-once$57)
+                                                  (br $do-once51)
                                                 )
                                                 (block
                                                   (set_local $za
@@ -5211,8 +5211,8 @@
                                               )
                                             )
                                           )
-                                          (loop $while-in$60
-                                            (block $while-out$59
+                                          (loop $while-in54
+                                            (block $while-out53
                                               (set_local $aa
                                                 (i32.add
                                                   (get_local $za)
@@ -5233,7 +5233,7 @@
                                                   (set_local $Aa
                                                     (get_local $aa)
                                                   )
-                                                  (br $while-in$60)
+                                                  (br $while-in54)
                                                 )
                                               )
                                               (set_local $aa
@@ -5258,7 +5258,7 @@
                                                   (set_local $Ca
                                                     (get_local $Aa)
                                                   )
-                                                  (br $while-out$59)
+                                                  (br $while-out53)
                                                 )
                                                 (block
                                                   (set_local $za
@@ -5269,7 +5269,7 @@
                                                   )
                                                 )
                                               )
-                                              (br $while-in$60)
+                                              (br $while-in54)
                                             )
                                           )
                                           (if
@@ -5286,7 +5286,7 @@
                                               (set_local $ya
                                                 (get_local $Ba)
                                               )
-                                              (br $do-once$57)
+                                              (br $do-once51)
                                             )
                                           )
                                         )
@@ -5346,7 +5346,7 @@
                                               (set_local $ya
                                                 (get_local $e)
                                               )
-                                              (br $do-once$57)
+                                              (br $do-once51)
                                             )
                                             (call $qa)
                                           )
@@ -5376,7 +5376,7 @@
                                         )
                                       )
                                     )
-                                    (block $do-once$61
+                                    (block $do-once55
                                       (if
                                         (i32.eq
                                           (get_local $ma)
@@ -5391,7 +5391,7 @@
                                           )
                                           (if
                                             (get_local $ya)
-                                            (br $do-once$61)
+                                            (br $do-once55)
                                           )
                                           (i32.store
                                             (i32.const 1212)
@@ -5484,7 +5484,7 @@
                                         (get_local $da)
                                       )
                                     )
-                                    (block $do-once$63
+                                    (block $do-once57
                                       (if
                                         (get_local $V)
                                         (if
@@ -5508,7 +5508,7 @@
                                               )
                                               (get_local $ya)
                                             )
-                                            (br $do-once$63)
+                                            (br $do-once57)
                                           )
                                         )
                                       )
@@ -5645,7 +5645,7 @@
                                   (get_local $fa)
                                 )
                               )
-                              (block $do-once$65
+                              (block $do-once59
                                 (if
                                   (i32.eqz
                                     (i32.and
@@ -5697,7 +5697,7 @@
                                         (set_local $Ga
                                           (get_local $$)
                                         )
-                                        (br $do-once$65)
+                                        (br $do-once59)
                                       )
                                     )
                                     (call $qa)
@@ -5729,7 +5729,7 @@
                                 )
                                 (get_local $la)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $e
@@ -5738,7 +5738,7 @@
                               (i32.const 8)
                             )
                           )
-                          (block $do-once$67
+                          (block $do-once61
                             (if
                               (i32.eqz
                                 (get_local $e)
@@ -5756,7 +5756,7 @@
                                     (set_local $Ha
                                       (i32.const 31)
                                     )
-                                    (br $do-once$67)
+                                    (br $do-once61)
                                   )
                                 )
                                 (set_local $V
@@ -5933,7 +5933,7 @@
                                 )
                                 (get_local $ka)
                               )
-                              (br $do-once$50)
+                              (br $do-once44)
                             )
                           )
                           (set_local $aa
@@ -5960,8 +5960,8 @@
                               (get_local $e)
                             )
                           )
-                          (loop $while-in$70
-                            (block $while-out$69
+                          (loop $while-in64
+                            (block $while-out63
                               (if
                                 (i32.eq
                                   (i32.and
@@ -5982,7 +5982,7 @@
                                   (set_local $N
                                     (i32.const 279)
                                   )
-                                  (br $while-out$69)
+                                  (br $while-out63)
                                 )
                               )
                               (set_local $e
@@ -6019,7 +6019,7 @@
                                   (set_local $N
                                     (i32.const 276)
                                   )
-                                  (br $while-out$69)
+                                  (br $while-out63)
                                 )
                                 (block
                                   (set_local $aa
@@ -6033,7 +6033,7 @@
                                   )
                                 )
                               )
-                              (br $while-in$70)
+                              (br $while-in64)
                             )
                           )
                           (if
@@ -6075,7 +6075,7 @@
                                   )
                                   (get_local $ka)
                                 )
-                                (br $do-once$50)
+                                (br $do-once44)
                               )
                             )
                             (if
@@ -6144,7 +6144,7 @@
                                       )
                                       (i32.const 0)
                                     )
-                                    (br $do-once$50)
+                                    (br $do-once44)
                                   )
                                   (call $qa)
                                 )
@@ -6172,8 +6172,8 @@
                   )
                 )
               )
-              (loop $while-in$72
-                (block $while-out$71
+              (loop $while-in66
+                (block $while-out65
                   (set_local $ka
                     (i32.load
                       (get_local $wa)
@@ -6205,7 +6205,7 @@
                           (set_local $La
                             (get_local $ea)
                           )
-                          (br $while-out$71)
+                          (br $while-out65)
                         )
                       )
                     )
@@ -6218,7 +6218,7 @@
                       )
                     )
                   )
-                  (br $while-in$72)
+                  (br $while-in66)
                 )
               )
               (set_local $ca
@@ -6416,8 +6416,8 @@
                   (i32.const 24)
                 )
               )
-              (loop $do-in$74
-                (block $do-out$73
+              (loop $do-in68
+                (block $do-out67
                   (set_local $ka
                     (i32.add
                       (get_local $ka)
@@ -6428,7 +6428,7 @@
                     (get_local $ka)
                     (i32.const 7)
                   )
-                  (br_if $do-in$74
+                  (br_if $do-in68
                     (i32.lt_u
                       (i32.add
                         (get_local $ka)
@@ -6590,7 +6590,7 @@
                         )
                         (get_local $c)
                       )
-                      (br $do-once$42)
+                      (br $do-once38)
                     )
                   )
                   (set_local $c
@@ -6783,7 +6783,7 @@
                         )
                         (get_local $ja)
                       )
-                      (br $do-once$42)
+                      (br $do-once38)
                     )
                   )
                   (set_local $ma
@@ -6810,8 +6810,8 @@
                       (get_local $e)
                     )
                   )
-                  (loop $while-in$76
-                    (block $while-out$75
+                  (loop $while-in70
+                    (block $while-out69
                       (if
                         (i32.eq
                           (i32.and
@@ -6832,7 +6832,7 @@
                           (set_local $N
                             (i32.const 305)
                           )
-                          (br $while-out$75)
+                          (br $while-out69)
                         )
                       )
                       (set_local $e
@@ -6869,7 +6869,7 @@
                           (set_local $N
                             (i32.const 302)
                           )
-                          (br $while-out$75)
+                          (br $while-out69)
                         )
                         (block
                           (set_local $ma
@@ -6883,7 +6883,7 @@
                           )
                         )
                       )
-                      (br $while-in$76)
+                      (br $while-in70)
                     )
                   )
                   (if
@@ -6925,7 +6925,7 @@
                           )
                           (get_local $ja)
                         )
-                        (br $do-once$42)
+                        (br $do-once38)
                       )
                     )
                     (if
@@ -6994,7 +6994,7 @@
                               )
                               (i32.const 0)
                             )
-                            (br $do-once$42)
+                            (br $do-once38)
                           )
                           (call $qa)
                         )
@@ -7189,7 +7189,7 @@
         (get_local $e)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.eqz
           (i32.and
@@ -7265,7 +7265,7 @@
                   (set_local $n
                     (get_local $i)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (i32.store
@@ -7393,7 +7393,7 @@
                   (set_local $n
                     (get_local $i)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
               (if
@@ -7452,7 +7452,7 @@
               (set_local $n
                 (get_local $i)
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $g
@@ -7471,7 +7471,7 @@
               )
             )
           )
-          (block $do-once$2
+          (block $do-once0
             (if
               (i32.eq
                 (get_local $j)
@@ -7513,7 +7513,7 @@
                         (set_local $s
                           (i32.const 0)
                         )
-                        (br $do-once$2)
+                        (br $do-once0)
                       )
                       (block
                         (set_local $t
@@ -7534,8 +7534,8 @@
                     )
                   )
                 )
-                (loop $while-in$5
-                  (block $while-out$4
+                (loop $while-in
+                  (block $while-out
                     (set_local $l
                       (i32.add
                         (get_local $t)
@@ -7556,7 +7556,7 @@
                         (set_local $u
                           (get_local $l)
                         )
-                        (br $while-in$5)
+                        (br $while-in)
                       )
                     )
                     (set_local $l
@@ -7581,7 +7581,7 @@
                         (set_local $w
                           (get_local $u)
                         )
-                        (br $while-out$4)
+                        (br $while-out)
                       )
                       (block
                         (set_local $t
@@ -7592,7 +7592,7 @@
                         )
                       )
                     )
-                    (br $while-in$5)
+                    (br $while-in)
                   )
                 )
                 (if
@@ -7609,7 +7609,7 @@
                     (set_local $s
                       (get_local $v)
                     )
-                    (br $do-once$2)
+                    (br $do-once0)
                   )
                 )
               )
@@ -7669,7 +7669,7 @@
                     (set_local $s
                       (get_local $j)
                     )
-                    (br $do-once$2)
+                    (br $do-once0)
                   )
                   (call $qa)
                 )
@@ -7744,7 +7744,7 @@
                       (set_local $n
                         (get_local $i)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -7794,7 +7794,7 @@
                       (set_local $n
                         (get_local $i)
                       )
-                      (br $do-once$0)
+                      (br $do-once)
                     )
                   )
                 )
@@ -7829,7 +7829,7 @@
                   (get_local $l)
                 )
               )
-              (block $do-once$6
+              (block $do-once2
                 (if
                   (get_local $o)
                   (if
@@ -7853,7 +7853,7 @@
                         )
                         (get_local $s)
                       )
-                      (br $do-once$6)
+                      (br $do-once2)
                     )
                   )
                 )
@@ -7907,7 +7907,7 @@
                     (set_local $n
                       (get_local $i)
                     )
-                    (br $do-once$0)
+                    (br $do-once)
                   )
                 )
               )
@@ -8072,7 +8072,7 @@
             (i32.const 3)
           )
         )
-        (block $do-once$8
+        (block $do-once4
           (if
             (i32.lt_u
               (get_local $b)
@@ -8157,7 +8157,7 @@
                       )
                     )
                   )
-                  (br $do-once$8)
+                  (br $do-once4)
                 )
               )
               (if
@@ -8230,7 +8230,7 @@
                   )
                 )
               )
-              (block $do-once$10
+              (block $do-once6
                 (if
                   (i32.eq
                     (get_local $w)
@@ -8272,7 +8272,7 @@
                             (set_local $y
                               (i32.const 0)
                             )
-                            (br $do-once$10)
+                            (br $do-once6)
                           )
                           (block
                             (set_local $z
@@ -8293,8 +8293,8 @@
                         )
                       )
                     )
-                    (loop $while-in$13
-                      (block $while-out$12
+                    (loop $while-in9
+                      (block $while-out8
                         (set_local $t
                           (i32.add
                             (get_local $z)
@@ -8315,7 +8315,7 @@
                             (set_local $A
                               (get_local $t)
                             )
-                            (br $while-in$13)
+                            (br $while-in9)
                           )
                         )
                         (set_local $t
@@ -8340,7 +8340,7 @@
                             (set_local $C
                               (get_local $A)
                             )
-                            (br $while-out$12)
+                            (br $while-out8)
                           )
                           (block
                             (set_local $z
@@ -8351,7 +8351,7 @@
                             )
                           )
                         )
-                        (br $while-in$13)
+                        (br $while-in9)
                       )
                     )
                     (if
@@ -8370,7 +8370,7 @@
                         (set_local $y
                           (get_local $B)
                         )
-                        (br $do-once$10)
+                        (br $do-once6)
                       )
                     )
                   )
@@ -8432,7 +8432,7 @@
                         (set_local $y
                           (get_local $w)
                         )
-                        (br $do-once$10)
+                        (br $do-once6)
                       )
                       (call $qa)
                     )
@@ -8491,7 +8491,7 @@
                               )
                             )
                           )
-                          (br $do-once$8)
+                          (br $do-once4)
                         )
                       )
                     )
@@ -8534,7 +8534,7 @@
                         (i32.eqz
                           (get_local $y)
                         )
-                        (br $do-once$8)
+                        (br $do-once4)
                       )
                     )
                   )
@@ -8568,7 +8568,7 @@
                       (get_local $i)
                     )
                   )
-                  (block $do-once$14
+                  (block $do-once10
                     (if
                       (get_local $h)
                       (if
@@ -8592,7 +8592,7 @@
                             )
                             (get_local $y)
                           )
-                          (br $do-once$14)
+                          (br $do-once10)
                         )
                       )
                     )
@@ -8630,7 +8630,7 @@
                           )
                           (get_local $y)
                         )
-                        (br $do-once$8)
+                        (br $do-once4)
                       )
                     )
                   )
@@ -8977,7 +8977,7 @@
         (get_local $G)
       )
     )
-    (block $do-once$16
+    (block $do-once12
       (if
         (i32.eqz
           (i32.and
@@ -9044,8 +9044,8 @@
               (get_local $s)
             )
           )
-          (loop $while-in$19
-            (block $while-out$18
+          (loop $while-in15
+            (block $while-out14
               (if
                 (i32.eq
                   (i32.and
@@ -9066,7 +9066,7 @@
                   (set_local $I
                     (i32.const 130)
                   )
-                  (br $while-out$18)
+                  (br $while-out14)
                 )
               )
               (set_local $n
@@ -9103,7 +9103,7 @@
                   (set_local $I
                     (i32.const 127)
                   )
-                  (br $while-out$18)
+                  (br $while-out14)
                 )
                 (block
                   (set_local $F
@@ -9117,7 +9117,7 @@
                   )
                 )
               )
-              (br $while-in$19)
+              (br $while-in15)
             )
           )
           (if
@@ -9159,7 +9159,7 @@
                   )
                   (get_local $m)
                 )
-                (br $do-once$16)
+                (br $do-once12)
               )
             )
             (if
@@ -9228,7 +9228,7 @@
                       )
                       (i32.const 0)
                     )
-                    (br $do-once$16)
+                    (br $do-once12)
                   )
                   (call $qa)
                 )
@@ -9259,8 +9259,8 @@
       )
       (return)
     )
-    (loop $while-in$21
-      (block $while-out$20
+    (loop $while-in17
+      (block $while-out16
         (set_local $m
           (i32.load
             (get_local $L)
@@ -9270,7 +9270,7 @@
           (i32.eqz
             (get_local $m)
           )
-          (br $while-out$20)
+          (br $while-out16)
           (set_local $L
             (i32.add
               (get_local $m)
@@ -9278,7 +9278,7 @@
             )
           )
         )
-        (br $while-in$21)
+        (br $while-in17)
       )
     )
     (i32.store
@@ -9407,8 +9407,8 @@
         (get_local $c)
       )
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (if
           (i32.eqz
             (i32.load
@@ -9495,7 +9495,7 @@
             (set_local $p
               (i32.const 6)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (if
@@ -9513,7 +9513,7 @@
             (set_local $p
               (i32.const 8)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (set_local $l
@@ -9648,7 +9648,7 @@
         (set_local $n
           (get_local $l)
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
     (if
@@ -9876,8 +9876,8 @@
                 (set_local $d
                   (get_local $b)
                 )
-                (loop $while-in$3
-                  (block $while-out$2
+                (loop $while-in
+                  (block $while-out
                     (if
                       (i32.eqz
                         (get_local $d)
@@ -9918,13 +9918,13 @@
                         (set_local $q
                           (get_local $d)
                         )
-                        (br $while-out$2)
+                        (br $while-out)
                       )
                       (set_local $d
                         (get_local $p)
                       )
                     )
-                    (br $while-in$3)
+                    (br $while-in)
                   )
                 )
                 (if
@@ -10058,8 +10058,8 @@
           (set_local $f
             (get_local $b)
           )
-          (loop $while-in$2
-            (block $while-out$1
+          (loop $while-in
+            (block $while-out
               (if
                 (i32.eqz
                   (i32.load8_s
@@ -10096,13 +10096,13 @@
                   (set_local $d
                     (i32.const 4)
                   )
-                  (br $while-out$1)
+                  (br $while-out)
                 )
                 (set_local $e
                   (get_local $h)
                 )
               )
-              (br $while-in$2)
+              (br $while-in)
             )
           )
         )
@@ -10117,8 +10117,8 @@
         (set_local $d
           (get_local $c)
         )
-        (loop $while-in$4
-          (block $while-out$3
+        (loop $while-in1
+          (block $while-out0
             (set_local $c
               (i32.load
                 (get_local $d)
@@ -10153,10 +10153,10 @@
                 (set_local $l
                   (get_local $d)
                 )
-                (br $while-out$3)
+                (br $while-out0)
               )
             )
-            (br $while-in$4)
+            (br $while-in1)
           )
         )
         (if
@@ -10179,8 +10179,8 @@
             (set_local $j
               (get_local $l)
             )
-            (loop $while-in$6
-              (block $while-out$5
+            (loop $while-in3
+              (block $while-out2
                 (set_local $l
                   (i32.add
                     (get_local $j)
@@ -10197,13 +10197,13 @@
                     (set_local $m
                       (get_local $l)
                     )
-                    (br $while-out$5)
+                    (br $while-out2)
                   )
                   (set_local $j
                     (get_local $l)
                   )
                 )
-                (br $while-in$6)
+                (br $while-in3)
               )
             )
           )
@@ -10228,7 +10228,7 @@
     (local $f i32)
     (local $g i32)
     (local $h i32)
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.eqz
           (get_local $a)
@@ -10273,8 +10273,8 @@
               (set_local $c
                 (get_local $b)
               )
-              (loop $while-in$3
-                (block $while-out$2
+              (loop $while-in
+                (block $while-out
                   (if
                     (i32.gt_s
                       (i32.load
@@ -10343,13 +10343,13 @@
                       (set_local $d
                         (get_local $g)
                       )
-                      (br $while-out$2)
+                      (br $while-out)
                     )
                     (set_local $c
                       (get_local $g)
                     )
                   )
-                  (br $while-in$3)
+                  (br $while-in)
                 )
               )
             )
@@ -10378,7 +10378,7 @@
                   (get_local $a)
                 )
               )
-              (br $do-once$0)
+              (br $do-once)
             )
           )
           (set_local $c
@@ -10491,7 +10491,7 @@
         )
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.eq
           (get_local $j)
@@ -10546,7 +10546,7 @@
                   (set_local $m
                     (get_local $n)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
             )
@@ -10776,8 +10776,8 @@
         )
       )
       (block
-        (loop $while-in$1
-          (block $while-out$0
+        (loop $while-in
+          (block $while-out
             (if
               (i32.eqz
                 (i32.and
@@ -10785,7 +10785,7 @@
                   (i32.const 3)
                 )
               )
-              (br $while-out$0)
+              (br $while-out)
             )
             (block
               (if
@@ -10821,11 +10821,11 @@
                 )
               )
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
-        (loop $while-in$3
-          (block $while-out$2
+        (loop $while-in1
+          (block $while-out0
             (if
               (i32.eqz
                 (i32.ge_s
@@ -10833,7 +10833,7 @@
                   (i32.const 4)
                 )
               )
-              (br $while-out$2)
+              (br $while-out0)
             )
             (block
               (i32.store
@@ -10861,13 +10861,13 @@
                 )
               )
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
     )
-    (loop $while-in$5
-      (block $while-out$4
+    (loop $while-in3
+      (block $while-out2
         (if
           (i32.eqz
             (i32.gt_s
@@ -10875,7 +10875,7 @@
               (i32.const 0)
             )
           )
-          (br $while-out$4)
+          (br $while-out2)
         )
         (block
           (i32.store8
@@ -10903,7 +10903,7 @@
             )
           )
         )
-        (br $while-in$5)
+        (br $while-in3)
       )
     )
     (return
@@ -10984,8 +10984,8 @@
                 (get_local $e)
               )
             )
-            (loop $while-in$1
-              (block $while-out$0
+            (loop $while-in
+              (block $while-out
                 (if
                   (i32.eqz
                     (i32.lt_s
@@ -10993,7 +10993,7 @@
                       (get_local $e)
                     )
                   )
-                  (br $while-out$0)
+                  (br $while-out)
                 )
                 (block
                   (i32.store8
@@ -11007,13 +11007,13 @@
                     )
                   )
                 )
-                (br $while-in$1)
+                (br $while-in)
               )
             )
           )
         )
-        (loop $while-in$3
-          (block $while-out$2
+        (loop $while-in1
+          (block $while-out0
             (if
               (i32.eqz
                 (i32.lt_s
@@ -11021,7 +11021,7 @@
                   (get_local $g)
                 )
               )
-              (br $while-out$2)
+              (br $while-out0)
             )
             (block
               (i32.store
@@ -11035,13 +11035,13 @@
                 )
               )
             )
-            (br $while-in$3)
+            (br $while-in1)
           )
         )
       )
     )
-    (loop $while-in$5
-      (block $while-out$4
+    (loop $while-in3
+      (block $while-out2
         (if
           (i32.eqz
             (i32.lt_s
@@ -11049,7 +11049,7 @@
               (get_local $d)
             )
           )
-          (br $while-out$4)
+          (br $while-out2)
         )
         (block
           (i32.store8
@@ -11063,7 +11063,7 @@
             )
           )
         )
-        (br $while-in$5)
+        (br $while-in3)
       )
     )
     (return
@@ -11103,7 +11103,7 @@
         (i32.const 0)
       )
     )
-    (block $do-once$0
+    (block $do-once
       (if
         (i32.lt_s
           (call $cb
@@ -11163,7 +11163,7 @@
                   (set_local $d
                     (i32.const 0)
                   )
-                  (br $do-once$0)
+                  (br $do-once)
                 )
               )
             )

--- a/test/passes/dce.txt
+++ b/test/passes/dce.txt
@@ -20,17 +20,17 @@
     )
     (if
       (i32.const 0)
-      (block $out
+      (block $out3
         (return)
       )
     )
-    (block $out
-      (br_table $out $out $out $out
+    (block $out4
+      (br_table $out4 $out4 $out4 $out4
         (i32.const 4)
       )
     )
-    (block $out
-      (br_if $out
+    (block $out5
+      (br_if $out5
         (i32.const 3)
       )
       (drop
@@ -65,9 +65,9 @@
         (unreachable)
       )
     )
-    (block $out
+    (block $out16
       (block $in
-        (br_if $out
+        (br_if $out16
           (i32.const 1)
         )
       )
@@ -76,9 +76,9 @@
     (if
       (i32.const 0)
       (block $block11
-        (block $out
-          (block $in
-            (br_if $in
+        (block $out18
+          (block $in19
+            (br_if $in19
               (i32.const 1)
             )
           )
@@ -86,17 +86,17 @@
         )
       )
     )
-    (block $out
-      (block $in
-        (br_table $out $in
+    (block $out20
+      (block $in21
+        (br_table $out20 $in21
           (i32.const 1)
         )
       )
       (unreachable)
     )
-    (block $out
-      (block $in
-        (br_table $in $out
+    (block $out22
+      (block $in23
+        (br_table $in23 $out22
           (i32.const 1)
         )
       )
@@ -105,9 +105,9 @@
     (if
       (i32.const 0)
       (block $block13
-        (block $out
-          (block $in
-            (br_table $in $in
+        (block $out25
+          (block $in26
+            (br_table $in26 $in26
               (i32.const 1)
             )
           )
@@ -131,9 +131,9 @@
       (i32.const 0)
       (unreachable)
     )
-    (block $out
-      (loop $in
-        (br_if $out
+    (block $out29
+      (loop $in30
+        (br_if $out29
           (i32.const 1)
         )
         (unreachable)
@@ -142,8 +142,8 @@
     (if
       (i32.const 0)
       (block $block20
-        (loop $in
-          (br_if $in
+        (loop $in32
+          (br_if $in32
             (i32.const 1)
           )
           (unreachable)

--- a/test/passes/duplicate-function-elimination.txt
+++ b/test/passes/duplicate-function-elimination.txt
@@ -213,7 +213,7 @@
   (type $0 (func))
   (func $keep2 (type $0)
     (block $foo
-      (block $block0
+      (block $block
         (drop
           (i32.const 0)
         )
@@ -223,7 +223,7 @@
   )
   (func $other (type $0)
     (block $bar
-      (block $block0
+      (block $block
         (drop
           (i32.const 1)
         )

--- a/test/passes/precompute.txt
+++ b/test/passes/precompute.txt
@@ -42,7 +42,7 @@
     )
     (nop)
     (drop
-      (block $d i32
+      (block $d0 i32
         (call $x
           (i32.const 5)
         )
@@ -51,7 +51,7 @@
       )
     )
     (drop
-      (block $d i32
+      (block $d2 i32
         (call $x
           (i32.const 6)
         )
@@ -60,7 +60,7 @@
       )
     )
     (drop
-      (block $d i32
+      (block $d4 i32
         (call $x
           (i32.const 7)
         )

--- a/test/passes/remove-unused-brs.txt
+++ b/test/passes/remove-unused-brs.txt
@@ -11,7 +11,7 @@
   )
   (func $b1 (type $0) (param $i1 i32)
     (block $topmost
-      (block $block0
+      (block $block
         (drop
           (i32.const 0)
         )
@@ -33,7 +33,7 @@
   (func $b4 (type $0) (param $i1 i32)
     (block $topmost
       (block $inner
-        (block $block0
+        (block $block
           (drop
             (i32.const 0)
           )
@@ -44,7 +44,7 @@
   (func $b5 (type $0) (param $i1 i32)
     (block $topmost
       (block $inner
-        (block $block0
+        (block $block
           (drop
             (i32.const 0)
           )
@@ -61,7 +61,7 @@
   )
   (func $b7 (type $0) (param $i1 i32)
     (block $topmost
-      (block $block0
+      (block $block
         (drop
           (i32.const 0)
         )
@@ -92,7 +92,7 @@
   (func $b10 (type $0) (param $i1 i32)
     (block $topmost
       (block $inner
-        (block $block0
+        (block $block
           (drop
             (i32.const 0)
           )
@@ -106,7 +106,7 @@
   (func $b11 (type $0) (param $i1 i32)
     (block $topmost
       (block $inner
-        (block $block0
+        (block $block
           (drop
             (i32.const 0)
           )
@@ -125,7 +125,7 @@
           (drop
             (i32.const 12)
           )
-          (block $block2
+          (block $block
             (drop
               (i32.const 1)
             )
@@ -135,7 +135,7 @@
           (drop
             (i32.const 27)
           )
-          (block $block4
+          (block $block0
             (drop
               (i32.const 2)
             )
@@ -195,7 +195,7 @@
     (block $topmost
       (if
         (i32.const 18)
-        (block $block1
+        (block $block
           (drop
             (i32.const 0)
           )
@@ -210,15 +210,15 @@
         )
       )
     )
-    (block $a
-      (block $b
-        (block $c
+    (block $a1
+      (block $b2
+        (block $c3
         )
       )
     )
-    (block $a
-      (block $b
-        (block $c
+    (block $a4
+      (block $b5
+        (block $c6
         )
       )
     )
@@ -233,7 +233,7 @@
         )
       )
     )
-    (block $a
+    (block $a7
       (if
         (i32.const 0)
         (drop
@@ -243,7 +243,7 @@
         )
       )
     )
-    (block $a
+    (block $a9
       (if
         (i32.const 0)
         (block $block8
@@ -299,7 +299,7 @@
           (i32.const 1)
         )
         (block $block2
-          (block $block1
+          (block $block
             (drop
               (i32.const 2)
             )
@@ -313,7 +313,7 @@
       (if
         (i32.const 0)
         (block $block4
-          (block $block3
+          (block $block13
             (drop
               (i32.const 2)
             )
@@ -329,7 +329,7 @@
       )
       (if
         (block $block6 i32
-          (block $block5
+          (block $block15
             (drop
               (i32.const 2)
             )
@@ -345,18 +345,18 @@
         )
       )
       (if
-        (block $a i32
+        (block $a17 i32
           (i32.const 0)
         )
-        (block $a
-          (block $block7
+        (block $a18
+          (block $block19
             (drop
               (i32.const 1)
             )
           )
         )
-        (block $a
-          (block $block8
+        (block $a20
+          (block $block21
             (drop
               (i32.const 2)
             )
@@ -370,7 +370,7 @@
     (block $do-once$0
       (if
         (call $b13)
-        (block $block1
+        (block $block
           (drop
             (i32.const 0)
           )
@@ -381,40 +381,40 @@
         (i32.const 1)
       )
     )
-    (block $do-once$0
+    (block $do-once$022
       (if
         (call $b13)
-        (block $block3
+        (block $block24
           (drop
             (call $b14)
           )
-          (br $do-once$0)
+          (br $do-once$022)
         )
       )
       (drop
         (i32.const 1)
       )
     )
-    (block $do-once$0
+    (block $do-once$025
       (if
         (i32.const 0)
-        (block $block5
+        (block $block27
           (drop
             (call $b14)
           )
-          (br $do-once$0)
+          (br $do-once$025)
         )
       )
       (drop
         (i32.const 1)
       )
     )
-    (block $do-once$0 i32
+    (block $do-once$028 i32
       (if
         (tee_local $x
           (i32.const 1)
         )
-        (br $do-once$0
+        (br $do-once$028
           (tee_local $x
             (i32.const 2)
           )
@@ -433,64 +433,64 @@
         )
       )
     )
-    (loop $in
-      (br $in)
+    (loop $in30
+      (br $in30)
     )
-    (loop $loop-in1
-      (block $out
-        (br_if $out
+    (loop $loop-in
+      (block $out31
+        (br_if $out31
           (i32.const 0)
         )
       )
     )
-    (loop $in
-      (block $out
-        (br_if $out
+    (loop $in33
+      (block $out34
+        (br_if $out34
           (i32.const 0)
         )
       )
     )
-    (loop $in
+    (loop $in36
       (nop)
     )
-    (loop $in
-      (block $out
+    (loop $in37
+      (block $out38
       )
     )
-    (loop $in
-      (block $out
-        (br_if $out
+    (loop $in39
+      (block $out40
+        (br_if $out40
           (i32.const 0)
         )
-        (br_if $in
+        (br_if $in39
           (i32.const 1)
         )
       )
     )
-    (loop $in
-      (block $out
-        (br_if $in
+    (loop $in42
+      (block $out43
+        (br_if $in42
           (i32.const 0)
         )
       )
     )
-    (loop $in
-      (block $out
+    (loop $in45
+      (block $out46
         (if
           (i32.const 0)
           (unreachable)
         )
-        (br $in)
+        (br $in45)
       )
     )
-    (loop $in
-      (block $out
-        (br_if $in
+    (loop $in48
+      (block $out49
+        (br_if $in48
           (i32.eqz
             (i32.const 0)
           )
         )
-        (block $block8
+        (block $block
           (call $loops)
         )
       )
@@ -507,47 +507,47 @@
         )
       )
     )
-    (loop $in
-      (block $out
+    (loop $in52
+      (block $out53
         (if
           (i32.const 0)
           (nop)
           (block
             (call $loops)
-            (br $in)
+            (br $in52)
           )
         )
       )
     )
-    (loop $in
-      (block $out
+    (loop $in55
+      (block $out56
         (if
           (i32.const 0)
           (block
             (call $loops)
-            (br $in)
+            (br $in55)
           )
           (nop)
         )
       )
     )
-    (loop $in
-      (block $out
+    (loop $in58
+      (block $out59
         (if
           (i32.const 0)
-          (block $block13
+          (block $block61
             (drop
               (i32.const 1)
             )
             (call $loops)
-            (br $in)
+            (br $in58)
           )
           (nop)
         )
       )
     )
-    (loop $in
-      (block $out
+    (loop $in62
+      (block $out63
         (if
           (i32.const 0)
           (nop)
@@ -556,13 +556,13 @@
             (drop
               (i32.const 100)
             )
-            (br $in)
+            (br $in62)
           )
         )
       )
     )
-    (loop $in
-      (block $out
+    (loop $in65
+      (block $out66
         (if
           (i32.const 0)
           (block
@@ -570,17 +570,17 @@
             (drop
               (i32.const 101)
             )
-            (br $in)
+            (br $in65)
           )
           (nop)
         )
       )
     )
-    (loop $in
-      (block $out
+    (loop $in68
+      (block $out69
         (if
           (i32.const 0)
-          (block $block17
+          (block $block71
             (drop
               (i32.const 1)
             )
@@ -588,34 +588,34 @@
             (drop
               (i32.const 102)
             )
-            (br $in)
+            (br $in68)
           )
           (nop)
         )
       )
     )
-    (loop $in
-      (block $out
-        (br_if $out
+    (loop $in72
+      (block $out73
+        (br_if $out73
           (i32.const 0)
         )
         (call $loops)
         (return)
-        (br $in)
+        (br $in72)
       )
     )
-    (loop $in
-      (block $out
-        (br_if $out
+    (loop $in75
+      (block $out76
+        (br_if $out76
           (i32.const 0)
         )
         (call $loops)
-        (br $out)
-        (br $in)
+        (br $out76)
+        (br $in75)
       )
     )
-    (loop $in
-      (block $out
+    (loop $in78
+      (block $out79
         (if
           (i32.const 0)
           (nop)
@@ -626,14 +626,14 @@
                 (i32.const 1)
               )
             )
-            (br $in)
+            (br $in78)
           )
         )
       )
     )
-    (loop $in
-      (block $out
-        (br_if $in
+    (loop $in81
+      (block $out82
+        (br_if $in81
           (i32.eqz
             (i32.const 0)
           )
@@ -652,18 +652,18 @@
         )
       )
     )
-    (loop $in
-      (block $out
-        (br $out)
-        (br $in)
+    (loop $in83
+      (block $out84
+        (br $out84)
+        (br $in83)
       )
     )
-    (loop $in
-      (block $out
-        (br_if $in
+    (loop $in85
+      (block $out86
+        (br_if $in85
           (i32.const 0)
         )
-        (br $in)
+        (br $in85)
       )
     )
     (loop $in-not
@@ -678,8 +678,8 @@
         (br $in-not)
       )
     )
-    (loop $in-todo2
-      (block $out-todo2
+    (loop $in-todo287
+      (block $out-todo288
         (if
           (i32.const 0)
           (nop)
@@ -688,7 +688,7 @@
             (drop
               (i32.const 1)
             )
-            (br $in-todo2)
+            (br $in-todo287)
           )
         )
       )
@@ -771,7 +771,7 @@
           (if
             (get_local $x)
             (br $out
-              (block $block1 i32
+              (block $block i32
                 (set_local $x
                   (i32.const 0)
                 )
@@ -801,7 +801,7 @@
               (i32.const 1)
             )
             (br $out
-              (block $block1 i32
+              (block $block i32
                 (set_local $x
                   (i32.const 0)
                 )
@@ -825,7 +825,7 @@
           (if
             (get_local $x)
             (br $out
-              (block $block1 i32
+              (block $block i32
                 (drop
                   (call $if-to-br_if-value-sideeffect
                     (i32.const 0)

--- a/test/passes/remove-unused-names.txt
+++ b/test/passes/remove-unused-names.txt
@@ -12,38 +12,38 @@
         (br $in)
       )
     )
-    (loop $in
-      (br $in)
+    (loop $in0
+      (br $in0)
     )
     (nop)
-    (block $out
-      (loop $in
-        (br $out)
-        (br $in)
+    (block $out4
+      (loop $in5
+        (br $out4)
+        (br $in5)
       )
     )
-    (block $out
-      (loop $in
-        (br $out)
-        (br $in)
+    (block $out6
+      (loop $in7
+        (br $out6)
+        (br $in7)
       )
     )
-    (loop $in
-      (block $out
-        (br $out)
-        (br $in)
+    (loop $in8
+      (block $out9
+        (br $out9)
+        (br $in8)
       )
     )
-    (loop $in
-      (block $out
-        (br $out)
-        (br $in)
+    (loop $in10
+      (block $out11
+        (br $out11)
+        (br $in10)
       )
     )
-    (block $out
-      (loop $in
-        (br $out)
-        (br $in)
+    (block $out12
+      (loop $in13
+        (br $out12)
+        (br $in13)
       )
     )
   )
@@ -52,13 +52,13 @@
       (br $b)
       (br $b)
     )
-    (block $b
-      (br_table $b $b
+    (block $b15
+      (br_table $b15 $b15
         (i32.const 3)
       )
     )
-    (block $b
-      (br_table $b $b
+    (block $b17
+      (br_table $b17 $b17
         (i32.const 3)
       )
     )

--- a/test/passes/simplify-locals.txt
+++ b/test/passes/simplify-locals.txt
@@ -224,8 +224,8 @@
       (call $waka)
       (nop)
       (set_local $a
-        (block $block0 i32
-          (block $block1
+        (block $block i32
+          (block $block4
             (nop)
             (i32.store
               (i32.const 104)
@@ -239,8 +239,8 @@
       )
       (call $waka)
       (set_local $a
-        (block $block2 i32
-          (block $block4
+        (block $block5 i32
+          (block $block6
             (nop)
             (i32.store
               (i32.const 106)
@@ -258,8 +258,8 @@
       )
       (call $waka)
       (set_local $a
-        (block $block5 i32
-          (block $block6
+        (block $block7 i32
+          (block $block8
             (nop)
             (i32.store
               (i32.const 108)
@@ -281,8 +281,8 @@
       )
       (call $waka)
       (set_local $a
-        (block $block7 i32
-          (block $block8
+        (block $block9 i32
+          (block $block10
             (nop)
             (i32.store
               (i32.const 110)
@@ -686,7 +686,7 @@
   (func $no-out-of-label (type $8) (param $x i32) (param $y i32)
     (loop $moar
       (set_local $x
-        (block $block0 i32
+        (block $block i32
           (br_if $moar
             (get_local $x)
           )
@@ -697,10 +697,10 @@
     (drop
       (get_local $x)
     )
-    (block $moar
+    (block $moar17
       (set_local $y
-        (block $block1 i32
-          (br_if $moar
+        (block $block18 i32
+          (br_if $moar17
             (get_local $y)
           )
           (i32.const 0)

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -124,10 +124,10 @@
     )
   )
   (func $switcher (param $0 i32) (result i32)
-    (block $switch$0
-      (block $switch-case$2
-        (block $switch-case$1
-          (br_table $switch-case$1 $switch-case$2 $switch$0
+    (block $switch
+      (block $switch-case0
+        (block $switch-case
+          (br_table $switch-case $switch-case0 $switch
             (i32.sub
               (get_local $0)
               (i32.const 1)
@@ -142,10 +142,10 @@
         (i32.const 2)
       )
     )
-    (block $switch$3
-      (block $switch-case$5
-        (block $switch-case$4
-          (br_table $switch-case$5 $switch$3 $switch$3 $switch$3 $switch$3 $switch$3 $switch$3 $switch-case$4 $switch$3
+    (block $switch1
+      (block $switch-case3
+        (block $switch-case2
+          (br_table $switch-case3 $switch1 $switch1 $switch1 $switch1 $switch1 $switch1 $switch-case2 $switch1
             (i32.sub
               (get_local $0)
               (i32.const 5)
@@ -161,11 +161,11 @@
       )
     )
     (block $label$break$Lout
-      (block $switch-case$13
-        (block $switch-case$10
-          (block $switch-case$7
-            (block $switch-case$6
-              (br_table $switch-case$13 $label$break$Lout $label$break$Lout $switch-case$10 $label$break$Lout $label$break$Lout $label$break$Lout $label$break$Lout $switch-case$7 $label$break$Lout $switch-case$6 $label$break$Lout
+      (block $switch-case9
+        (block $switch-case6
+          (block $switch-case5
+            (block $switch-case4
+              (br_table $switch-case9 $label$break$Lout $label$break$Lout $switch-case6 $label$break$Lout $label$break$Lout $label$break$Lout $label$break$Lout $switch-case5 $label$break$Lout $switch-case4 $label$break$Lout
                 (i32.sub
                   (get_local $0)
                   (i32.const 2)
@@ -180,11 +180,11 @@
       (block $label$break$L1
         (loop $label$continue$L3
           (block $label$break$L3
-            (block $switch-default$18
-              (block $switch-case$17
-                (block $switch-case$16
-                  (block $switch-case$15
-                    (br_table $switch-case$15 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-case$17 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-case$16 $switch-default$18
+            (block $switch-default
+              (block $switch-case13
+                (block $switch-case12
+                  (block $switch-case11
+                    (br_table $switch-case11 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case13 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case12 $switch-default
                       (i32.sub
                         (get_local $0)
                         (i32.const -1)
@@ -293,7 +293,7 @@
     (set_local $0
       (i32.const 1)
     )
-    (loop $for-in$1
+    (loop $for-in
       (if
         (i32.lt_s
           (get_local $0)
@@ -309,7 +309,7 @@
               (i32.const 1)
             )
           )
-          (br $for-in$1)
+          (br $for-in)
         )
       )
     )
@@ -349,22 +349,22 @@
     )
   )
   (func $continues
-    (loop $while-in$1
+    (loop $while-in
       (call $print
         (i32.const 1)
       )
-      (loop $unlikely-continue$3
+      (loop $unlikely-continue
         (call $print
           (i32.const 5)
         )
-        (br_if $unlikely-continue$3
+        (br_if $unlikely-continue
           (call $return_int)
         )
       )
       (call $print
         (i32.const 2)
       )
-      (br $while-in$1)
+      (br $while-in)
     )
   )
   (func $bitcasts (param $0 i32) (param $1 f32)
@@ -495,9 +495,9 @@
     )
   )
   (func $phi (result i32)
-    (block $do-once$0 i32
+    (block $do-once i32
       (drop
-        (br_if $do-once$0
+        (br_if $do-once
           (i32.const 0)
           (call $lb
             (i32.const 1)
@@ -560,7 +560,7 @@
     (block $label$break$L1
       (if
         (get_local $0)
-        (loop $while-in$2
+        (loop $while-in
           (br_if $label$break$L1
             (i32.eqz
               (get_local $0)
@@ -569,7 +569,7 @@
           (call $zeroInit
             (i32.const 0)
           )
-          (br $while-in$2)
+          (br $while-in)
         )
       )
     )
@@ -723,8 +723,8 @@
   )
   (func $loophi (param $0 i32) (param $1 i32)
     (local $2 i32)
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (call $loophi
           (get_local $0)
           (i32.const 0)
@@ -733,11 +733,11 @@
           (tee_local $2
             (get_local $0)
           )
-          (br_if $while-out$0
+          (br_if $while-out
             (get_local $2)
           )
         )
-        (br_if $while-in$1
+        (br_if $while-in
           (i32.eq
             (tee_local $0
               (i32.add
@@ -763,7 +763,7 @@
         (set_local $0
           (i32.const 0)
         )
-        (loop $while-in$1
+        (loop $while-in
           (set_local $2
             (get_local $0)
           )
@@ -773,7 +773,7 @@
               (get_local $2)
             )
           )
-          (br_if $while-in$1
+          (br_if $while-in
             (tee_local $0
               (i32.add
                 (get_local $0)
@@ -809,8 +809,8 @@
       (i32.const -1)
     )
     (block $jumpthreading$inner$1
-      (loop $while-in$1
-        (br_if $while-in$1
+      (loop $while-in
+        (br_if $while-in
           (i32.eqz
             (tee_local $0
               (i32.add
@@ -902,7 +902,7 @@
     (call $h
       (i32.const -4)
     )
-    (block $jumpthreading$outer$6
+    (block $label$break$L1
       (block $jumpthreading$inner$6
         (if
           (get_local $0)
@@ -913,7 +913,7 @@
             (br $jumpthreading$inner$6)
           )
         )
-        (br $jumpthreading$outer$6)
+        (br $label$break$L1)
       )
       (call $h
         (i32.const 11)
@@ -922,35 +922,33 @@
     (call $h
       (i32.const -5)
     )
-    (block $jumpthreading$outer$8
+    (block $label$break$L10
       (block $jumpthreading$inner$8
-        (block $jumpthreading$outer$7
-          (block $jumpthreading$inner$7
-            (if
-              (get_local $0)
-              (block
-                (call $h
-                  (i32.const 12)
-                )
-                (br_if $jumpthreading$inner$7
-                  (i32.eq
-                    (get_local $0)
-                    (i32.const 8)
-                  )
-                )
-                (br $jumpthreading$inner$8)
-              )
-            )
-            (br $jumpthreading$outer$8)
-          )
-          (call $h
-            (i32.const 13)
-          )
-          (br_if $jumpthreading$inner$8
+        (block $jumpthreading$inner$7
+          (if
             (get_local $0)
+            (block
+              (call $h
+                (i32.const 12)
+              )
+              (br_if $jumpthreading$inner$7
+                (i32.eq
+                  (get_local $0)
+                  (i32.const 8)
+                )
+              )
+              (br $jumpthreading$inner$8)
+            )
           )
+          (br $label$break$L10)
         )
-        (br $jumpthreading$outer$8)
+        (call $h
+          (i32.const 13)
+        )
+        (br_if $jumpthreading$inner$8
+          (get_local $0)
+        )
+        (br $label$break$L10)
       )
       (call $h
         (i32.const 14)
@@ -967,7 +965,7 @@
     (local $2 i32)
     (local $3 i32)
     (local $4 i32)
-    (loop $while-in$1
+    (loop $while-in
       (block $jumpthreading$outer$1
         (block $jumpthreading$inner$1
           (if
@@ -983,14 +981,14 @@
               )
             )
           )
-          (br $while-in$1)
+          (br $while-in)
         )
         (i32.store
           (get_local $3)
           (get_local $4)
         )
       )
-      (br $while-in$1)
+      (br $while-in)
     )
   )
   (func $__Z12multi_varargiz (param $0 i32)
@@ -998,8 +996,8 @@
     (local $2 i32)
     (if
       (get_local $1)
-      (loop $while-in$1
-        (br_if $while-in$1
+      (loop $while-in
+        (br_if $while-in
           (i32.eqz
             (get_local $2)
           )

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -111,10 +111,10 @@
     )
   )
   (func $switcher (param $0 i32) (result i32)
-    (block $switch$0
-      (block $switch-case$2
-        (block $switch-case$1
-          (br_table $switch-case$1 $switch-case$2 $switch$0
+    (block $switch
+      (block $switch-case0
+        (block $switch-case
+          (br_table $switch-case $switch-case0 $switch
             (i32.sub
               (get_local $0)
               (i32.const 1)
@@ -129,10 +129,10 @@
         (i32.const 2)
       )
     )
-    (block $switch$3
-      (block $switch-case$5
-        (block $switch-case$4
-          (br_table $switch-case$5 $switch$3 $switch$3 $switch$3 $switch$3 $switch$3 $switch$3 $switch-case$4 $switch$3
+    (block $switch1
+      (block $switch-case3
+        (block $switch-case2
+          (br_table $switch-case3 $switch1 $switch1 $switch1 $switch1 $switch1 $switch1 $switch-case2 $switch1
             (i32.sub
               (get_local $0)
               (i32.const 5)
@@ -148,11 +148,11 @@
       )
     )
     (block $label$break$Lout
-      (block $switch-case$13
-        (block $switch-case$10
-          (block $switch-case$7
-            (block $switch-case$6
-              (br_table $switch-case$13 $label$break$Lout $label$break$Lout $switch-case$10 $label$break$Lout $label$break$Lout $label$break$Lout $label$break$Lout $switch-case$7 $label$break$Lout $switch-case$6 $label$break$Lout
+      (block $switch-case9
+        (block $switch-case6
+          (block $switch-case5
+            (block $switch-case4
+              (br_table $switch-case9 $label$break$Lout $label$break$Lout $switch-case6 $label$break$Lout $label$break$Lout $label$break$Lout $label$break$Lout $switch-case5 $label$break$Lout $switch-case4 $label$break$Lout
                 (i32.sub
                   (get_local $0)
                   (i32.const 2)
@@ -167,11 +167,11 @@
       (block $label$break$L1
         (loop $label$continue$L3
           (block $label$break$L3
-            (block $switch-default$18
-              (block $switch-case$17
-                (block $switch-case$16
-                  (block $switch-case$15
-                    (br_table $switch-case$15 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-case$17 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-case$16 $switch-default$18
+            (block $switch-default
+              (block $switch-case13
+                (block $switch-case12
+                  (block $switch-case11
+                    (br_table $switch-case11 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case13 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case12 $switch-default
                       (i32.sub
                         (get_local $0)
                         (i32.const -1)
@@ -274,7 +274,7 @@
     (set_local $0
       (i32.const 1)
     )
-    (loop $for-in$1
+    (loop $for-in
       (if
         (i32.lt_s
           (get_local $0)
@@ -290,7 +290,7 @@
               (i32.const 1)
             )
           )
-          (br $for-in$1)
+          (br $for-in)
         )
       )
     )
@@ -330,22 +330,22 @@
     )
   )
   (func $continues
-    (loop $while-in$1
+    (loop $while-in
       (call $print
         (i32.const 1)
       )
-      (loop $unlikely-continue$3
+      (loop $unlikely-continue
         (call $print
           (i32.const 5)
         )
-        (br_if $unlikely-continue$3
+        (br_if $unlikely-continue
           (call $return_int)
         )
       )
       (call $print
         (i32.const 2)
       )
-      (br $while-in$1)
+      (br $while-in)
     )
   )
   (func $bitcasts (param $0 i32) (param $1 f32)
@@ -476,9 +476,9 @@
     )
   )
   (func $phi (result i32)
-    (block $do-once$0 i32
+    (block $do-once i32
       (drop
-        (br_if $do-once$0
+        (br_if $do-once
           (i32.const 0)
           (call $lb
             (i32.const 1)
@@ -541,7 +541,7 @@
     (block $label$break$L1
       (if
         (get_local $0)
-        (loop $while-in$2
+        (loop $while-in
           (br_if $label$break$L1
             (i32.eqz
               (get_local $0)
@@ -550,7 +550,7 @@
           (call $zeroInit
             (i32.const 0)
           )
-          (br $while-in$2)
+          (br $while-in)
         )
       )
     )
@@ -704,8 +704,8 @@
   )
   (func $loophi (param $0 i32) (param $1 i32)
     (local $2 i32)
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (call $loophi
           (get_local $0)
           (i32.const 0)
@@ -714,11 +714,11 @@
           (tee_local $2
             (get_local $0)
           )
-          (br_if $while-out$0
+          (br_if $while-out
             (get_local $2)
           )
         )
-        (br_if $while-in$1
+        (br_if $while-in
           (i32.eq
             (tee_local $0
               (i32.add
@@ -744,7 +744,7 @@
         (set_local $0
           (i32.const 0)
         )
-        (loop $while-in$1
+        (loop $while-in
           (set_local $2
             (get_local $0)
           )
@@ -754,7 +754,7 @@
               (get_local $2)
             )
           )
-          (br_if $while-in$1
+          (br_if $while-in
             (tee_local $0
               (i32.add
                 (get_local $0)
@@ -790,8 +790,8 @@
       (i32.const -1)
     )
     (block $jumpthreading$inner$1
-      (loop $while-in$1
-        (br_if $while-in$1
+      (loop $while-in
+        (br_if $while-in
           (i32.eqz
             (tee_local $0
               (i32.add
@@ -883,7 +883,7 @@
     (call $h
       (i32.const -4)
     )
-    (block $jumpthreading$outer$6
+    (block $label$break$L1
       (block $jumpthreading$inner$6
         (if
           (get_local $0)
@@ -894,7 +894,7 @@
             (br $jumpthreading$inner$6)
           )
         )
-        (br $jumpthreading$outer$6)
+        (br $label$break$L1)
       )
       (call $h
         (i32.const 11)
@@ -903,35 +903,33 @@
     (call $h
       (i32.const -5)
     )
-    (block $jumpthreading$outer$8
+    (block $label$break$L10
       (block $jumpthreading$inner$8
-        (block $jumpthreading$outer$7
-          (block $jumpthreading$inner$7
-            (if
-              (get_local $0)
-              (block
-                (call $h
-                  (i32.const 12)
-                )
-                (br_if $jumpthreading$inner$7
-                  (i32.eq
-                    (get_local $0)
-                    (i32.const 8)
-                  )
-                )
-                (br $jumpthreading$inner$8)
-              )
-            )
-            (br $jumpthreading$outer$8)
-          )
-          (call $h
-            (i32.const 13)
-          )
-          (br_if $jumpthreading$inner$8
+        (block $jumpthreading$inner$7
+          (if
             (get_local $0)
+            (block
+              (call $h
+                (i32.const 12)
+              )
+              (br_if $jumpthreading$inner$7
+                (i32.eq
+                  (get_local $0)
+                  (i32.const 8)
+                )
+              )
+              (br $jumpthreading$inner$8)
+            )
           )
+          (br $label$break$L10)
         )
-        (br $jumpthreading$outer$8)
+        (call $h
+          (i32.const 13)
+        )
+        (br_if $jumpthreading$inner$8
+          (get_local $0)
+        )
+        (br $label$break$L10)
       )
       (call $h
         (i32.const 14)
@@ -948,7 +946,7 @@
     (local $2 i32)
     (local $3 i32)
     (local $4 i32)
-    (loop $while-in$1
+    (loop $while-in
       (block $jumpthreading$outer$1
         (block $jumpthreading$inner$1
           (if
@@ -964,14 +962,14 @@
               )
             )
           )
-          (br $while-in$1)
+          (br $while-in)
         )
         (i32.store
           (get_local $3)
           (get_local $4)
         )
       )
-      (br $while-in$1)
+      (br $while-in)
     )
   )
   (func $__Z12multi_varargiz (param $0 i32)
@@ -979,8 +977,8 @@
     (local $2 i32)
     (if
       (get_local $1)
-      (loop $while-in$1
-        (br_if $while-in$1
+      (loop $while-in
+        (br_if $while-in
           (i32.eqz
             (get_local $2)
           )

--- a/test/unit.fromasm.imprecise.no-opts
+++ b/test/unit.fromasm.imprecise.no-opts
@@ -198,10 +198,10 @@
   )
   (func $switcher (param $x i32) (result i32)
     (local $waka i32)
-    (block $switch$0
-      (block $switch-case$2
-        (block $switch-case$1
-          (br_table $switch-case$1 $switch-case$2 $switch$0
+    (block $switch
+      (block $switch-case0
+        (block $switch-case
+          (br_table $switch-case $switch-case0 $switch
             (i32.sub
               (get_local $x)
               (i32.const 1)
@@ -216,10 +216,10 @@
         (i32.const 2)
       )
     )
-    (block $switch$3
-      (block $switch-case$5
-        (block $switch-case$4
-          (br_table $switch-case$5 $switch$3 $switch$3 $switch$3 $switch$3 $switch$3 $switch$3 $switch-case$4 $switch$3
+    (block $switch1
+      (block $switch-case3
+        (block $switch-case2
+          (br_table $switch-case3 $switch1 $switch1 $switch1 $switch1 $switch1 $switch1 $switch-case2 $switch1
             (i32.sub
               (get_local $x)
               (i32.const 5)
@@ -235,11 +235,11 @@
       )
     )
     (block $label$break$Lout
-      (block $switch-case$13
-        (block $switch-case$10
-          (block $switch-case$7
-            (block $switch-case$6
-              (br_table $switch-case$13 $label$break$Lout $label$break$Lout $switch-case$10 $label$break$Lout $label$break$Lout $label$break$Lout $label$break$Lout $switch-case$7 $label$break$Lout $switch-case$6 $label$break$Lout
+      (block $switch-case9
+        (block $switch-case6
+          (block $switch-case5
+            (block $switch-case4
+              (br_table $switch-case9 $label$break$Lout $label$break$Lout $switch-case6 $label$break$Lout $label$break$Lout $label$break$Lout $label$break$Lout $switch-case5 $label$break$Lout $switch-case4 $label$break$Lout
                 (i32.sub
                   (get_local $x)
                   (i32.const 2)
@@ -251,20 +251,20 @@
           (br $label$break$Lout)
         )
         (block
-          (loop $while-in$9
-            (block $while-out$8
-              (br $while-out$8)
-              (br $while-in$9)
+          (loop $while-in
+            (block $while-out
+              (br $while-out)
+              (br $while-in)
             )
           )
           (br $label$break$Lout)
         )
       )
       (block
-        (loop $while-in$12
-          (block $while-out$11
+        (loop $while-in8
+          (block $while-out7
             (br $label$break$Lout)
-            (br $while-in$12)
+            (br $while-in8)
           )
         )
         (br $label$break$Lout)
@@ -274,12 +274,12 @@
       (block $label$break$L1
         (loop $label$continue$L3
           (block $label$break$L3
-            (block $switch$14
-              (block $switch-default$18
-                (block $switch-case$17
-                  (block $switch-case$16
-                    (block $switch-case$15
-                      (br_table $switch-case$15 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-case$17 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-case$16 $switch-default$18
+            (block $switch10
+              (block $switch-default
+                (block $switch-case13
+                  (block $switch-case12
+                    (block $switch-case11
+                      (br_table $switch-case11 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case13 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case12 $switch-default
                         (i32.sub
                           (get_local $x)
                           (i32.const -1)
@@ -288,19 +288,19 @@
                     )
                     (block
                       (br $label$break$L1)
-                      (br $switch$14)
+                      (br $switch10)
                     )
                   )
                   (block
                     (set_local $waka
                       (i32.const 1)
                     )
-                    (br $switch$14)
+                    (br $switch10)
                   )
                 )
                 (block
                   (br $label$break$L3)
-                  (br $switch$14)
+                  (br $switch10)
                 )
               )
               (br $label$break$L1)
@@ -496,8 +496,8 @@
     (set_local $i
       (i32.const 1)
     )
-    (loop $for-in$1
-      (block $for-out$0
+    (loop $for-in
+      (block $for-out
         (if
           (i32.eqz
             (i32.lt_s
@@ -505,7 +505,7 @@
               (i32.const 200)
             )
           )
-          (br $for-out$0)
+          (br $for-out)
         )
         (call $h
           (get_local $i)
@@ -516,7 +516,7 @@
             (i32.const 1)
           )
         )
-        (br $for-in$1)
+        (br $for-in)
       )
     )
   )
@@ -572,26 +572,26 @@
     )
   )
   (func $continues
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (call $print
           (i32.const 1)
         )
-        (block $do-once$2
-          (loop $unlikely-continue$3
+        (block $do-once
+          (loop $unlikely-continue
             (call $print
               (i32.const 5)
             )
             (if
               (call $return_int)
-              (br $unlikely-continue$3)
+              (br $unlikely-continue)
             )
           )
         )
         (call $print
           (i32.const 2)
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
   )
@@ -824,7 +824,7 @@
   )
   (func $phi (result i32)
     (local $x i32)
-    (block $do-once$0
+    (block $do-once
       (block
         (if
           (call $lb
@@ -834,7 +834,7 @@
             (set_local $x
               (i32.const 0)
             )
-            (br $do-once$0)
+            (br $do-once)
           )
         )
         (set_local $x
@@ -847,7 +847,7 @@
     )
   )
   (func $smallIf
-    (block $do-once$0
+    (block $do-once
       (if
         (call $return_int)
         (drop
@@ -855,7 +855,7 @@
             (i32.const 3)
           )
         )
-        (br $do-once$0)
+        (br $do-once)
       )
       (nop)
     )
@@ -924,8 +924,8 @@
     (block $label$break$L1
       (if
         (get_local $$s)
-        (loop $while-in$2
-          (block $while-out$1
+        (loop $while-in
+          (block $while-out
             (if
               (i32.eqz
                 (get_local $$s)
@@ -935,7 +935,7 @@
             (call $zeroInit
               (i32.const 0)
             )
-            (br $while-in$2)
+            (br $while-in)
           )
         )
         (drop
@@ -1155,8 +1155,8 @@
     (set_local $loopvar
       (get_local $x)
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (call $loophi
           (get_local $loopvar)
           (i32.const 0)
@@ -1168,7 +1168,7 @@
           (get_local $temp)
           (if
             (get_local $temp)
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (set_local $inc
@@ -1185,9 +1185,9 @@
           (set_local $loopvar
             (get_local $inc)
           )
-          (br $while-out$0)
+          (br $while-out)
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
   )
@@ -1205,8 +1205,8 @@
         (set_local $j
           (i32.const 0)
         )
-        (loop $while-in$1
-          (block $while-out$0
+        (loop $while-in
+          (block $while-out
             (set_local $temp
               (get_local $j)
             )
@@ -1233,9 +1233,9 @@
               (set_local $j
                 (get_local $jnc)
               )
-              (br $while-out$0)
+              (br $while-out)
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
         (br $label$continue$L7)
@@ -1270,8 +1270,8 @@
     (call $h
       (i32.const -1)
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (set_local $x
           (i32.add
             (get_local $x)
@@ -1287,10 +1287,10 @@
             (set_local $label
               (i32.const 2)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
     (if
@@ -1463,7 +1463,7 @@
         )
       )
     )
-    (block $label$break$L1
+    (block $label$break$L10
       (if
         (i32.eq
           (get_local $label)
@@ -1473,7 +1473,7 @@
           (call $h
             (i32.const 14)
           )
-          (br $label$break$L1)
+          (br $label$break$L10)
         )
       )
     )
@@ -1493,8 +1493,8 @@
     (local $$11 i32)
     (local $$exitcond i32)
     (local $label i32)
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (if
           (get_local $$14)
           (if
@@ -1540,7 +1540,7 @@
             )
           )
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
   )
@@ -1552,19 +1552,19 @@
     (local $$20 i32)
     (if
       (get_local $$2)
-      (loop $while-in$1
-        (block $while-out$0
+      (loop $while-in
+        (block $while-out
           (set_local $$12
             (get_local $$$06$i4)
           )
           (if
             (get_local $$exitcond$i6)
-            (br $while-out$0)
+            (br $while-out)
             (set_local $$$06$i4
               (get_local $$20)
             )
           )
-          (br $while-in$1)
+          (br $while-in)
         )
       )
       (drop
@@ -1580,13 +1580,13 @@
     (set_local $temp
       (call $return_int)
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (set_local $label
           (i32.const 14)
         )
-        (br $while-out$0)
-        (br $while-in$1)
+        (br $while-out)
+        (br $while-in)
       )
     )
     (if
@@ -1617,7 +1617,7 @@
     )
   )
   (func $dropIgnoredImportInIf (param $$0 i32) (param $$1 i32) (param $$2 i32)
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $$0)
         (block
@@ -1630,14 +1630,14 @@
             )
           )
         )
-        (br $do-once$0)
+        (br $do-once)
       )
       (nop)
     )
     (return)
   )
   (func $dropIgnoredImportsInIf (param $$0 i32) (param $$1 i32) (param $$2 i32)
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $$0)
         (drop

--- a/test/unit.fromasm.no-opts
+++ b/test/unit.fromasm.no-opts
@@ -204,10 +204,10 @@
   )
   (func $switcher (param $x i32) (result i32)
     (local $waka i32)
-    (block $switch$0
-      (block $switch-case$2
-        (block $switch-case$1
-          (br_table $switch-case$1 $switch-case$2 $switch$0
+    (block $switch
+      (block $switch-case0
+        (block $switch-case
+          (br_table $switch-case $switch-case0 $switch
             (i32.sub
               (get_local $x)
               (i32.const 1)
@@ -222,10 +222,10 @@
         (i32.const 2)
       )
     )
-    (block $switch$3
-      (block $switch-case$5
-        (block $switch-case$4
-          (br_table $switch-case$5 $switch$3 $switch$3 $switch$3 $switch$3 $switch$3 $switch$3 $switch-case$4 $switch$3
+    (block $switch1
+      (block $switch-case3
+        (block $switch-case2
+          (br_table $switch-case3 $switch1 $switch1 $switch1 $switch1 $switch1 $switch1 $switch-case2 $switch1
             (i32.sub
               (get_local $x)
               (i32.const 5)
@@ -241,11 +241,11 @@
       )
     )
     (block $label$break$Lout
-      (block $switch-case$13
-        (block $switch-case$10
-          (block $switch-case$7
-            (block $switch-case$6
-              (br_table $switch-case$13 $label$break$Lout $label$break$Lout $switch-case$10 $label$break$Lout $label$break$Lout $label$break$Lout $label$break$Lout $switch-case$7 $label$break$Lout $switch-case$6 $label$break$Lout
+      (block $switch-case9
+        (block $switch-case6
+          (block $switch-case5
+            (block $switch-case4
+              (br_table $switch-case9 $label$break$Lout $label$break$Lout $switch-case6 $label$break$Lout $label$break$Lout $label$break$Lout $label$break$Lout $switch-case5 $label$break$Lout $switch-case4 $label$break$Lout
                 (i32.sub
                   (get_local $x)
                   (i32.const 2)
@@ -257,20 +257,20 @@
           (br $label$break$Lout)
         )
         (block
-          (loop $while-in$9
-            (block $while-out$8
-              (br $while-out$8)
-              (br $while-in$9)
+          (loop $while-in
+            (block $while-out
+              (br $while-out)
+              (br $while-in)
             )
           )
           (br $label$break$Lout)
         )
       )
       (block
-        (loop $while-in$12
-          (block $while-out$11
+        (loop $while-in8
+          (block $while-out7
             (br $label$break$Lout)
-            (br $while-in$12)
+            (br $while-in8)
           )
         )
         (br $label$break$Lout)
@@ -280,12 +280,12 @@
       (block $label$break$L1
         (loop $label$continue$L3
           (block $label$break$L3
-            (block $switch$14
-              (block $switch-default$18
-                (block $switch-case$17
-                  (block $switch-case$16
-                    (block $switch-case$15
-                      (br_table $switch-case$15 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-case$17 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-default$18 $switch-case$16 $switch-default$18
+            (block $switch10
+              (block $switch-default
+                (block $switch-case13
+                  (block $switch-case12
+                    (block $switch-case11
+                      (br_table $switch-case11 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case13 $switch-default $switch-default $switch-default $switch-default $switch-default $switch-case12 $switch-default
                         (i32.sub
                           (get_local $x)
                           (i32.const -1)
@@ -294,19 +294,19 @@
                     )
                     (block
                       (br $label$break$L1)
-                      (br $switch$14)
+                      (br $switch10)
                     )
                   )
                   (block
                     (set_local $waka
                       (i32.const 1)
                     )
-                    (br $switch$14)
+                    (br $switch10)
                   )
                 )
                 (block
                   (br $label$break$L3)
-                  (br $switch$14)
+                  (br $switch10)
                 )
               )
               (br $label$break$L1)
@@ -502,8 +502,8 @@
     (set_local $i
       (i32.const 1)
     )
-    (loop $for-in$1
-      (block $for-out$0
+    (loop $for-in
+      (block $for-out
         (if
           (i32.eqz
             (i32.lt_s
@@ -511,7 +511,7 @@
               (i32.const 200)
             )
           )
-          (br $for-out$0)
+          (br $for-out)
         )
         (call $h
           (get_local $i)
@@ -522,7 +522,7 @@
             (i32.const 1)
           )
         )
-        (br $for-in$1)
+        (br $for-in)
       )
     )
   )
@@ -578,26 +578,26 @@
     )
   )
   (func $continues
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (call $print
           (i32.const 1)
         )
-        (block $do-once$2
-          (loop $unlikely-continue$3
+        (block $do-once
+          (loop $unlikely-continue
             (call $print
               (i32.const 5)
             )
             (if
               (call $return_int)
-              (br $unlikely-continue$3)
+              (br $unlikely-continue)
             )
           )
         )
         (call $print
           (i32.const 2)
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
   )
@@ -830,7 +830,7 @@
   )
   (func $phi (result i32)
     (local $x i32)
-    (block $do-once$0
+    (block $do-once
       (block
         (if
           (call $lb
@@ -840,7 +840,7 @@
             (set_local $x
               (i32.const 0)
             )
-            (br $do-once$0)
+            (br $do-once)
           )
         )
         (set_local $x
@@ -853,7 +853,7 @@
     )
   )
   (func $smallIf
-    (block $do-once$0
+    (block $do-once
       (if
         (call $return_int)
         (drop
@@ -861,7 +861,7 @@
             (i32.const 3)
           )
         )
-        (br $do-once$0)
+        (br $do-once)
       )
       (nop)
     )
@@ -930,8 +930,8 @@
     (block $label$break$L1
       (if
         (get_local $$s)
-        (loop $while-in$2
-          (block $while-out$1
+        (loop $while-in
+          (block $while-out
             (if
               (i32.eqz
                 (get_local $$s)
@@ -941,7 +941,7 @@
             (call $zeroInit
               (i32.const 0)
             )
-            (br $while-in$2)
+            (br $while-in)
           )
         )
         (drop
@@ -1161,8 +1161,8 @@
     (set_local $loopvar
       (get_local $x)
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (call $loophi
           (get_local $loopvar)
           (i32.const 0)
@@ -1174,7 +1174,7 @@
           (get_local $temp)
           (if
             (get_local $temp)
-            (br $while-out$0)
+            (br $while-out)
           )
         )
         (set_local $inc
@@ -1191,9 +1191,9 @@
           (set_local $loopvar
             (get_local $inc)
           )
-          (br $while-out$0)
+          (br $while-out)
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
   )
@@ -1211,8 +1211,8 @@
         (set_local $j
           (i32.const 0)
         )
-        (loop $while-in$1
-          (block $while-out$0
+        (loop $while-in
+          (block $while-out
             (set_local $temp
               (get_local $j)
             )
@@ -1239,9 +1239,9 @@
               (set_local $j
                 (get_local $jnc)
               )
-              (br $while-out$0)
+              (br $while-out)
             )
-            (br $while-in$1)
+            (br $while-in)
           )
         )
         (br $label$continue$L7)
@@ -1276,8 +1276,8 @@
     (call $h
       (i32.const -1)
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (set_local $x
           (i32.add
             (get_local $x)
@@ -1293,10 +1293,10 @@
             (set_local $label
               (i32.const 2)
             )
-            (br $while-out$0)
+            (br $while-out)
           )
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
     (if
@@ -1469,7 +1469,7 @@
         )
       )
     )
-    (block $label$break$L1
+    (block $label$break$L10
       (if
         (i32.eq
           (get_local $label)
@@ -1479,7 +1479,7 @@
           (call $h
             (i32.const 14)
           )
-          (br $label$break$L1)
+          (br $label$break$L10)
         )
       )
     )
@@ -1499,8 +1499,8 @@
     (local $$11 i32)
     (local $$exitcond i32)
     (local $label i32)
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (if
           (get_local $$14)
           (if
@@ -1546,7 +1546,7 @@
             )
           )
         )
-        (br $while-in$1)
+        (br $while-in)
       )
     )
   )
@@ -1558,19 +1558,19 @@
     (local $$20 i32)
     (if
       (get_local $$2)
-      (loop $while-in$1
-        (block $while-out$0
+      (loop $while-in
+        (block $while-out
           (set_local $$12
             (get_local $$$06$i4)
           )
           (if
             (get_local $$exitcond$i6)
-            (br $while-out$0)
+            (br $while-out)
             (set_local $$$06$i4
               (get_local $$20)
             )
           )
-          (br $while-in$1)
+          (br $while-in)
         )
       )
       (drop
@@ -1586,13 +1586,13 @@
     (set_local $temp
       (call $return_int)
     )
-    (loop $while-in$1
-      (block $while-out$0
+    (loop $while-in
+      (block $while-out
         (set_local $label
           (i32.const 14)
         )
-        (br $while-out$0)
-        (br $while-in$1)
+        (br $while-out)
+        (br $while-in)
       )
     )
     (if
@@ -1623,7 +1623,7 @@
     )
   )
   (func $dropIgnoredImportInIf (param $$0 i32) (param $$1 i32) (param $$2 i32)
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $$0)
         (block
@@ -1636,14 +1636,14 @@
             )
           )
         )
-        (br $do-once$0)
+        (br $do-once)
       )
       (nop)
     )
     (return)
   )
   (func $dropIgnoredImportsInIf (param $$0 i32) (param $$1 i32) (param $$2 i32)
-    (block $do-once$0
+    (block $do-once
       (if
         (get_local $$0)
         (drop

--- a/test/wasm-only.fromasm
+++ b/test/wasm-only.fromasm
@@ -315,11 +315,11 @@
     )
   )
   (func $switch64 (param $0 i64) (result i32)
-    (block $switch$0 i32
-      (block $switch-default$3
-        (block $switch-case$2
-          (block $switch-case$1
-            (br_table $switch-case$2 $switch-default$3 $switch-case$1 $switch-default$3
+    (block $switch i32
+      (block $switch-default
+        (block $switch-case0
+          (block $switch-case
+            (br_table $switch-case0 $switch-default $switch-case $switch-default
               (i32.wrap/i64
                 (i64.sub
                   (get_local $0)
@@ -328,11 +328,11 @@
               )
             )
           )
-          (br $switch$0
+          (br $switch
             (i32.const 11000)
           )
         )
-        (br $switch$0
+        (br $switch
           (i32.const 10)
         )
       )

--- a/test/wasm-only.fromasm.imprecise
+++ b/test/wasm-only.fromasm.imprecise
@@ -243,11 +243,11 @@
     )
   )
   (func $switch64 (param $0 i64) (result i32)
-    (block $switch$0 i32
-      (block $switch-default$3
-        (block $switch-case$2
-          (block $switch-case$1
-            (br_table $switch-case$2 $switch-default$3 $switch-case$1 $switch-default$3
+    (block $switch i32
+      (block $switch-default
+        (block $switch-case0
+          (block $switch-case
+            (br_table $switch-case0 $switch-default $switch-case $switch-default
               (i32.wrap/i64
                 (i64.sub
                   (get_local $0)
@@ -256,11 +256,11 @@
               )
             )
           )
-          (br $switch$0
+          (br $switch
             (i32.const 11000)
           )
         )
-        (br $switch$0
+        (br $switch
           (i32.const 10)
         )
       )

--- a/test/wasm-only.fromasm.imprecise.no-opts
+++ b/test/wasm-only.fromasm.imprecise.no-opts
@@ -676,11 +676,11 @@
   )
   (func $switch64 (param $$a444 i64) (result i32)
     (local $$waka i32)
-    (block $switch$0
-      (block $switch-default$3
-        (block $switch-case$2
-          (block $switch-case$1
-            (br_table $switch-case$2 $switch-default$3 $switch-case$1 $switch-default$3
+    (block $switch
+      (block $switch-default
+        (block $switch-case0
+          (block $switch-case
+            (br_table $switch-case0 $switch-default $switch-case $switch-default
               (i32.wrap/i64
                 (i64.sub
                   (get_local $$a444)
@@ -693,14 +693,14 @@
             (set_local $$waka
               (i32.const 11000)
             )
-            (br $switch$0)
+            (br $switch)
           )
         )
         (block
           (set_local $$waka
             (i32.const 10)
           )
-          (br $switch$0)
+          (br $switch)
         )
       )
       (set_local $$waka

--- a/test/wasm-only.fromasm.no-opts
+++ b/test/wasm-only.fromasm.no-opts
@@ -724,11 +724,11 @@
   )
   (func $switch64 (param $$a444 i64) (result i32)
     (local $$waka i32)
-    (block $switch$0
-      (block $switch-default$3
-        (block $switch-case$2
-          (block $switch-case$1
-            (br_table $switch-case$2 $switch-default$3 $switch-case$1 $switch-default$3
+    (block $switch
+      (block $switch-default
+        (block $switch-case0
+          (block $switch-case
+            (br_table $switch-case0 $switch-default $switch-case $switch-default
               (i32.wrap/i64
                 (i64.sub
                   (get_local $$a444)
@@ -741,14 +741,14 @@
             (set_local $$waka
               (i32.const 11000)
             )
-            (br $switch$0)
+            (br $switch)
           )
         )
         (block
           (set_local $$waka
             (i32.const 10)
           )
-          (br $switch$0)
+          (br $switch)
         )
       )
       (set_local $$waka


### PR DESCRIPTION
As discussed in #735.

This just adds validation for the property and makes IR producers follow it. No optimizations that can take advantage of the property yet.