### PR TITLE
Tiny fixes for native wasm support

### DIFF
--- a/scripts/spidermonkify.py
+++ b/scripts/spidermonkify.py
@@ -22,7 +22,6 @@ This is meant to be run using BINARYEN_SCRIPTS in emcc, and not standalone.
 '''
 
 import os
-import shutil
 import subprocess
 import sys
 
@@ -35,27 +34,11 @@ wast_target = sys.argv[2]
 
 wasm_target = wast_target[:-5] + '.wasm'
 
-base_wast_target = os.path.basename(wast_target)
-base_wasm_target = os.path.basename(wasm_target)
-
-
-def fix(js, before, after):
-  assert js.count(before) == 1
-  return js.replace(before, after)
-
-# fix up js
-js = open(js_target).read()
-# use the wasm, not wast
-js = js.replace('"' + base_wast_target + '"', '"' + base_wasm_target + '"')
-js = js.replace("'" + base_wast_target + "'", "'" + base_wasm_target + "'")
-open(js_target, 'w').write(js)
-shutil.copyfile(wast_target + '.mappedGlobals', wasm_target + '.mappedGlobals')
-
 # convert to binary using spidermonkey
 '''
 using something like
 mozjs -e 'os.file.writeTypedArrayToFile("moz.wasm",
-new Uint8Array(wasmTextToBinary(os.file.readFile("test/hello_world.wast"))))'
+new Uint8Array(wasmTextToBinary(os.file.readFile("a.out.wast"))))'
 investigate with
 >>> map(chr, map(ord, open('moz.wasm').read()))
 or

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -664,6 +664,10 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
     }, debug, false /* do not validate globally yet */);
   }
 
