### PR TITLE
Fix simplify-locals when adding a value to a br_if

### DIFF
--- a/scripts/fuzz_passes_wast.py
+++ b/scripts/fuzz_passes_wast.py
@@ -53,10 +53,11 @@ args = sys.argv[2:]
 
 def run():
   try:
-    print 'run', ['bin/wasm-opt', wast]
-    subprocess.check_call(['bin/wasm-opt', wast])
+    cmd = ['bin/wasm-opt', wast]
+    print 'run', cmd
+    subprocess.check_call(cmd, stderr=open('/dev/null'))
   except Exception, e:
-    print ">>> !!! ", e, " !!!"
+    return ">>> !!! ", e, " !!!"
   return 'ok'
 
 original_wast = None
@@ -105,6 +106,7 @@ try:
   tested = set()
 
   def pick_passes():
+    # return '--waka'.split(' ')
     ret = []
     while 1:
       str_ret = str(ret)

--- a/test/passes/simplify-locals.txt
+++ b/test/passes/simplify-locals.txt
@@ -578,21 +578,25 @@
     (set_local $x
       (block $out i32
         (nop)
-        (br_if $out
-          (tee_local $x
-            (block $waka i32
-              (nop)
-              (br_if $waka
-                (tee_local $x
-                  (i32.const 12)
+        (drop
+          (br_if $out
+            (tee_local $x
+              (block $waka i32
+                (nop)
+                (drop
+                  (br_if $waka
+                    (tee_local $x
+                      (i32.const 12)
+                    )
+                    (i32.const 1)
+                  )
                 )
-                (i32.const 1)
+                (nop)
+                (i32.const 34)
               )
-              (nop)
-              (i32.const 34)
             )
+            (i32.const 1)
           )
-          (i32.const 1)
         )
         (drop
           (get_local $x)
@@ -613,21 +617,23 @@
           )
           (nop)
         )
-        (br_if $out
-          (tee_local $x
-            (if i32
-              (i32.const 1)
-              (block $block3 i32
-                (nop)
-                (i32.const 14)
-              )
-              (block $block5 i32
-                (nop)
-                (i32.const 25)
+        (drop
+          (br_if $out
+            (tee_local $x
+              (if i32
+                (i32.const 1)
+                (block $block3 i32
+                  (nop)
+                  (i32.const 14)
+                )
+                (block $block5 i32
+                  (nop)
+                  (i32.const 25)
+                )
               )
             )
+            (i32.const 1)
           )
-          (i32.const 1)
         )
         (block $sink-out-of-me-i-have-but-one-exit
           (nop)
@@ -720,11 +726,13 @@
             (get_local $a)
           )
           (nop)
-          (br_if $while-out$0
-            (tee_local $a
-              (i32.const 4)
+          (drop
+            (br_if $while-out$0
+              (tee_local $a
+                (i32.const 4)
+              )
+              (get_local $e)
             )
-            (get_local $e)
           )
           (nop)
           (i32.add
@@ -762,6 +770,38 @@
     )
     (return
       (i32.const 0)
+    )
+  )
+  (func $drop-br_if (type $9) (param $label i32) (param $$cond2 i32) (param $$$0151 i32) (result i32)
+    (nop)
+    (tee_local $label
+      (block $label$break$L4 i32
+        (if
+          (i32.eq
+            (get_local $label)
+            (i32.const 15)
+          )
+          (block $block
+            (nop)
+            (nop)
+            (drop
+              (br_if $label$break$L4
+                (tee_local $label
+                  (i32.const 0)
+                )
+                (i32.eqz
+                  (i32.eq
+                    (get_local $$$0151)
+                    (i32.const 0)
+                  )
+                )
+              )
+            )
+          )
+        )
+        (nop)
+        (i32.const 1)
+      )
     )
   )
 )

--- a/test/passes/simplify-locals.wast
+++ b/test/passes/simplify-locals.wast
@@ -801,4 +801,34 @@
       (i32.const 0)
     )
   )
+  (func $drop-br_if (param $label i32) (param $$cond2 i32) (param $$$0151 i32) (result i32)
+    (block $label$break$L4
+      (if
+        (i32.eq
+          (get_local $label)
+          (i32.const 15)
+        )
+        (block $block
+          (set_local $label
+            (i32.const 0)
+          )
+          (set_local $$cond2
+            (i32.eq
+              (get_local $$$0151)
+              (i32.const 0)
+            )
+          )
+          (br_if $label$break$L4 ;; when we add a value to this, its type changes as it returns the value too, so must be dropped
+            (i32.eqz
+              (get_local $$cond2)
+            )
+          )
+        )
+      )
+      (set_local $label
+        (i32.const 1)
+      )
+    )
+    (get_local $label)
+  )
 )


### PR DESCRIPTION
Per new wasm rules the `br_if` returns the value too, so we must `drop` it too.