### PR TITLE
Don't create table sections for imported tables

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1003,6 +1003,8 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
   tableImport->base = TABLE;
   tableImport->kind = ExternalKind::Table;
   wasm.addImport(tableImport.release());
+  wasm.table.exists = true;
+  wasm.table.isImported = true;
 
   // Import memory offset
   {

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1004,7 +1004,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
   tableImport->kind = ExternalKind::Table;
   wasm.addImport(tableImport.release());
   wasm.table.exists = true;
-  wasm.table.isImported = true;
+  wasm.table.imported = true;
 
   // Import memory offset
   {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -620,19 +620,12 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
   }
   void visitTable(Table *curr) {
     // if table wasn't imported, declare it
-    bool found = false;
-    for (auto& import : currModule->imports) {
-      if (import->kind == ExternalKind::Table) {
-        found = true;
-        break;
-      }
-    }
-    if (!found) {
+    if (!curr->isImported) {
       doIndent(o, indent);
       printTableHeader(curr);
+      o << maybeNewLine;
     }
     if (curr->segments.empty()) return;
-    if (!found) o << '\n';
     doIndent(o, indent);
     for (auto& segment : curr->segments) {
       // Don't print empty segments
@@ -645,6 +638,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
       }
       o << ')';
     }
+    o << maybeNewLine;
   }
   void printMemoryHeader(Memory* curr) {
     printOpening(o, "memory") << ' ';
@@ -712,8 +706,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
       o << maybeNewLine;
     }
     if (curr->table.exists) {
-      visitTable(&curr->table);
-      o << maybeNewLine;
+      visitTable(&curr->table); // Prints its own newlines
     }
     visitMemory(&curr->memory);
     for (auto& child : curr->globals) {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -620,7 +620,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
   }
   void visitTable(Table *curr) {
     // if table wasn't imported, declare it
-    if (!curr->isImported) {
+    if (!curr->imported) {
       doIndent(o, indent);
       printTableHeader(curr);
       o << maybeNewLine;

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -845,7 +845,7 @@ public:
   }
 
   void writeFunctionTableDeclaration() {
-    if (!wasm->table.exists) return;
+    if (!wasm->table.exists || wasm->table.isImported) return;
     if (debug) std::cerr << "== writeFunctionTableDeclaration" << std::endl;
     auto start = startSection(BinaryConsts::Section::Table);
     o << U32LEB(1); // Declare 1 table.

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -845,7 +845,7 @@ public:
   }
 
   void writeFunctionTableDeclaration() {
-    if (!wasm->table.exists || wasm->table.isImported) return;
+    if (!wasm->table.exists || wasm->table.imported) return;
     if (debug) std::cerr << "== writeFunctionTableDeclaration" << std::endl;
     auto start = startSection(BinaryConsts::Section::Table);
     o << U32LEB(1); // Declare 1 table.
@@ -1639,7 +1639,7 @@ public:
           WASM_UNUSED(elementType);
           if (elementType != BinaryConsts::ElementType::AnyFunc) throw ParseException("Imported table type is not AnyFunc");
           wasm.table.exists = true;
-          wasm.table.isImported = true;
+          wasm.table.imported = true;
           getResizableLimits(wasm.table.initial, &wasm.table.max);
           break;
         }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -845,7 +845,7 @@ public:
   }
 
   void writeFunctionTableDeclaration() {
-    if (!wasm->table.exists) return; // or is imported!!
+    if (!wasm->table.exists) return;
     if (debug) std::cerr << "== writeFunctionTableDeclaration" << std::endl;
     auto start = startSection(BinaryConsts::Section::Table);
     o << U32LEB(1); // Declare 1 table.
@@ -1639,6 +1639,7 @@ public:
           WASM_UNUSED(elementType);
           if (elementType != BinaryConsts::ElementType::AnyFunc) throw ParseException("Imported table type is not AnyFunc");
           wasm.table.exists = true;
+          wasm.table.isImported = true;
           getResizableLimits(wasm.table.initial, &wasm.table.max);
           break;
         }
@@ -1892,6 +1893,7 @@ public:
     if (debug) std::cerr << "== readFunctionTableDeclaration" << std::endl;
     auto numTables = getU32LEB();
     if (numTables != 1) throw ParseException("Only 1 table definition allowed in MVP");
+    if (wasm.table.exists) throw ParseException("Table cannot be both imported and defined");
     wasm.table.exists = true;
     auto elemType = getU32LEB();
     if (elemType != BinaryConsts::ElementType::AnyFunc) throw ParseException("ElementType must be AnyFunc in MVP");

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -1591,7 +1591,7 @@ private:
         im->kind = ExternalKind::Table;
         if (wasm.table.exists) throw ParseException("more than one table");
         wasm.table.exists = true;
-        wasm.table.isImported = true;
+        wasm.table.imported = true;
       } else if ((*s[3])[0]->str() == GLOBAL) {
         im->kind = ExternalKind::Global;
       } else {
@@ -1766,7 +1766,7 @@ private:
   void parseTable(Element& s, bool preParseImport = false) {
     if (wasm.table.exists) throw ParseException("more than one table");
     wasm.table.exists = true;
-    wasm.table.isImported = preParseImport;
+    wasm.table.imported = preParseImport;
     Index i = 1;
     if (i == s.size()) return; // empty table in old notation
     if (s[i]->dollared()) {

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -1764,7 +1764,6 @@ private:
 
 
   void parseTable(Element& s, bool preParseImport = false) {
-    std::cerr << "ParseTable elem " << s << " import " << preParseImport<<"\n";
     if (wasm.table.exists) throw ParseException("more than one table");
     wasm.table.exists = true;
     wasm.table.isImported = preParseImport;

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -385,7 +385,7 @@ public:
       }
     }
     if (curr->kind == ExternalKind::Table) {
-      shouldBeTrue(getModule()->table.isImported, curr->name, "Table import record exists but table is not marked as imported");
+      shouldBeTrue(getModule()->table.imported, curr->name, "Table import record exists but table is not marked as imported");
     }
   }
 

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -384,6 +384,9 @@ public:
         }
       }
     }
