### PR TITLE
Handle unreachable tee_local properly in coalesce-locals

### DIFF
--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -181,7 +181,11 @@ struct CoalesceLocals : public WalkerPass<CFGWalker<CoalesceLocals, Visitor<Coal
     auto* curr = (*currp)->cast<SetLocal>();
     // if in unreachable code, ignore
     if (!self->currBasicBlock) {
-      ExpressionManipulator::nop(curr);
+      if (curr->isTee()) {
+        ExpressionManipulator::convert<SetLocal, Unreachable>(curr);
+      } else {
+        ExpressionManipulator::nop(curr);
+      }
       return;
     }
     self->currBasicBlock->contents.actions.emplace_back(Action::Set, curr->index, currp);

--- a/test/passes/coalesce-locals.txt
+++ b/test/passes/coalesce-locals.txt
@@ -931,4 +931,14 @@
       (nop)
     )
   )
+  (func $nop-in-unreachable (type $2)
+    (local $0 i32)
+    (block $block
+      (unreachable)
+      (i32.store
+        (unreachable)
+        (unreachable)
+      )
+    )
+  )
 )

--- a/test/passes/coalesce-locals.wast
+++ b/test/passes/coalesce-locals.wast
@@ -954,4 +954,14 @@
       (set_local $a (get_local $a))
     )
   )
+  (func $nop-in-unreachable
+    (local $x i32)
+    (block
+      (unreachable)
+      (i32.store
+        (get_local $x)
+        (tee_local $x (i32.const 0))
+      )
+    )
+  )
 )


### PR DESCRIPTION
Found by the fuzzer. A `tee_local` in unreachable code can't be converted into a `nop` as the type is wrong.