+  // if we see no function tables in the processing below, then the table still exists and has size 0
+
+  wasm.table.initial = wasm.table.max = 0;
+
   // first pass - do almost everything, but function imports and indirect calls
 
   for (unsigned i = 1; i < body->size(); i++) {
@@ -784,7 +788,6 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
           // TODO: when not using aliasing function pointers, we could merge them by noticing that
           //       index 0 in each table is the null func, and each other index should only have one
           //       non-null func. However, that breaks down when function pointer casts are emulated.
-          wasm.table.exists = true;
           if (wasm.table.segments.size() == 0) {
             wasm.table.segments.emplace_back(wasm.allocator.alloc<Const>()->set(Literal(uint32_t(0))));
           }

--- a/src/js/wasm.js-post.js
+++ b/src/js/wasm.js-post.js
@@ -223,13 +223,6 @@ function integrateWasmJS(Module) {
     env['memory'] = providedBuffer;
     assert(env['memory'] instanceof ArrayBuffer);
 
-    if (!('memoryBase' in env)) {
-      env['memoryBase'] = STATIC_BASE; // tell the memory segments where to place themselves
-    }
-    if (!('tableBase' in env)) {
-      env['tableBase'] = 0; // tell the memory segments where to place themselves
-    }
-
     wasmJS['providedTotalMemory'] = Module['buffer'].byteLength;
 
     // Prepare to generate wasm, using either asm2wasm or s-exprs
@@ -296,6 +289,13 @@ function integrateWasmJS(Module) {
       } else {
         env['table'] = new Array(TABLE_SIZE); // works in binaryen interpreter at least
       }
+    }
+
+    if (!env['memoryBase']) {
+      env['memoryBase'] = STATIC_BASE; // tell the memory segments where to place themselves
+    }
+    if (!env['tableBase']) {
+      env['tableBase'] = 0; // table starts at 0 by default, in dynamic linking this will change
     }
     
     // try the methods. each should return the exports if it succeeded

--- a/src/js/wasm.js-post.js
+++ b/src/js/wasm.js-post.js
@@ -290,7 +290,7 @@ function integrateWasmJS(Module) {
 
     // import table
     if (!env['table']) {
-      var TABLE_SIZE = 1024; // TODO
+      var TABLE_SIZE = Module['wasmTableSize'] || 1024;
       if (typeof WebAssembly === 'object' && typeof WebAssembly.Table === 'function') {
         env['table'] = new WebAssembly.Table({ initial: TABLE_SIZE, maximum: TABLE_SIZE, element: 'anyfunc' });
       } else {

--- a/src/js/wasm.js-post.js
+++ b/src/js/wasm.js-post.js
@@ -283,7 +283,8 @@ function integrateWasmJS(Module) {
 
     // import table
     if (!env['table']) {
-      var TABLE_SIZE = Module['wasmTableSize'] || 1024;
+      var TABLE_SIZE = Module['wasmTableSize'];
+      if (TABLE_SIZE === undefined) TABLE_SIZE = 1024; // works in binaryen interpreter at least
       if (typeof WebAssembly === 'object' && typeof WebAssembly.Table === 'function') {
         env['table'] = new WebAssembly.Table({ initial: TABLE_SIZE, maximum: TABLE_SIZE, element: 'anyfunc' });
       } else {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -615,7 +615,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
   void printTableHeader(Table* curr) {
     printOpening(o, "table") << ' ';
     o << curr->initial;
-    if (curr->max && curr->max != Table::kMaxSize) o << ' ' << curr->max;
+    if (curr->max != Table::kMaxSize) o << ' ' << curr->max;
     o << " anyfunc)";
   }
   void visitTable(Table *curr) {

--- a/test/empty.fromasm
+++ b/test/empty.fromasm
@@ -1,6 +1,6 @@
 (module
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (data (get_global $memoryBase) "empty.asm.js")

--- a/test/empty.fromasm.imprecise
+++ b/test/empty.fromasm.imprecise
@@ -1,6 +1,6 @@
 (module
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
 )

--- a/test/empty.fromasm.imprecise.no-opts
+++ b/test/empty.fromasm.imprecise.no-opts
@@ -1,6 +1,6 @@
 (module
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
 )

--- a/test/empty.fromasm.no-opts
+++ b/test/empty.fromasm.no-opts
@@ -1,6 +1,6 @@
 (module
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
 )

--- a/test/empty_table.wast
+++ b/test/empty_table.wast
@@ -1,0 +1,4 @@
+(module
+  (table 0 0 anyfunc)
+  (memory $0 0)
+)

--- a/test/empty_table.wast.fromBinary
+++ b/test/empty_table.wast.fromBinary
@@ -1,0 +1,5 @@
+(module
+  (table 0 0 anyfunc)
+  (memory $0 0)
+)
+

--- a/test/empty_table.wast.fromBinary.noDebugInfo
+++ b/test/empty_table.wast.fromBinary.noDebugInfo
@@ -1,0 +1,5 @@
+(module
+  (table 0 0 anyfunc)
+  (memory $0 0)
+)
+

--- a/test/hello_world.fromasm
+++ b/test/hello_world.fromasm
@@ -1,6 +1,6 @@
 (module
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (data (get_global $memoryBase) "hello_world.asm.js")

--- a/test/hello_world.fromasm.imprecise
+++ b/test/hello_world.fromasm.imprecise
@@ -1,6 +1,6 @@
 (module
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (export "add" (func $add))

--- a/test/hello_world.fromasm.imprecise.no-opts
+++ b/test/hello_world.fromasm.imprecise.no-opts
@@ -1,6 +1,6 @@
 (module
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (export "add" (func $add))

--- a/test/hello_world.fromasm.no-opts
+++ b/test/hello_world.fromasm.no-opts
@@ -1,6 +1,6 @@
 (module
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (export "add" (func $add))

--- a/test/i64-setTempRet0.fromasm
+++ b/test/i64-setTempRet0.fromasm
@@ -4,7 +4,7 @@
   (import "env" "illegalImportResult" (func $illegalImportResult (result i64)))
   (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (data (get_global $memoryBase) "i64-setTempRet0.asm.js")

--- a/test/i64-setTempRet0.fromasm.imprecise
+++ b/test/i64-setTempRet0.fromasm.imprecise
@@ -4,7 +4,7 @@
   (import "env" "illegalImportResult" (func $illegalImportResult (result i64)))
   (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (global $tempRet0 (mut i32) (i32.const 0))

--- a/test/i64-setTempRet0.fromasm.imprecise.no-opts
+++ b/test/i64-setTempRet0.fromasm.imprecise.no-opts
@@ -4,7 +4,7 @@
   (import "env" "illegalImportResult" (func $illegalImportResult (result i64)))
   (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (global $tempRet0 (mut i32) (i32.const 0))

--- a/test/i64-setTempRet0.fromasm.no-opts
+++ b/test/i64-setTempRet0.fromasm.no-opts
@@ -4,7 +4,7 @@
   (import "env" "illegalImportResult" (func $illegalImportResult (result i64)))
   (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (global $tempRet0 (mut i32) (i32.const 0))

--- a/test/min.fromasm
+++ b/test/min.fromasm
@@ -1,7 +1,7 @@
 (module
   (import "env" "tempDoublePtr" (global $tDP$asm2wasm$import i32))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (data (get_global $memoryBase) "min.asm.js")

--- a/test/min.fromasm.imprecise
+++ b/test/min.fromasm.imprecise
@@ -1,7 +1,7 @@
 (module
   (import "env" "tempDoublePtr" (global $tDP$asm2wasm$import i32))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (global $tDP (mut i32) (get_global $tDP$asm2wasm$import))

--- a/test/min.fromasm.imprecise.no-opts
+++ b/test/min.fromasm.imprecise.no-opts
@@ -1,7 +1,7 @@
 (module
   (import "env" "tempDoublePtr" (global $tDP$asm2wasm$import i32))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (global $tDP (mut i32) (get_global $tDP$asm2wasm$import))

--- a/test/min.fromasm.no-opts
+++ b/test/min.fromasm.no-opts
@@ -1,7 +1,7 @@
 (module
   (import "env" "tempDoublePtr" (global $tDP$asm2wasm$import i32))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (global $tDP (mut i32) (get_global $tDP$asm2wasm$import))

--- a/test/two_sides.fromasm
+++ b/test/two_sides.fromasm
@@ -2,7 +2,7 @@
   (type $FUNCSIG$id (func (param f64) (result i32)))
   (import "asm2wasm" "f64-to-int" (func $f64-to-int (param f64) (result i32)))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (data (get_global $memoryBase) "two_sides.asm.js")

--- a/test/two_sides.fromasm.imprecise
+++ b/test/two_sides.fromasm.imprecise
@@ -1,6 +1,6 @@
 (module
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (export "_test" (func $_test))

--- a/test/two_sides.fromasm.imprecise.no-opts
+++ b/test/two_sides.fromasm.imprecise.no-opts
@@ -1,6 +1,6 @@
 (module
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (export "_test" (func $_test))

--- a/test/two_sides.fromasm.no-opts
+++ b/test/two_sides.fromasm.no-opts
@@ -2,7 +2,7 @@
   (type $FUNCSIG$id (func (param f64) (result i32)))
   (import "asm2wasm" "f64-to-int" (func $f64-to-int (param f64) (result i32)))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (export "_test" (func $_test))

--- a/test/wasm-only.fromasm
+++ b/test/wasm-only.fromasm
@@ -8,7 +8,7 @@
   (import "env" "illegalImport" (func $legalimport$illegalImport (param f64 i32 i32 i32)))
   (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (data (get_global $memoryBase) "wasm-only.asm.js")

--- a/test/wasm-only.fromasm.imprecise
+++ b/test/wasm-only.fromasm.imprecise
@@ -8,7 +8,7 @@
   (import "env" "illegalImport" (func $legalimport$illegalImport (param f64 i32 i32 i32)))
   (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (export "test64" (func $test64))

--- a/test/wasm-only.fromasm.imprecise.no-opts
+++ b/test/wasm-only.fromasm.imprecise.no-opts
@@ -8,7 +8,7 @@
   (import "env" "illegalImport" (func $legalimport$illegalImport (param f64 i32 i32 i32)))
   (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (export "test64" (func $test64))

--- a/test/wasm-only.fromasm.no-opts
+++ b/test/wasm-only.fromasm.no-opts
@@ -8,7 +8,7 @@
   (import "env" "illegalImport" (func $legalimport$illegalImport (param f64 i32 i32 i32)))
   (import "env" "illegalImportResult" (func $legalimport$illegalImportResult (result i32)))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 0 anyfunc))
+  (import "env" "table" (table 0 0 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (export "test64" (func $test64))


### PR DESCRIPTION
There is now an almost-working path to running wasm natively (binaryen+spidermonkify.py script), which is allowing me to find a bunch of tiny issues. Corresponds to https://github.com/kripken/emscripten/pull/4618.