+    if (curr->kind == ExternalKind::Table) {
+      shouldBeTrue(getModule()->table.isImported, curr->name, "Table import record exists but table is not marked as imported");
+    }
   }
 
   void visitExport(Export* curr) {

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1469,11 +1469,12 @@ public:
   // Currently the wasm object always 'has' one Table. It 'exists' if it has been defined or imported.
   // The table can exist but be empty and have no defined initial or max size.
   bool exists;
+  bool isImported;
   Name name;
   Address initial, max;
   std::vector<Segment> segments;
 
-  Table() : exists(false), initial(0), max(kMaxSize) {
+  Table() : exists(false), isImported(false), initial(0), max(kMaxSize) {
     name = Name::fromInt(0);
   }
 };

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1469,12 +1469,12 @@ public:
   // Currently the wasm object always 'has' one Table. It 'exists' if it has been defined or imported.
   // The table can exist but be empty and have no defined initial or max size.
   bool exists;
-  bool isImported;
+  bool imported;
   Name name;
   Address initial, max;
   std::vector<Segment> segments;
 
-  Table() : exists(false), isImported(false), initial(0), max(kMaxSize) {
+  Table() : exists(false), imported(false), initial(0), max(kMaxSize) {
     name = Name::fromInt(0);
   }
 };

--- a/test/table-import.wast
+++ b/test/table-import.wast
@@ -1,0 +1,9 @@
+(module
+  (type $0 (func))
+  (import "env" "table" (table 1 1 anyfunc))
+  (elem (i32.const 0) $foo)
+  (memory $0 0)
+  (func $foo (type $0)
+    (nop)
+  )
+)

--- a/test/table-import.wast.fromBinary
+++ b/test/table-import.wast.fromBinary
@@ -1,0 +1,10 @@
+(module
+  (type $0 (func))
+  (import "env" "table" (table 1 1 anyfunc))
+  (elem (i32.const 0) $foo)
+  (memory $0 0)
+  (func $foo (type $0)
+    (nop)
+  )
+)
+

--- a/test/table-import.wast.fromBinary.noDebugInfo
+++ b/test/table-import.wast.fromBinary.noDebugInfo
@@ -1,0 +1,10 @@
+(module
+  (type $0 (func))
+  (import "env" "table" (table 1 1 anyfunc))
+  (elem (i32.const 0) $0)
+  (memory $0 0)
+  (func $0 (type $0)
+    (nop)
+  )
+)
+


### PR DESCRIPTION
Previously the Print pass searched the imports for for a table import and skipped printing a local table declaration if found. Instead this refactors to make importation explicit, and also create importation records (previously we were inconsistent about whether such records were created in the IR depending on the wast syntax).