### PR TITLE
Remove memory maximum in asm2wasm when memory growth is on

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -981,6 +981,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
   // apply memory growth, if relevant
   if (memoryGrowth) {
     emscripten::generateMemoryGrowthFunction(wasm);
+    wasm.memory.max = Memory::kMaxSize;
   }
 
 #if 0

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -24,7 +24,7 @@
   (import "env" "___unlock" (func $xa (param i32)))
   (import "env" "___syscall146" (func $ya (param i32 i32) (result i32)))
   (import "asm2wasm" "i32u-div" (func $i32u-div (param i32 i32) (result i32)))
-  (import "env" "memory" (memory $0 256 256))
+  (import "env" "memory" (memory $0 256))
   (import "env" "table" (table 8 8 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -23,7 +23,7 @@
   (import "env" "___syscall54" (func $wa (param i32 i32) (result i32)))
   (import "env" "___unlock" (func $xa (param i32)))
   (import "env" "___syscall146" (func $ya (param i32 i32) (result i32)))
-  (import "env" "memory" (memory $0 256 256))
+  (import "env" "memory" (memory $0 256))
   (import "env" "table" (table 8 8 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))

--- a/test/memorygrowth.fromasm.imprecise.no-opts
+++ b/test/memorygrowth.fromasm.imprecise.no-opts
@@ -23,7 +23,7 @@
   (import "env" "___syscall54" (func $wa (param i32 i32) (result i32)))
   (import "env" "___unlock" (func $xa (param i32)))
   (import "env" "___syscall146" (func $ya (param i32 i32) (result i32)))
-  (import "env" "memory" (memory $0 256 256))
+  (import "env" "memory" (memory $0 256))
   (import "env" "table" (table 8 8 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))

--- a/test/memorygrowth.fromasm.no-opts
+++ b/test/memorygrowth.fromasm.no-opts
@@ -24,7 +24,7 @@
   (import "env" "___unlock" (func $xa (param i32)))
   (import "env" "___syscall146" (func $ya (param i32 i32) (result i32)))
   (import "asm2wasm" "i32u-div" (func $i32u-div (param i32 i32) (result i32)))
-  (import "env" "memory" (memory $0 256 256))
+  (import "env" "memory" (memory $0 256))
   (import "env" "table" (table 8 8 anyfunc))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))


### PR DESCRIPTION
This makes the wast valid. However, running it natively hangs, something else worse is going on.