### PR TITLE
fix_uninit_pointer_deref

### DIFF
--- a/src/support/archive.cpp
+++ b/src/support/archive.cpp
@@ -60,7 +60,7 @@ uint32_t ArchiveMemberHeader::getSize() const {
   return static_cast<uint32_t>(sizeInt);
 }
 
-Archive::Archive(Buffer& b, bool& error) : data(b), symbolTable({nullptr, 0}), stringTable({nullptr, 0}) {
+Archive::Archive(Buffer& b, bool& error) : data(b), symbolTable({nullptr, 0}), stringTable({nullptr, 0}), firstRegularData(nullptr) {
   error = false;
   if (data.size() < strlen(magic) ||
       memcmp(data.data(), magic, strlen(magic))) {


### PR DESCRIPTION
Fix crash on loading archives, firstRegularData member field was not initialized to null which caused dereferencing a garbage pointer.