### PR TITLE
Minor cfg-traversal opts

### DIFF
--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -58,7 +58,8 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
   // traversal state
   BasicBlock* currBasicBlock; // the current block in play during traversal. can be nullptr if unreachable,
                               // but note that we don't do a deep unreachability analysis - just enough
-                              // to be useful, given that DCE has run before.
+                              // to avoid constructing obviously-unreachable blocks (we do a full reachability
+                              // analysis on the CFG once it is constructed).
   std::map<Expression*, std::vector<BasicBlock*>> branches; // a block or loop => its branches
   std::vector<BasicBlock*> ifStack;
   std::vector<BasicBlock*> loopStack;

--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -175,9 +175,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
         break;
       }
       case Expression::Id::IfId: {
-        self->pushTask(SubType::doPostVisitControlFlow, currp);
         self->pushTask(SubType::doEndIf, currp);
-        self->pushTask(SubType::doVisitIf, currp);
         auto* ifFalse = curr->cast<If>()->ifFalse;
         if (ifFalse) {
           self->pushTask(SubType::scan, &curr->cast<If>()->ifFalse);
@@ -186,7 +184,6 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
         self->pushTask(SubType::scan, &curr->cast<If>()->ifTrue);
         self->pushTask(SubType::doStartIfTrue, currp);
         self->pushTask(SubType::scan, &curr->cast<If>()->condition);
-        self->pushTask(SubType::doPreVisitControlFlow, currp);
         return; // don't do anything else
       }
       case Expression::Id::LoopId: {

--- a/test/passes/coalesce-locals-learning.txt
+++ b/test/passes/coalesce-locals-learning.txt
@@ -108,15 +108,11 @@
     )
     (block $block
       (br $block)
+      (nop)
       (drop
-        (i32.const 0)
+        (unreachable)
       )
-      (drop
-        (get_local $0)
-      )
-      (drop
-        (i32.const -1)
-      )
+      (nop)
     )
     (drop
       (get_local $0)
@@ -395,10 +391,10 @@
     (block $block
       (br $block)
       (drop
-        (get_local $0)
+        (unreachable)
       )
       (drop
-        (get_local $0)
+        (unreachable)
       )
     )
   )
@@ -407,10 +403,10 @@
     (block $block
       (unreachable)
       (drop
-        (get_local $0)
+        (unreachable)
       )
       (drop
-        (get_local $0)
+        (unreachable)
       )
     )
   )
@@ -419,10 +415,10 @@
     (block $block
       (return)
       (drop
-        (get_local $0)
+        (unreachable)
       )
       (drop
-        (get_local $0)
+        (unreachable)
       )
     )
   )
@@ -466,7 +462,7 @@
             (i32.const 100)
           )
           (drop
-            (get_local $0)
+            (unreachable)
           )
         )
         (drop

--- a/test/passes/coalesce-locals.txt
+++ b/test/passes/coalesce-locals.txt
@@ -108,15 +108,11 @@
     )
     (block $block
       (br $block)
+      (nop)
       (drop
-        (i32.const 0)
+        (unreachable)
       )
-      (drop
-        (get_local $0)
-      )
-      (drop
-        (i32.const -1)
-      )
+      (nop)
     )
     (drop
       (get_local $0)
@@ -393,10 +389,10 @@
     (block $block
       (br $block)
       (drop
-        (get_local $0)
+        (unreachable)
       )
       (drop
-        (get_local $0)
+        (unreachable)
       )
     )
   )
@@ -405,10 +401,10 @@
     (block $block
       (unreachable)
       (drop
-        (get_local $0)
+        (unreachable)
       )
       (drop
-        (get_local $0)
+        (unreachable)
       )
     )
   )
@@ -417,10 +413,10 @@
     (block $block
       (return)
       (drop
-        (get_local $0)
+        (unreachable)
       )
       (drop
-        (get_local $0)
+        (unreachable)
       )
     )
   )
@@ -464,7 +460,7 @@
             (i32.const 100)
           )
           (drop
-            (get_local $0)
+            (unreachable)
           )
         )
         (drop
@@ -896,6 +892,43 @@
     )
     (drop
       (get_local $0)
+    )
+  )
+  (func $in-unreachable (type $2)
+    (local $0 i32)
+    (block $x
+      (return)
+      (nop)
+      (drop
+        (unreachable)
+      )
+      (nop)
+    )
+    (block $y
+      (unreachable)
+      (nop)
+      (drop
+        (unreachable)
+      )
+      (nop)
+    )
+    (block $z
+      (br $z)
+      (nop)
+      (drop
+        (unreachable)
+      )
+      (nop)
+    )
+    (block $z14
+      (br_table $z14 $z14
+        (i32.const 100)
+      )
+      (nop)
+      (drop
+        (unreachable)
+      )
+      (nop)
     )
   )
 )

--- a/test/passes/coalesce-locals.wast
+++ b/test/passes/coalesce-locals.wast
@@ -925,4 +925,33 @@
       (get_local $z)
     )
   )
+  (func $in-unreachable
+    (local $a i32)
+    (block $x
+      (return)
+      (set_local $a (i32.const 1))
+      (drop (get_local $a))
+      (set_local $a (get_local $a))
+    )
+    (block $y
+      (unreachable)
+      (set_local $a (i32.const 1))
+      (drop (get_local $a))
+      (set_local $a (get_local $a))
+    )
+    (block $z
+      (br $z)
+      (set_local $a (i32.const 1))
+      (drop (get_local $a))
+      (set_local $a (get_local $a))
+    )
+    (block $z
+      (br_table $z $z
+        (i32.const 100)
+      )
+      (set_local $a (i32.const 1))
+      (drop (get_local $a))
+      (set_local $a (get_local $a))
+    )
+  )
 )


### PR DESCRIPTION
Cleans up and removes some obviously unneeded processing in Coalesce-Locals. Makes it 7% faster.