### PR TITLE
Don't create memory sections for imported memories; fixes #772

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -998,6 +998,8 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
   memoryImport->module = ENV;
   memoryImport->base = MEMORY;
   memoryImport->kind = ExternalKind::Memory;
+  wasm.memory.exists = true;
+  wasm.memory.imported = true;
   wasm.addImport(memoryImport.release());
 
   // import table

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -649,14 +649,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
   }
   void visitMemory(Memory* curr) {
     // if memory wasn't imported, declare it
-    bool found = false;
-    for (auto& import : currModule->imports) {
-      if (import->kind == ExternalKind::Memory) {
-        found = true;
-        break;
-      }
-    }
-    if (!found) {
+    if (!curr->imported) {
       doIndent(o, indent);
       printMemoryHeader(curr);
       o << '\n';

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -586,7 +586,7 @@ public:
   }
 
   void writeMemory() {
-    if (wasm->memory.max == 0) return;
+    if (!wasm->memory.exists || wasm->memory.imported) return;
     if (debug) std::cerr << "== writeMemory" << std::endl;
     auto start = startSection(BinaryConsts::Section::Memory);
     o << U32LEB(1); // Define 1 memory
@@ -1559,6 +1559,8 @@ public:
     auto numMemories = getU32LEB();
     if (!numMemories) return;
     assert(numMemories == 1);
+    if (wasm.memory.exists) throw ParseException("Memory cannot be both imported and defined");
+    wasm.memory.exists = true;
     getResizableLimits(wasm.memory.initial, wasm.memory.max, Memory::kMaxSize);
   }
 
@@ -1641,6 +1643,8 @@ public:
           break;
         }
         case ExternalKind::Memory: {
+          wasm.memory.exists = true;
+          wasm.memory.imported = true;
           getResizableLimits(wasm.memory.initial, wasm.memory.max, Memory::kMaxSize);
           break;
         }

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -387,6 +387,9 @@ public:
     if (curr->kind == ExternalKind::Table) {
       shouldBeTrue(getModule()->table.imported, curr->name, "Table import record exists but table is not marked as imported");
     }
+    if (curr->kind == ExternalKind::Memory) {
+      shouldBeTrue(getModule()->memory.imported, curr->name, "Memory import record exists but memory is not marked as imported");
+    }
   }
 
   void visitExport(Export* curr) {

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1502,7 +1502,11 @@ public:
   Address initial, max; // sizes are in pages
   std::vector<Segment> segments;
 
-  Memory() : initial(0), max(kMaxSize) {
+  // See comment in Table.
+  bool exists;
+  bool imported;
+
+  Memory() : initial(0), max(kMaxSize), exists(false), imported(false) {
     name = Name::fromInt(0);
   }
 };

--- a/test/memory-import.wast
+++ b/test/memory-import.wast
@@ -1,0 +1,9 @@
+(module
+  (type $0 (func (result i32)))
+  (import "env" "memory" (memory $0 1 1))
+  (func $foo (type $0) (result i32)
+    (i32.load offset=13
+      (i32.const 37)
+    )
+  )
+)

--- a/test/memory-import.wast.fromBinary
+++ b/test/memory-import.wast.fromBinary
@@ -1,0 +1,10 @@
+(module
+  (type $0 (func (result i32)))
+  (import "env" "memory" (memory $0 1 1))
+  (func $foo (type $0) (result i32)
+    (i32.load offset=13
+      (i32.const 37)
+    )
+  )
+)
+

--- a/test/memory-import.wast.fromBinary.noDebugInfo
+++ b/test/memory-import.wast.fromBinary.noDebugInfo
@@ -1,0 +1,10 @@
+(module
+  (type $0 (func (result i32)))
+  (import "env" "memory" (memory $0 1 1))
+  (func $0 (type $0) (result i32)
+    (i32.load offset=13
+      (i32.const 37)
+    )
+  )
+)
+


### PR DESCRIPTION
I've made a naive and simple code similar to what's being done for tables. Tests all pass until I get an error just before running the torture tests:

```
[ checking torture testcases... ]

Traceback (most recent call last):
  File "./check.py", line 558, in <module>
    import test.waterfall.src.link_assembly_files as link_assembly_files
ImportError: No module named waterfall.src.link_assembly_files
```