### PR TITLE
Fix bug where we set memory max unnecessarily

### DIFF
--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -1689,8 +1689,6 @@ private:
       }
       if (j < inner.size()) {
         wasm.memory.max = atoi(inner[j++]->c_str());
-      } else {
-        wasm.memory.max = wasm.memory.initial;
       }
     }
     wasm.addImport(im.release());

--- a/test/empty_imported_table.wast
+++ b/test/empty_imported_table.wast
@@ -1,0 +1,4 @@
+(module
+  (import "env" "table" (table 0 0 anyfunc))
+  (memory $0 0)
+)

--- a/test/empty_imported_table.wast.fromBinary
+++ b/test/empty_imported_table.wast.fromBinary
@@ -1,0 +1,5 @@
+(module
+  (import "env" "table" (table 0 0 anyfunc))
+  (memory $0 0)
+)
+

--- a/test/empty_imported_table.wast.fromBinary.noDebugInfo
+++ b/test/empty_imported_table.wast.fromBinary.noDebugInfo
@@ -1,0 +1,5 @@
+(module
+  (import "env" "table" (table 0 0 anyfunc))
+  (memory $0 0)
+)
+

--- a/test/imported_memory.wast
+++ b/test/imported_memory.wast
@@ -1,0 +1,3 @@
+(module
+  (import "env" "memory" (memory $0 256 256))
+)

--- a/test/imported_memory.wast.fromBinary
+++ b/test/imported_memory.wast.fromBinary
@@ -1,0 +1,4 @@
+(module
+  (import "env" "memory" (memory $0 256 256))
+)
+

--- a/test/imported_memory.wast.fromBinary.noDebugInfo
+++ b/test/imported_memory.wast.fromBinary.noDebugInfo
@@ -1,0 +1,4 @@
+(module
+  (import "env" "memory" (memory $0 256 256))
+)
+

--- a/test/imported_memory_growth.wast
+++ b/test/imported_memory_growth.wast
@@ -1,0 +1,3 @@
+(module
+  (import "env" "memory" (memory $0 256))
+)

--- a/test/imported_memory_growth.wast.fromBinary
+++ b/test/imported_memory_growth.wast.fromBinary
@@ -1,0 +1,4 @@
+(module
+  (import "env" "memory" (memory $0 256))
+)
+

--- a/test/imported_memory_growth.wast.fromBinary.noDebugInfo
+++ b/test/imported_memory_growth.wast.fromBinary.noDebugInfo
@@ -1,0 +1,4 @@
+(module
+  (import "env" "memory" (memory $0 256))
+)
+


### PR DESCRIPTION
If no max is specified, then there is no max.