### PR TITLE
deploy_scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,3 +177,11 @@ TARGET_LINK_LIBRARIES(wasm-dis passes support asmjs)
 SET_PROPERTY(TARGET wasm-dis PROPERTY CXX_STANDARD 11)
 SET_PROPERTY(TARGET wasm-dis PROPERTY CXX_STANDARD_REQUIRED ON)
 INSTALL(TARGETS wasm-dis DESTINATION bin)
+
+# Deploy scripts that are utilized at runtime to bin/ directory, so that the build directory can be packaged as a standalone toolchain.
+FILE(COPY "${CMAKE_CURRENT_SOURCE_DIR}/scripts" DESTINATION "${PROJECT_BINARY_DIR}/bin/")
+FILE(COPY "${CMAKE_CURRENT_SOURCE_DIR}/src/js" DESTINATION "${PROJECT_BINARY_DIR}/bin/")
+IF(NOT "${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
+  FILE(COPY "${CMAKE_CURRENT_SOURCE_DIR}/bin/binaryen.js" DESTINATION "${PROJECT_BINARY_DIR}/bin/")
+  FILE(COPY "${CMAKE_CURRENT_SOURCE_DIR}/bin/wasm.js" DESTINATION "${PROJECT_BINARY_DIR}/bin/")
+ENDIF()

--- a/check.py
+++ b/check.py
@@ -243,7 +243,7 @@ print '[ checking --help is useful... ]\n'
 
 not_executable_suffix = ['.txt', '.js']
 executables = sorted(filter(lambda x: not any(x.endswith(s) for s in
-                                              not_executable_suffix),
+                                              not_executable_suffix) and os.path.isfile(x),
                             os.listdir('bin')))
 for e in executables:
   print '.. %s --help' % e


### PR DESCRIPTION
Deploy scripts that are utilized at runtime to bin/ directory, so that the build directory can be packaged as a standalone toolchain.

At present `-s BINARYEN_ROOT` needs to point to the root directory of a Binaryen git repository. When bundling Binaryen for distribution, we'd like to minimize the number of extra files, so having the output `bin/` directory be a root of all distributable build artifacts would be a clean way to do it. These copy steps deploy all files needed at runtime to the `bin/` directory.