### PR TITLE
Do not use exported memory as a root set of RemoveUnusedFunctions pass

### DIFF
--- a/src/passes/RemoveUnusedFunctions.cpp
+++ b/src/passes/RemoveUnusedFunctions.cpp
@@ -36,7 +36,8 @@ struct RemoveUnusedFunctions : public Pass {
     }
     // Exports are roots.
     for (auto& curr : module->exports) {
-      root.push_back(module->getFunction(curr->value));
+      if (curr->kind == ExternalKind::Function)
+        root.push_back(module->getFunction(curr->value));
     }
     // For now, all functions that can be called indirectly are marked as roots.
     for (auto& segment : module->table.segments) {

--- a/src/passes/RemoveUnusedFunctions.cpp
+++ b/src/passes/RemoveUnusedFunctions.cpp
@@ -36,8 +36,9 @@ struct RemoveUnusedFunctions : public Pass {
     }
     // Exports are roots.
     for (auto& curr : module->exports) {
-      if (curr->kind == ExternalKind::Function)
+      if (curr->kind == ExternalKind::Function) {
         root.push_back(module->getFunction(curr->value));
+      }
     }
     // For now, all functions that can be called indirectly are marked as roots.
     for (auto& segment : module->table.segments) {

--- a/test/passes/remove-unused-functions.txt
+++ b/test/passes/remove-unused-functions.txt
@@ -3,6 +3,7 @@
   (table 1 1 anyfunc)
   (elem (i32.const 0) $called_indirect)
   (memory $0 0)
+  (export "memory" (memory $0))
   (export "exported" (func $exported))
   (start $start)
   (func $start (type $0)

--- a/test/passes/remove-unused-functions.wast
+++ b/test/passes/remove-unused-functions.wast
@@ -2,6 +2,7 @@
   (memory 0)
   (start $start)
   (type $0 (func))
+  (export "memory" (memory $0))
   (export "exported" $exported)
   (table 1 1 anyfunc)
   (elem (i32.const 0) $called_indirect)


### PR DESCRIPTION
RemoveUnusedFunctions pass of wasm-opt fails when the memory is exported.
That's due to a wrong root set handling on the exported symbols.
This CL fixes the failure by ignoring non-function exported symbol.