### PR TITLE
Reorder locals after simplify-locals

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -107,6 +107,7 @@ void PassRunner::addDefaultFunctionOptimizationPasses() {
   add("precompute");
   add("simplify-locals");
   add("vacuum"); // previous pass creates garbage
+  add("reorder-locals");
   add("remove-unused-brs"); // simplify-locals opens opportunities for phi optimizations
   add("coalesce-locals");
   add("vacuum"); // previous pass creates garbage

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -144,14 +144,14 @@
         (block
           (if
             (i32.and
-              (tee_local $2
+              (tee_local $1
                 (i32.shr_u
                   (tee_local $16
                     (i32.load
                       (i32.const 176)
                     )
                   )
-                  (tee_local $5
+                  (tee_local $6
                     (i32.shr_u
                       (tee_local $8
                         (select
@@ -177,7 +177,7 @@
               (i32.const 3)
             )
             (block
-              (set_local $5
+              (set_local $1
                 (i32.load
                   (tee_local $17
                     (i32.add
@@ -190,16 +190,16 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (tee_local $2
+                                      (tee_local $11
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $2)
+                                              (get_local $1)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $5)
+                                          (get_local $6)
                                         )
                                       )
                                       (i32.const 1)
@@ -221,12 +221,12 @@
               (if
                 (i32.ne
                   (get_local $0)
-                  (get_local $5)
+                  (get_local $1)
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $5)
+                      (get_local $1)
                       (i32.load
                         (i32.const 192)
                       )
@@ -236,9 +236,9 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $6
+                        (tee_local $5
                           (i32.add
-                            (get_local $5)
+                            (get_local $1)
                             (i32.const 12)
                           )
                         )
@@ -247,12 +247,12 @@
                     )
                     (block
                       (i32.store
-                        (get_local $6)
+                        (get_local $5)
                         (get_local $0)
                       )
                       (i32.store
                         (get_local $7)
-                        (get_local $5)
+                        (get_local $1)
                       )
                     )
                     (call $_abort)
@@ -265,7 +265,7 @@
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $2)
+                        (get_local $11)
                       )
                       (i32.const -1)
                     )
@@ -275,9 +275,9 @@
               (i32.store offset=4
                 (get_local $3)
                 (i32.or
-                  (tee_local $5
+                  (tee_local $1
                     (i32.shl
-                      (get_local $2)
+                      (get_local $11)
                       (i32.const 3)
                     )
                   )
@@ -289,7 +289,7 @@
                   (i32.add
                     (i32.add
                       (get_local $3)
-                      (get_local $5)
+                      (get_local $1)
                     )
                     (i32.const 4)
                   )
@@ -317,30 +317,30 @@
             )
             (block
               (if
-                (get_local $2)
+                (get_local $1)
                 (block
                   (set_local $0
                     (i32.and
                       (i32.shr_u
-                        (tee_local $5
+                        (tee_local $1
                           (i32.add
                             (i32.and
                               (tee_local $0
                                 (i32.and
                                   (i32.shl
-                                    (get_local $2)
-                                    (get_local $5)
+                                    (get_local $1)
+                                    (get_local $6)
                                   )
                                   (i32.or
-                                    (tee_local $5
+                                    (tee_local $1
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $5)
+                                        (get_local $6)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $5)
+                                      (get_local $1)
                                     )
                                   )
                                 )
@@ -360,7 +360,7 @@
                   )
                   (set_local $0
                     (i32.load
-                      (tee_local $6
+                      (tee_local $5
                         (i32.add
                           (tee_local $3
                             (i32.load
@@ -371,18 +371,18 @@
                                       (i32.const 216)
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $13
+                                          (tee_local $11
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $5
+                                                      (tee_local $1
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $6
+                                                            (tee_local $5
                                                               (i32.shr_u
-                                                                (get_local $5)
+                                                                (get_local $1)
                                                                 (get_local $0)
                                                               )
                                                             )
@@ -393,13 +393,13 @@
                                                       )
                                                       (get_local $0)
                                                     )
-                                                    (tee_local $6
+                                                    (tee_local $5
                                                       (i32.and
                                                         (i32.shr_u
                                                           (tee_local $3
                                                             (i32.shr_u
-                                                              (get_local $6)
                                                               (get_local $5)
+                                                              (get_local $1)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -414,7 +414,7 @@
                                                         (tee_local $10
                                                           (i32.shr_u
                                                             (get_local $3)
-                                                            (get_local $6)
+                                                            (get_local $5)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -478,7 +478,7 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $5
+                            (tee_local $1
                               (i32.add
                                 (get_local $0)
                                 (i32.const 12)
@@ -489,7 +489,7 @@
                         )
                         (block
                           (i32.store
-                            (get_local $5)
+                            (get_local $1)
                             (get_local $10)
                           )
                           (i32.store
@@ -513,7 +513,7 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $13)
+                              (get_local $11)
                             )
                             (i32.const -1)
                           )
@@ -542,7 +542,7 @@
                       (tee_local $7
                         (i32.sub
                           (i32.shl
-                            (get_local $13)
+                            (get_local $11)
                             (i32.const 3)
                           )
                           (get_local $8)
@@ -585,12 +585,12 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $5
+                          (tee_local $6
                             (i32.load
                               (i32.const 176)
                             )
                           )
-                          (tee_local $2
+                          (tee_local $1
                             (i32.shl
                               (i32.const 1)
                               (get_local $19)
@@ -627,8 +627,8 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $5)
-                              (get_local $2)
+                              (get_local $6)
+                              (get_local $1)
                             )
                           )
                           (set_local $38
@@ -669,7 +669,7 @@
                     (get_local $16)
                   )
                   (return
-                    (get_local $6)
+                    (get_local $5)
                   )
                 )
               )
@@ -700,7 +700,7 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $2
+                  (set_local $1
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
@@ -746,7 +746,7 @@
                                       (tee_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $2
+                                            (tee_local $1
                                               (i32.shr_u
                                                 (get_local $0)
                                                 (get_local $10)
@@ -758,12 +758,12 @@
                                         )
                                       )
                                     )
-                                    (tee_local $2
+                                    (tee_local $1
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $5
+                                          (tee_local $6
                                             (i32.shr_u
-                                              (get_local $2)
+                                              (get_local $1)
                                               (get_local $0)
                                             )
                                           )
@@ -774,8 +774,8 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $5)
-                                    (get_local $2)
+                                    (get_local $6)
+                                    (get_local $1)
                                   )
                                 )
                                 (i32.const 2)
@@ -788,7 +788,7 @@
                       (get_local $8)
                     )
                   )
-                  (set_local $5
+                  (set_local $6
                     (get_local $17)
                   )
                   (set_local $0
@@ -799,7 +799,7 @@
                       (if
                         (tee_local $17
                           (i32.load offset=16
-                            (get_local $5)
+                            (get_local $6)
                           )
                         )
                         (set_local $3
@@ -808,7 +808,7 @@
                         (if
                           (tee_local $10
                             (i32.load offset=20
-                              (get_local $5)
+                              (get_local $6)
                             )
                           )
                           (set_local $3
@@ -816,9 +816,9 @@
                           )
                           (block
                             (set_local $7
-                              (get_local $2)
+                              (get_local $1)
                             )
-                            (set_local $1
+                            (set_local $2
                               (get_local $0)
                             )
                             (br $while-out)
@@ -838,17 +838,17 @@
                               (get_local $8)
                             )
                           )
-                          (get_local $2)
+                          (get_local $1)
                         )
                       )
-                      (set_local $2
+                      (set_local $1
                         (select
                           (get_local $17)
-                          (get_local $2)
+                          (get_local $1)
                           (get_local $10)
                         )
                       )
-                      (set_local $5
+                      (set_local $6
                         (get_local $3)
                       )
                       (set_local $0
@@ -863,7 +863,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $2)
                       (tee_local $0
                         (i32.load
                           (i32.const 192)
@@ -874,38 +874,38 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $1)
-                      (tee_local $5
+                      (get_local $2)
+                      (tee_local $6
                         (i32.add
-                          (get_local $1)
+                          (get_local $2)
                           (get_local $8)
                         )
                       )
                     )
                     (call $_abort)
                   )
-                  (set_local $2
+                  (set_local $1
                     (i32.load offset=24
-                      (get_local $1)
+                      (get_local $2)
                     )
                   )
                   (block $do-once4
                     (if
                       (i32.eq
-                        (tee_local $6
+                        (tee_local $5
                           (i32.load offset=12
-                            (get_local $1)
+                            (get_local $2)
                           )
                         )
-                        (get_local $1)
+                        (get_local $2)
                       )
                       (block
                         (if
-                          (tee_local $13
+                          (tee_local $11
                             (i32.load
                               (tee_local $3
                                 (i32.add
-                                  (get_local $1)
+                                  (get_local $2)
                                   (i32.const 20)
                                 )
                               )
@@ -913,7 +913,7 @@
                           )
                           (block
                             (set_local $17
-                              (get_local $13)
+                              (get_local $11)
                             )
                             (set_local $9
                               (get_local $3)
@@ -924,7 +924,7 @@
                               (i32.load
                                 (tee_local $10
                                   (i32.add
-                                    (get_local $1)
+                                    (get_local $2)
                                     (i32.const 16)
                                   )
                                 )
@@ -943,7 +943,7 @@
                         )
                         (loop $while-in7
                           (if
-                            (tee_local $13
+                            (tee_local $11
                               (i32.load
                                 (tee_local $3
                                   (i32.add
@@ -955,7 +955,7 @@
                             )
                             (block
                               (set_local $17
-                                (get_local $13)
+                                (get_local $11)
                               )
                               (set_local $9
                                 (get_local $3)
@@ -964,7 +964,7 @@
                             )
                           )
                           (if
-                            (tee_local $13
+                            (tee_local $11
                               (i32.load
                                 (tee_local $3
                                   (i32.add
@@ -976,7 +976,7 @@
                             )
                             (block
                               (set_local $17
-                                (get_local $13)
+                                (get_local $11)
                               )
                               (set_local $9
                                 (get_local $3)
@@ -1007,7 +1007,7 @@
                           (i32.lt_u
                             (tee_local $3
                               (i32.load offset=8
-                                (get_local $1)
+                                (get_local $2)
                               )
                             )
                             (get_local $0)
@@ -1017,14 +1017,14 @@
                         (if
                           (i32.ne
                             (i32.load
-                              (tee_local $13
+                              (tee_local $11
                                 (i32.add
                                   (get_local $3)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $1)
+                            (get_local $2)
                           )
                           (call $_abort)
                         )
@@ -1033,24 +1033,24 @@
                             (i32.load
                               (tee_local $10
                                 (i32.add
-                                  (get_local $6)
+                                  (get_local $5)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $1)
+                            (get_local $2)
                           )
                           (block
                             (i32.store
-                              (get_local $13)
-                              (get_local $6)
+                              (get_local $11)
+                              (get_local $5)
                             )
                             (i32.store
                               (get_local $10)
                               (get_local $3)
                             )
                             (set_local $19
-                              (get_local $6)
+                              (get_local $5)
                             )
                           )
                           (call $_abort)
@@ -1060,19 +1060,19 @@
                   )
                   (block $do-once8
                     (if
-                      (get_local $2)
+                      (get_local $1)
                       (block
                         (if
                           (i32.eq
-                            (get_local $1)
+                            (get_local $2)
                             (i32.load
                               (tee_local $0
                                 (i32.add
                                   (i32.const 480)
                                   (i32.shl
-                                    (tee_local $6
+                                    (tee_local $5
                                       (i32.load offset=28
-                                        (get_local $1)
+                                        (get_local $2)
                                       )
                                     )
                                     (i32.const 2)
@@ -1100,7 +1100,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $6)
+                                        (get_local $5)
                                       )
                                       (i32.const -1)
                                     )
@@ -1113,7 +1113,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $2)
+                                (get_local $1)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -1123,21 +1123,21 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $6
+                                  (tee_local $5
                                     (i32.add
-                                      (get_local $2)
+                                      (get_local $1)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $1)
+                                (get_local $2)
                               )
                               (i32.store
-                                (get_local $6)
+                                (get_local $5)
                                 (get_local $19)
                               )
                               (i32.store offset=20
-                                (get_local $2)
+                                (get_local $1)
                                 (get_local $19)
                               )
                             )
@@ -1151,7 +1151,7 @@
                         (if
                           (i32.lt_u
                             (get_local $19)
-                            (tee_local $6
+                            (tee_local $5
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1161,18 +1161,18 @@
                         )
                         (i32.store offset=24
                           (get_local $19)
-                          (get_local $2)
+                          (get_local $1)
                         )
                         (if
                           (tee_local $0
                             (i32.load offset=16
-                              (get_local $1)
+                              (get_local $2)
                             )
                           )
                           (if
                             (i32.lt_u
                               (get_local $0)
-                              (get_local $6)
+                              (get_local $5)
                             )
                             (call $_abort)
                             (block
@@ -1190,7 +1190,7 @@
                         (if
                           (tee_local $0
                             (i32.load offset=20
-                              (get_local $1)
+                              (get_local $2)
                             )
                           )
                           (if
@@ -1223,9 +1223,9 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $2)
                         (i32.or
-                          (tee_local $2
+                          (tee_local $1
                             (i32.add
                               (get_local $7)
                               (get_local $8)
@@ -1238,8 +1238,8 @@
                         (tee_local $0
                           (i32.add
                             (i32.add
-                              (get_local $1)
                               (get_local $2)
+                              (get_local $1)
                             )
                             (i32.const 4)
                           )
@@ -1254,14 +1254,14 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $2)
                         (i32.or
                           (get_local $8)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $5)
+                        (get_local $6)
                         (i32.or
                           (get_local $7)
                           (i32.const 1)
@@ -1269,7 +1269,7 @@
                       )
                       (i32.store
                         (i32.add
-                          (get_local $5)
+                          (get_local $6)
                           (get_local $7)
                         )
                         (get_local $7)
@@ -1281,7 +1281,7 @@
                           )
                         )
                         (block
-                          (set_local $2
+                          (set_local $1
                             (i32.load
                               (i32.const 196)
                             )
@@ -1291,7 +1291,7 @@
                               (i32.const 216)
                               (i32.shl
                                 (i32.shl
-                                  (tee_local $6
+                                  (tee_local $5
                                     (i32.shr_u
                                       (get_local $0)
                                       (i32.const 3)
@@ -1313,15 +1313,15 @@
                               (tee_local $10
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $6)
+                                  (get_local $5)
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (tee_local $13
+                                (tee_local $11
                                   (i32.load
-                                    (tee_local $6
+                                    (tee_local $5
                                       (i32.add
                                         (get_local $0)
                                         (i32.const 8)
@@ -1336,10 +1336,10 @@
                               (call $_abort)
                               (block
                                 (set_local $39
-                                  (get_local $6)
+                                  (get_local $5)
                                 )
                                 (set_local $32
-                                  (get_local $13)
+                                  (get_local $11)
                                 )
                               )
                             )
@@ -1364,18 +1364,18 @@
                           )
                           (i32.store
                             (get_local $39)
-                            (get_local $2)
+                            (get_local $1)
                           )
                           (i32.store offset=12
                             (get_local $32)
-                            (get_local $2)
+                            (get_local $1)
                           )
                           (i32.store offset=8
-                            (get_local $2)
+                            (get_local $1)
                             (get_local $32)
                           )
                           (i32.store offset=12
-                            (get_local $2)
+                            (get_local $1)
                             (get_local $0)
                           )
                         )
@@ -1386,13 +1386,13 @@
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $5)
+                        (get_local $6)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $1)
+                      (get_local $2)
                       (i32.const 8)
                     )
                   )
@@ -1407,7 +1407,7 @@
             (i32.const -65)
           )
           (block
-            (set_local $2
+            (set_local $1
               (i32.and
                 (tee_local $0
                   (i32.add
@@ -1428,7 +1428,7 @@
                 (set_local $3
                   (i32.sub
                     (i32.const 0)
-                    (get_local $2)
+                    (get_local $1)
                   )
                 )
                 (block $label$break$L123
@@ -1438,7 +1438,7 @@
                         (i32.shl
                           (tee_local $8
                             (if i32
-                              (tee_local $13
+                              (tee_local $11
                                 (i32.shr_u
                                   (get_local $0)
                                   (i32.const 8)
@@ -1446,14 +1446,14 @@
                               )
                               (if i32
                                 (i32.gt_u
-                                  (get_local $2)
+                                  (get_local $1)
                                   (i32.const 16777215)
                                 )
                                 (i32.const 31)
                                 (i32.or
                                   (i32.and
                                     (i32.shr_u
-                                      (get_local $2)
+                                      (get_local $1)
                                       (i32.add
                                         (tee_local $16
                                           (i32.add
@@ -1461,18 +1461,18 @@
                                               (i32.const 14)
                                               (i32.or
                                                 (i32.or
-                                                  (tee_local $13
+                                                  (tee_local $11
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $6
+                                                          (tee_local $5
                                                             (i32.shl
-                                                              (get_local $13)
+                                                              (get_local $11)
                                                               (tee_local $0
                                                                 (i32.and
                                                                   (i32.shr_u
                                                                     (i32.add
-                                                                      (get_local $13)
+                                                                      (get_local $11)
                                                                       (i32.const 1048320)
                                                                     )
                                                                     (i32.const 16)
@@ -1491,14 +1491,14 @@
                                                   )
                                                   (get_local $0)
                                                 )
-                                                (tee_local $6
+                                                (tee_local $5
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
                                                         (tee_local $17
                                                           (i32.shl
-                                                            (get_local $6)
-                                                            (get_local $13)
+                                                            (get_local $5)
+                                                            (get_local $11)
                                                           )
                                                         )
                                                         (i32.const 245760)
@@ -1513,7 +1513,7 @@
                                             (i32.shr_u
                                               (i32.shl
                                                 (get_local $17)
-                                                (get_local $6)
+                                                (get_local $5)
                                               )
                                               (i32.const 15)
                                             )
@@ -1538,7 +1538,7 @@
                       )
                     )
                     (block
-                      (set_local $6
+                      (set_local $5
                         (get_local $3)
                       )
                       (set_local $17
@@ -1546,7 +1546,7 @@
                       )
                       (set_local $0
                         (i32.shl
-                          (get_local $2)
+                          (get_local $1)
                           (select
                             (i32.const 0)
                             (i32.sub
@@ -1563,7 +1563,7 @@
                           )
                         )
                       )
-                      (set_local $13
+                      (set_local $11
                         (get_local $16)
                       )
                       (set_local $7
@@ -1577,42 +1577,42 @@
                                 (tee_local $19
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $13)
+                                      (get_local $11)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $2)
+                                (get_local $1)
                               )
                             )
-                            (get_local $6)
+                            (get_local $5)
                           )
                           (if
                             (i32.eq
                               (get_local $19)
-                              (get_local $2)
+                              (get_local $1)
                             )
                             (block
                               (set_local $27
                                 (get_local $3)
                               )
                               (set_local $25
-                                (get_local $13)
+                                (get_local $11)
                               )
                               (set_local $29
-                                (get_local $13)
+                                (get_local $11)
                               )
-                              (set_local $6
+                              (set_local $5
                                 (i32.const 90)
                               )
                               (br $label$break$L123)
                             )
                             (block
-                              (set_local $6
+                              (set_local $5
                                 (get_local $3)
                               )
                               (set_local $7
-                                (get_local $13)
+                                (get_local $11)
                               )
                             )
                           )
@@ -1622,7 +1622,7 @@
                             (get_local $17)
                             (tee_local $3
                               (i32.load offset=20
-                                (get_local $13)
+                                (get_local $11)
                               )
                             )
                             (i32.or
@@ -1631,11 +1631,11 @@
                               )
                               (i32.eq
                                 (get_local $3)
-                                (tee_local $13
+                                (tee_local $11
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $13)
+                                        (get_local $11)
                                         (i32.const 16)
                                       )
                                       (i32.shl
@@ -1655,20 +1655,20 @@
                         (if
                           (tee_local $3
                             (i32.eqz
-                              (get_local $13)
+                              (get_local $11)
                             )
                           )
                           (block
                             (set_local $33
-                              (get_local $6)
+                              (get_local $5)
                             )
-                            (set_local $5
+                            (set_local $6
                               (get_local $19)
                             )
                             (set_local $30
                               (get_local $7)
                             )
-                            (set_local $6
+                            (set_local $5
                               (i32.const 86)
                             )
                           )
@@ -1697,13 +1697,13 @@
                       (set_local $33
                         (get_local $3)
                       )
-                      (set_local $5
+                      (set_local $6
                         (i32.const 0)
                       )
                       (set_local $30
                         (i32.const 0)
                       )
-                      (set_local $6
+                      (set_local $5
                         (i32.const 86)
                       )
                     )
@@ -1711,7 +1711,7 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $6)
+                    (get_local $5)
                     (i32.const 86)
                   )
                   (if
@@ -1719,7 +1719,7 @@
                       (if i32
                         (i32.and
                           (i32.eqz
-                            (get_local $5)
+                            (get_local $6)
                           )
                           (i32.eqz
                             (get_local $30)
@@ -1748,7 +1748,7 @@
                             )
                             (block
                               (set_local $8
-                                (get_local $2)
+                                (get_local $1)
                               )
                               (br $do-once)
                             )
@@ -1799,7 +1799,7 @@
                                       (tee_local $8
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $5
+                                            (tee_local $6
                                               (i32.shr_u
                                                 (get_local $8)
                                                 (get_local $16)
@@ -1811,12 +1811,12 @@
                                         )
                                       )
                                     )
-                                    (tee_local $5
+                                    (tee_local $6
                                       (i32.and
                                         (i32.shr_u
                                           (tee_local $7
                                             (i32.shr_u
-                                              (get_local $5)
+                                              (get_local $6)
                                               (get_local $8)
                                             )
                                           )
@@ -1832,7 +1832,7 @@
                                         (tee_local $0
                                           (i32.shr_u
                                             (get_local $7)
-                                            (get_local $5)
+                                            (get_local $6)
                                           )
                                         )
                                         (i32.const 1)
@@ -1850,7 +1850,7 @@
                             )
                           )
                         )
-                        (get_local $5)
+                        (get_local $6)
                       )
                     )
                     (block
@@ -1863,7 +1863,7 @@
                       (set_local $29
                         (get_local $30)
                       )
-                      (set_local $6
+                      (set_local $5
                         (i32.const 90)
                       )
                     )
@@ -1871,7 +1871,7 @@
                       (set_local $4
                         (get_local $33)
                       )
-                      (set_local $11
+                      (set_local $12
                         (get_local $30)
                       )
                     )
@@ -1879,11 +1879,11 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $6)
+                    (get_local $5)
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $6
+                    (set_local $5
                       (i32.const 0)
                     )
                     (set_local $0
@@ -1896,13 +1896,13 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $2)
+                            (get_local $1)
                           )
                         )
                         (get_local $27)
                       )
                     )
-                    (set_local $5
+                    (set_local $6
                       (select
                         (get_local $7)
                         (get_local $27)
@@ -1924,7 +1924,7 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $5)
+                          (get_local $6)
                         )
                         (set_local $25
                           (get_local $0)
@@ -1943,7 +1943,7 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $5)
+                          (get_local $6)
                         )
                         (set_local $29
                           (get_local $7)
@@ -1952,9 +1952,9 @@
                       )
                       (block
                         (set_local $4
-                          (get_local $5)
+                          (get_local $6)
                         )
-                        (set_local $11
+                        (set_local $12
                           (get_local $7)
                         )
                       )
@@ -1969,19 +1969,19 @@
                         (i32.load
                           (i32.const 184)
                         )
-                        (get_local $2)
+                        (get_local $1)
                       )
                     )
                     (i32.const 0)
                     (i32.ne
-                      (get_local $11)
+                      (get_local $12)
                       (i32.const 0)
                     )
                   )
                   (block
                     (if
                       (i32.lt_u
-                        (get_local $11)
+                        (get_local $12)
                         (tee_local $10
                           (i32.load
                             (i32.const 192)
@@ -1992,19 +1992,19 @@
                     )
                     (if
                       (i32.ge_u
-                        (get_local $11)
+                        (get_local $12)
                         (tee_local $7
                           (i32.add
-                            (get_local $11)
-                            (get_local $2)
+                            (get_local $12)
+                            (get_local $1)
                           )
                         )
                       )
                       (call $_abort)
                     )
-                    (set_local $5
+                    (set_local $6
                       (i32.load offset=24
-                        (get_local $11)
+                        (get_local $12)
                       )
                     )
                     (block $do-once17
@@ -2012,10 +2012,10 @@
                         (i32.eq
                           (tee_local $0
                             (i32.load offset=12
-                              (get_local $11)
+                              (get_local $12)
                             )
                           )
-                          (get_local $11)
+                          (get_local $12)
                         )
                         (block
                           (if
@@ -2023,7 +2023,7 @@
                               (i32.load
                                 (tee_local $8
                                   (i32.add
-                                    (get_local $11)
+                                    (get_local $12)
                                     (i32.const 20)
                                   )
                                 )
@@ -2042,7 +2042,7 @@
                                 (i32.load
                                   (tee_local $16
                                     (i32.add
-                                      (get_local $11)
+                                      (get_local $12)
                                       (i32.const 16)
                                     )
                                   )
@@ -2125,7 +2125,7 @@
                             (i32.lt_u
                               (tee_local $8
                                 (i32.load offset=8
-                                  (get_local $11)
+                                  (get_local $12)
                                 )
                               )
                               (get_local $10)
@@ -2142,7 +2142,7 @@
                                   )
                                 )
                               )
-                              (get_local $11)
+                              (get_local $12)
                             )
                             (call $_abort)
                           )
@@ -2156,7 +2156,7 @@
                                   )
                                 )
                               )
-                              (get_local $11)
+                              (get_local $12)
                             )
                             (block
                               (i32.store
@@ -2178,11 +2178,11 @@
                     )
                     (block $do-once21
                       (if
-                        (get_local $5)
+                        (get_local $6)
                         (block
                           (if
                             (i32.eq
-                              (get_local $11)
+                              (get_local $12)
                               (i32.load
                                 (tee_local $10
                                   (i32.add
@@ -2190,7 +2190,7 @@
                                     (i32.shl
                                       (tee_local $0
                                         (i32.load offset=28
-                                          (get_local $11)
+                                          (get_local $12)
                                         )
                                       )
                                       (i32.const 2)
@@ -2231,7 +2231,7 @@
                             (block
                               (if
                                 (i32.lt_u
-                                  (get_local $5)
+                                  (get_local $6)
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -2243,19 +2243,19 @@
                                   (i32.load
                                     (tee_local $0
                                       (i32.add
-                                        (get_local $5)
+                                        (get_local $6)
                                         (i32.const 16)
                                       )
                                     )
                                   )
-                                  (get_local $11)
+                                  (get_local $12)
                                 )
                                 (i32.store
                                   (get_local $0)
                                   (get_local $9)
                                 )
                                 (i32.store offset=20
-                                  (get_local $5)
+                                  (get_local $6)
                                   (get_local $9)
                                 )
                               )
@@ -2279,12 +2279,12 @@
                           )
                           (i32.store offset=24
                             (get_local $9)
-                            (get_local $5)
+                            (get_local $6)
                           )
                           (if
                             (tee_local $10
                               (i32.load offset=16
-                                (get_local $11)
+                                (get_local $12)
                               )
                             )
                             (if
@@ -2308,7 +2308,7 @@
                           (if
                             (tee_local $10
                               (i32.load offset=20
-                                (get_local $11)
+                                (get_local $12)
                               )
                             )
                             (if
@@ -2342,9 +2342,9 @@
                         )
                         (block
                           (i32.store offset=4
-                            (get_local $11)
+                            (get_local $12)
                             (i32.or
-                              (get_local $2)
+                              (get_local $1)
                               (i32.const 3)
                             )
                           )
@@ -2362,7 +2362,7 @@
                             )
                             (get_local $4)
                           )
-                          (set_local $5
+                          (set_local $6
                             (i32.shr_u
                               (get_local $4)
                               (i32.const 3)
@@ -2379,7 +2379,7 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $5)
+                                      (get_local $6)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -2396,7 +2396,7 @@
                                   (tee_local $8
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $5)
+                                      (get_local $6)
                                     )
                                   )
                                 )
@@ -2404,7 +2404,7 @@
                                   (i32.lt_u
                                     (tee_local $16
                                       (i32.load
-                                        (tee_local $5
+                                        (tee_local $6
                                           (i32.add
                                             (get_local $10)
                                             (i32.const 8)
@@ -2419,7 +2419,7 @@
                                   (call $_abort)
                                   (block
                                     (set_local $14
-                                      (get_local $5)
+                                      (get_local $6)
                                     )
                                     (set_local $26
                                       (get_local $16)
@@ -2464,7 +2464,7 @@
                               (br $do-once25)
                             )
                           )
-                          (set_local $5
+                          (set_local $6
                             (i32.add
                               (i32.const 480)
                               (i32.shl
@@ -2487,7 +2487,7 @@
                                           (i32.shr_u
                                             (get_local $4)
                                             (i32.add
-                                              (tee_local $5
+                                              (tee_local $6
                                                 (i32.add
                                                   (i32.sub
                                                     (i32.const 14)
@@ -2557,7 +2557,7 @@
                                           (i32.const 1)
                                         )
                                         (i32.shl
-                                          (get_local $5)
+                                          (get_local $6)
                                           (i32.const 1)
                                         )
                                       )
@@ -2611,12 +2611,12 @@
                                 )
                               )
                               (i32.store
-                                (get_local $5)
+                                (get_local $6)
                                 (get_local $7)
                               )
                               (i32.store offset=24
                                 (get_local $7)
-                                (get_local $5)
+                                (get_local $6)
                               )
                               (i32.store offset=12
                                 (get_local $7)
@@ -2650,7 +2650,7 @@
                           )
                           (set_local $0
                             (i32.load
-                              (get_local $5)
+                              (get_local $6)
                             )
                           )
                           (loop $while-in28
@@ -2669,7 +2669,7 @@
                                   (set_local $15
                                     (get_local $0)
                                   )
-                                  (set_local $6
+                                  (set_local $5
                                     (i32.const 148)
                                   )
                                   (br $while-out27)
@@ -2678,7 +2678,7 @@
                               (if
                                 (tee_local $8
                                   (i32.load
-                                    (tee_local $5
+                                    (tee_local $6
                                       (i32.add
                                         (i32.add
                                           (get_local $0)
@@ -2709,12 +2709,12 @@
                                 )
                                 (block
                                   (set_local $23
-                                    (get_local $5)
+                                    (get_local $6)
                                   )
                                   (set_local $21
                                     (get_local $0)
                                   )
-                                  (set_local $6
+                                  (set_local $5
                                     (i32.const 145)
                                   )
                                 )
@@ -2723,7 +2723,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $6)
+                              (get_local $5)
                               (i32.const 145)
                             )
                             (if
@@ -2755,7 +2755,7 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $6)
+                                (get_local $5)
                                 (i32.const 148)
                               )
                               (if
@@ -2811,12 +2811,12 @@
                         )
                         (block
                           (i32.store offset=4
-                            (get_local $11)
+                            (get_local $12)
                             (i32.or
                               (tee_local $16
                                 (i32.add
                                   (get_local $4)
-                                  (get_local $2)
+                                  (get_local $1)
                                 )
                               )
                               (i32.const 3)
@@ -2826,7 +2826,7 @@
                             (tee_local $0
                               (i32.add
                                 (i32.add
-                                  (get_local $11)
+                                  (get_local $12)
                                   (get_local $16)
                                 )
                                 (i32.const 4)
@@ -2844,18 +2844,18 @@
                     )
                     (return
                       (i32.add
-                        (get_local $11)
+                        (get_local $12)
                         (i32.const 8)
                       )
                     )
                   )
                   (set_local $8
-                    (get_local $2)
+                    (get_local $1)
                   )
                 )
               )
               (set_local $8
-                (get_local $2)
+                (get_local $1)
               )
             )
           )
@@ -2867,7 +2867,7 @@
     )
     (if
       (i32.ge_u
-        (tee_local $11
+        (tee_local $12
           (i32.load
             (i32.const 184)
           )
@@ -2884,7 +2884,7 @@
           (i32.gt_u
             (tee_local $4
               (i32.sub
-                (get_local $11)
+                (get_local $12)
                 (get_local $8)
               )
             )
@@ -2938,7 +2938,7 @@
             (i32.store offset=4
               (get_local $15)
               (i32.or
-                (get_local $11)
+                (get_local $12)
                 (i32.const 3)
               )
             )
@@ -2947,7 +2947,7 @@
                 (i32.add
                   (i32.add
                     (get_local $15)
-                    (get_local $11)
+                    (get_local $12)
                   )
                   (i32.const 4)
                 )
@@ -2990,7 +2990,7 @@
         )
         (i32.store
           (i32.const 200)
-          (tee_local $11
+          (tee_local $12
             (i32.add
               (tee_local $15
                 (i32.load
@@ -3002,7 +3002,7 @@
           )
         )
         (i32.store offset=4
-          (get_local $11)
+          (get_local $12)
           (i32.or
             (get_local $4)
             (i32.const 1)
@@ -3099,7 +3099,7 @@
                     (i32.const 656)
                   )
                 )
-                (tee_local $11
+                (tee_local $12
                   (i32.add
                     (get_local $8)
                     (i32.const 47)
@@ -3166,7 +3166,7 @@
             )
             (i32.const 0)
             (i32.eq
-              (tee_local $6
+              (tee_local $5
                 (block $label$break$L257 i32
                   (if i32
                     (i32.and
@@ -3217,10 +3217,10 @@
                                     (i32.const 0)
                                   )
                                   (block
-                                    (set_local $5
+                                    (set_local $6
                                       (get_local $14)
                                     )
-                                    (set_local $13
+                                    (set_local $11
                                       (get_local $9)
                                     )
                                     (br $while-out33)
@@ -3233,7 +3233,7 @@
                                     )
                                   )
                                 )
-                                (set_local $6
+                                (set_local $5
                                   (i32.const 173)
                                 )
                                 (br $label$break$L259)
@@ -3263,10 +3263,10 @@
                                   )
                                   (i32.add
                                     (i32.load
-                                      (get_local $5)
+                                      (get_local $6)
                                     )
                                     (i32.load
-                                      (get_local $13)
+                                      (get_local $11)
                                     )
                                   )
                                 )
@@ -3288,20 +3288,20 @@
                                   )
                                 )
                                 (block
-                                  (set_local $12
+                                  (set_local $13
                                     (get_local $9)
                                   )
                                   (set_local $18
                                     (get_local $14)
                                   )
-                                  (set_local $6
+                                  (set_local $5
                                     (i32.const 183)
                                   )
                                 )
                               )
                             )
                           )
-                          (set_local $6
+                          (set_local $5
                             (i32.const 173)
                           )
                         )
@@ -3310,7 +3310,7 @@
                         (if
                           (if i32
                             (i32.eq
-                              (get_local $6)
+                              (get_local $5)
                               (i32.const 173)
                             )
                             (i32.ne
@@ -3337,19 +3337,19 @@
                                       (i32.const -1)
                                     )
                                   )
-                                  (tee_local $2
+                                  (tee_local $1
                                     (get_local $3)
                                   )
                                 )
                                 (i32.add
                                   (i32.sub
                                     (get_local $4)
-                                    (get_local $2)
+                                    (get_local $1)
                                   )
                                   (i32.and
                                     (i32.add
                                       (get_local $9)
-                                      (get_local $2)
+                                      (get_local $1)
                                     )
                                     (i32.sub
                                       (i32.const 0)
@@ -3360,7 +3360,7 @@
                                 (get_local $4)
                               )
                             )
-                            (set_local $2
+                            (set_local $1
                               (i32.add
                                 (tee_local $14
                                   (i32.load
@@ -3386,11 +3386,11 @@
                                   (select
                                     (i32.or
                                       (i32.le_u
-                                        (get_local $2)
+                                        (get_local $1)
                                         (get_local $14)
                                       )
                                       (i32.gt_u
-                                        (get_local $2)
+                                        (get_local $1)
                                         (tee_local $9
                                           (i32.load
                                             (i32.const 616)
@@ -3426,13 +3426,13 @@
                                     )
                                   )
                                   (block
-                                    (set_local $12
+                                    (set_local $13
                                       (get_local $9)
                                     )
                                     (set_local $18
                                       (get_local $0)
                                     )
-                                    (set_local $6
+                                    (set_local $5
                                       (i32.const 183)
                                     )
                                   )
@@ -3445,7 +3445,7 @@
                       (block $label$break$L279
                         (if
                           (i32.eq
-                            (get_local $6)
+                            (get_local $5)
                             (i32.const 183)
                           )
                           (block
@@ -3468,17 +3468,17 @@
                                       (i32.const 2147483647)
                                     )
                                     (i32.ne
-                                      (get_local $12)
+                                      (get_local $13)
                                       (i32.const -1)
                                     )
                                   )
                                 )
                                 (i32.lt_u
-                                  (tee_local $2
+                                  (tee_local $1
                                     (i32.and
                                       (i32.add
                                         (i32.sub
-                                          (get_local $11)
+                                          (get_local $12)
                                           (get_local $18)
                                         )
                                         (tee_local $3
@@ -3500,7 +3500,7 @@
                               (if
                                 (i32.eq
                                   (call $_sbrk
-                                    (get_local $2)
+                                    (get_local $1)
                                   )
                                   (i32.const -1)
                                 )
@@ -3512,28 +3512,28 @@
                                   )
                                   (br $label$break$L279)
                                 )
-                                (set_local $1
+                                (set_local $2
                                   (i32.add
-                                    (get_local $2)
+                                    (get_local $1)
                                     (get_local $18)
                                   )
                                 )
                               )
-                              (set_local $1
+                              (set_local $2
                                 (get_local $18)
                               )
                             )
                             (if
                               (i32.ne
-                                (get_local $12)
+                                (get_local $13)
                                 (i32.const -1)
                               )
                               (block
                                 (set_local $20
-                                  (get_local $12)
+                                  (get_local $13)
                                 )
                                 (set_local $22
-                                  (get_local $1)
+                                  (get_local $2)
                                 )
                                 (br $label$break$L257
                                   (i32.const 193)
@@ -3562,7 +3562,7 @@
           )
           (i32.and
             (i32.lt_u
-              (tee_local $1
+              (tee_local $2
                 (call $_sbrk
                   (get_local $4)
                 )
@@ -3575,7 +3575,7 @@
             )
             (i32.and
               (i32.ne
-                (get_local $1)
+                (get_local $2)
                 (i32.const -1)
               )
               (i32.ne
@@ -3587,10 +3587,10 @@
           (i32.const 0)
         )
         (i32.gt_u
-          (tee_local $12
+          (tee_local $13
             (i32.sub
               (get_local $4)
-              (get_local $1)
+              (get_local $2)
             )
           )
           (i32.add
@@ -3602,25 +3602,25 @@
       )
       (block
         (set_local $20
-          (get_local $1)
+          (get_local $2)
         )
         (set_local $22
-          (get_local $12)
+          (get_local $13)
         )
-        (set_local $6
+        (set_local $5
           (i32.const 193)
         )
       )
     )
     (if
       (i32.eq
-        (get_local $6)
+        (get_local $5)
         (i32.const 193)
       )
       (block
         (i32.store
           (i32.const 608)
-          (tee_local $12
+          (tee_local $13
             (i32.add
               (i32.load
                 (i32.const 608)
@@ -3631,25 +3631,25 @@
         )
         (if
           (i32.gt_u
-            (get_local $12)
+            (get_local $13)
             (i32.load
               (i32.const 612)
             )
           )
           (i32.store
             (i32.const 612)
-            (get_local $12)
+            (get_local $13)
           )
         )
         (block $do-once40
           (if
-            (tee_local $12
+            (tee_local $13
               (i32.load
                 (i32.const 200)
               )
             )
             (block
-              (set_local $1
+              (set_local $2
                 (i32.const 624)
               )
               (loop $do-in
@@ -3660,14 +3660,14 @@
                       (i32.add
                         (tee_local $4
                           (i32.load
-                            (get_local $1)
+                            (get_local $2)
                           )
                         )
-                        (tee_local $11
+                        (tee_local $12
                           (i32.load
                             (tee_local $18
                               (i32.add
-                                (get_local $1)
+                                (get_local $2)
                                 (i32.const 4)
                               )
                             )
@@ -3683,12 +3683,12 @@
                         (get_local $18)
                       )
                       (set_local $48
-                        (get_local $11)
+                        (get_local $12)
                       )
                       (set_local $49
-                        (get_local $1)
+                        (get_local $2)
                       )
-                      (set_local $6
+                      (set_local $5
                         (i32.const 203)
                       )
                       (br $do-out)
@@ -3696,9 +3696,9 @@
                   )
                   (br_if $do-in
                     (i32.ne
-                      (tee_local $1
+                      (tee_local $2
                         (i32.load offset=8
-                          (get_local $1)
+                          (get_local $2)
                         )
                       )
                       (i32.const 0)
@@ -3710,11 +3710,11 @@
                 (select
                   (i32.and
                     (i32.lt_u
-                      (get_local $12)
+                      (get_local $13)
                       (get_local $20)
                     )
                     (i32.ge_u
-                      (get_local $12)
+                      (get_local $13)
                       (get_local $46)
                     )
                   )
@@ -3730,7 +3730,7 @@
                     )
                     (i32.const 0)
                     (i32.eq
-                      (get_local $6)
+                      (get_local $5)
                       (i32.const 203)
                     )
                   )
@@ -3743,17 +3743,17 @@
                       (get_local $22)
                     )
                   )
-                  (set_local $1
+                  (set_local $2
                     (i32.add
-                      (get_local $12)
-                      (tee_local $11
+                      (get_local $13)
+                      (tee_local $12
                         (select
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $1
+                              (tee_local $2
                                 (i32.add
-                                  (get_local $12)
+                                  (get_local $13)
                                   (i32.const 8)
                                 )
                               )
@@ -3762,7 +3762,7 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $1)
+                            (get_local $2)
                             (i32.const 7)
                           )
                         )
@@ -3773,7 +3773,7 @@
                     (i32.add
                       (i32.sub
                         (get_local $22)
-                        (get_local $11)
+                        (get_local $12)
                       )
                       (i32.load
                         (i32.const 188)
@@ -3782,14 +3782,14 @@
                   )
                   (i32.store
                     (i32.const 200)
-                    (get_local $1)
+                    (get_local $2)
                   )
                   (i32.store
                     (i32.const 188)
                     (get_local $18)
                   )
                   (i32.store offset=4
-                    (get_local $1)
+                    (get_local $2)
                     (i32.or
                       (get_local $18)
                       (i32.const 1)
@@ -3797,7 +3797,7 @@
                   )
                   (i32.store offset=4
                     (i32.add
-                      (get_local $1)
+                      (get_local $2)
                       (get_local $18)
                     )
                     (i32.const 40)
@@ -3837,7 +3837,7 @@
                   (get_local $22)
                 )
               )
-              (set_local $1
+              (set_local $2
                 (i32.const 624)
               )
               (loop $while-in43
@@ -3845,27 +3845,27 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $1)
+                        (get_local $2)
                       )
                       (get_local $18)
                     )
                     (block
                       (set_local $50
-                        (get_local $1)
+                        (get_local $2)
                       )
                       (set_local $40
-                        (get_local $1)
+                        (get_local $2)
                       )
-                      (set_local $6
+                      (set_local $5
                         (i32.const 211)
                       )
                       (br $while-out42)
                     )
                   )
                   (br_if $while-in43
-                    (tee_local $1
+                    (tee_local $2
                       (i32.load offset=8
-                        (get_local $1)
+                        (get_local $2)
                       )
                     )
                   )
@@ -3876,7 +3876,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $6)
+                  (get_local $5)
                   (i32.const 211)
                 )
                 (if
@@ -3895,7 +3895,7 @@
                       (get_local $20)
                     )
                     (i32.store
-                      (tee_local $1
+                      (tee_local $2
                         (i32.add
                           (get_local $40)
                           (i32.const 4)
@@ -3903,19 +3903,19 @@
                       )
                       (i32.add
                         (i32.load
-                          (get_local $1)
+                          (get_local $2)
                         )
                         (get_local $22)
                       )
                     )
-                    (set_local $11
+                    (set_local $12
                       (i32.add
                         (get_local $20)
                         (select
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $1
+                              (tee_local $2
                                 (i32.add
                                   (get_local $20)
                                   (i32.const 8)
@@ -3926,7 +3926,7 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $1)
+                            (get_local $2)
                             (i32.const 7)
                           )
                         )
@@ -3939,7 +3939,7 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $1
+                              (tee_local $2
                                 (i32.add
                                   (get_local $18)
                                   (i32.const 8)
@@ -3950,15 +3950,15 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $1)
+                            (get_local $2)
                             (i32.const 7)
                           )
                         )
                       )
                     )
-                    (set_local $1
+                    (set_local $2
                       (i32.add
-                        (get_local $11)
+                        (get_local $12)
                         (get_local $8)
                       )
                     )
@@ -3966,13 +3966,13 @@
                       (i32.sub
                         (i32.sub
                           (get_local $4)
-                          (get_local $11)
+                          (get_local $12)
                         )
                         (get_local $8)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $11)
+                      (get_local $12)
                       (i32.or
                         (get_local $8)
                         (i32.const 3)
@@ -3982,7 +3982,7 @@
                       (if
                         (i32.ne
                           (get_local $4)
-                          (get_local $12)
+                          (get_local $13)
                         )
                         (block
                           (if
@@ -4006,10 +4006,10 @@
                               )
                               (i32.store
                                 (i32.const 196)
-                                (get_local $1)
+                                (get_local $2)
                               )
                               (i32.store offset=4
-                                (get_local $1)
+                                (get_local $2)
                                 (i32.or
                                   (get_local $0)
                                   (i32.const 1)
@@ -4017,7 +4017,7 @@
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $1)
+                                  (get_local $2)
                                   (get_local $0)
                                 )
                                 (get_local $0)
@@ -4026,7 +4026,7 @@
                             )
                           )
                           (i32.store
-                            (tee_local $5
+                            (tee_local $6
                               (i32.add
                                 (if i32
                                   (i32.eq
@@ -4041,13 +4041,13 @@
                                     (i32.const 1)
                                   )
                                   (block i32
-                                    (set_local $13
+                                    (set_local $11
                                       (i32.and
                                         (get_local $0)
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $5
+                                    (set_local $6
                                       (i32.shr_u
                                         (get_local $0)
                                         (i32.const 3)
@@ -4079,7 +4079,7 @@
                                                 (if
                                                   (tee_local $3
                                                     (i32.load
-                                                      (tee_local $2
+                                                      (tee_local $1
                                                         (i32.add
                                                           (tee_local $9
                                                             (i32.add
@@ -4097,7 +4097,7 @@
                                                       (get_local $3)
                                                     )
                                                     (set_local $9
-                                                      (get_local $2)
+                                                      (get_local $1)
                                                     )
                                                   )
                                                   (if
@@ -4120,7 +4120,7 @@
                                                   (if
                                                     (tee_local $3
                                                       (i32.load
-                                                        (tee_local $2
+                                                        (tee_local $1
                                                           (i32.add
                                                             (get_local $14)
                                                             (i32.const 20)
@@ -4133,7 +4133,7 @@
                                                         (get_local $3)
                                                       )
                                                       (set_local $9
-                                                        (get_local $2)
+                                                        (get_local $1)
                                                       )
                                                       (br $while-in50)
                                                     )
@@ -4141,7 +4141,7 @@
                                                   (if
                                                     (tee_local $3
                                                       (i32.load
-                                                        (tee_local $2
+                                                        (tee_local $1
                                                           (i32.add
                                                             (get_local $14)
                                                             (i32.const 16)
@@ -4154,7 +4154,7 @@
                                                         (get_local $3)
                                                       )
                                                       (set_local $9
-                                                        (get_local $2)
+                                                        (get_local $1)
                                                       )
                                                       (br $while-in50)
                                                     )
@@ -4180,7 +4180,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (tee_local $2
+                                                    (tee_local $1
                                                       (i32.load offset=8
                                                         (get_local $4)
                                                       )
@@ -4194,7 +4194,7 @@
                                                     (i32.load
                                                       (tee_local $3
                                                         (i32.add
-                                                          (get_local $2)
+                                                          (get_local $1)
                                                           (i32.const 12)
                                                         )
                                                       )
@@ -4222,7 +4222,7 @@
                                                     )
                                                     (i32.store
                                                       (get_local $9)
-                                                      (get_local $2)
+                                                      (get_local $1)
                                                     )
                                                     (set_local $24
                                                       (get_local $21)
@@ -4243,7 +4243,7 @@
                                               (i32.ne
                                                 (get_local $4)
                                                 (i32.load
-                                                  (tee_local $2
+                                                  (tee_local $1
                                                     (i32.add
                                                       (i32.const 480)
                                                       (i32.shl
@@ -4297,7 +4297,7 @@
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $2)
+                                                  (get_local $1)
                                                   (get_local $24)
                                                 )
                                                 (br_if $do-once51
@@ -4340,7 +4340,7 @@
                                           (if
                                             (tee_local $9
                                               (i32.load
-                                                (tee_local $2
+                                                (tee_local $1
                                                   (i32.add
                                                     (get_local $4)
                                                     (i32.const 16)
@@ -4370,7 +4370,7 @@
                                             (i32.eqz
                                               (tee_local $9
                                                 (i32.load offset=4
-                                                  (get_local $2)
+                                                  (get_local $1)
                                                 )
                                               )
                                             )
@@ -4414,7 +4414,7 @@
                                                     (i32.const 216)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $5)
+                                                        (get_local $6)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4457,7 +4457,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $5)
+                                                      (get_local $6)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4489,7 +4489,7 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $2
+                                                      (tee_local $1
                                                         (i32.add
                                                           (get_local $21)
                                                           (i32.const 8)
@@ -4500,7 +4500,7 @@
                                                   )
                                                   (block
                                                     (set_local $41
-                                                      (get_local $2)
+                                                      (get_local $1)
                                                     )
                                                     (br $do-once57)
                                                   )
@@ -4522,13 +4522,13 @@
                                     )
                                     (set_local $15
                                       (i32.add
-                                        (get_local $13)
+                                        (get_local $11)
                                         (get_local $15)
                                       )
                                     )
                                     (i32.add
                                       (get_local $4)
-                                      (get_local $13)
+                                      (get_local $11)
                                     )
                                   )
                                   (get_local $4)
@@ -4538,13 +4538,13 @@
                             )
                             (i32.and
                               (i32.load
-                                (get_local $5)
+                                (get_local $6)
                               )
                               (i32.const -2)
                             )
                           )
                           (i32.store offset=4
-                            (get_local $1)
+                            (get_local $2)
                             (i32.or
                               (get_local $15)
                               (i32.const 1)
@@ -4552,12 +4552,12 @@
                           )
                           (i32.store
                             (i32.add
-                              (get_local $1)
+                              (get_local $2)
                               (get_local $15)
                             )
                             (get_local $15)
                           )
-                          (set_local $5
+                          (set_local $6
                             (i32.shr_u
                               (get_local $15)
                               (i32.const 3)
@@ -4574,7 +4574,7 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $5)
+                                      (get_local $6)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4589,10 +4589,10 @@
                                         (i32.const 176)
                                       )
                                     )
-                                    (tee_local $2
+                                    (tee_local $1
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $5)
+                                        (get_local $6)
                                       )
                                     )
                                   )
@@ -4601,7 +4601,7 @@
                                       (i32.ge_u
                                         (tee_local $3
                                           (i32.load
-                                            (tee_local $5
+                                            (tee_local $6
                                               (i32.add
                                                 (get_local $0)
                                                 (i32.const 8)
@@ -4615,7 +4615,7 @@
                                       )
                                       (block
                                         (set_local $42
-                                          (get_local $5)
+                                          (get_local $6)
                                         )
                                         (set_local $34
                                           (get_local $3)
@@ -4630,7 +4630,7 @@
                                       (i32.const 176)
                                       (i32.or
                                         (get_local $23)
-                                        (get_local $2)
+                                        (get_local $1)
                                       )
                                     )
                                     (set_local $42
@@ -4647,31 +4647,31 @@
                               )
                               (i32.store
                                 (get_local $42)
-                                (get_local $1)
+                                (get_local $2)
                               )
                               (i32.store offset=12
                                 (get_local $34)
-                                (get_local $1)
+                                (get_local $2)
                               )
                               (i32.store offset=8
-                                (get_local $1)
+                                (get_local $2)
                                 (get_local $34)
                               )
                               (i32.store offset=12
-                                (get_local $1)
+                                (get_local $2)
                                 (get_local $0)
                               )
                               (br $do-once44)
                             )
                           )
-                          (set_local $2
+                          (set_local $1
                             (i32.add
                               (i32.const 480)
                               (i32.shl
                                 (tee_local $3
                                   (block $do-once61 i32
                                     (if i32
-                                      (tee_local $2
+                                      (tee_local $1
                                         (i32.shr_u
                                           (get_local $15)
                                           (i32.const 8)
@@ -4702,14 +4702,14 @@
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (tee_local $13
+                                                                  (tee_local $11
                                                                     (i32.shl
-                                                                      (get_local $2)
+                                                                      (get_local $1)
                                                                       (tee_local $23
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $2)
+                                                                              (get_local $1)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -4728,13 +4728,13 @@
                                                           )
                                                           (get_local $23)
                                                         )
-                                                        (tee_local $13
+                                                        (tee_local $11
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $5
+                                                                (tee_local $6
                                                                   (i32.shl
-                                                                    (get_local $13)
+                                                                    (get_local $11)
                                                                     (get_local $3)
                                                                   )
                                                                 )
@@ -4749,8 +4749,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $5)
-                                                        (get_local $13)
+                                                        (get_local $6)
+                                                        (get_local $11)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4776,13 +4776,13 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $1)
+                            (get_local $2)
                             (get_local $3)
                           )
                           (i32.store offset=4
                             (tee_local $0
                               (i32.add
-                                (get_local $1)
+                                (get_local $2)
                                 (i32.const 16)
                               )
                             )
@@ -4817,20 +4817,20 @@
                                 )
                               )
                               (i32.store
-                                (get_local $2)
                                 (get_local $1)
+                                (get_local $2)
                               )
                               (i32.store offset=24
-                                (get_local $1)
                                 (get_local $2)
+                                (get_local $1)
                               )
                               (i32.store offset=12
-                                (get_local $1)
-                                (get_local $1)
+                                (get_local $2)
+                                (get_local $2)
                               )
                               (i32.store offset=8
-                                (get_local $1)
-                                (get_local $1)
+                                (get_local $2)
+                                (get_local $2)
                               )
                               (br $do-once44)
                             )
@@ -4856,7 +4856,7 @@
                           )
                           (set_local $0
                             (i32.load
-                              (get_local $2)
+                              (get_local $1)
                             )
                           )
                           (loop $while-in64
@@ -4875,16 +4875,16 @@
                                   (set_local $35
                                     (get_local $0)
                                   )
-                                  (set_local $6
+                                  (set_local $5
                                     (i32.const 281)
                                   )
                                   (br $while-out63)
                                 )
                               )
                               (if
-                                (tee_local $13
+                                (tee_local $11
                                   (i32.load
-                                    (tee_local $2
+                                    (tee_local $1
                                       (i32.add
                                         (i32.add
                                           (get_local $0)
@@ -4909,18 +4909,18 @@
                                     )
                                   )
                                   (set_local $0
-                                    (get_local $13)
+                                    (get_local $11)
                                   )
                                   (br $while-in64)
                                 )
                                 (block
                                   (set_local $43
-                                    (get_local $2)
+                                    (get_local $1)
                                   )
                                   (set_local $51
                                     (get_local $0)
                                   )
-                                  (set_local $6
+                                  (set_local $5
                                     (i32.const 278)
                                   )
                                 )
@@ -4929,7 +4929,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $6)
+                              (get_local $5)
                               (i32.const 278)
                             )
                             (if
@@ -4943,25 +4943,25 @@
                               (block
                                 (i32.store
                                   (get_local $43)
-                                  (get_local $1)
+                                  (get_local $2)
                                 )
                                 (i32.store offset=24
-                                  (get_local $1)
+                                  (get_local $2)
                                   (get_local $51)
                                 )
                                 (i32.store offset=12
-                                  (get_local $1)
-                                  (get_local $1)
+                                  (get_local $2)
+                                  (get_local $2)
                                 )
                                 (i32.store offset=8
-                                  (get_local $1)
-                                  (get_local $1)
+                                  (get_local $2)
+                                  (get_local $2)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $6)
+                                (get_local $5)
                                 (i32.const 281)
                               )
                               (if
@@ -4977,7 +4977,7 @@
                                         )
                                       )
                                     )
-                                    (tee_local $13
+                                    (tee_local $11
                                       (i32.load
                                         (i32.const 192)
                                       )
@@ -4985,28 +4985,28 @@
                                   )
                                   (i32.ge_u
                                     (get_local $35)
-                                    (get_local $13)
+                                    (get_local $11)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
                                     (get_local $14)
-                                    (get_local $1)
+                                    (get_local $2)
                                   )
                                   (i32.store
                                     (get_local $0)
-                                    (get_local $1)
+                                    (get_local $2)
                                   )
                                   (i32.store offset=8
-                                    (get_local $1)
+                                    (get_local $2)
                                     (get_local $14)
                                   )
                                   (i32.store offset=12
-                                    (get_local $1)
+                                    (get_local $2)
                                     (get_local $35)
                                   )
                                   (i32.store offset=24
-                                    (get_local $1)
+                                    (get_local $2)
                                     (i32.const 0)
                                   )
                                 )
@@ -5029,10 +5029,10 @@
                           )
                           (i32.store
                             (i32.const 200)
-                            (get_local $1)
+                            (get_local $2)
                           )
                           (i32.store offset=4
-                            (get_local $1)
+                            (get_local $2)
                             (i32.or
                               (get_local $14)
                               (i32.const 1)
@@ -5043,7 +5043,7 @@
                     )
                     (return
                       (i32.add
-                        (get_local $11)
+                        (get_local $12)
                         (i32.const 8)
                       )
                     )
@@ -5054,23 +5054,23 @@
                 (if
                   (if i32
                     (i32.le_u
-                      (tee_local $1
+                      (tee_local $2
                         (i32.load
                           (get_local $28)
                         )
                       )
-                      (get_local $12)
+                      (get_local $13)
                     )
                     (i32.gt_u
                       (tee_local $15
                         (i32.add
-                          (get_local $1)
+                          (get_local $2)
                           (i32.load offset=4
                             (get_local $28)
                           )
                         )
                       )
-                      (get_local $12)
+                      (get_local $13)
                     )
                     (i32.const 0)
                   )
@@ -5089,7 +5089,7 @@
               )
               (set_local $15
                 (i32.add
-                  (tee_local $11
+                  (tee_local $12
                     (i32.add
                       (get_local $0)
                       (i32.const -47)
@@ -5098,14 +5098,14 @@
                   (i32.const 8)
                 )
               )
-              (set_local $1
+              (set_local $2
                 (i32.add
-                  (tee_local $11
+                  (tee_local $12
                     (select
-                      (get_local $12)
-                      (tee_local $1
+                      (get_local $13)
+                      (tee_local $2
                         (i32.add
-                          (get_local $11)
+                          (get_local $12)
                           (select
                             (i32.and
                               (i32.sub
@@ -5123,10 +5123,10 @@
                         )
                       )
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $2)
                         (tee_local $15
                           (i32.add
-                            (get_local $12)
+                            (get_local $13)
                             (i32.const 16)
                           )
                         )
@@ -5200,32 +5200,32 @@
               (i32.store
                 (tee_local $14
                   (i32.add
-                    (get_local $11)
+                    (get_local $12)
                     (i32.const 4)
                   )
                 )
                 (i32.const 27)
               )
               (i32.store
-                (get_local $1)
+                (get_local $2)
                 (i32.load
                   (i32.const 624)
                 )
               )
               (i32.store offset=4
-                (get_local $1)
+                (get_local $2)
                 (i32.load
                   (i32.const 628)
                 )
               )
               (i32.store offset=8
-                (get_local $1)
+                (get_local $2)
                 (i32.load
                   (i32.const 632)
                 )
               )
               (i32.store offset=12
-                (get_local $1)
+                (get_local $2)
                 (i32.load
                   (i32.const 636)
                 )
@@ -5244,19 +5244,19 @@
               )
               (i32.store
                 (i32.const 632)
-                (get_local $1)
+                (get_local $2)
               )
-              (set_local $1
+              (set_local $2
                 (i32.add
-                  (get_local $11)
+                  (get_local $12)
                   (i32.const 24)
                 )
               )
               (loop $do-in68
                 (i32.store
-                  (tee_local $1
+                  (tee_local $2
                     (i32.add
-                      (get_local $1)
+                      (get_local $2)
                       (i32.const 4)
                     )
                   )
@@ -5265,7 +5265,7 @@
                 (br_if $do-in68
                   (i32.lt_u
                     (i32.add
-                      (get_local $1)
+                      (get_local $2)
                       (i32.const 4)
                     )
                     (get_local $0)
@@ -5274,8 +5274,8 @@
               )
               (if
                 (i32.ne
-                  (get_local $11)
                   (get_local $12)
+                  (get_local $13)
                 )
                 (block
                   (i32.store
@@ -5288,30 +5288,30 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $12)
+                    (get_local $13)
                     (i32.or
-                      (tee_local $1
+                      (tee_local $2
                         (i32.sub
-                          (get_local $11)
                           (get_local $12)
+                          (get_local $13)
                         )
                       )
                       (i32.const 1)
                     )
                   )
                   (i32.store
-                    (get_local $11)
-                    (get_local $1)
+                    (get_local $12)
+                    (get_local $2)
                   )
                   (set_local $4
                     (i32.shr_u
-                      (get_local $1)
+                      (get_local $2)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $2)
                       (i32.const 256)
                     )
                     (block
@@ -5334,7 +5334,7 @@
                               (i32.const 176)
                             )
                           )
-                          (tee_local $13
+                          (tee_local $11
                             (i32.shl
                               (i32.const 1)
                               (get_local $4)
@@ -5343,7 +5343,7 @@
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $2
+                            (tee_local $1
                               (i32.load
                                 (tee_local $4
                                   (i32.add
@@ -5363,7 +5363,7 @@
                               (get_local $4)
                             )
                             (set_local $36
-                              (get_local $2)
+                              (get_local $1)
                             )
                           )
                         )
@@ -5372,7 +5372,7 @@
                             (i32.const 176)
                             (i32.or
                               (get_local $0)
-                              (get_local $13)
+                              (get_local $11)
                             )
                           )
                           (set_local $44
@@ -5388,18 +5388,18 @@
                       )
                       (i32.store
                         (get_local $44)
-                        (get_local $12)
+                        (get_local $13)
                       )
                       (i32.store offset=12
                         (get_local $36)
-                        (get_local $12)
+                        (get_local $13)
                       )
                       (i32.store offset=8
-                        (get_local $12)
+                        (get_local $13)
                         (get_local $36)
                       )
                       (i32.store offset=12
-                        (get_local $12)
+                        (get_local $13)
                         (get_local $18)
                       )
                       (br $do-once40)
@@ -5413,20 +5413,20 @@
                           (if i32
                             (tee_local $18
                               (i32.shr_u
-                                (get_local $1)
+                                (get_local $2)
                                 (i32.const 8)
                               )
                             )
                             (if i32
                               (i32.gt_u
-                                (get_local $1)
+                                (get_local $2)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $1)
+                                    (get_local $2)
                                     (i32.add
                                       (tee_local $4
                                         (i32.add
@@ -5441,7 +5441,7 @@
                                                         (tee_local $0
                                                           (i32.shl
                                                             (get_local $18)
-                                                            (tee_local $13
+                                                            (tee_local $11
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
@@ -5462,13 +5462,13 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $13)
+                                                (get_local $11)
                                               )
                                               (tee_local $0
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (tee_local $2
+                                                      (tee_local $1
                                                         (i32.shl
                                                           (get_local $0)
                                                           (get_local $18)
@@ -5485,7 +5485,7 @@
                                           )
                                           (i32.shr_u
                                             (i32.shl
-                                              (get_local $2)
+                                              (get_local $1)
                                               (get_local $0)
                                             )
                                             (i32.const 15)
@@ -5511,11 +5511,11 @@
                     )
                   )
                   (i32.store offset=28
-                    (get_local $12)
+                    (get_local $13)
                     (get_local $3)
                   )
                   (i32.store offset=20
-                    (get_local $12)
+                    (get_local $13)
                     (i32.const 0)
                   )
                   (i32.store
@@ -5530,7 +5530,7 @@
                             (i32.const 180)
                           )
                         )
-                        (tee_local $2
+                        (tee_local $1
                           (i32.shl
                             (i32.const 1)
                             (get_local $3)
@@ -5543,31 +5543,31 @@
                         (i32.const 180)
                         (i32.or
                           (get_local $0)
-                          (get_local $2)
+                          (get_local $1)
                         )
                       )
                       (i32.store
                         (get_local $4)
-                        (get_local $12)
+                        (get_local $13)
                       )
                       (i32.store offset=24
-                        (get_local $12)
+                        (get_local $13)
                         (get_local $4)
                       )
                       (i32.store offset=12
-                        (get_local $12)
-                        (get_local $12)
+                        (get_local $13)
+                        (get_local $13)
                       )
                       (i32.store offset=8
-                        (get_local $12)
-                        (get_local $12)
+                        (get_local $13)
+                        (get_local $13)
                       )
                       (br $do-once40)
                     )
                   )
-                  (set_local $2
+                  (set_local $1
                     (i32.shl
-                      (get_local $1)
+                      (get_local $2)
                       (select
                         (i32.const 0)
                         (i32.sub
@@ -5599,20 +5599,20 @@
                             )
                             (i32.const -8)
                           )
-                          (get_local $1)
+                          (get_local $2)
                         )
                         (block
                           (set_local $37
                             (get_local $0)
                           )
-                          (set_local $6
+                          (set_local $5
                             (i32.const 307)
                           )
                           (br $while-out69)
                         )
                       )
                       (if
-                        (tee_local $13
+                        (tee_local $11
                           (i32.load
                             (tee_local $4
                               (i32.add
@@ -5622,7 +5622,7 @@
                                 )
                                 (i32.shl
                                   (i32.shr_u
-                                    (get_local $2)
+                                    (get_local $1)
                                     (i32.const 31)
                                   )
                                   (i32.const 2)
@@ -5632,14 +5632,14 @@
                           )
                         )
                         (block
-                          (set_local $2
+                          (set_local $1
                             (i32.shl
-                              (get_local $2)
+                              (get_local $1)
                               (i32.const 1)
                             )
                           )
                           (set_local $0
-                            (get_local $13)
+                            (get_local $11)
                           )
                           (br $while-in70)
                         )
@@ -5650,7 +5650,7 @@
                           (set_local $52
                             (get_local $0)
                           )
-                          (set_local $6
+                          (set_local $5
                             (i32.const 304)
                           )
                         )
@@ -5659,7 +5659,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $6)
+                      (get_local $5)
                       (i32.const 304)
                     )
                     (if
@@ -5673,31 +5673,31 @@
                       (block
                         (i32.store
                           (get_local $45)
-                          (get_local $12)
+                          (get_local $13)
                         )
                         (i32.store offset=24
-                          (get_local $12)
+                          (get_local $13)
                           (get_local $52)
                         )
                         (i32.store offset=12
-                          (get_local $12)
-                          (get_local $12)
+                          (get_local $13)
+                          (get_local $13)
                         )
                         (i32.store offset=8
-                          (get_local $12)
-                          (get_local $12)
+                          (get_local $13)
+                          (get_local $13)
                         )
                       )
                     )
                     (if
                       (i32.eq
-                        (get_local $6)
+                        (get_local $5)
                         (i32.const 307)
                       )
                       (if
                         (i32.and
                           (i32.ge_u
-                            (tee_local $2
+                            (tee_local $1
                               (i32.load
                                 (tee_local $0
                                   (i32.add
@@ -5707,7 +5707,7 @@
                                 )
                               )
                             )
-                            (tee_local $1
+                            (tee_local $2
                               (i32.load
                                 (i32.const 192)
                               )
@@ -5715,28 +5715,28 @@
                           )
                           (i32.ge_u
                             (get_local $37)
-                            (get_local $1)
+                            (get_local $2)
                           )
                         )
                         (block
                           (i32.store offset=12
-                            (get_local $2)
-                            (get_local $12)
+                            (get_local $1)
+                            (get_local $13)
                           )
                           (i32.store
                             (get_local $0)
-                            (get_local $12)
+                            (get_local $13)
                           )
                           (i32.store offset=8
-                            (get_local $12)
-                            (get_local $2)
+                            (get_local $13)
+                            (get_local $1)
                           )
                           (i32.store offset=12
-                            (get_local $12)
+                            (get_local $13)
                             (get_local $37)
                           )
                           (i32.store offset=24
-                            (get_local $12)
+                            (get_local $13)
                             (i32.const 0)
                           )
                         )
@@ -5751,7 +5751,7 @@
               (if
                 (i32.or
                   (i32.eqz
-                    (tee_local $2
+                    (tee_local $1
                       (i32.load
                         (i32.const 192)
                       )
@@ -5759,7 +5759,7 @@
                   )
                   (i32.lt_u
                     (get_local $20)
-                    (get_local $2)
+                    (get_local $1)
                   )
                 )
                 (i32.store
@@ -5789,7 +5789,7 @@
                 (i32.const 208)
                 (i32.const -1)
               )
-              (set_local $2
+              (set_local $1
                 (i32.const 0)
               )
               (loop $do-in72
@@ -5799,7 +5799,7 @@
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $2)
+                          (get_local $1)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -5814,9 +5814,9 @@
                 )
                 (br_if $do-in72
                   (i32.ne
-                    (tee_local $2
+                    (tee_local $1
                       (i32.add
-                        (get_local $2)
+                        (get_local $1)
                         (i32.const 1)
                       )
                     )
@@ -5826,7 +5826,7 @@
               )
               (i32.store
                 (i32.const 200)
-                (tee_local $2
+                (tee_local $1
                   (i32.add
                     (get_local $20)
                     (tee_local $0
@@ -5834,7 +5834,7 @@
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (tee_local $2
+                            (tee_local $1
                               (i32.add
                                 (get_local $20)
                                 (i32.const 8)
@@ -5845,7 +5845,7 @@
                         )
                         (i32.const 0)
                         (i32.and
-                          (get_local $2)
+                          (get_local $1)
                           (i32.const 7)
                         )
                       )
@@ -5855,7 +5855,7 @@
               )
               (i32.store
                 (i32.const 188)
-                (tee_local $1
+                (tee_local $2
                   (i32.sub
                     (i32.add
                       (get_local $22)
@@ -5866,16 +5866,16 @@
                 )
               )
               (i32.store offset=4
-                (get_local $2)
+                (get_local $1)
                 (i32.or
-                  (get_local $1)
+                  (get_local $2)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $2)
                   (get_local $1)
+                  (get_local $2)
                 )
                 (i32.const 40)
               )
@@ -5909,7 +5909,7 @@
             )
             (i32.store
               (i32.const 200)
-              (tee_local $12
+              (tee_local $13
                 (i32.add
                   (tee_local $22
                     (i32.load
@@ -5921,7 +5921,7 @@
               )
             )
             (i32.store offset=4
-              (get_local $12)
+              (get_local $13)
               (i32.or
                 (get_local $20)
                 (i32.const 1)
@@ -8525,16 +8525,16 @@
                     )
                   )
                 )
+                (set_local $0
+                  (get_local $2)
+                )
               )
-            )
-            (set_local $2
-              (get_local $0)
             )
           )
           (call $___unlock
             (i32.const 36)
           )
-          (get_local $2)
+          (get_local $0)
         )
       )
     )

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -142,14 +142,14 @@
         (block
           (if
             (i32.and
-              (tee_local $2
+              (tee_local $1
                 (i32.shr_u
                   (tee_local $16
                     (i32.load
                       (i32.const 176)
                     )
                   )
-                  (tee_local $5
+                  (tee_local $6
                     (i32.shr_u
                       (tee_local $8
                         (select
@@ -175,7 +175,7 @@
               (i32.const 3)
             )
             (block
-              (set_local $5
+              (set_local $1
                 (i32.load
                   (tee_local $17
                     (i32.add
@@ -188,16 +188,16 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (tee_local $2
+                                      (tee_local $11
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $2)
+                                              (get_local $1)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $5)
+                                          (get_local $6)
                                         )
                                       )
                                       (i32.const 1)
@@ -219,12 +219,12 @@
               (if
                 (i32.ne
                   (get_local $0)
-                  (get_local $5)
+                  (get_local $1)
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $5)
+                      (get_local $1)
                       (i32.load
                         (i32.const 192)
                       )
@@ -234,9 +234,9 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $6
+                        (tee_local $5
                           (i32.add
-                            (get_local $5)
+                            (get_local $1)
                             (i32.const 12)
                           )
                         )
@@ -245,12 +245,12 @@
                     )
                     (block
                       (i32.store
-                        (get_local $6)
+                        (get_local $5)
                         (get_local $0)
                       )
                       (i32.store
                         (get_local $7)
-                        (get_local $5)
+                        (get_local $1)
                       )
                     )
                     (call $_abort)
@@ -263,7 +263,7 @@
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $2)
+                        (get_local $11)
                       )
                       (i32.const -1)
                     )
@@ -273,9 +273,9 @@
               (i32.store offset=4
                 (get_local $3)
                 (i32.or
-                  (tee_local $5
+                  (tee_local $1
                     (i32.shl
-                      (get_local $2)
+                      (get_local $11)
                       (i32.const 3)
                     )
                   )
@@ -287,7 +287,7 @@
                   (i32.add
                     (i32.add
                       (get_local $3)
-                      (get_local $5)
+                      (get_local $1)
                     )
                     (i32.const 4)
                   )
@@ -315,30 +315,30 @@
             )
             (block
               (if
-                (get_local $2)
+                (get_local $1)
                 (block
                   (set_local $0
                     (i32.and
                       (i32.shr_u
-                        (tee_local $5
+                        (tee_local $1
                           (i32.add
                             (i32.and
                               (tee_local $0
                                 (i32.and
                                   (i32.shl
-                                    (get_local $2)
-                                    (get_local $5)
+                                    (get_local $1)
+                                    (get_local $6)
                                   )
                                   (i32.or
-                                    (tee_local $5
+                                    (tee_local $1
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $5)
+                                        (get_local $6)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $5)
+                                      (get_local $1)
                                     )
                                   )
                                 )
@@ -358,7 +358,7 @@
                   )
                   (set_local $0
                     (i32.load
-                      (tee_local $6
+                      (tee_local $5
                         (i32.add
                           (tee_local $3
                             (i32.load
@@ -369,18 +369,18 @@
                                       (i32.const 216)
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $13
+                                          (tee_local $11
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $5
+                                                      (tee_local $1
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $6
+                                                            (tee_local $5
                                                               (i32.shr_u
-                                                                (get_local $5)
+                                                                (get_local $1)
                                                                 (get_local $0)
                                                               )
                                                             )
@@ -391,13 +391,13 @@
                                                       )
                                                       (get_local $0)
                                                     )
-                                                    (tee_local $6
+                                                    (tee_local $5
                                                       (i32.and
                                                         (i32.shr_u
                                                           (tee_local $3
                                                             (i32.shr_u
-                                                              (get_local $6)
                                                               (get_local $5)
+                                                              (get_local $1)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -412,7 +412,7 @@
                                                         (tee_local $10
                                                           (i32.shr_u
                                                             (get_local $3)
-                                                            (get_local $6)
+                                                            (get_local $5)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -476,7 +476,7 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $5
+                            (tee_local $1
                               (i32.add
                                 (get_local $0)
                                 (i32.const 12)
@@ -487,7 +487,7 @@
                         )
                         (block
                           (i32.store
-                            (get_local $5)
+                            (get_local $1)
                             (get_local $10)
                           )
                           (i32.store
@@ -511,7 +511,7 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $13)
+                              (get_local $11)
                             )
                             (i32.const -1)
                           )
@@ -540,7 +540,7 @@
                       (tee_local $7
                         (i32.sub
                           (i32.shl
-                            (get_local $13)
+                            (get_local $11)
                             (i32.const 3)
                           )
                           (get_local $8)
@@ -583,12 +583,12 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $5
+                          (tee_local $6
                             (i32.load
                               (i32.const 176)
                             )
                           )
-                          (tee_local $2
+                          (tee_local $1
                             (i32.shl
                               (i32.const 1)
                               (get_local $19)
@@ -625,8 +625,8 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $5)
-                              (get_local $2)
+                              (get_local $6)
+                              (get_local $1)
                             )
                           )
                           (set_local $38
@@ -667,7 +667,7 @@
                     (get_local $16)
                   )
                   (return
-                    (get_local $6)
+                    (get_local $5)
                   )
                 )
               )
@@ -698,7 +698,7 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $2
+                  (set_local $1
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
@@ -744,7 +744,7 @@
                                       (tee_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $2
+                                            (tee_local $1
                                               (i32.shr_u
                                                 (get_local $0)
                                                 (get_local $10)
@@ -756,12 +756,12 @@
                                         )
                                       )
                                     )
-                                    (tee_local $2
+                                    (tee_local $1
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $5
+                                          (tee_local $6
                                             (i32.shr_u
-                                              (get_local $2)
+                                              (get_local $1)
                                               (get_local $0)
                                             )
                                           )
@@ -772,8 +772,8 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $5)
-                                    (get_local $2)
+                                    (get_local $6)
+                                    (get_local $1)
                                   )
                                 )
                                 (i32.const 2)
@@ -786,7 +786,7 @@
                       (get_local $8)
                     )
                   )
-                  (set_local $5
+                  (set_local $6
                     (get_local $17)
                   )
                   (set_local $0
@@ -797,7 +797,7 @@
                       (if
                         (tee_local $17
                           (i32.load offset=16
-                            (get_local $5)
+                            (get_local $6)
                           )
                         )
                         (set_local $3
@@ -806,7 +806,7 @@
                         (if
                           (tee_local $10
                             (i32.load offset=20
-                              (get_local $5)
+                              (get_local $6)
                             )
                           )
                           (set_local $3
@@ -814,9 +814,9 @@
                           )
                           (block
                             (set_local $7
-                              (get_local $2)
+                              (get_local $1)
                             )
-                            (set_local $1
+                            (set_local $2
                               (get_local $0)
                             )
                             (br $while-out)
@@ -836,17 +836,17 @@
                               (get_local $8)
                             )
                           )
-                          (get_local $2)
+                          (get_local $1)
                         )
                       )
-                      (set_local $2
+                      (set_local $1
                         (select
                           (get_local $17)
-                          (get_local $2)
+                          (get_local $1)
                           (get_local $10)
                         )
                       )
-                      (set_local $5
+                      (set_local $6
                         (get_local $3)
                       )
                       (set_local $0
@@ -861,7 +861,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $2)
                       (tee_local $0
                         (i32.load
                           (i32.const 192)
@@ -872,38 +872,38 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $1)
-                      (tee_local $5
+                      (get_local $2)
+                      (tee_local $6
                         (i32.add
-                          (get_local $1)
+                          (get_local $2)
                           (get_local $8)
                         )
                       )
                     )
                     (call $_abort)
                   )
-                  (set_local $2
+                  (set_local $1
                     (i32.load offset=24
-                      (get_local $1)
+                      (get_local $2)
                     )
                   )
                   (block $do-once4
                     (if
                       (i32.eq
-                        (tee_local $6
+                        (tee_local $5
                           (i32.load offset=12
-                            (get_local $1)
+                            (get_local $2)
                           )
                         )
-                        (get_local $1)
+                        (get_local $2)
                       )
                       (block
                         (if
-                          (tee_local $13
+                          (tee_local $11
                             (i32.load
                               (tee_local $3
                                 (i32.add
-                                  (get_local $1)
+                                  (get_local $2)
                                   (i32.const 20)
                                 )
                               )
@@ -911,7 +911,7 @@
                           )
                           (block
                             (set_local $17
-                              (get_local $13)
+                              (get_local $11)
                             )
                             (set_local $9
                               (get_local $3)
@@ -922,7 +922,7 @@
                               (i32.load
                                 (tee_local $10
                                   (i32.add
-                                    (get_local $1)
+                                    (get_local $2)
                                     (i32.const 16)
                                   )
                                 )
@@ -941,7 +941,7 @@
                         )
                         (loop $while-in7
                           (if
-                            (tee_local $13
+                            (tee_local $11
                               (i32.load
                                 (tee_local $3
                                   (i32.add
@@ -953,7 +953,7 @@
                             )
                             (block
                               (set_local $17
-                                (get_local $13)
+                                (get_local $11)
                               )
                               (set_local $9
                                 (get_local $3)
@@ -962,7 +962,7 @@
                             )
                           )
                           (if
-                            (tee_local $13
+                            (tee_local $11
                               (i32.load
                                 (tee_local $3
                                   (i32.add
@@ -974,7 +974,7 @@
                             )
                             (block
                               (set_local $17
-                                (get_local $13)
+                                (get_local $11)
                               )
                               (set_local $9
                                 (get_local $3)
@@ -1005,7 +1005,7 @@
                           (i32.lt_u
                             (tee_local $3
                               (i32.load offset=8
-                                (get_local $1)
+                                (get_local $2)
                               )
                             )
                             (get_local $0)
@@ -1015,14 +1015,14 @@
                         (if
                           (i32.ne
                             (i32.load
-                              (tee_local $13
+                              (tee_local $11
                                 (i32.add
                                   (get_local $3)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $1)
+                            (get_local $2)
                           )
                           (call $_abort)
                         )
@@ -1031,24 +1031,24 @@
                             (i32.load
                               (tee_local $10
                                 (i32.add
-                                  (get_local $6)
+                                  (get_local $5)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $1)
+                            (get_local $2)
                           )
                           (block
                             (i32.store
-                              (get_local $13)
-                              (get_local $6)
+                              (get_local $11)
+                              (get_local $5)
                             )
                             (i32.store
                               (get_local $10)
                               (get_local $3)
                             )
                             (set_local $19
-                              (get_local $6)
+                              (get_local $5)
                             )
                           )
                           (call $_abort)
@@ -1058,19 +1058,19 @@
                   )
                   (block $do-once8
                     (if
-                      (get_local $2)
+                      (get_local $1)
                       (block
                         (if
                           (i32.eq
-                            (get_local $1)
+                            (get_local $2)
                             (i32.load
                               (tee_local $0
                                 (i32.add
                                   (i32.const 480)
                                   (i32.shl
-                                    (tee_local $6
+                                    (tee_local $5
                                       (i32.load offset=28
-                                        (get_local $1)
+                                        (get_local $2)
                                       )
                                     )
                                     (i32.const 2)
@@ -1098,7 +1098,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $6)
+                                        (get_local $5)
                                       )
                                       (i32.const -1)
                                     )
@@ -1111,7 +1111,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $2)
+                                (get_local $1)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -1121,21 +1121,21 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $6
+                                  (tee_local $5
                                     (i32.add
-                                      (get_local $2)
+                                      (get_local $1)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $1)
+                                (get_local $2)
                               )
                               (i32.store
-                                (get_local $6)
+                                (get_local $5)
                                 (get_local $19)
                               )
                               (i32.store offset=20
-                                (get_local $2)
+                                (get_local $1)
                                 (get_local $19)
                               )
                             )
@@ -1149,7 +1149,7 @@
                         (if
                           (i32.lt_u
                             (get_local $19)
-                            (tee_local $6
+                            (tee_local $5
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1159,18 +1159,18 @@
                         )
                         (i32.store offset=24
                           (get_local $19)
-                          (get_local $2)
+                          (get_local $1)
                         )
                         (if
                           (tee_local $0
                             (i32.load offset=16
-                              (get_local $1)
+                              (get_local $2)
                             )
                           )
                           (if
                             (i32.lt_u
                               (get_local $0)
-                              (get_local $6)
+                              (get_local $5)
                             )
                             (call $_abort)
                             (block
@@ -1188,7 +1188,7 @@
                         (if
                           (tee_local $0
                             (i32.load offset=20
-                              (get_local $1)
+                              (get_local $2)
                             )
                           )
                           (if
@@ -1221,9 +1221,9 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $2)
                         (i32.or
-                          (tee_local $2
+                          (tee_local $1
                             (i32.add
                               (get_local $7)
                               (get_local $8)
@@ -1236,8 +1236,8 @@
                         (tee_local $0
                           (i32.add
                             (i32.add
-                              (get_local $1)
                               (get_local $2)
+                              (get_local $1)
                             )
                             (i32.const 4)
                           )
@@ -1252,14 +1252,14 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $2)
                         (i32.or
                           (get_local $8)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $5)
+                        (get_local $6)
                         (i32.or
                           (get_local $7)
                           (i32.const 1)
@@ -1267,7 +1267,7 @@
                       )
                       (i32.store
                         (i32.add
-                          (get_local $5)
+                          (get_local $6)
                           (get_local $7)
                         )
                         (get_local $7)
@@ -1279,7 +1279,7 @@
                           )
                         )
                         (block
-                          (set_local $2
+                          (set_local $1
                             (i32.load
                               (i32.const 196)
                             )
@@ -1289,7 +1289,7 @@
                               (i32.const 216)
                               (i32.shl
                                 (i32.shl
-                                  (tee_local $6
+                                  (tee_local $5
                                     (i32.shr_u
                                       (get_local $0)
                                       (i32.const 3)
@@ -1311,15 +1311,15 @@
                               (tee_local $10
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $6)
+                                  (get_local $5)
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (tee_local $13
+                                (tee_local $11
                                   (i32.load
-                                    (tee_local $6
+                                    (tee_local $5
                                       (i32.add
                                         (get_local $0)
                                         (i32.const 8)
@@ -1334,10 +1334,10 @@
                               (call $_abort)
                               (block
                                 (set_local $39
-                                  (get_local $6)
+                                  (get_local $5)
                                 )
                                 (set_local $32
-                                  (get_local $13)
+                                  (get_local $11)
                                 )
                               )
                             )
@@ -1362,18 +1362,18 @@
                           )
                           (i32.store
                             (get_local $39)
-                            (get_local $2)
+                            (get_local $1)
                           )
                           (i32.store offset=12
                             (get_local $32)
-                            (get_local $2)
+                            (get_local $1)
                           )
                           (i32.store offset=8
-                            (get_local $2)
+                            (get_local $1)
                             (get_local $32)
                           )
                           (i32.store offset=12
-                            (get_local $2)
+                            (get_local $1)
                             (get_local $0)
                           )
                         )
@@ -1384,13 +1384,13 @@
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $5)
+                        (get_local $6)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $1)
+                      (get_local $2)
                       (i32.const 8)
                     )
                   )
@@ -1405,7 +1405,7 @@
             (i32.const -65)
           )
           (block
-            (set_local $2
+            (set_local $1
               (i32.and
                 (tee_local $0
                   (i32.add
@@ -1426,7 +1426,7 @@
                 (set_local $3
                   (i32.sub
                     (i32.const 0)
-                    (get_local $2)
+                    (get_local $1)
                   )
                 )
                 (block $label$break$L123
@@ -1436,7 +1436,7 @@
                         (i32.shl
                           (tee_local $8
                             (if i32
-                              (tee_local $13
+                              (tee_local $11
                                 (i32.shr_u
                                   (get_local $0)
                                   (i32.const 8)
@@ -1444,14 +1444,14 @@
                               )
                               (if i32
                                 (i32.gt_u
-                                  (get_local $2)
+                                  (get_local $1)
                                   (i32.const 16777215)
                                 )
                                 (i32.const 31)
                                 (i32.or
                                   (i32.and
                                     (i32.shr_u
-                                      (get_local $2)
+                                      (get_local $1)
                                       (i32.add
                                         (tee_local $16
                                           (i32.add
@@ -1459,18 +1459,18 @@
                                               (i32.const 14)
                                               (i32.or
                                                 (i32.or
-                                                  (tee_local $13
+                                                  (tee_local $11
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $6
+                                                          (tee_local $5
                                                             (i32.shl
-                                                              (get_local $13)
+                                                              (get_local $11)
                                                               (tee_local $0
                                                                 (i32.and
                                                                   (i32.shr_u
                                                                     (i32.add
-                                                                      (get_local $13)
+                                                                      (get_local $11)
                                                                       (i32.const 1048320)
                                                                     )
                                                                     (i32.const 16)
@@ -1489,14 +1489,14 @@
                                                   )
                                                   (get_local $0)
                                                 )
-                                                (tee_local $6
+                                                (tee_local $5
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
                                                         (tee_local $17
                                                           (i32.shl
-                                                            (get_local $6)
-                                                            (get_local $13)
+                                                            (get_local $5)
+                                                            (get_local $11)
                                                           )
                                                         )
                                                         (i32.const 245760)
@@ -1511,7 +1511,7 @@
                                             (i32.shr_u
                                               (i32.shl
                                                 (get_local $17)
-                                                (get_local $6)
+                                                (get_local $5)
                                               )
                                               (i32.const 15)
                                             )
@@ -1536,7 +1536,7 @@
                       )
                     )
                     (block
-                      (set_local $6
+                      (set_local $5
                         (get_local $3)
                       )
                       (set_local $17
@@ -1544,7 +1544,7 @@
                       )
                       (set_local $0
                         (i32.shl
-                          (get_local $2)
+                          (get_local $1)
                           (select
                             (i32.const 0)
                             (i32.sub
@@ -1561,7 +1561,7 @@
                           )
                         )
                       )
-                      (set_local $13
+                      (set_local $11
                         (get_local $16)
                       )
                       (set_local $7
@@ -1575,42 +1575,42 @@
                                 (tee_local $19
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $13)
+                                      (get_local $11)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $2)
+                                (get_local $1)
                               )
                             )
-                            (get_local $6)
+                            (get_local $5)
                           )
                           (if
                             (i32.eq
                               (get_local $19)
-                              (get_local $2)
+                              (get_local $1)
                             )
                             (block
                               (set_local $27
                                 (get_local $3)
                               )
                               (set_local $25
-                                (get_local $13)
+                                (get_local $11)
                               )
                               (set_local $29
-                                (get_local $13)
+                                (get_local $11)
                               )
-                              (set_local $6
+                              (set_local $5
                                 (i32.const 90)
                               )
                               (br $label$break$L123)
                             )
                             (block
-                              (set_local $6
+                              (set_local $5
                                 (get_local $3)
                               )
                               (set_local $7
-                                (get_local $13)
+                                (get_local $11)
                               )
                             )
                           )
@@ -1620,7 +1620,7 @@
                             (get_local $17)
                             (tee_local $3
                               (i32.load offset=20
-                                (get_local $13)
+                                (get_local $11)
                               )
                             )
                             (i32.or
@@ -1629,11 +1629,11 @@
                               )
                               (i32.eq
                                 (get_local $3)
-                                (tee_local $13
+                                (tee_local $11
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $13)
+                                        (get_local $11)
                                         (i32.const 16)
                                       )
                                       (i32.shl
@@ -1653,20 +1653,20 @@
                         (if
                           (tee_local $3
                             (i32.eqz
-                              (get_local $13)
+                              (get_local $11)
                             )
                           )
                           (block
                             (set_local $33
-                              (get_local $6)
+                              (get_local $5)
                             )
-                            (set_local $5
+                            (set_local $6
                               (get_local $19)
                             )
                             (set_local $30
                               (get_local $7)
                             )
-                            (set_local $6
+                            (set_local $5
                               (i32.const 86)
                             )
                           )
@@ -1695,13 +1695,13 @@
                       (set_local $33
                         (get_local $3)
                       )
-                      (set_local $5
+                      (set_local $6
                         (i32.const 0)
                       )
                       (set_local $30
                         (i32.const 0)
                       )
-                      (set_local $6
+                      (set_local $5
                         (i32.const 86)
                       )
                     )
@@ -1709,7 +1709,7 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $6)
+                    (get_local $5)
                     (i32.const 86)
                   )
                   (if
@@ -1717,7 +1717,7 @@
                       (if i32
                         (i32.and
                           (i32.eqz
-                            (get_local $5)
+                            (get_local $6)
                           )
                           (i32.eqz
                             (get_local $30)
@@ -1746,7 +1746,7 @@
                             )
                             (block
                               (set_local $8
-                                (get_local $2)
+                                (get_local $1)
                               )
                               (br $do-once)
                             )
@@ -1797,7 +1797,7 @@
                                       (tee_local $8
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $5
+                                            (tee_local $6
                                               (i32.shr_u
                                                 (get_local $8)
                                                 (get_local $16)
@@ -1809,12 +1809,12 @@
                                         )
                                       )
                                     )
-                                    (tee_local $5
+                                    (tee_local $6
                                       (i32.and
                                         (i32.shr_u
                                           (tee_local $7
                                             (i32.shr_u
-                                              (get_local $5)
+                                              (get_local $6)
                                               (get_local $8)
                                             )
                                           )
@@ -1830,7 +1830,7 @@
                                         (tee_local $0
                                           (i32.shr_u
                                             (get_local $7)
-                                            (get_local $5)
+                                            (get_local $6)
                                           )
                                         )
                                         (i32.const 1)
@@ -1848,7 +1848,7 @@
                             )
                           )
                         )
-                        (get_local $5)
+                        (get_local $6)
                       )
                     )
                     (block
@@ -1861,7 +1861,7 @@
                       (set_local $29
                         (get_local $30)
                       )
-                      (set_local $6
+                      (set_local $5
                         (i32.const 90)
                       )
                     )
@@ -1869,7 +1869,7 @@
                       (set_local $4
                         (get_local $33)
                       )
-                      (set_local $11
+                      (set_local $12
                         (get_local $30)
                       )
                     )
@@ -1877,11 +1877,11 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $6)
+                    (get_local $5)
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $6
+                    (set_local $5
                       (i32.const 0)
                     )
                     (set_local $0
@@ -1894,13 +1894,13 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $2)
+                            (get_local $1)
                           )
                         )
                         (get_local $27)
                       )
                     )
-                    (set_local $5
+                    (set_local $6
                       (select
                         (get_local $7)
                         (get_local $27)
@@ -1922,7 +1922,7 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $5)
+                          (get_local $6)
                         )
                         (set_local $25
                           (get_local $0)
@@ -1941,7 +1941,7 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $5)
+                          (get_local $6)
                         )
                         (set_local $29
                           (get_local $7)
@@ -1950,9 +1950,9 @@
                       )
                       (block
                         (set_local $4
-                          (get_local $5)
+                          (get_local $6)
                         )
-                        (set_local $11
+                        (set_local $12
                           (get_local $7)
                         )
                       )
@@ -1967,19 +1967,19 @@
                         (i32.load
                           (i32.const 184)
                         )
-                        (get_local $2)
+                        (get_local $1)
                       )
                     )
                     (i32.const 0)
                     (i32.ne
-                      (get_local $11)
+                      (get_local $12)
                       (i32.const 0)
                     )
                   )
                   (block
                     (if
                       (i32.lt_u
-                        (get_local $11)
+                        (get_local $12)
                         (tee_local $10
                           (i32.load
                             (i32.const 192)
@@ -1990,19 +1990,19 @@
                     )
                     (if
                       (i32.ge_u
-                        (get_local $11)
+                        (get_local $12)
                         (tee_local $7
                           (i32.add
-                            (get_local $11)
-                            (get_local $2)
+                            (get_local $12)
+                            (get_local $1)
                           )
                         )
                       )
                       (call $_abort)
                     )
-                    (set_local $5
+                    (set_local $6
                       (i32.load offset=24
-                        (get_local $11)
+                        (get_local $12)
                       )
                     )
                     (block $do-once17
@@ -2010,10 +2010,10 @@
                         (i32.eq
                           (tee_local $0
                             (i32.load offset=12
-                              (get_local $11)
+                              (get_local $12)
                             )
                           )
-                          (get_local $11)
+                          (get_local $12)
                         )
                         (block
                           (if
@@ -2021,7 +2021,7 @@
                               (i32.load
                                 (tee_local $8
                                   (i32.add
-                                    (get_local $11)
+                                    (get_local $12)
                                     (i32.const 20)
                                   )
                                 )
@@ -2040,7 +2040,7 @@
                                 (i32.load
                                   (tee_local $16
                                     (i32.add
-                                      (get_local $11)
+                                      (get_local $12)
                                       (i32.const 16)
                                     )
                                   )
@@ -2123,7 +2123,7 @@
                             (i32.lt_u
                               (tee_local $8
                                 (i32.load offset=8
-                                  (get_local $11)
+                                  (get_local $12)
                                 )
                               )
                               (get_local $10)
@@ -2140,7 +2140,7 @@
                                   )
                                 )
                               )
-                              (get_local $11)
+                              (get_local $12)
                             )
                             (call $_abort)
                           )
@@ -2154,7 +2154,7 @@
                                   )
                                 )
                               )
-                              (get_local $11)
+                              (get_local $12)
                             )
                             (block
                               (i32.store
@@ -2176,11 +2176,11 @@
                     )
                     (block $do-once21
                       (if
-                        (get_local $5)
+                        (get_local $6)
                         (block
                           (if
                             (i32.eq
-                              (get_local $11)
+                              (get_local $12)
                               (i32.load
                                 (tee_local $10
                                   (i32.add
@@ -2188,7 +2188,7 @@
                                     (i32.shl
                                       (tee_local $0
                                         (i32.load offset=28
-                                          (get_local $11)
+                                          (get_local $12)
                                         )
                                       )
                                       (i32.const 2)
@@ -2229,7 +2229,7 @@
                             (block
                               (if
                                 (i32.lt_u
-                                  (get_local $5)
+                                  (get_local $6)
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -2241,19 +2241,19 @@
                                   (i32.load
                                     (tee_local $0
                                       (i32.add
-                                        (get_local $5)
+                                        (get_local $6)
                                         (i32.const 16)
                                       )
                                     )
                                   )
-                                  (get_local $11)
+                                  (get_local $12)
                                 )
                                 (i32.store
                                   (get_local $0)
                                   (get_local $9)
                                 )
                                 (i32.store offset=20
-                                  (get_local $5)
+                                  (get_local $6)
                                   (get_local $9)
                                 )
                               )
@@ -2277,12 +2277,12 @@
                           )
                           (i32.store offset=24
                             (get_local $9)
-                            (get_local $5)
+                            (get_local $6)
                           )
                           (if
                             (tee_local $10
                               (i32.load offset=16
-                                (get_local $11)
+                                (get_local $12)
                               )
                             )
                             (if
@@ -2306,7 +2306,7 @@
                           (if
                             (tee_local $10
                               (i32.load offset=20
-                                (get_local $11)
+                                (get_local $12)
                               )
                             )
                             (if
@@ -2340,9 +2340,9 @@
                         )
                         (block
                           (i32.store offset=4
-                            (get_local $11)
+                            (get_local $12)
                             (i32.or
-                              (get_local $2)
+                              (get_local $1)
                               (i32.const 3)
                             )
                           )
@@ -2360,7 +2360,7 @@
                             )
                             (get_local $4)
                           )
-                          (set_local $5
+                          (set_local $6
                             (i32.shr_u
                               (get_local $4)
                               (i32.const 3)
@@ -2377,7 +2377,7 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $5)
+                                      (get_local $6)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -2394,7 +2394,7 @@
                                   (tee_local $8
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $5)
+                                      (get_local $6)
                                     )
                                   )
                                 )
@@ -2402,7 +2402,7 @@
                                   (i32.lt_u
                                     (tee_local $16
                                       (i32.load
-                                        (tee_local $5
+                                        (tee_local $6
                                           (i32.add
                                             (get_local $10)
                                             (i32.const 8)
@@ -2417,7 +2417,7 @@
                                   (call $_abort)
                                   (block
                                     (set_local $14
-                                      (get_local $5)
+                                      (get_local $6)
                                     )
                                     (set_local $26
                                       (get_local $16)
@@ -2462,7 +2462,7 @@
                               (br $do-once25)
                             )
                           )
-                          (set_local $5
+                          (set_local $6
                             (i32.add
                               (i32.const 480)
                               (i32.shl
@@ -2485,7 +2485,7 @@
                                           (i32.shr_u
                                             (get_local $4)
                                             (i32.add
-                                              (tee_local $5
+                                              (tee_local $6
                                                 (i32.add
                                                   (i32.sub
                                                     (i32.const 14)
@@ -2555,7 +2555,7 @@
                                           (i32.const 1)
                                         )
                                         (i32.shl
-                                          (get_local $5)
+                                          (get_local $6)
                                           (i32.const 1)
                                         )
                                       )
@@ -2609,12 +2609,12 @@
                                 )
                               )
                               (i32.store
-                                (get_local $5)
+                                (get_local $6)
                                 (get_local $7)
                               )
                               (i32.store offset=24
                                 (get_local $7)
-                                (get_local $5)
+                                (get_local $6)
                               )
                               (i32.store offset=12
                                 (get_local $7)
@@ -2648,7 +2648,7 @@
                           )
                           (set_local $0
                             (i32.load
-                              (get_local $5)
+                              (get_local $6)
                             )
                           )
                           (loop $while-in28
@@ -2667,7 +2667,7 @@
                                   (set_local $15
                                     (get_local $0)
                                   )
-                                  (set_local $6
+                                  (set_local $5
                                     (i32.const 148)
                                   )
                                   (br $while-out27)
@@ -2676,7 +2676,7 @@
                               (if
                                 (tee_local $8
                                   (i32.load
-                                    (tee_local $5
+                                    (tee_local $6
                                       (i32.add
                                         (i32.add
                                           (get_local $0)
@@ -2707,12 +2707,12 @@
                                 )
                                 (block
                                   (set_local $23
-                                    (get_local $5)
+                                    (get_local $6)
                                   )
                                   (set_local $21
                                     (get_local $0)
                                   )
-                                  (set_local $6
+                                  (set_local $5
                                     (i32.const 145)
                                   )
                                 )
@@ -2721,7 +2721,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $6)
+                              (get_local $5)
                               (i32.const 145)
                             )
                             (if
@@ -2753,7 +2753,7 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $6)
+                                (get_local $5)
                                 (i32.const 148)
                               )
                               (if
@@ -2809,12 +2809,12 @@
                         )
                         (block
                           (i32.store offset=4
-                            (get_local $11)
+                            (get_local $12)
                             (i32.or
                               (tee_local $16
                                 (i32.add
                                   (get_local $4)
-                                  (get_local $2)
+                                  (get_local $1)
                                 )
                               )
                               (i32.const 3)
@@ -2824,7 +2824,7 @@
                             (tee_local $0
                               (i32.add
                                 (i32.add
-                                  (get_local $11)
+                                  (get_local $12)
                                   (get_local $16)
                                 )
                                 (i32.const 4)
@@ -2842,18 +2842,18 @@
                     )
                     (return
                       (i32.add
-                        (get_local $11)
+                        (get_local $12)
                         (i32.const 8)
                       )
                     )
                   )
                   (set_local $8
-                    (get_local $2)
+                    (get_local $1)
                   )
                 )
               )
               (set_local $8
-                (get_local $2)
+                (get_local $1)
               )
             )
           )
@@ -2865,7 +2865,7 @@
     )
     (if
       (i32.ge_u
-        (tee_local $11
+        (tee_local $12
           (i32.load
             (i32.const 184)
           )
@@ -2882,7 +2882,7 @@
           (i32.gt_u
             (tee_local $4
               (i32.sub
-                (get_local $11)
+                (get_local $12)
                 (get_local $8)
               )
             )
@@ -2936,7 +2936,7 @@
             (i32.store offset=4
               (get_local $15)
               (i32.or
-                (get_local $11)
+                (get_local $12)
                 (i32.const 3)
               )
             )
@@ -2945,7 +2945,7 @@
                 (i32.add
                   (i32.add
                     (get_local $15)
-                    (get_local $11)
+                    (get_local $12)
                   )
                   (i32.const 4)
                 )
@@ -2988,7 +2988,7 @@
         )
         (i32.store
           (i32.const 200)
-          (tee_local $11
+          (tee_local $12
             (i32.add
               (tee_local $15
                 (i32.load
@@ -3000,7 +3000,7 @@
           )
         )
         (i32.store offset=4
-          (get_local $11)
+          (get_local $12)
           (i32.or
             (get_local $4)
             (i32.const 1)
@@ -3097,7 +3097,7 @@
                     (i32.const 656)
                   )
                 )
-                (tee_local $11
+                (tee_local $12
                   (i32.add
                     (get_local $8)
                     (i32.const 47)
@@ -3164,7 +3164,7 @@
             )
             (i32.const 0)
             (i32.eq
-              (tee_local $6
+              (tee_local $5
                 (block $label$break$L257 i32
                   (if i32
                     (i32.and
@@ -3215,10 +3215,10 @@
                                     (i32.const 0)
                                   )
                                   (block
-                                    (set_local $5
+                                    (set_local $6
                                       (get_local $14)
                                     )
-                                    (set_local $13
+                                    (set_local $11
                                       (get_local $9)
                                     )
                                     (br $while-out33)
@@ -3231,7 +3231,7 @@
                                     )
                                   )
                                 )
-                                (set_local $6
+                                (set_local $5
                                   (i32.const 173)
                                 )
                                 (br $label$break$L259)
@@ -3261,10 +3261,10 @@
                                   )
                                   (i32.add
                                     (i32.load
-                                      (get_local $5)
+                                      (get_local $6)
                                     )
                                     (i32.load
-                                      (get_local $13)
+                                      (get_local $11)
                                     )
                                   )
                                 )
@@ -3286,20 +3286,20 @@
                                   )
                                 )
                                 (block
-                                  (set_local $12
+                                  (set_local $13
                                     (get_local $9)
                                   )
                                   (set_local $18
                                     (get_local $14)
                                   )
-                                  (set_local $6
+                                  (set_local $5
                                     (i32.const 183)
                                   )
                                 )
                               )
                             )
                           )
-                          (set_local $6
+                          (set_local $5
                             (i32.const 173)
                           )
                         )
@@ -3308,7 +3308,7 @@
                         (if
                           (if i32
                             (i32.eq
-                              (get_local $6)
+                              (get_local $5)
                               (i32.const 173)
                             )
                             (i32.ne
@@ -3335,19 +3335,19 @@
                                       (i32.const -1)
                                     )
                                   )
-                                  (tee_local $2
+                                  (tee_local $1
                                     (get_local $3)
                                   )
                                 )
                                 (i32.add
                                   (i32.sub
                                     (get_local $4)
-                                    (get_local $2)
+                                    (get_local $1)
                                   )
                                   (i32.and
                                     (i32.add
                                       (get_local $9)
-                                      (get_local $2)
+                                      (get_local $1)
                                     )
                                     (i32.sub
                                       (i32.const 0)
@@ -3358,7 +3358,7 @@
                                 (get_local $4)
                               )
                             )
-                            (set_local $2
+                            (set_local $1
                               (i32.add
                                 (tee_local $14
                                   (i32.load
@@ -3384,11 +3384,11 @@
                                   (select
                                     (i32.or
                                       (i32.le_u
-                                        (get_local $2)
+                                        (get_local $1)
                                         (get_local $14)
                                       )
                                       (i32.gt_u
-                                        (get_local $2)
+                                        (get_local $1)
                                         (tee_local $9
                                           (i32.load
                                             (i32.const 616)
@@ -3424,13 +3424,13 @@
                                     )
                                   )
                                   (block
-                                    (set_local $12
+                                    (set_local $13
                                       (get_local $9)
                                     )
                                     (set_local $18
                                       (get_local $0)
                                     )
-                                    (set_local $6
+                                    (set_local $5
                                       (i32.const 183)
                                     )
                                   )
@@ -3443,7 +3443,7 @@
                       (block $label$break$L279
                         (if
                           (i32.eq
-                            (get_local $6)
+                            (get_local $5)
                             (i32.const 183)
                           )
                           (block
@@ -3466,17 +3466,17 @@
                                       (i32.const 2147483647)
                                     )
                                     (i32.ne
-                                      (get_local $12)
+                                      (get_local $13)
                                       (i32.const -1)
                                     )
                                   )
                                 )
                                 (i32.lt_u
-                                  (tee_local $2
+                                  (tee_local $1
                                     (i32.and
                                       (i32.add
                                         (i32.sub
-                                          (get_local $11)
+                                          (get_local $12)
                                           (get_local $18)
                                         )
                                         (tee_local $3
@@ -3498,7 +3498,7 @@
                               (if
                                 (i32.eq
                                   (call $_sbrk
-                                    (get_local $2)
+                                    (get_local $1)
                                   )
                                   (i32.const -1)
                                 )
@@ -3510,28 +3510,28 @@
                                   )
                                   (br $label$break$L279)
                                 )
-                                (set_local $1
+                                (set_local $2
                                   (i32.add
-                                    (get_local $2)
+                                    (get_local $1)
                                     (get_local $18)
                                   )
                                 )
                               )
-                              (set_local $1
+                              (set_local $2
                                 (get_local $18)
                               )
                             )
                             (if
                               (i32.ne
-                                (get_local $12)
+                                (get_local $13)
                                 (i32.const -1)
                               )
                               (block
                                 (set_local $20
-                                  (get_local $12)
+                                  (get_local $13)
                                 )
                                 (set_local $22
-                                  (get_local $1)
+                                  (get_local $2)
                                 )
                                 (br $label$break$L257
                                   (i32.const 193)
@@ -3560,7 +3560,7 @@
           )
           (i32.and
             (i32.lt_u
-              (tee_local $1
+              (tee_local $2
                 (call $_sbrk
                   (get_local $4)
                 )
@@ -3573,7 +3573,7 @@
             )
             (i32.and
               (i32.ne
-                (get_local $1)
+                (get_local $2)
                 (i32.const -1)
               )
               (i32.ne
@@ -3585,10 +3585,10 @@
           (i32.const 0)
         )
         (i32.gt_u
-          (tee_local $12
+          (tee_local $13
             (i32.sub
               (get_local $4)
-              (get_local $1)
+              (get_local $2)
             )
           )
           (i32.add
@@ -3600,25 +3600,25 @@
       )
       (block
         (set_local $20
-          (get_local $1)
+          (get_local $2)
         )
         (set_local $22
-          (get_local $12)
+          (get_local $13)
         )
-        (set_local $6
+        (set_local $5
           (i32.const 193)
         )
       )
     )
     (if
       (i32.eq
-        (get_local $6)
+        (get_local $5)
         (i32.const 193)
       )
       (block
         (i32.store
           (i32.const 608)
-          (tee_local $12
+          (tee_local $13
             (i32.add
               (i32.load
                 (i32.const 608)
@@ -3629,25 +3629,25 @@
         )
         (if
           (i32.gt_u
-            (get_local $12)
+            (get_local $13)
             (i32.load
               (i32.const 612)
             )
           )
           (i32.store
             (i32.const 612)
-            (get_local $12)
+            (get_local $13)
           )
         )
         (block $do-once40
           (if
-            (tee_local $12
+            (tee_local $13
               (i32.load
                 (i32.const 200)
               )
             )
             (block
-              (set_local $1
+              (set_local $2
                 (i32.const 624)
               )
               (loop $do-in
@@ -3658,14 +3658,14 @@
                       (i32.add
                         (tee_local $4
                           (i32.load
-                            (get_local $1)
+                            (get_local $2)
                           )
                         )
-                        (tee_local $11
+                        (tee_local $12
                           (i32.load
                             (tee_local $18
                               (i32.add
-                                (get_local $1)
+                                (get_local $2)
                                 (i32.const 4)
                               )
                             )
@@ -3681,12 +3681,12 @@
                         (get_local $18)
                       )
                       (set_local $48
-                        (get_local $11)
+                        (get_local $12)
                       )
                       (set_local $49
-                        (get_local $1)
+                        (get_local $2)
                       )
-                      (set_local $6
+                      (set_local $5
                         (i32.const 203)
                       )
                       (br $do-out)
@@ -3694,9 +3694,9 @@
                   )
                   (br_if $do-in
                     (i32.ne
-                      (tee_local $1
+                      (tee_local $2
                         (i32.load offset=8
-                          (get_local $1)
+                          (get_local $2)
                         )
                       )
                       (i32.const 0)
@@ -3708,11 +3708,11 @@
                 (select
                   (i32.and
                     (i32.lt_u
-                      (get_local $12)
+                      (get_local $13)
                       (get_local $20)
                     )
                     (i32.ge_u
-                      (get_local $12)
+                      (get_local $13)
                       (get_local $46)
                     )
                   )
@@ -3728,7 +3728,7 @@
                     )
                     (i32.const 0)
                     (i32.eq
-                      (get_local $6)
+                      (get_local $5)
                       (i32.const 203)
                     )
                   )
@@ -3741,17 +3741,17 @@
                       (get_local $22)
                     )
                   )
-                  (set_local $1
+                  (set_local $2
                     (i32.add
-                      (get_local $12)
-                      (tee_local $11
+                      (get_local $13)
+                      (tee_local $12
                         (select
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $1
+                              (tee_local $2
                                 (i32.add
-                                  (get_local $12)
+                                  (get_local $13)
                                   (i32.const 8)
                                 )
                               )
@@ -3760,7 +3760,7 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $1)
+                            (get_local $2)
                             (i32.const 7)
                           )
                         )
@@ -3771,7 +3771,7 @@
                     (i32.add
                       (i32.sub
                         (get_local $22)
-                        (get_local $11)
+                        (get_local $12)
                       )
                       (i32.load
                         (i32.const 188)
@@ -3780,14 +3780,14 @@
                   )
                   (i32.store
                     (i32.const 200)
-                    (get_local $1)
+                    (get_local $2)
                   )
                   (i32.store
                     (i32.const 188)
                     (get_local $18)
                   )
                   (i32.store offset=4
-                    (get_local $1)
+                    (get_local $2)
                     (i32.or
                       (get_local $18)
                       (i32.const 1)
@@ -3795,7 +3795,7 @@
                   )
                   (i32.store offset=4
                     (i32.add
-                      (get_local $1)
+                      (get_local $2)
                       (get_local $18)
                     )
                     (i32.const 40)
@@ -3835,7 +3835,7 @@
                   (get_local $22)
                 )
               )
-              (set_local $1
+              (set_local $2
                 (i32.const 624)
               )
               (loop $while-in43
@@ -3843,27 +3843,27 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $1)
+                        (get_local $2)
                       )
                       (get_local $18)
                     )
                     (block
                       (set_local $50
-                        (get_local $1)
+                        (get_local $2)
                       )
                       (set_local $40
-                        (get_local $1)
+                        (get_local $2)
                       )
-                      (set_local $6
+                      (set_local $5
                         (i32.const 211)
                       )
                       (br $while-out42)
                     )
                   )
                   (br_if $while-in43
-                    (tee_local $1
+                    (tee_local $2
                       (i32.load offset=8
-                        (get_local $1)
+                        (get_local $2)
                       )
                     )
                   )
@@ -3874,7 +3874,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $6)
+                  (get_local $5)
                   (i32.const 211)
                 )
                 (if
@@ -3893,7 +3893,7 @@
                       (get_local $20)
                     )
                     (i32.store
-                      (tee_local $1
+                      (tee_local $2
                         (i32.add
                           (get_local $40)
                           (i32.const 4)
@@ -3901,19 +3901,19 @@
                       )
                       (i32.add
                         (i32.load
-                          (get_local $1)
+                          (get_local $2)
                         )
                         (get_local $22)
                       )
                     )
-                    (set_local $11
+                    (set_local $12
                       (i32.add
                         (get_local $20)
                         (select
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $1
+                              (tee_local $2
                                 (i32.add
                                   (get_local $20)
                                   (i32.const 8)
@@ -3924,7 +3924,7 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $1)
+                            (get_local $2)
                             (i32.const 7)
                           )
                         )
@@ -3937,7 +3937,7 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $1
+                              (tee_local $2
                                 (i32.add
                                   (get_local $18)
                                   (i32.const 8)
@@ -3948,15 +3948,15 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $1)
+                            (get_local $2)
                             (i32.const 7)
                           )
                         )
                       )
                     )
-                    (set_local $1
+                    (set_local $2
                       (i32.add
-                        (get_local $11)
+                        (get_local $12)
                         (get_local $8)
                       )
                     )
@@ -3964,13 +3964,13 @@
                       (i32.sub
                         (i32.sub
                           (get_local $4)
-                          (get_local $11)
+                          (get_local $12)
                         )
                         (get_local $8)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $11)
+                      (get_local $12)
                       (i32.or
                         (get_local $8)
                         (i32.const 3)
@@ -3980,7 +3980,7 @@
                       (if
                         (i32.ne
                           (get_local $4)
-                          (get_local $12)
+                          (get_local $13)
                         )
                         (block
                           (if
@@ -4004,10 +4004,10 @@
                               )
                               (i32.store
                                 (i32.const 196)
-                                (get_local $1)
+                                (get_local $2)
                               )
                               (i32.store offset=4
-                                (get_local $1)
+                                (get_local $2)
                                 (i32.or
                                   (get_local $0)
                                   (i32.const 1)
@@ -4015,7 +4015,7 @@
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $1)
+                                  (get_local $2)
                                   (get_local $0)
                                 )
                                 (get_local $0)
@@ -4024,7 +4024,7 @@
                             )
                           )
                           (i32.store
-                            (tee_local $5
+                            (tee_local $6
                               (i32.add
                                 (if i32
                                   (i32.eq
@@ -4039,13 +4039,13 @@
                                     (i32.const 1)
                                   )
                                   (block i32
-                                    (set_local $13
+                                    (set_local $11
                                       (i32.and
                                         (get_local $0)
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $5
+                                    (set_local $6
                                       (i32.shr_u
                                         (get_local $0)
                                         (i32.const 3)
@@ -4077,7 +4077,7 @@
                                                 (if
                                                   (tee_local $3
                                                     (i32.load
-                                                      (tee_local $2
+                                                      (tee_local $1
                                                         (i32.add
                                                           (tee_local $9
                                                             (i32.add
@@ -4095,7 +4095,7 @@
                                                       (get_local $3)
                                                     )
                                                     (set_local $9
-                                                      (get_local $2)
+                                                      (get_local $1)
                                                     )
                                                   )
                                                   (if
@@ -4118,7 +4118,7 @@
                                                   (if
                                                     (tee_local $3
                                                       (i32.load
-                                                        (tee_local $2
+                                                        (tee_local $1
                                                           (i32.add
                                                             (get_local $14)
                                                             (i32.const 20)
@@ -4131,7 +4131,7 @@
                                                         (get_local $3)
                                                       )
                                                       (set_local $9
-                                                        (get_local $2)
+                                                        (get_local $1)
                                                       )
                                                       (br $while-in50)
                                                     )
@@ -4139,7 +4139,7 @@
                                                   (if
                                                     (tee_local $3
                                                       (i32.load
-                                                        (tee_local $2
+                                                        (tee_local $1
                                                           (i32.add
                                                             (get_local $14)
                                                             (i32.const 16)
@@ -4152,7 +4152,7 @@
                                                         (get_local $3)
                                                       )
                                                       (set_local $9
-                                                        (get_local $2)
+                                                        (get_local $1)
                                                       )
                                                       (br $while-in50)
                                                     )
@@ -4178,7 +4178,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (tee_local $2
+                                                    (tee_local $1
                                                       (i32.load offset=8
                                                         (get_local $4)
                                                       )
@@ -4192,7 +4192,7 @@
                                                     (i32.load
                                                       (tee_local $3
                                                         (i32.add
-                                                          (get_local $2)
+                                                          (get_local $1)
                                                           (i32.const 12)
                                                         )
                                                       )
@@ -4220,7 +4220,7 @@
                                                     )
                                                     (i32.store
                                                       (get_local $9)
-                                                      (get_local $2)
+                                                      (get_local $1)
                                                     )
                                                     (set_local $24
                                                       (get_local $21)
@@ -4241,7 +4241,7 @@
                                               (i32.ne
                                                 (get_local $4)
                                                 (i32.load
-                                                  (tee_local $2
+                                                  (tee_local $1
                                                     (i32.add
                                                       (i32.const 480)
                                                       (i32.shl
@@ -4295,7 +4295,7 @@
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $2)
+                                                  (get_local $1)
                                                   (get_local $24)
                                                 )
                                                 (br_if $do-once51
@@ -4338,7 +4338,7 @@
                                           (if
                                             (tee_local $9
                                               (i32.load
-                                                (tee_local $2
+                                                (tee_local $1
                                                   (i32.add
                                                     (get_local $4)
                                                     (i32.const 16)
@@ -4368,7 +4368,7 @@
                                             (i32.eqz
                                               (tee_local $9
                                                 (i32.load offset=4
-                                                  (get_local $2)
+                                                  (get_local $1)
                                                 )
                                               )
                                             )
@@ -4412,7 +4412,7 @@
                                                     (i32.const 216)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $5)
+                                                        (get_local $6)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4455,7 +4455,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $5)
+                                                      (get_local $6)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4487,7 +4487,7 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $2
+                                                      (tee_local $1
                                                         (i32.add
                                                           (get_local $21)
                                                           (i32.const 8)
@@ -4498,7 +4498,7 @@
                                                   )
                                                   (block
                                                     (set_local $41
-                                                      (get_local $2)
+                                                      (get_local $1)
                                                     )
                                                     (br $do-once57)
                                                   )
@@ -4520,13 +4520,13 @@
                                     )
                                     (set_local $15
                                       (i32.add
-                                        (get_local $13)
+                                        (get_local $11)
                                         (get_local $15)
                                       )
                                     )
                                     (i32.add
                                       (get_local $4)
-                                      (get_local $13)
+                                      (get_local $11)
                                     )
                                   )
                                   (get_local $4)
@@ -4536,13 +4536,13 @@
                             )
                             (i32.and
                               (i32.load
-                                (get_local $5)
+                                (get_local $6)
                               )
                               (i32.const -2)
                             )
                           )
                           (i32.store offset=4
-                            (get_local $1)
+                            (get_local $2)
                             (i32.or
                               (get_local $15)
                               (i32.const 1)
@@ -4550,12 +4550,12 @@
                           )
                           (i32.store
                             (i32.add
-                              (get_local $1)
+                              (get_local $2)
                               (get_local $15)
                             )
                             (get_local $15)
                           )
-                          (set_local $5
+                          (set_local $6
                             (i32.shr_u
                               (get_local $15)
                               (i32.const 3)
@@ -4572,7 +4572,7 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $5)
+                                      (get_local $6)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4587,10 +4587,10 @@
                                         (i32.const 176)
                                       )
                                     )
-                                    (tee_local $2
+                                    (tee_local $1
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $5)
+                                        (get_local $6)
                                       )
                                     )
                                   )
@@ -4599,7 +4599,7 @@
                                       (i32.ge_u
                                         (tee_local $3
                                           (i32.load
-                                            (tee_local $5
+                                            (tee_local $6
                                               (i32.add
                                                 (get_local $0)
                                                 (i32.const 8)
@@ -4613,7 +4613,7 @@
                                       )
                                       (block
                                         (set_local $42
-                                          (get_local $5)
+                                          (get_local $6)
                                         )
                                         (set_local $34
                                           (get_local $3)
@@ -4628,7 +4628,7 @@
                                       (i32.const 176)
                                       (i32.or
                                         (get_local $23)
-                                        (get_local $2)
+                                        (get_local $1)
                                       )
                                     )
                                     (set_local $42
@@ -4645,31 +4645,31 @@
                               )
                               (i32.store
                                 (get_local $42)
-                                (get_local $1)
+                                (get_local $2)
                               )
                               (i32.store offset=12
                                 (get_local $34)
-                                (get_local $1)
+                                (get_local $2)
                               )
                               (i32.store offset=8
-                                (get_local $1)
+                                (get_local $2)
                                 (get_local $34)
                               )
                               (i32.store offset=12
-                                (get_local $1)
+                                (get_local $2)
                                 (get_local $0)
                               )
                               (br $do-once44)
                             )
                           )
-                          (set_local $2
+                          (set_local $1
                             (i32.add
                               (i32.const 480)
                               (i32.shl
                                 (tee_local $3
                                   (block $do-once61 i32
                                     (if i32
-                                      (tee_local $2
+                                      (tee_local $1
                                         (i32.shr_u
                                           (get_local $15)
                                           (i32.const 8)
@@ -4700,14 +4700,14 @@
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (tee_local $13
+                                                                  (tee_local $11
                                                                     (i32.shl
-                                                                      (get_local $2)
+                                                                      (get_local $1)
                                                                       (tee_local $23
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $2)
+                                                                              (get_local $1)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -4726,13 +4726,13 @@
                                                           )
                                                           (get_local $23)
                                                         )
-                                                        (tee_local $13
+                                                        (tee_local $11
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $5
+                                                                (tee_local $6
                                                                   (i32.shl
-                                                                    (get_local $13)
+                                                                    (get_local $11)
                                                                     (get_local $3)
                                                                   )
                                                                 )
@@ -4747,8 +4747,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $5)
-                                                        (get_local $13)
+                                                        (get_local $6)
+                                                        (get_local $11)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4774,13 +4774,13 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $1)
+                            (get_local $2)
                             (get_local $3)
                           )
                           (i32.store offset=4
                             (tee_local $0
                               (i32.add
-                                (get_local $1)
+                                (get_local $2)
                                 (i32.const 16)
                               )
                             )
@@ -4815,20 +4815,20 @@
                                 )
                               )
                               (i32.store
-                                (get_local $2)
                                 (get_local $1)
+                                (get_local $2)
                               )
                               (i32.store offset=24
-                                (get_local $1)
                                 (get_local $2)
+                                (get_local $1)
                               )
                               (i32.store offset=12
-                                (get_local $1)
-                                (get_local $1)
+                                (get_local $2)
+                                (get_local $2)
                               )
                               (i32.store offset=8
-                                (get_local $1)
-                                (get_local $1)
+                                (get_local $2)
+                                (get_local $2)
                               )
                               (br $do-once44)
                             )
@@ -4854,7 +4854,7 @@
                           )
                           (set_local $0
                             (i32.load
-                              (get_local $2)
+                              (get_local $1)
                             )
                           )
                           (loop $while-in64
@@ -4873,16 +4873,16 @@
                                   (set_local $35
                                     (get_local $0)
                                   )
-                                  (set_local $6
+                                  (set_local $5
                                     (i32.const 281)
                                   )
                                   (br $while-out63)
                                 )
                               )
                               (if
-                                (tee_local $13
+                                (tee_local $11
                                   (i32.load
-                                    (tee_local $2
+                                    (tee_local $1
                                       (i32.add
                                         (i32.add
                                           (get_local $0)
@@ -4907,18 +4907,18 @@
                                     )
                                   )
                                   (set_local $0
-                                    (get_local $13)
+                                    (get_local $11)
                                   )
                                   (br $while-in64)
                                 )
                                 (block
                                   (set_local $43
-                                    (get_local $2)
+                                    (get_local $1)
                                   )
                                   (set_local $51
                                     (get_local $0)
                                   )
-                                  (set_local $6
+                                  (set_local $5
                                     (i32.const 278)
                                   )
                                 )
@@ -4927,7 +4927,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $6)
+                              (get_local $5)
                               (i32.const 278)
                             )
                             (if
@@ -4941,25 +4941,25 @@
                               (block
                                 (i32.store
                                   (get_local $43)
-                                  (get_local $1)
+                                  (get_local $2)
                                 )
                                 (i32.store offset=24
-                                  (get_local $1)
+                                  (get_local $2)
                                   (get_local $51)
                                 )
                                 (i32.store offset=12
-                                  (get_local $1)
-                                  (get_local $1)
+                                  (get_local $2)
+                                  (get_local $2)
                                 )
                                 (i32.store offset=8
-                                  (get_local $1)
-                                  (get_local $1)
+                                  (get_local $2)
+                                  (get_local $2)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $6)
+                                (get_local $5)
                                 (i32.const 281)
                               )
                               (if
@@ -4975,7 +4975,7 @@
                                         )
                                       )
                                     )
-                                    (tee_local $13
+                                    (tee_local $11
                                       (i32.load
                                         (i32.const 192)
                                       )
@@ -4983,28 +4983,28 @@
                                   )
                                   (i32.ge_u
                                     (get_local $35)
-                                    (get_local $13)
+                                    (get_local $11)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
                                     (get_local $14)
-                                    (get_local $1)
+                                    (get_local $2)
                                   )
                                   (i32.store
                                     (get_local $0)
-                                    (get_local $1)
+                                    (get_local $2)
                                   )
                                   (i32.store offset=8
-                                    (get_local $1)
+                                    (get_local $2)
                                     (get_local $14)
                                   )
                                   (i32.store offset=12
-                                    (get_local $1)
+                                    (get_local $2)
                                     (get_local $35)
                                   )
                                   (i32.store offset=24
-                                    (get_local $1)
+                                    (get_local $2)
                                     (i32.const 0)
                                   )
                                 )
@@ -5027,10 +5027,10 @@
                           )
                           (i32.store
                             (i32.const 200)
-                            (get_local $1)
+                            (get_local $2)
                           )
                           (i32.store offset=4
-                            (get_local $1)
+                            (get_local $2)
                             (i32.or
                               (get_local $14)
                               (i32.const 1)
@@ -5041,7 +5041,7 @@
                     )
                     (return
                       (i32.add
-                        (get_local $11)
+                        (get_local $12)
                         (i32.const 8)
                       )
                     )
@@ -5052,23 +5052,23 @@
                 (if
                   (if i32
                     (i32.le_u
-                      (tee_local $1
+                      (tee_local $2
                         (i32.load
                           (get_local $28)
                         )
                       )
-                      (get_local $12)
+                      (get_local $13)
                     )
                     (i32.gt_u
                       (tee_local $15
                         (i32.add
-                          (get_local $1)
+                          (get_local $2)
                           (i32.load offset=4
                             (get_local $28)
                           )
                         )
                       )
-                      (get_local $12)
+                      (get_local $13)
                     )
                     (i32.const 0)
                   )
@@ -5087,7 +5087,7 @@
               )
               (set_local $15
                 (i32.add
-                  (tee_local $11
+                  (tee_local $12
                     (i32.add
                       (get_local $0)
                       (i32.const -47)
@@ -5096,14 +5096,14 @@
                   (i32.const 8)
                 )
               )
-              (set_local $1
+              (set_local $2
                 (i32.add
-                  (tee_local $11
+                  (tee_local $12
                     (select
-                      (get_local $12)
-                      (tee_local $1
+                      (get_local $13)
+                      (tee_local $2
                         (i32.add
-                          (get_local $11)
+                          (get_local $12)
                           (select
                             (i32.and
                               (i32.sub
@@ -5121,10 +5121,10 @@
                         )
                       )
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $2)
                         (tee_local $15
                           (i32.add
-                            (get_local $12)
+                            (get_local $13)
                             (i32.const 16)
                           )
                         )
@@ -5198,32 +5198,32 @@
               (i32.store
                 (tee_local $14
                   (i32.add
-                    (get_local $11)
+                    (get_local $12)
                     (i32.const 4)
                   )
                 )
                 (i32.const 27)
               )
               (i32.store
-                (get_local $1)
+                (get_local $2)
                 (i32.load
                   (i32.const 624)
                 )
               )
               (i32.store offset=4
-                (get_local $1)
+                (get_local $2)
                 (i32.load
                   (i32.const 628)
                 )
               )
               (i32.store offset=8
-                (get_local $1)
+                (get_local $2)
                 (i32.load
                   (i32.const 632)
                 )
               )
               (i32.store offset=12
-                (get_local $1)
+                (get_local $2)
                 (i32.load
                   (i32.const 636)
                 )
@@ -5242,19 +5242,19 @@
               )
               (i32.store
                 (i32.const 632)
-                (get_local $1)
+                (get_local $2)
               )
-              (set_local $1
+              (set_local $2
                 (i32.add
-                  (get_local $11)
+                  (get_local $12)
                   (i32.const 24)
                 )
               )
               (loop $do-in68
                 (i32.store
-                  (tee_local $1
+                  (tee_local $2
                     (i32.add
-                      (get_local $1)
+                      (get_local $2)
                       (i32.const 4)
                     )
                   )
@@ -5263,7 +5263,7 @@
                 (br_if $do-in68
                   (i32.lt_u
                     (i32.add
-                      (get_local $1)
+                      (get_local $2)
                       (i32.const 4)
                     )
                     (get_local $0)
@@ -5272,8 +5272,8 @@
               )
               (if
                 (i32.ne
-                  (get_local $11)
                   (get_local $12)
+                  (get_local $13)
                 )
                 (block
                   (i32.store
@@ -5286,30 +5286,30 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $12)
+                    (get_local $13)
                     (i32.or
-                      (tee_local $1
+                      (tee_local $2
                         (i32.sub
-                          (get_local $11)
                           (get_local $12)
+                          (get_local $13)
                         )
                       )
                       (i32.const 1)
                     )
                   )
                   (i32.store
-                    (get_local $11)
-                    (get_local $1)
+                    (get_local $12)
+                    (get_local $2)
                   )
                   (set_local $4
                     (i32.shr_u
-                      (get_local $1)
+                      (get_local $2)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $2)
                       (i32.const 256)
                     )
                     (block
@@ -5332,7 +5332,7 @@
                               (i32.const 176)
                             )
                           )
-                          (tee_local $13
+                          (tee_local $11
                             (i32.shl
                               (i32.const 1)
                               (get_local $4)
@@ -5341,7 +5341,7 @@
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $2
+                            (tee_local $1
                               (i32.load
                                 (tee_local $4
                                   (i32.add
@@ -5361,7 +5361,7 @@
                               (get_local $4)
                             )
                             (set_local $36
-                              (get_local $2)
+                              (get_local $1)
                             )
                           )
                         )
@@ -5370,7 +5370,7 @@
                             (i32.const 176)
                             (i32.or
                               (get_local $0)
-                              (get_local $13)
+                              (get_local $11)
                             )
                           )
                           (set_local $44
@@ -5386,18 +5386,18 @@
                       )
                       (i32.store
                         (get_local $44)
-                        (get_local $12)
+                        (get_local $13)
                       )
                       (i32.store offset=12
                         (get_local $36)
-                        (get_local $12)
+                        (get_local $13)
                       )
                       (i32.store offset=8
-                        (get_local $12)
+                        (get_local $13)
                         (get_local $36)
                       )
                       (i32.store offset=12
-                        (get_local $12)
+                        (get_local $13)
                         (get_local $18)
                       )
                       (br $do-once40)
@@ -5411,20 +5411,20 @@
                           (if i32
                             (tee_local $18
                               (i32.shr_u
-                                (get_local $1)
+                                (get_local $2)
                                 (i32.const 8)
                               )
                             )
                             (if i32
                               (i32.gt_u
-                                (get_local $1)
+                                (get_local $2)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $1)
+                                    (get_local $2)
                                     (i32.add
                                       (tee_local $4
                                         (i32.add
@@ -5439,7 +5439,7 @@
                                                         (tee_local $0
                                                           (i32.shl
                                                             (get_local $18)
-                                                            (tee_local $13
+                                                            (tee_local $11
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
@@ -5460,13 +5460,13 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $13)
+                                                (get_local $11)
                                               )
                                               (tee_local $0
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (tee_local $2
+                                                      (tee_local $1
                                                         (i32.shl
                                                           (get_local $0)
                                                           (get_local $18)
@@ -5483,7 +5483,7 @@
                                           )
                                           (i32.shr_u
                                             (i32.shl
-                                              (get_local $2)
+                                              (get_local $1)
                                               (get_local $0)
                                             )
                                             (i32.const 15)
@@ -5509,11 +5509,11 @@
                     )
                   )
                   (i32.store offset=28
-                    (get_local $12)
+                    (get_local $13)
                     (get_local $3)
                   )
                   (i32.store offset=20
-                    (get_local $12)
+                    (get_local $13)
                     (i32.const 0)
                   )
                   (i32.store
@@ -5528,7 +5528,7 @@
                             (i32.const 180)
                           )
                         )
-                        (tee_local $2
+                        (tee_local $1
                           (i32.shl
                             (i32.const 1)
                             (get_local $3)
@@ -5541,31 +5541,31 @@
                         (i32.const 180)
                         (i32.or
                           (get_local $0)
-                          (get_local $2)
+                          (get_local $1)
                         )
                       )
                       (i32.store
                         (get_local $4)
-                        (get_local $12)
+                        (get_local $13)
                       )
                       (i32.store offset=24
-                        (get_local $12)
+                        (get_local $13)
                         (get_local $4)
                       )
                       (i32.store offset=12
-                        (get_local $12)
-                        (get_local $12)
+                        (get_local $13)
+                        (get_local $13)
                       )
                       (i32.store offset=8
-                        (get_local $12)
-                        (get_local $12)
+                        (get_local $13)
+                        (get_local $13)
                       )
                       (br $do-once40)
                     )
                   )
-                  (set_local $2
+                  (set_local $1
                     (i32.shl
-                      (get_local $1)
+                      (get_local $2)
                       (select
                         (i32.const 0)
                         (i32.sub
@@ -5597,20 +5597,20 @@
                             )
                             (i32.const -8)
                           )
-                          (get_local $1)
+                          (get_local $2)
                         )
                         (block
                           (set_local $37
                             (get_local $0)
                           )
-                          (set_local $6
+                          (set_local $5
                             (i32.const 307)
                           )
                           (br $while-out69)
                         )
                       )
                       (if
-                        (tee_local $13
+                        (tee_local $11
                           (i32.load
                             (tee_local $4
                               (i32.add
@@ -5620,7 +5620,7 @@
                                 )
                                 (i32.shl
                                   (i32.shr_u
-                                    (get_local $2)
+                                    (get_local $1)
                                     (i32.const 31)
                                   )
                                   (i32.const 2)
@@ -5630,14 +5630,14 @@
                           )
                         )
                         (block
-                          (set_local $2
+                          (set_local $1
                             (i32.shl
-                              (get_local $2)
+                              (get_local $1)
                               (i32.const 1)
                             )
                           )
                           (set_local $0
-                            (get_local $13)
+                            (get_local $11)
                           )
                           (br $while-in70)
                         )
@@ -5648,7 +5648,7 @@
                           (set_local $52
                             (get_local $0)
                           )
-                          (set_local $6
+                          (set_local $5
                             (i32.const 304)
                           )
                         )
@@ -5657,7 +5657,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $6)
+                      (get_local $5)
                       (i32.const 304)
                     )
                     (if
@@ -5671,31 +5671,31 @@
                       (block
                         (i32.store
                           (get_local $45)
-                          (get_local $12)
+                          (get_local $13)
                         )
                         (i32.store offset=24
-                          (get_local $12)
+                          (get_local $13)
                           (get_local $52)
                         )
                         (i32.store offset=12
-                          (get_local $12)
-                          (get_local $12)
+                          (get_local $13)
+                          (get_local $13)
                         )
                         (i32.store offset=8
-                          (get_local $12)
-                          (get_local $12)
+                          (get_local $13)
+                          (get_local $13)
                         )
                       )
                     )
                     (if
                       (i32.eq
-                        (get_local $6)
+                        (get_local $5)
                         (i32.const 307)
                       )
                       (if
                         (i32.and
                           (i32.ge_u
-                            (tee_local $2
+                            (tee_local $1
                               (i32.load
                                 (tee_local $0
                                   (i32.add
@@ -5705,7 +5705,7 @@
                                 )
                               )
                             )
-                            (tee_local $1
+                            (tee_local $2
                               (i32.load
                                 (i32.const 192)
                               )
@@ -5713,28 +5713,28 @@
                           )
                           (i32.ge_u
                             (get_local $37)
-                            (get_local $1)
+                            (get_local $2)
                           )
                         )
                         (block
                           (i32.store offset=12
-                            (get_local $2)
-                            (get_local $12)
+                            (get_local $1)
+                            (get_local $13)
                           )
                           (i32.store
                             (get_local $0)
-                            (get_local $12)
+                            (get_local $13)
                           )
                           (i32.store offset=8
-                            (get_local $12)
-                            (get_local $2)
+                            (get_local $13)
+                            (get_local $1)
                           )
                           (i32.store offset=12
-                            (get_local $12)
+                            (get_local $13)
                             (get_local $37)
                           )
                           (i32.store offset=24
-                            (get_local $12)
+                            (get_local $13)
                             (i32.const 0)
                           )
                         )
@@ -5749,7 +5749,7 @@
               (if
                 (i32.or
                   (i32.eqz
-                    (tee_local $2
+                    (tee_local $1
                       (i32.load
                         (i32.const 192)
                       )
@@ -5757,7 +5757,7 @@
                   )
                   (i32.lt_u
                     (get_local $20)
-                    (get_local $2)
+                    (get_local $1)
                   )
                 )
                 (i32.store
@@ -5787,7 +5787,7 @@
                 (i32.const 208)
                 (i32.const -1)
               )
-              (set_local $2
+              (set_local $1
                 (i32.const 0)
               )
               (loop $do-in72
@@ -5797,7 +5797,7 @@
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $2)
+                          (get_local $1)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -5812,9 +5812,9 @@
                 )
                 (br_if $do-in72
                   (i32.ne
-                    (tee_local $2
+                    (tee_local $1
                       (i32.add
-                        (get_local $2)
+                        (get_local $1)
                         (i32.const 1)
                       )
                     )
@@ -5824,7 +5824,7 @@
               )
               (i32.store
                 (i32.const 200)
-                (tee_local $2
+                (tee_local $1
                   (i32.add
                     (get_local $20)
                     (tee_local $0
@@ -5832,7 +5832,7 @@
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (tee_local $2
+                            (tee_local $1
                               (i32.add
                                 (get_local $20)
                                 (i32.const 8)
@@ -5843,7 +5843,7 @@
                         )
                         (i32.const 0)
                         (i32.and
-                          (get_local $2)
+                          (get_local $1)
                           (i32.const 7)
                         )
                       )
@@ -5853,7 +5853,7 @@
               )
               (i32.store
                 (i32.const 188)
-                (tee_local $1
+                (tee_local $2
                   (i32.sub
                     (i32.add
                       (get_local $22)
@@ -5864,16 +5864,16 @@
                 )
               )
               (i32.store offset=4
-                (get_local $2)
+                (get_local $1)
                 (i32.or
-                  (get_local $1)
+                  (get_local $2)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $2)
                   (get_local $1)
+                  (get_local $2)
                 )
                 (i32.const 40)
               )
@@ -5907,7 +5907,7 @@
             )
             (i32.store
               (i32.const 200)
-              (tee_local $12
+              (tee_local $13
                 (i32.add
                   (tee_local $22
                     (i32.load
@@ -5919,7 +5919,7 @@
               )
             )
             (i32.store offset=4
-              (get_local $12)
+              (get_local $13)
               (i32.or
                 (get_local $20)
                 (i32.const 1)
@@ -8523,16 +8523,16 @@
                     )
                   )
                 )
+                (set_local $0
+                  (get_local $2)
+                )
               )
-            )
-            (set_local $2
-              (get_local $0)
             )
           )
           (call $___unlock
             (i32.const 36)
           )
-          (get_local $2)
+          (get_local $0)
         )
       )
     )

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -661,7 +661,7 @@
           )
         )
         (block i32
-          (set_local $0
+          (set_local $1
             (if i32
               (i32.load
                 (i32.const 12)
@@ -678,7 +678,7 @@
             (i32.const 44)
           )
           (if
-            (tee_local $1
+            (tee_local $0
               (i32.load
                 (i32.const 40)
               )
@@ -688,45 +688,45 @@
                 (if i32
                   (i32.gt_s
                     (i32.load offset=76
-                      (get_local $1)
+                      (get_local $0)
                     )
                     (i32.const -1)
                   )
                   (call $___lockfile
-                    (get_local $1)
+                    (get_local $0)
                   )
                   (i32.const 0)
                 )
               )
-              (set_local $0
+              (set_local $1
                 (if i32
                   (i32.gt_u
                     (i32.load offset=20
-                      (get_local $1)
+                      (get_local $0)
                     )
                     (i32.load offset=28
-                      (get_local $1)
+                      (get_local $0)
                     )
                   )
                   (i32.or
                     (call $___fflush_unlocked
-                      (get_local $1)
+                      (get_local $0)
                     )
-                    (get_local $0)
+                    (get_local $1)
                   )
-                  (get_local $0)
+                  (get_local $1)
                 )
               )
               (if
                 (get_local $2)
                 (call $___unlockfile
-                  (get_local $1)
+                  (get_local $0)
                 )
               )
               (br_if $while-in
-                (tee_local $1
+                (tee_local $0
                   (i32.load offset=56
-                    (get_local $1)
+                    (get_local $0)
                   )
                 )
               )
@@ -735,7 +735,7 @@
           (call $___unlock
             (i32.const 44)
           )
-          (get_local $0)
+          (get_local $1)
         )
       )
     )
@@ -824,13 +824,13 @@
       (get_local $7)
     )
     (i32.store
-      (tee_local $4
+      (tee_local $3
         (i32.add
           (get_local $7)
           (i32.const 32)
         )
       )
-      (tee_local $3
+      (tee_local $5
         (i32.load
           (tee_local $6
             (i32.add
@@ -842,8 +842,8 @@
       )
     )
     (i32.store offset=4
-      (get_local $4)
-      (tee_local $3
+      (get_local $3)
+      (tee_local $4
         (i32.sub
           (i32.load
             (tee_local $10
@@ -853,16 +853,16 @@
               )
             )
           )
-          (get_local $3)
+          (get_local $5)
         )
       )
     )
     (i32.store offset=8
-      (get_local $4)
+      (get_local $3)
       (get_local $1)
     )
     (i32.store offset=12
-      (get_local $4)
+      (get_local $3)
       (get_local $2)
     )
     (set_local $13
@@ -878,14 +878,14 @@
       )
     )
     (set_local $1
-      (get_local $4)
+      (get_local $3)
     )
-    (set_local $4
+    (set_local $5
       (i32.const 2)
     )
     (set_local $11
       (i32.add
-        (get_local $3)
+        (get_local $4)
         (get_local $2)
       )
     )
@@ -897,7 +897,7 @@
               (br_if $jumpthreading$inner$0
                 (i32.eq
                   (get_local $11)
-                  (tee_local $5
+                  (tee_local $4
                     (if i32
                       (i32.load
                         (i32.const 16)
@@ -919,7 +919,7 @@
                         )
                         (i32.store offset=8
                           (get_local $9)
-                          (get_local $4)
+                          (get_local $5)
                         )
                         (set_local $3
                           (call $___syscall_ret
@@ -947,7 +947,7 @@
                         )
                         (i32.store offset=8
                           (get_local $8)
-                          (get_local $4)
+                          (get_local $5)
                         )
                         (call $___syscall_ret
                           (call $___syscall146
@@ -962,7 +962,7 @@
               )
               (br_if $jumpthreading$inner$1
                 (i32.lt_s
-                  (get_local $5)
+                  (get_local $4)
                   (i32.const 0)
                 )
               )
@@ -970,13 +970,13 @@
                 (set_local $11
                   (i32.sub
                     (get_local $11)
-                    (get_local $5)
+                    (get_local $4)
                   )
                 )
                 (set_local $1
                   (if i32
                     (i32.gt_u
-                      (get_local $5)
+                      (get_local $4)
                       (tee_local $12
                         (i32.load offset=4
                           (get_local $1)
@@ -996,9 +996,9 @@
                         (get_local $10)
                         (get_local $3)
                       )
-                      (set_local $5
+                      (set_local $4
                         (i32.sub
-                          (get_local $5)
+                          (get_local $4)
                           (get_local $12)
                         )
                       )
@@ -1008,9 +1008,9 @@
                           (i32.const 8)
                         )
                       )
-                      (set_local $4
+                      (set_local $5
                         (i32.add
-                          (get_local $4)
+                          (get_local $5)
                           (i32.const -1)
                         )
                       )
@@ -1020,7 +1020,7 @@
                     )
                     (if i32
                       (i32.eq
-                        (get_local $4)
+                        (get_local $5)
                         (i32.const 2)
                       )
                       (block i32
@@ -1030,13 +1030,13 @@
                             (i32.load
                               (get_local $6)
                             )
-                            (get_local $5)
+                            (get_local $4)
                           )
                         )
                         (set_local $3
                           (get_local $1)
                         )
-                        (set_local $4
+                        (set_local $5
                           (i32.const 2)
                         )
                         (get_local $12)
@@ -1056,14 +1056,14 @@
                     (i32.load
                       (get_local $3)
                     )
-                    (get_local $5)
+                    (get_local $4)
                   )
                 )
                 (i32.store offset=4
                   (get_local $3)
                   (i32.sub
                     (get_local $1)
-                    (get_local $5)
+                    (get_local $4)
                   )
                 )
                 (set_local $1
@@ -1130,7 +1130,7 @@
             )
           )
           (i32.eq
-            (get_local $4)
+            (get_local $5)
             (i32.const 2)
           )
         )
@@ -1176,7 +1176,7 @@
         (i32.const 120)
       )
     )
-    (set_local $8
+    (set_local $7
       (get_local $3)
     )
     (set_local $6
@@ -1185,10 +1185,10 @@
         (i32.const 136)
       )
     )
-    (set_local $7
+    (set_local $9
       (i32.add
         (tee_local $4
-          (tee_local $9
+          (tee_local $8
             (i32.add
               (get_local $3)
               (i32.const 80)
@@ -1211,7 +1211,7 @@
               (i32.const 4)
             )
           )
-          (get_local $7)
+          (get_local $9)
         )
       )
     )
@@ -1228,14 +1228,14 @@
             (i32.const 0)
             (get_local $1)
             (get_local $5)
+            (get_local $7)
             (get_local $8)
-            (get_local $9)
           )
           (i32.const 0)
         )
         (i32.const -1)
         (block i32
-          (set_local $12
+          (set_local $14
             (if i32
               (i32.gt_s
                 (i32.load offset=76
@@ -1274,7 +1274,7 @@
               )
             )
           )
-          (set_local $2
+          (set_local $1
             (select
               (i32.const -1)
               (if i32
@@ -1290,13 +1290,13 @@
                   (get_local $0)
                   (get_local $1)
                   (get_local $5)
+                  (get_local $7)
                   (get_local $8)
-                  (get_local $9)
                 )
                 (block i32
-                  (set_local $2
+                  (set_local $12
                     (i32.load
-                      (tee_local $7
+                      (tee_local $11
                         (i32.add
                           (get_local $0)
                           (i32.const 44)
@@ -1305,11 +1305,11 @@
                     )
                   )
                   (i32.store
-                    (get_local $7)
+                    (get_local $11)
                     (get_local $6)
                   )
                   (i32.store
-                    (tee_local $13
+                    (tee_local $9
                       (i32.add
                         (get_local $0)
                         (i32.const 28)
@@ -1318,7 +1318,7 @@
                     (get_local $6)
                   )
                   (i32.store
-                    (tee_local $11
+                    (tee_local $13
                       (i32.add
                         (get_local $0)
                         (i32.const 20)
@@ -1331,7 +1331,7 @@
                     (i32.const 80)
                   )
                   (i32.store
-                    (tee_local $14
+                    (tee_local $2
                       (i32.add
                         (get_local $0)
                         (i32.const 16)
@@ -1347,12 +1347,12 @@
                       (get_local $0)
                       (get_local $1)
                       (get_local $5)
+                      (get_local $7)
                       (get_local $8)
-                      (get_local $9)
                     )
                   )
                   (if i32
-                    (get_local $2)
+                    (get_local $12)
                     (block i32
                       (drop
                         (call_indirect $FUNCSIG$iiii
@@ -1375,28 +1375,28 @@
                           (get_local $1)
                           (i32.const -1)
                           (i32.load
-                            (get_local $11)
+                            (get_local $13)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $7)
-                        (get_local $2)
+                        (get_local $11)
+                        (get_local $12)
                       )
                       (i32.store
                         (get_local $10)
                         (i32.const 0)
                       )
                       (i32.store
-                        (get_local $14)
+                        (get_local $2)
+                        (i32.const 0)
+                      )
+                      (i32.store
+                        (get_local $9)
                         (i32.const 0)
                       )
                       (i32.store
                         (get_local $13)
-                        (i32.const 0)
-                      )
-                      (i32.store
-                        (get_local $11)
                         (i32.const 0)
                       )
                       (get_local $1)
@@ -1406,7 +1406,7 @@
                 )
               )
               (i32.and
-                (tee_local $1
+                (tee_local $2
                   (i32.load
                     (get_local $0)
                   )
@@ -1418,17 +1418,17 @@
           (i32.store
             (get_local $0)
             (i32.or
-              (get_local $1)
+              (get_local $2)
               (get_local $4)
             )
           )
           (if
-            (get_local $12)
+            (get_local $14)
             (call $___unlockfile
               (get_local $0)
             )
           )
-          (get_local $2)
+          (get_local $1)
         )
       )
     )
@@ -2309,8 +2309,8 @@
     (local $18 i32)
     (local $19 i32)
     (local $20 i32)
-    (local $21 i32)
-    (local $22 f64)
+    (local $21 f64)
+    (local $22 i32)
     (local $23 i32)
     (local $24 i32)
     (local $25 i32)
@@ -2344,7 +2344,7 @@
     (local $53 i32)
     (local $54 i32)
     (local $55 i32)
-    (set_local $27
+    (set_local $25
       (get_global $STACKTOP)
     )
     (set_global $STACKTOP
@@ -2362,20 +2362,20 @@
     )
     (set_local $20
       (i32.add
-        (get_local $27)
+        (get_local $25)
         (i32.const 16)
       )
     )
-    (set_local $18
-      (get_local $27)
+    (set_local $17
+      (get_local $25)
     )
-    (set_local $41
+    (set_local $40
       (i32.add
-        (get_local $27)
+        (get_local $25)
         (i32.const 528)
       )
     )
-    (set_local $33
+    (set_local $32
       (i32.ne
         (get_local $0)
         (i32.const 0)
@@ -2384,9 +2384,9 @@
     (set_local $45
       (tee_local $23
         (i32.add
-          (tee_local $13
+          (tee_local $19
             (i32.add
-              (get_local $27)
+              (get_local $25)
               (i32.const 536)
             )
           )
@@ -2396,7 +2396,7 @@
     )
     (set_local $46
       (i32.add
-        (get_local $13)
+        (get_local $19)
         (i32.const 39)
       )
     )
@@ -2404,7 +2404,7 @@
       (i32.add
         (tee_local $47
           (i32.add
-            (get_local $27)
+            (get_local $25)
             (i32.const 8)
           )
         )
@@ -2413,9 +2413,9 @@
     )
     (set_local $37
       (i32.add
-        (tee_local $13
+        (tee_local $19
           (i32.add
-            (get_local $27)
+            (get_local $25)
             (i32.const 576)
           )
         )
@@ -2424,19 +2424,19 @@
     )
     (set_local $48
       (i32.add
-        (get_local $13)
+        (get_local $19)
         (i32.const 11)
       )
     )
     (set_local $51
       (i32.sub
-        (tee_local $32
+        (tee_local $30
           (get_local $37)
         )
-        (tee_local $42
+        (tee_local $41
           (tee_local $24
             (i32.add
-              (get_local $27)
+              (get_local $25)
               (i32.const 588)
             )
           )
@@ -2446,12 +2446,12 @@
     (set_local $52
       (i32.sub
         (i32.const -2)
-        (get_local $42)
+        (get_local $41)
       )
     )
     (set_local $53
       (i32.add
-        (get_local $32)
+        (get_local $30)
         (i32.const 2)
       )
     )
@@ -2459,7 +2459,7 @@
       (i32.add
         (tee_local $54
           (i32.add
-            (get_local $27)
+            (get_local $25)
             (i32.const 24)
           )
         )
@@ -2467,7 +2467,7 @@
       )
     )
     (set_local $49
-      (tee_local $34
+      (tee_local $33
         (i32.add
           (get_local $24)
           (i32.const 9)
@@ -2486,7 +2486,7 @@
     (set_local $5
       (i32.const 0)
     )
-    (set_local $13
+    (set_local $19
       (i32.const 0)
     )
     (block $label$break$L343
@@ -2526,7 +2526,7 @@
               (i32.eqz
                 (i32.shr_s
                   (i32.shl
-                    (tee_local $5
+                    (tee_local $6
                       (i32.load8_s
                         (get_local $1)
                       )
@@ -2537,13 +2537,8 @@
                 )
               )
             )
-            (block
-              (set_local $6
-                (get_local $5)
-              )
-              (set_local $5
-                (get_local $1)
-              )
+            (set_local $5
+              (get_local $1)
             )
             (loop $label$continue$L9
               (block $label$break$L9
@@ -2566,18 +2561,18 @@
                     (set_local $39
                       (get_local $5)
                     )
-                    (set_local $43
+                    (set_local $42
                       (get_local $5)
                     )
-                    (set_local $28
+                    (set_local $26
                       (i32.const 9)
                     )
                     (br $label$break$L9)
                   )
-                  (set_local $29
+                  (set_local $27
                     (get_local $5)
                   )
-                  (set_local $35
+                  (set_local $34
                     (get_local $5)
                   )
                   (br $label$break$L9)
@@ -2598,11 +2593,11 @@
             (block $label$break$L12
               (if
                 (i32.eq
-                  (get_local $28)
+                  (get_local $26)
                   (i32.const 9)
                 )
                 (loop $while-in
-                  (set_local $28
+                  (set_local $26
                     (i32.const 0)
                   )
                   (if
@@ -2613,25 +2608,25 @@
                       (i32.const 37)
                     )
                     (block
-                      (set_local $29
+                      (set_local $27
                         (get_local $39)
                       )
-                      (set_local $35
-                        (get_local $43)
+                      (set_local $34
+                        (get_local $42)
                       )
                       (br $label$break$L12)
                     )
                   )
-                  (set_local $35
+                  (set_local $34
                     (i32.add
-                      (get_local $43)
+                      (get_local $42)
                       (i32.const 1)
                     )
                   )
                   (if
                     (i32.eq
                       (i32.load8_s
-                        (tee_local $29
+                        (tee_local $27
                           (i32.add
                             (get_local $39)
                             (i32.const 2)
@@ -2642,10 +2637,10 @@
                     )
                     (block
                       (set_local $39
-                        (get_local $29)
+                        (get_local $27)
                       )
-                      (set_local $43
-                        (get_local $35)
+                      (set_local $42
+                        (get_local $34)
                       )
                       (br $while-in)
                     )
@@ -2655,12 +2650,12 @@
             )
             (set_local $6
               (i32.sub
-                (get_local $35)
+                (get_local $34)
                 (get_local $1)
               )
             )
             (if
-              (get_local $33)
+              (get_local $32)
               (if
                 (i32.eqz
                   (i32.and
@@ -2681,12 +2676,12 @@
             )
             (if
               (i32.ne
-                (get_local $35)
+                (get_local $34)
                 (get_local $1)
               )
               (block
                 (set_local $1
-                  (get_local $29)
+                  (get_local $27)
                 )
                 (set_local $5
                   (get_local $6)
@@ -2694,18 +2689,18 @@
                 (br $label$continue$L1)
               )
             )
-            (set_local $21
+            (set_local $18
               (if i32
                 (i32.lt_u
-                  (tee_local $9
+                  (tee_local $8
                     (i32.add
                       (i32.shr_s
                         (i32.shl
-                          (tee_local $5
+                          (tee_local $7
                             (i32.load8_s
-                              (tee_local $10
+                              (tee_local $5
                                 (i32.add
-                                  (get_local $29)
+                                  (get_local $27)
                                   (i32.const 1)
                                 )
                               )
@@ -2721,19 +2716,19 @@
                   (i32.const 10)
                 )
                 (block i32
-                  (set_local $5
+                  (set_local $7
                     (i32.load8_s
-                      (tee_local $10
+                      (tee_local $5
                         (select
                           (i32.add
-                            (get_local $29)
+                            (get_local $27)
                             (i32.const 3)
                           )
-                          (get_local $10)
-                          (tee_local $8
+                          (get_local $5)
+                          (tee_local $11
                             (i32.eq
                               (i32.load8_s offset=2
-                                (get_local $29)
+                                (get_local $27)
                               )
                               (i32.const 36)
                             )
@@ -2742,35 +2737,30 @@
                       )
                     )
                   )
-                  (set_local $7
+                  (set_local $19
                     (select
                       (i32.const 1)
-                      (get_local $13)
-                      (get_local $8)
+                      (get_local $19)
+                      (get_local $11)
                     )
                   )
                   (select
-                    (get_local $9)
-                    (i32.const -1)
                     (get_local $8)
+                    (i32.const -1)
+                    (get_local $11)
                   )
                 )
-                (block i32
-                  (set_local $7
-                    (get_local $13)
-                  )
-                  (i32.const -1)
-                )
+                (i32.const -1)
               )
             )
             (block $label$break$L25
               (if
                 (i32.eq
                   (i32.and
-                    (tee_local $8
+                    (tee_local $11
                       (i32.shr_s
                         (i32.shl
-                          (get_local $5)
+                          (get_local $7)
                           (i32.const 24)
                         )
                         (i32.const 24)
@@ -2781,12 +2771,6 @@
                   (i32.const 32)
                 )
                 (block
-                  (set_local $13
-                    (get_local $5)
-                  )
-                  (set_local $5
-                    (get_local $8)
-                  )
                   (set_local $8
                     (i32.const 0)
                   )
@@ -2797,7 +2781,7 @@
                           (i32.shl
                             (i32.const 1)
                             (i32.add
-                              (get_local $5)
+                              (get_local $11)
                               (i32.const -32)
                             )
                           )
@@ -2805,7 +2789,10 @@
                         )
                       )
                       (block
-                        (set_local $5
+                        (set_local $11
+                          (get_local $7)
+                        )
+                        (set_local $7
                           (get_local $8)
                         )
                         (br $label$break$L25)
@@ -2818,7 +2805,7 @@
                           (i32.add
                             (i32.shr_s
                               (i32.shl
-                                (get_local $13)
+                                (get_local $7)
                                 (i32.const 24)
                               )
                               (i32.const 24)
@@ -2832,14 +2819,14 @@
                     (br_if $while-in4
                       (i32.eq
                         (i32.and
-                          (tee_local $5
+                          (tee_local $11
                             (i32.shr_s
                               (i32.shl
-                                (tee_local $13
+                                (tee_local $7
                                   (i32.load8_s
-                                    (tee_local $10
+                                    (tee_local $5
                                       (i32.add
-                                        (get_local $10)
+                                        (get_local $5)
                                         (i32.const 1)
                                       )
                                     )
@@ -2855,16 +2842,21 @@
                         (i32.const 32)
                       )
                     )
-                    (set_local $5
-                      (get_local $8)
+                    (block
+                      (set_local $11
+                        (get_local $7)
+                      )
+                      (set_local $7
+                        (get_local $8)
+                      )
                     )
                   )
                 )
                 (block
-                  (set_local $13
-                    (get_local $5)
+                  (set_local $11
+                    (get_local $7)
                   )
-                  (set_local $5
+                  (set_local $7
                     (i32.const 0)
                   )
                 )
@@ -2875,7 +2867,7 @@
                 (i32.eq
                   (i32.shr_s
                     (i32.shl
-                      (get_local $13)
+                      (get_local $11)
                       (i32.const 24)
                     )
                     (i32.const 24)
@@ -2883,17 +2875,17 @@
                   (i32.const 42)
                 )
                 (block
-                  (set_local $13
+                  (set_local $19
                     (block $jumpthreading$outer$0 i32
                       (block $jumpthreading$inner$0
                         (br_if $jumpthreading$inner$0
                           (i32.ge_u
-                            (tee_local $8
+                            (tee_local $11
                               (i32.add
                                 (i32.load8_s
-                                  (tee_local $13
+                                  (tee_local $8
                                     (i32.add
-                                      (get_local $10)
+                                      (get_local $5)
                                       (i32.const 1)
                                     )
                                   )
@@ -2907,7 +2899,7 @@
                         (br_if $jumpthreading$inner$0
                           (i32.ne
                             (i32.load8_s offset=2
-                              (get_local $10)
+                              (get_local $5)
                             )
                             (i32.const 36)
                           )
@@ -2916,19 +2908,19 @@
                           (i32.add
                             (get_local $4)
                             (i32.shl
-                              (get_local $8)
+                              (get_local $11)
                               (i32.const 2)
                             )
                           )
                           (i32.const 10)
                         )
-                        (set_local $13
+                        (set_local $19
                           (i32.add
                             (get_local $3)
                             (i32.shl
                               (i32.add
                                 (i32.load8_s
-                                  (get_local $13)
+                                  (get_local $8)
                                 )
                                 (i32.const -48)
                               )
@@ -2936,26 +2928,26 @@
                             )
                           )
                         )
-                        (set_local $10
+                        (set_local $5
                           (i32.add
-                            (get_local $10)
+                            (get_local $5)
                             (i32.const 3)
                           )
                         )
-                        (set_local $7
+                        (set_local $13
                           (i32.load
-                            (get_local $13)
+                            (get_local $19)
                           )
                         )
                         (br $jumpthreading$outer$0
                           (i32.const 1)
                         )
                       )
-                      (set_local $28
+                      (set_local $26
                         (i32.const 0)
                       )
                       (if
-                        (get_local $7)
+                        (get_local $19)
                         (block
                           (set_local $15
                             (i32.const -1)
@@ -2965,27 +2957,27 @@
                       )
                       (if
                         (i32.eqz
-                          (get_local $33)
+                          (get_local $32)
                         )
                         (block
-                          (set_local $8
-                            (get_local $5)
+                          (set_local $11
+                            (get_local $7)
                           )
-                          (set_local $10
-                            (get_local $13)
+                          (set_local $5
+                            (get_local $8)
                           )
-                          (set_local $13
+                          (set_local $19
                             (i32.const 0)
                           )
-                          (set_local $17
+                          (set_local $13
                             (i32.const 0)
                           )
                           (br $do-once5)
                         )
                       )
-                      (set_local $7
+                      (set_local $13
                         (i32.load
-                          (tee_local $10
+                          (tee_local $19
                             (i32.and
                               (i32.add
                                 (i32.load
@@ -3001,50 +2993,45 @@
                       (i32.store
                         (get_local $2)
                         (i32.add
-                          (get_local $10)
+                          (get_local $19)
                           (i32.const 4)
                         )
                       )
-                      (set_local $10
-                        (get_local $13)
+                      (set_local $5
+                        (get_local $8)
                       )
                       (i32.const 0)
                     )
                   )
-                  (set_local $8
+                  (set_local $11
                     (if i32
                       (i32.lt_s
-                        (get_local $7)
+                        (get_local $13)
                         (i32.const 0)
                       )
                       (block i32
-                        (set_local $17
+                        (set_local $13
                           (i32.sub
                             (i32.const 0)
-                            (get_local $7)
+                            (get_local $13)
                           )
                         )
                         (i32.or
-                          (get_local $5)
+                          (get_local $7)
                           (i32.const 8192)
                         )
                       )
-                      (block i32
-                        (set_local $17
-                          (get_local $7)
-                        )
-                        (get_local $5)
-                      )
+                      (get_local $7)
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (tee_local $13
+                    (tee_local $11
                       (i32.add
                         (i32.shr_s
                           (i32.shl
-                            (get_local $13)
+                            (get_local $11)
                             (i32.const 24)
                           )
                           (i32.const 24)
@@ -3059,13 +3046,13 @@
                       (i32.const 0)
                     )
                     (loop $while-in8
-                      (set_local $13
+                      (set_local $11
                         (i32.add
                           (i32.mul
                             (get_local $8)
                             (i32.const 10)
                           )
-                          (get_local $13)
+                          (get_local $11)
                         )
                       )
                       (if
@@ -3073,9 +3060,9 @@
                           (tee_local $9
                             (i32.add
                               (i32.load8_s
-                                (tee_local $10
+                                (tee_local $5
                                   (i32.add
-                                    (get_local $10)
+                                    (get_local $5)
                                     (i32.const 1)
                                   )
                                 )
@@ -3087,21 +3074,21 @@
                         )
                         (block
                           (set_local $8
-                            (get_local $13)
+                            (get_local $11)
                           )
-                          (set_local $13
+                          (set_local $11
                             (get_local $9)
                           )
                           (br $while-in8)
                         )
-                        (set_local $9
-                          (get_local $13)
+                        (set_local $13
+                          (get_local $11)
                         )
                       )
                     )
                     (if
                       (i32.lt_s
-                        (get_local $9)
+                        (get_local $13)
                         (i32.const 0)
                       )
                       (block
@@ -3110,39 +3097,28 @@
                         )
                         (br $label$break$L1)
                       )
-                      (block
-                        (set_local $8
-                          (get_local $5)
-                        )
-                        (set_local $13
-                          (get_local $7)
-                        )
-                        (set_local $17
-                          (get_local $9)
-                        )
+                      (set_local $11
+                        (get_local $7)
                       )
                     )
                   )
                   (block
-                    (set_local $8
-                      (get_local $5)
-                    )
-                    (set_local $13
+                    (set_local $11
                       (get_local $7)
                     )
-                    (set_local $17
+                    (set_local $13
                       (i32.const 0)
                     )
                   )
                 )
               )
             )
-            (set_local $9
+            (set_local $8
               (block $label$break$L46 i32
                 (if i32
                   (i32.eq
                     (i32.load8_s
-                      (get_local $10)
+                      (get_local $5)
                     )
                     (i32.const 46)
                   )
@@ -3153,9 +3129,9 @@
                           (i32.shl
                             (tee_local $7
                               (i32.load8_s
-                                (tee_local $5
+                                (tee_local $8
                                   (i32.add
-                                    (get_local $10)
+                                    (get_local $5)
                                     (i32.const 1)
                                   )
                                 )
@@ -3184,15 +3160,20 @@
                             )
                             (i32.const 10)
                           )
-                          (set_local $10
-                            (i32.const 0)
+                          (block
+                            (set_local $5
+                              (get_local $8)
+                            )
+                            (set_local $8
+                              (i32.const 0)
+                            )
                           )
                           (block
                             (set_local $7
                               (i32.const 0)
                             )
                             (br $label$break$L46
-                              (get_local $5)
+                              (get_local $8)
                             )
                           )
                         )
@@ -3200,7 +3181,7 @@
                           (set_local $7
                             (i32.add
                               (i32.mul
-                                (get_local $10)
+                                (get_local $8)
                                 (i32.const 10)
                               )
                               (get_local $7)
@@ -3224,7 +3205,7 @@
                               (i32.const 10)
                             )
                             (block
-                              (set_local $10
+                              (set_local $8
                                 (get_local $7)
                               )
                               (set_local $7
@@ -3241,12 +3222,12 @@
                     )
                     (if
                       (i32.lt_u
-                        (tee_local $5
+                        (tee_local $7
                           (i32.add
                             (i32.load8_s
-                              (tee_local $9
+                              (tee_local $8
                                 (i32.add
-                                  (get_local $10)
+                                  (get_local $5)
                                   (i32.const 2)
                                 )
                               )
@@ -3259,7 +3240,7 @@
                       (if
                         (i32.eq
                           (i32.load8_s offset=3
-                            (get_local $10)
+                            (get_local $5)
                           )
                           (i32.const 36)
                         )
@@ -3268,19 +3249,19 @@
                             (i32.add
                               (get_local $4)
                               (i32.shl
-                                (get_local $5)
+                                (get_local $7)
                                 (i32.const 2)
                               )
                             )
                             (i32.const 10)
                           )
-                          (set_local $5
+                          (set_local $7
                             (i32.add
                               (get_local $3)
                               (i32.shl
                                 (i32.add
                                   (i32.load8_s
-                                    (get_local $9)
+                                    (get_local $8)
                                   )
                                   (i32.const -48)
                                 )
@@ -3290,12 +3271,12 @@
                           )
                           (set_local $7
                             (i32.load
-                              (get_local $5)
+                              (get_local $7)
                             )
                           )
                           (br $label$break$L46
                             (i32.add
-                              (get_local $10)
+                              (get_local $5)
                               (i32.const 4)
                             )
                           )
@@ -3303,7 +3284,7 @@
                       )
                     )
                     (if
-                      (get_local $13)
+                      (get_local $19)
                       (block
                         (set_local $15
                           (i32.const -1)
@@ -3312,7 +3293,7 @@
                       )
                     )
                     (if i32
-                      (get_local $33)
+                      (get_local $32)
                       (block i32
                         (set_local $7
                           (i32.load
@@ -3336,13 +3317,13 @@
                             (i32.const 4)
                           )
                         )
-                        (get_local $9)
+                        (get_local $8)
                       )
                       (block i32
                         (set_local $7
                           (i32.const 0)
                         )
-                        (get_local $9)
+                        (get_local $8)
                       )
                     )
                   )
@@ -3350,21 +3331,21 @@
                     (set_local $7
                       (i32.const -1)
                     )
-                    (get_local $10)
+                    (get_local $5)
                   )
                 )
               )
             )
-            (set_local $11
+            (set_local $9
               (i32.const 0)
             )
             (loop $while-in13
               (if
                 (i32.gt_u
-                  (tee_local $5
+                  (tee_local $10
                     (i32.add
                       (i32.load8_s
-                        (get_local $9)
+                        (get_local $8)
                       )
                       (i32.const -65)
                     )
@@ -3378,16 +3359,16 @@
                   (br $label$break$L1)
                 )
               )
-              (set_local $10
+              (set_local $5
                 (i32.add
-                  (get_local $9)
+                  (get_local $8)
                   (i32.const 1)
                 )
               )
               (if
                 (i32.lt_u
                   (i32.add
-                    (tee_local $5
+                    (tee_local $10
                       (i32.and
                         (tee_local $12
                           (i32.load8_s
@@ -3395,11 +3376,11 @@
                               (i32.add
                                 (i32.const 3611)
                                 (i32.mul
-                                  (get_local $11)
+                                  (get_local $9)
                                   (i32.const 58)
                                 )
                               )
-                              (get_local $5)
+                              (get_local $10)
                             )
                           )
                         )
@@ -3411,24 +3392,16 @@
                   (i32.const 8)
                 )
                 (block
+                  (set_local $8
+                    (get_local $5)
+                  )
                   (set_local $9
                     (get_local $10)
                   )
-                  (set_local $11
-                    (get_local $5)
-                  )
                   (br $while-in13)
                 )
-                (block
-                  (set_local $16
-                    (get_local $5)
-                  )
-                  (set_local $5
-                    (get_local $10)
-                  )
-                  (set_local $19
-                    (get_local $9)
-                  )
+                (set_local $16
+                  (get_local $8)
                 )
               )
             )
@@ -3449,9 +3422,9 @@
                 (br $label$break$L1)
               )
             )
-            (set_local $10
+            (set_local $8
               (i32.gt_s
-                (get_local $21)
+                (get_local $18)
                 (i32.const -1)
               )
             )
@@ -3469,7 +3442,7 @@
                     (i32.const 19)
                   )
                   (if
-                    (get_local $10)
+                    (get_local $8)
                     (block
                       (set_local $15
                         (i32.const -1)
@@ -3480,25 +3453,25 @@
                   )
                   (block
                     (if
-                      (get_local $10)
+                      (get_local $8)
                       (block
                         (i32.store
                           (i32.add
                             (get_local $4)
                             (i32.shl
-                              (get_local $21)
+                              (get_local $18)
                               (i32.const 2)
                             )
                           )
-                          (get_local $16)
+                          (get_local $10)
                         )
                         (set_local $12
                           (i32.load offset=4
-                            (tee_local $9
+                            (tee_local $10
                               (i32.add
                                 (get_local $3)
                                 (i32.shl
-                                  (get_local $21)
+                                  (get_local $18)
                                   (i32.const 3)
                                 )
                               )
@@ -3506,15 +3479,15 @@
                           )
                         )
                         (i32.store
-                          (tee_local $10
-                            (get_local $18)
+                          (tee_local $8
+                            (get_local $17)
                           )
                           (i32.load
-                            (get_local $9)
+                            (get_local $10)
                           )
                         )
                         (i32.store offset=4
-                          (get_local $10)
+                          (get_local $8)
                           (get_local $12)
                         )
                         (br $jumpthreading$inner$1)
@@ -3522,7 +3495,7 @@
                     )
                     (if
                       (i32.eqz
-                        (get_local $33)
+                        (get_local $32)
                       )
                       (block
                         (set_local $15
@@ -3532,20 +3505,20 @@
                       )
                     )
                     (call $_pop_arg_336
-                      (get_local $18)
-                      (get_local $16)
+                      (get_local $17)
+                      (get_local $10)
                       (get_local $2)
                     )
                   )
                 )
                 (br $jumpthreading$outer$1)
               )
-              (set_local $28
+              (set_local $26
                 (i32.const 0)
               )
               (if
                 (i32.eqz
-                  (get_local $33)
+                  (get_local $32)
                 )
                 (block
                   (set_local $1
@@ -3558,17 +3531,17 @@
                 )
               )
             )
-            (set_local $10
+            (set_local $11
               (select
-                (tee_local $9
+                (tee_local $8
                   (i32.and
-                    (get_local $8)
+                    (get_local $11)
                     (i32.const -65537)
                   )
                 )
-                (get_local $8)
+                (get_local $11)
                 (i32.and
-                  (get_local $8)
+                  (get_local $11)
                   (i32.const 8192)
                 )
               )
@@ -3595,25 +3568,25 @@
                                                   (block $switch-case27
                                                     (br_table $switch-case42 $switch-default120 $switch-case40 $switch-default120 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case29 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case42 $switch-default120 $switch-case37 $switch-case34 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-case34 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case29 $switch-default120
                                                       (i32.sub
-                                                        (tee_local $16
+                                                        (tee_local $12
                                                           (select
                                                             (i32.and
-                                                              (tee_local $8
+                                                              (tee_local $10
                                                                 (i32.load8_s
-                                                                  (get_local $19)
+                                                                  (get_local $16)
                                                                 )
                                                               )
                                                               (i32.const -33)
                                                             )
-                                                            (get_local $8)
+                                                            (get_local $10)
                                                             (i32.and
                                                               (i32.ne
-                                                                (get_local $11)
+                                                                (get_local $9)
                                                                 (i32.const 0)
                                                               )
                                                               (i32.eq
                                                                 (i32.and
-                                                                  (get_local $8)
+                                                                  (get_local $10)
                                                                   (i32.const 15)
                                                                 )
                                                                 (i32.const 3)
@@ -3635,14 +3608,14 @@
                                                                 (block $switch-case19
                                                                   (br_table $switch-case19 $switch-case20 $switch-case21 $switch-case22 $switch-case23 $switch-default26 $switch-case24 $switch-case25 $switch-default26
                                                                     (i32.sub
-                                                                      (get_local $11)
+                                                                      (get_local $9)
                                                                       (i32.const 0)
                                                                     )
                                                                   )
                                                                 )
                                                                 (i32.store
                                                                   (i32.load
-                                                                    (get_local $18)
+                                                                    (get_local $17)
                                                                   )
                                                                   (get_local $15)
                                                                 )
@@ -3656,7 +3629,7 @@
                                                               )
                                                               (i32.store
                                                                 (i32.load
-                                                                  (get_local $18)
+                                                                  (get_local $17)
                                                                 )
                                                                 (get_local $15)
                                                               )
@@ -3671,7 +3644,7 @@
                                                             (i32.store
                                                               (tee_local $1
                                                                 (i32.load
-                                                                  (get_local $18)
+                                                                  (get_local $17)
                                                                 )
                                                               )
                                                               (get_local $15)
@@ -3699,7 +3672,7 @@
                                                           )
                                                           (i32.store16
                                                             (i32.load
-                                                              (get_local $18)
+                                                              (get_local $17)
                                                             )
                                                             (get_local $15)
                                                           )
@@ -3713,7 +3686,7 @@
                                                         )
                                                         (i32.store8
                                                           (i32.load
-                                                            (get_local $18)
+                                                            (get_local $17)
                                                           )
                                                           (get_local $15)
                                                         )
@@ -3727,7 +3700,7 @@
                                                       )
                                                       (i32.store
                                                         (i32.load
-                                                          (get_local $18)
+                                                          (get_local $17)
                                                         )
                                                         (get_local $15)
                                                       )
@@ -3742,7 +3715,7 @@
                                                     (i32.store
                                                       (tee_local $1
                                                         (i32.load
-                                                          (get_local $18)
+                                                          (get_local $17)
                                                         )
                                                       )
                                                       (get_local $15)
@@ -3778,7 +3751,7 @@
                                                 )
                                                 (set_local $1
                                                   (i32.or
-                                                    (get_local $10)
+                                                    (get_local $11)
                                                     (i32.const 8)
                                                   )
                                                 )
@@ -3792,13 +3765,13 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $16
+                                                (set_local $12
                                                   (i32.const 120)
                                                 )
                                                 (br $jumpthreading$inner$2)
                                               )
                                               (set_local $1
-                                                (get_local $10)
+                                                (get_local $11)
                                               )
                                               (br $jumpthreading$inner$2)
                                             )
@@ -3808,7 +3781,7 @@
                                                   (tee_local $6
                                                     (i32.load
                                                       (tee_local $1
-                                                        (get_local $18)
+                                                        (get_local $17)
                                                       )
                                                     )
                                                   )
@@ -3875,7 +3848,7 @@
                                             )
                                             (if
                                               (i32.and
-                                                (get_local $10)
+                                                (get_local $11)
                                                 (i32.const 8)
                                               )
                                               (block
@@ -3883,11 +3856,11 @@
                                                   (get_local $8)
                                                 )
                                                 (set_local $1
-                                                  (get_local $10)
+                                                  (get_local $11)
                                                 )
                                                 (set_local $7
                                                   (select
-                                                    (tee_local $10
+                                                    (tee_local $11
                                                       (i32.add
                                                         (i32.sub
                                                           (get_local $45)
@@ -3899,7 +3872,7 @@
                                                     (get_local $7)
                                                     (i32.lt_s
                                                       (get_local $7)
-                                                      (get_local $10)
+                                                      (get_local $11)
                                                     )
                                                   )
                                                 )
@@ -3916,7 +3889,7 @@
                                                   (get_local $8)
                                                 )
                                                 (set_local $1
-                                                  (get_local $10)
+                                                  (get_local $11)
                                                 )
                                                 (set_local $8
                                                   (i32.const 0)
@@ -3931,7 +3904,7 @@
                                           (set_local $1
                                             (i32.load
                                               (tee_local $6
-                                                (get_local $18)
+                                                (get_local $17)
                                               )
                                             )
                                           )
@@ -3947,7 +3920,7 @@
                                             (block
                                               (i32.store
                                                 (tee_local $8
-                                                  (get_local $18)
+                                                  (get_local $17)
                                                 )
                                                 (tee_local $1
                                                   (call $_i64Subtract
@@ -3975,7 +3948,7 @@
                                           )
                                           (if
                                             (i32.and
-                                              (get_local $10)
+                                              (get_local $11)
                                               (i32.const 2048)
                                             )
                                             (block
@@ -3991,7 +3964,7 @@
                                               (set_local $8
                                                 (tee_local $9
                                                   (i32.and
-                                                    (get_local $10)
+                                                    (get_local $11)
                                                     (i32.const 1)
                                                   )
                                                 )
@@ -4010,7 +3983,7 @@
                                         (set_local $1
                                           (i32.load
                                             (tee_local $6
-                                              (get_local $18)
+                                              (get_local $17)
                                             )
                                           )
                                         )
@@ -4028,7 +4001,7 @@
                                         (br $jumpthreading$inner$3)
                                       )
                                       (set_local $1
-                                        (get_local $18)
+                                        (get_local $17)
                                       )
                                       (i32.store8
                                         (get_local $46)
@@ -4039,10 +4012,10 @@
                                       (set_local $6
                                         (get_local $46)
                                       )
-                                      (set_local $10
-                                        (get_local $9)
-                                      )
                                       (set_local $11
+                                        (get_local $8)
+                                      )
+                                      (set_local $10
                                         (i32.const 1)
                                       )
                                       (set_local $8
@@ -4069,7 +4042,7 @@
                                     (select
                                       (tee_local $1
                                         (i32.load
-                                          (get_local $18)
+                                          (get_local $17)
                                         )
                                       )
                                       (i32.const 4101)
@@ -4082,7 +4055,7 @@
                                   (br $jumpthreading$inner$4)
                                 )
                                 (set_local $1
-                                  (get_local $18)
+                                  (get_local $17)
                                 )
                                 (i32.store
                                   (get_local $47)
@@ -4095,40 +4068,34 @@
                                   (i32.const 0)
                                 )
                                 (i32.store
-                                  (get_local $18)
+                                  (get_local $17)
                                   (get_local $47)
                                 )
-                                (set_local $8
+                                (set_local $7
                                   (i32.const -1)
                                 )
                                 (br $jumpthreading$inner$5)
                               )
-                              (if
+                              (br_if $jumpthreading$inner$5
                                 (get_local $7)
-                                (block
-                                  (set_local $8
-                                    (get_local $7)
-                                  )
-                                  (br $jumpthreading$inner$5)
+                              )
+                              (block
+                                (call $_pad
+                                  (get_local $0)
+                                  (i32.const 32)
+                                  (get_local $13)
+                                  (i32.const 0)
+                                  (get_local $11)
                                 )
-                                (block
-                                  (call $_pad
-                                    (get_local $0)
-                                    (i32.const 32)
-                                    (get_local $17)
-                                    (i32.const 0)
-                                    (get_local $10)
-                                  )
-                                  (set_local $6
-                                    (i32.const 0)
-                                  )
-                                  (br $jumpthreading$inner$6)
+                                (set_local $6
+                                  (i32.const 0)
                                 )
+                                (br $jumpthreading$inner$6)
                               )
                             )
                             (set_local $14
                               (f64.load
-                                (get_local $18)
+                                (get_local $17)
                               )
                             )
                             (i32.store
@@ -4139,7 +4106,7 @@
                               (get_global $tempDoublePtr)
                               (get_local $14)
                             )
-                            (set_local $36
+                            (set_local $35
                               (if i32
                                 (i32.lt_s
                                   (i32.load offset=4
@@ -4148,7 +4115,7 @@
                                   (i32.const 0)
                                 )
                                 (block i32
-                                  (set_local $30
+                                  (set_local $28
                                     (i32.const 1)
                                   )
                                   (set_local $14
@@ -4160,20 +4127,20 @@
                                 )
                                 (if i32
                                   (i32.and
-                                    (get_local $10)
+                                    (get_local $11)
                                     (i32.const 2048)
                                   )
                                   (block i32
-                                    (set_local $30
+                                    (set_local $28
                                       (i32.const 1)
                                     )
                                     (i32.const 4111)
                                   )
                                   (block i32
-                                    (set_local $30
+                                    (set_local $28
                                       (tee_local $1
                                         (i32.and
-                                          (get_local $10)
+                                          (get_local $11)
                                           (i32.const 1)
                                         )
                                       )
@@ -4221,7 +4188,7 @@
                                     (if
                                       (tee_local $5
                                         (f64.ne
-                                          (tee_local $22
+                                          (tee_local $21
                                             (f64.mul
                                               (call $_frexpl
                                                 (get_local $14)
@@ -4245,33 +4212,33 @@
                                     )
                                     (if
                                       (i32.eq
-                                        (tee_local $25
+                                        (tee_local $16
                                           (i32.or
-                                            (get_local $16)
+                                            (get_local $12)
                                             (i32.const 32)
                                           )
                                         )
                                         (i32.const 97)
                                       )
                                       (block
-                                        (set_local $19
+                                        (set_local $9
                                           (select
                                             (i32.add
-                                              (get_local $36)
+                                              (get_local $35)
                                               (i32.const 9)
                                             )
-                                            (get_local $36)
-                                            (tee_local $9
+                                            (get_local $35)
+                                            (tee_local $16
                                               (i32.and
-                                                (get_local $16)
+                                                (get_local $12)
                                                 (i32.const 32)
                                               )
                                             )
                                           )
                                         )
-                                        (set_local $8
+                                        (set_local $10
                                           (i32.or
-                                            (get_local $30)
+                                            (get_local $28)
                                             (i32.const 2)
                                           )
                                         )
@@ -4291,7 +4258,7 @@
                                                 )
                                               )
                                             )
-                                            (get_local $22)
+                                            (get_local $21)
                                             (block f64
                                               (set_local $14
                                                 (f64.const 8)
@@ -4318,7 +4285,7 @@
                                                     (get_local $14)
                                                     (f64.sub
                                                       (f64.neg
-                                                        (get_local $22)
+                                                        (get_local $21)
                                                       )
                                                       (get_local $14)
                                                     )
@@ -4326,14 +4293,14 @@
                                                 )
                                                 (f64.sub
                                                   (f64.add
-                                                    (get_local $22)
+                                                    (get_local $21)
                                                     (get_local $14)
                                                   )
                                                   (get_local $14)
                                                 )
                                                 (i32.eq
                                                   (i32.load8_s
-                                                    (get_local $19)
+                                                    (get_local $9)
                                                   )
                                                   (i32.const 45)
                                                 )
@@ -4404,14 +4371,14 @@
                                           )
                                         )
                                         (i32.store8
-                                          (tee_local $11
+                                          (tee_local $6
                                             (i32.add
                                               (get_local $6)
                                               (i32.const -2)
                                             )
                                           )
                                           (i32.add
-                                            (get_local $16)
+                                            (get_local $12)
                                             (i32.const 15)
                                           )
                                         )
@@ -4421,10 +4388,10 @@
                                             (i32.const 1)
                                           )
                                         )
-                                        (set_local $16
+                                        (set_local $18
                                           (i32.eqz
                                             (i32.and
-                                              (get_local $10)
+                                              (get_local $11)
                                               (i32.const 8)
                                             )
                                           )
@@ -4438,7 +4405,7 @@
                                             (i32.or
                                               (i32.load8_u
                                                 (i32.add
-                                                  (tee_local $6
+                                                  (tee_local $8
                                                     (call $f64-to-int
                                                       (get_local $14)
                                                     )
@@ -4446,7 +4413,7 @@
                                                   (i32.const 4075)
                                                 )
                                               )
-                                              (get_local $9)
+                                              (get_local $16)
                                             )
                                           )
                                           (set_local $14
@@ -4454,7 +4421,7 @@
                                               (f64.sub
                                                 (get_local $14)
                                                 (f64.convert_s/i32
-                                                  (get_local $6)
+                                                  (get_local $8)
                                                 )
                                               )
                                               (f64.const 16)
@@ -4465,22 +4432,22 @@
                                               (if i32
                                                 (i32.eq
                                                   (i32.sub
-                                                    (tee_local $6
+                                                    (tee_local $8
                                                       (i32.add
                                                         (get_local $5)
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (get_local $42)
+                                                    (get_local $41)
                                                   )
                                                   (i32.const 1)
                                                 )
                                                 (block i32
                                                   (drop
                                                     (br_if $do-once57
-                                                      (get_local $6)
+                                                      (get_local $8)
                                                       (i32.and
-                                                        (get_local $16)
+                                                        (get_local $18)
                                                         (i32.and
                                                           (get_local $12)
                                                           (f64.eq
@@ -4492,7 +4459,7 @@
                                                     )
                                                   )
                                                   (i32.store8
-                                                    (get_local $6)
+                                                    (get_local $8)
                                                     (i32.const 46)
                                                   )
                                                   (i32.add
@@ -4500,7 +4467,7 @@
                                                     (i32.const 2)
                                                   )
                                                 )
-                                                (get_local $6)
+                                                (get_local $8)
                                               )
                                             )
                                           )
@@ -4514,22 +4481,22 @@
                                         (call $_pad
                                           (get_local $0)
                                           (i32.const 32)
-                                          (get_local $17)
-                                          (tee_local $6
+                                          (get_local $13)
+                                          (tee_local $7
                                             (i32.add
-                                              (tee_local $7
+                                              (tee_local $8
                                                 (select
                                                   (i32.sub
                                                     (i32.add
                                                       (get_local $53)
                                                       (get_local $7)
                                                     )
-                                                    (get_local $11)
+                                                    (get_local $6)
                                                   )
                                                   (i32.add
                                                     (i32.sub
                                                       (get_local $51)
-                                                      (get_local $11)
+                                                      (get_local $6)
                                                     )
                                                     (get_local $5)
                                                   )
@@ -4548,10 +4515,10 @@
                                                   )
                                                 )
                                               )
-                                              (get_local $8)
+                                              (get_local $10)
                                             )
                                           )
-                                          (get_local $10)
+                                          (get_local $11)
                                         )
                                         (if
                                           (i32.eqz
@@ -4564,8 +4531,8 @@
                                           )
                                           (drop
                                             (call $___fwritex
-                                              (get_local $19)
-                                              (get_local $8)
+                                              (get_local $9)
+                                              (get_local $10)
                                               (get_local $0)
                                             )
                                           )
@@ -4573,17 +4540,17 @@
                                         (call $_pad
                                           (get_local $0)
                                           (i32.const 48)
-                                          (get_local $17)
-                                          (get_local $6)
+                                          (get_local $13)
+                                          (get_local $7)
                                           (i32.xor
-                                            (get_local $10)
+                                            (get_local $11)
                                             (i32.const 65536)
                                           )
                                         )
                                         (set_local $5
                                           (i32.sub
                                             (get_local $5)
-                                            (get_local $42)
+                                            (get_local $41)
                                           )
                                         )
                                         (if
@@ -4607,13 +4574,13 @@
                                           (get_local $0)
                                           (i32.const 48)
                                           (i32.sub
-                                            (get_local $7)
+                                            (get_local $8)
                                             (i32.add
                                               (get_local $5)
                                               (tee_local $5
                                                 (i32.sub
-                                                  (get_local $32)
-                                                  (get_local $11)
+                                                  (get_local $30)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -4632,7 +4599,7 @@
                                           )
                                           (drop
                                             (call $___fwritex
-                                              (get_local $11)
+                                              (get_local $6)
                                               (get_local $5)
                                               (get_local $0)
                                             )
@@ -4641,26 +4608,26 @@
                                         (call $_pad
                                           (get_local $0)
                                           (i32.const 32)
-                                          (get_local $17)
-                                          (get_local $6)
+                                          (get_local $13)
+                                          (get_local $7)
                                           (i32.xor
-                                            (get_local $10)
+                                            (get_local $11)
                                             (i32.const 8192)
                                           )
                                         )
                                         (br $do-once49
                                           (select
-                                            (get_local $17)
-                                            (get_local $6)
+                                            (get_local $13)
+                                            (get_local $7)
                                             (i32.lt_s
-                                              (get_local $6)
-                                              (get_local $17)
+                                              (get_local $7)
+                                              (get_local $13)
                                             )
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $19
+                                    (set_local $18
                                       (select
                                         (i32.const 6)
                                         (get_local $7)
@@ -4670,7 +4637,7 @@
                                         )
                                       )
                                     )
-                                    (set_local $40
+                                    (set_local $31
                                       (tee_local $8
                                         (select
                                           (get_local $54)
@@ -4692,7 +4659,7 @@
                                                 )
                                                 (set_local $14
                                                   (f64.mul
-                                                    (get_local $22)
+                                                    (get_local $21)
                                                     (f64.const 268435456)
                                                   )
                                                 )
@@ -4700,7 +4667,7 @@
                                               )
                                               (block i32
                                                 (set_local $14
-                                                  (get_local $22)
+                                                  (get_local $21)
                                                 )
                                                 (i32.load
                                                   (get_local $20)
@@ -4712,21 +4679,21 @@
                                         )
                                       )
                                     )
-                                    (set_local $6
+                                    (set_local $5
                                       (get_local $8)
                                     )
                                     (loop $while-in60
                                       (i32.store
-                                        (get_local $6)
-                                        (tee_local $5
+                                        (get_local $5)
+                                        (tee_local $6
                                           (call $f64-to-int
                                             (get_local $14)
                                           )
                                         )
                                       )
-                                      (set_local $6
+                                      (set_local $5
                                         (i32.add
-                                          (get_local $6)
+                                          (get_local $5)
                                           (i32.const 4)
                                         )
                                       )
@@ -4737,7 +4704,7 @@
                                               (f64.sub
                                                 (get_local $14)
                                                 (f64.convert_u/i32
-                                                  (get_local $5)
+                                                  (get_local $6)
                                                 )
                                               )
                                               (f64.const 1e9)
@@ -4757,11 +4724,11 @@
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $9
+                                        (set_local $6
                                           (get_local $8)
                                         )
                                         (loop $while-in62
-                                          (set_local $21
+                                          (set_local $10
                                             (select
                                               (i32.const 29)
                                               (get_local $7)
@@ -4771,41 +4738,41 @@
                                               )
                                             )
                                           )
-                                          (set_local $9
+                                          (set_local $6
                                             (block $do-once63 i32
                                               (if i32
                                                 (i32.lt_u
                                                   (tee_local $7
                                                     (i32.add
-                                                      (get_local $6)
+                                                      (get_local $5)
                                                       (i32.const -4)
                                                     )
                                                   )
-                                                  (get_local $9)
+                                                  (get_local $6)
                                                 )
-                                                (get_local $9)
+                                                (get_local $6)
                                                 (block i32
-                                                  (set_local $5
+                                                  (set_local $9
                                                     (i32.const 0)
                                                   )
                                                   (loop $while-in66
-                                                    (set_local $12
+                                                    (set_local $29
                                                       (call $___uremdi3
-                                                        (tee_local $5
+                                                        (tee_local $9
                                                           (call $_i64Add
                                                             (call $_bitshift64Shl
                                                               (i32.load
                                                                 (get_local $7)
                                                               )
                                                               (i32.const 0)
-                                                              (get_local $21)
+                                                              (get_local $10)
                                                             )
                                                             (get_global $tempRet0)
-                                                            (get_local $5)
+                                                            (get_local $9)
                                                             (i32.const 0)
                                                           )
                                                         )
-                                                        (tee_local $11
+                                                        (tee_local $22
                                                           (get_global $tempRet0)
                                                         )
                                                         (i32.const 1000000000)
@@ -4814,12 +4781,12 @@
                                                     )
                                                     (i32.store
                                                       (get_local $7)
-                                                      (get_local $12)
+                                                      (get_local $29)
                                                     )
-                                                    (set_local $5
+                                                    (set_local $9
                                                       (call $___udivdi3
-                                                        (get_local $5)
-                                                        (get_local $11)
+                                                        (get_local $9)
+                                                        (get_local $22)
                                                         (i32.const 1000000000)
                                                         (i32.const 0)
                                                       )
@@ -4832,64 +4799,54 @@
                                                             (i32.const -4)
                                                           )
                                                         )
-                                                        (get_local $9)
+                                                        (get_local $6)
                                                       )
                                                     )
                                                   )
                                                   (drop
                                                     (br_if $do-once63
-                                                      (get_local $9)
+                                                      (get_local $6)
                                                       (i32.eqz
-                                                        (get_local $5)
+                                                        (get_local $9)
                                                       )
                                                     )
                                                   )
                                                   (i32.store
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.add
-                                                        (get_local $9)
+                                                        (get_local $6)
                                                         (i32.const -4)
                                                       )
                                                     )
-                                                    (get_local $5)
+                                                    (get_local $9)
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
                                           )
-                                          (set_local $5
-                                            (get_local $6)
-                                          )
                                           (loop $while-in68
                                             (block $while-out67
-                                              (if
+                                              (br_if $while-out67
                                                 (i32.le_u
                                                   (get_local $5)
-                                                  (get_local $9)
-                                                )
-                                                (block
-                                                  (set_local $6
-                                                    (get_local $5)
-                                                  )
-                                                  (br $while-out67)
+                                                  (get_local $6)
                                                 )
                                               )
                                               (if
-                                                (i32.load
-                                                  (tee_local $6
-                                                    (i32.add
-                                                      (get_local $5)
-                                                      (i32.const -4)
+                                                (i32.eqz
+                                                  (i32.load
+                                                    (tee_local $7
+                                                      (i32.add
+                                                        (get_local $5)
+                                                        (i32.const -4)
+                                                      )
                                                     )
                                                   )
                                                 )
-                                                (set_local $6
-                                                  (get_local $5)
-                                                )
                                                 (block
                                                   (set_local $5
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (br $while-in68)
                                                 )
@@ -4903,7 +4860,7 @@
                                                 (i32.load
                                                   (get_local $20)
                                                 )
-                                                (get_local $21)
+                                                (get_local $10)
                                               )
                                             )
                                           )
@@ -4913,26 +4870,39 @@
                                               (i32.const 0)
                                             )
                                           )
-                                          (set_local $5
-                                            (get_local $9)
+                                          (block
+                                            (set_local $9
+                                              (get_local $7)
+                                            )
+                                            (set_local $7
+                                              (get_local $5)
+                                            )
                                           )
                                         )
                                       )
-                                      (set_local $5
-                                        (get_local $8)
+                                      (block
+                                        (set_local $9
+                                          (get_local $7)
+                                        )
+                                        (set_local $6
+                                          (get_local $8)
+                                        )
+                                        (set_local $7
+                                          (get_local $5)
+                                        )
                                       )
                                     )
                                     (if
                                       (i32.lt_s
-                                        (get_local $7)
+                                        (get_local $9)
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $12
+                                        (set_local $22
                                           (i32.add
                                             (call $i32s-div
                                               (i32.add
-                                                (get_local $19)
+                                                (get_local $18)
                                                 (i32.const 25)
                                               )
                                               (i32.const 9)
@@ -4940,20 +4910,23 @@
                                             (i32.const 1)
                                           )
                                         )
-                                        (set_local $21
+                                        (set_local $29
                                           (i32.eq
-                                            (get_local $25)
+                                            (get_local $16)
                                             (i32.const 102)
                                           )
                                         )
+                                        (set_local $5
+                                          (get_local $7)
+                                        )
                                         (loop $while-in70
-                                          (set_local $26
+                                          (set_local $10
                                             (select
                                               (i32.const 9)
                                               (tee_local $7
                                                 (i32.sub
                                                   (i32.const 0)
-                                                  (get_local $7)
+                                                  (get_local $9)
                                                 )
                                               )
                                               (i32.gt_s
@@ -4962,52 +4935,52 @@
                                               )
                                             )
                                           )
-                                          (set_local $6
+                                          (set_local $7
                                             (select
                                               (i32.add
                                                 (tee_local $7
                                                   (select
                                                     (get_local $8)
-                                                    (tee_local $5
+                                                    (tee_local $6
                                                       (block $do-once71 i32
                                                         (if i32
                                                           (i32.lt_u
-                                                            (get_local $5)
                                                             (get_local $6)
+                                                            (get_local $5)
                                                           )
                                                           (block i32
-                                                            (set_local $44
+                                                            (set_local $43
                                                               (i32.add
                                                                 (i32.shl
                                                                   (i32.const 1)
-                                                                  (get_local $26)
+                                                                  (get_local $10)
                                                                 )
                                                                 (i32.const -1)
                                                               )
                                                             )
-                                                            (set_local $31
+                                                            (set_local $36
                                                               (i32.shr_u
                                                                 (i32.const 1000000000)
-                                                                (get_local $26)
+                                                                (get_local $10)
                                                               )
                                                             )
                                                             (set_local $9
                                                               (i32.const 0)
                                                             )
                                                             (set_local $7
-                                                              (get_local $5)
+                                                              (get_local $6)
                                                             )
                                                             (loop $while-in74
                                                               (i32.store
                                                                 (get_local $7)
                                                                 (i32.add
                                                                   (i32.shr_u
-                                                                    (tee_local $11
+                                                                    (tee_local $44
                                                                       (i32.load
                                                                         (get_local $7)
                                                                       )
                                                                     )
-                                                                    (get_local $26)
+                                                                    (get_local $10)
                                                                   )
                                                                   (get_local $9)
                                                                 )
@@ -5015,10 +4988,10 @@
                                                               (set_local $9
                                                                 (i32.mul
                                                                   (i32.and
-                                                                    (get_local $11)
                                                                     (get_local $44)
+                                                                    (get_local $43)
                                                                   )
-                                                                  (get_local $31)
+                                                                  (get_local $36)
                                                                 )
                                                               )
                                                               (br_if $while-in74
@@ -5029,100 +5002,116 @@
                                                                       (i32.const 4)
                                                                     )
                                                                   )
-                                                                  (get_local $6)
+                                                                  (get_local $5)
                                                                 )
                                                               )
                                                             )
-                                                            (set_local $5
+                                                            (set_local $6
                                                               (select
-                                                                (get_local $5)
+                                                                (get_local $6)
                                                                 (i32.add
-                                                                  (get_local $5)
+                                                                  (get_local $6)
                                                                   (i32.const 4)
                                                                 )
                                                                 (i32.load
-                                                                  (get_local $5)
+                                                                  (get_local $6)
                                                                 )
                                                               )
                                                             )
                                                             (drop
                                                               (br_if $do-once71
-                                                                (get_local $5)
+                                                                (get_local $6)
                                                                 (i32.eqz
                                                                   (get_local $9)
                                                                 )
                                                               )
                                                             )
                                                             (i32.store
-                                                              (get_local $6)
+                                                              (get_local $5)
                                                               (get_local $9)
                                                             )
-                                                            (set_local $6
+                                                            (set_local $5
                                                               (i32.add
-                                                                (get_local $6)
+                                                                (get_local $5)
                                                                 (i32.const 4)
                                                               )
                                                             )
-                                                            (get_local $5)
+                                                            (get_local $6)
                                                           )
                                                           (select
-                                                            (get_local $5)
+                                                            (get_local $6)
                                                             (i32.add
-                                                              (get_local $5)
+                                                              (get_local $6)
                                                               (i32.const 4)
                                                             )
                                                             (i32.load
-                                                              (get_local $5)
+                                                              (get_local $6)
                                                             )
                                                           )
                                                         )
                                                       )
                                                     )
-                                                    (get_local $21)
+                                                    (get_local $29)
                                                   )
                                                 )
                                                 (i32.shl
-                                                  (get_local $12)
+                                                  (get_local $22)
                                                   (i32.const 2)
                                                 )
                                               )
-                                              (get_local $6)
+                                              (get_local $5)
                                               (i32.gt_s
                                                 (i32.shr_s
                                                   (i32.sub
-                                                    (get_local $6)
+                                                    (get_local $5)
                                                     (get_local $7)
                                                   )
                                                   (i32.const 2)
                                                 )
-                                                (get_local $12)
+                                                (get_local $22)
                                               )
                                             )
                                           )
                                           (i32.store
                                             (get_local $20)
-                                            (tee_local $7
+                                            (tee_local $9
                                               (i32.add
                                                 (i32.load
                                                   (get_local $20)
                                                 )
-                                                (get_local $26)
+                                                (get_local $10)
                                               )
                                             )
                                           )
-                                          (br_if $while-in70
+                                          (if
                                             (i32.lt_s
-                                              (get_local $7)
+                                              (get_local $9)
                                               (i32.const 0)
                                             )
-                                          )
-                                          (set_local $9
-                                            (get_local $6)
+                                            (block
+                                              (set_local $5
+                                                (get_local $7)
+                                              )
+                                              (br $while-in70)
+                                            )
+                                            (block
+                                              (set_local $5
+                                                (get_local $6)
+                                              )
+                                              (set_local $9
+                                                (get_local $7)
+                                              )
+                                            )
                                           )
                                         )
                                       )
-                                      (set_local $9
-                                        (get_local $6)
+                                      (block
+                                        (set_local $5
+                                          (get_local $6)
+                                        )
+                                        (set_local $9
+                                          (get_local $7)
+                                        )
                                       )
                                     )
                                     (block $do-once75
@@ -5136,7 +5125,7 @@
                                             (i32.mul
                                               (i32.shr_s
                                                 (i32.sub
-                                                  (get_local $40)
+                                                  (get_local $31)
                                                   (get_local $5)
                                                 )
                                                 (i32.const 2)
@@ -5146,7 +5135,7 @@
                                           )
                                           (br_if $do-once75
                                             (i32.lt_u
-                                              (tee_local $11
+                                              (tee_local $10
                                                 (i32.load
                                                   (get_local $5)
                                                 )
@@ -5166,7 +5155,7 @@
                                             )
                                             (br_if $while-in78
                                               (i32.ge_u
-                                                (get_local $11)
+                                                (get_local $10)
                                                 (tee_local $7
                                                   (i32.mul
                                                     (get_local $7)
@@ -5182,18 +5171,18 @@
                                         )
                                       )
                                     )
-                                    (set_local $12
+                                    (set_local $16
                                       (if i32
                                         (i32.lt_s
                                           (tee_local $7
                                             (i32.add
                                               (i32.sub
-                                                (get_local $19)
+                                                (get_local $18)
                                                 (select
                                                   (get_local $6)
                                                   (i32.const 0)
                                                   (i32.ne
-                                                    (get_local $25)
+                                                    (get_local $16)
                                                     (i32.const 102)
                                                   )
                                                 )
@@ -5201,15 +5190,15 @@
                                               (i32.shr_s
                                                 (i32.shl
                                                   (i32.and
-                                                    (tee_local $44
+                                                    (tee_local $29
                                                       (i32.ne
-                                                        (get_local $19)
+                                                        (get_local $18)
                                                         (i32.const 0)
                                                       )
                                                     )
-                                                    (tee_local $21
+                                                    (tee_local $43
                                                       (i32.eq
-                                                        (get_local $25)
+                                                        (get_local $16)
                                                         (i32.const 103)
                                                       )
                                                     )
@@ -5225,7 +5214,7 @@
                                               (i32.shr_s
                                                 (i32.sub
                                                   (get_local $9)
-                                                  (get_local $40)
+                                                  (get_local $31)
                                                 )
                                                 (i32.const 2)
                                               )
@@ -5244,7 +5233,7 @@
                                               (i32.shl
                                                 (i32.add
                                                   (call $i32s-div
-                                                    (tee_local $11
+                                                    (tee_local $10
                                                       (i32.add
                                                         (get_local $7)
                                                         (i32.const 9216)
@@ -5260,10 +5249,10 @@
                                           )
                                           (if
                                             (i32.lt_s
-                                              (tee_local $11
+                                              (tee_local $10
                                                 (i32.add
                                                   (call $i32s-rem
-                                                    (get_local $11)
+                                                    (get_local $10)
                                                     (i32.const 9)
                                                   )
                                                   (i32.const 1)
@@ -5272,21 +5261,21 @@
                                               (i32.const 9)
                                             )
                                             (block
-                                              (set_local $12
+                                              (set_local $16
                                                 (i32.const 10)
                                               )
                                               (loop $while-in80
-                                                (set_local $12
+                                                (set_local $16
                                                   (i32.mul
-                                                    (get_local $12)
+                                                    (get_local $16)
                                                     (i32.const 10)
                                                   )
                                                 )
                                                 (br_if $while-in80
                                                   (i32.ne
-                                                    (tee_local $11
+                                                    (tee_local $10
                                                       (i32.add
-                                                        (get_local $11)
+                                                        (get_local $10)
                                                         (i32.const 1)
                                                       )
                                                     )
@@ -5295,7 +5284,7 @@
                                                 )
                                               )
                                             )
-                                            (set_local $12
+                                            (set_local $16
                                               (i32.const 10)
                                             )
                                           )
@@ -5303,7 +5292,7 @@
                                             (if
                                               (i32.eqz
                                                 (i32.and
-                                                  (tee_local $26
+                                                  (tee_local $36
                                                     (i32.eq
                                                       (i32.add
                                                         (get_local $7)
@@ -5313,28 +5302,28 @@
                                                     )
                                                   )
                                                   (i32.eqz
-                                                    (tee_local $31
+                                                    (tee_local $10
                                                       (call $i32u-rem
-                                                        (tee_local $11
+                                                        (tee_local $22
                                                           (i32.load
                                                             (get_local $7)
                                                           )
                                                         )
-                                                        (get_local $12)
+                                                        (get_local $16)
                                                       )
                                                     )
                                                   )
                                                 )
                                               )
                                               (block
-                                                (set_local $22
+                                                (set_local $21
                                                   (select
                                                     (f64.const 9007199254740994)
                                                     (f64.const 9007199254740992)
                                                     (i32.and
                                                       (call $i32u-div
-                                                        (get_local $11)
-                                                        (get_local $12)
+                                                        (get_local $22)
+                                                        (get_local $16)
                                                       )
                                                       (i32.const 1)
                                                     )
@@ -5343,10 +5332,10 @@
                                                 (set_local $14
                                                   (if f64
                                                     (i32.lt_u
-                                                      (get_local $31)
-                                                      (tee_local $25
+                                                      (get_local $10)
+                                                      (tee_local $44
                                                         (call $i32s-div
-                                                          (get_local $12)
+                                                          (get_local $16)
                                                           (i32.const 2)
                                                         )
                                                       )
@@ -5356,26 +5345,26 @@
                                                       (f64.const 1)
                                                       (f64.const 1.5)
                                                       (i32.and
-                                                        (get_local $26)
+                                                        (get_local $36)
                                                         (i32.eq
-                                                          (get_local $31)
-                                                          (get_local $25)
+                                                          (get_local $10)
+                                                          (get_local $44)
                                                         )
                                                       )
                                                     )
                                                   )
                                                 )
-                                                (set_local $22
+                                                (set_local $21
                                                   (block $do-once83 f64
                                                     (if f64
-                                                      (get_local $30)
+                                                      (get_local $28)
                                                       (block f64
                                                         (drop
                                                           (br_if $do-once83
-                                                            (get_local $22)
+                                                            (get_local $21)
                                                             (i32.ne
                                                               (i32.load8_s
-                                                                (get_local $36)
+                                                                (get_local $35)
                                                               )
                                                               (i32.const 45)
                                                             )
@@ -5387,37 +5376,37 @@
                                                           )
                                                         )
                                                         (f64.neg
-                                                          (get_local $22)
+                                                          (get_local $21)
                                                         )
                                                       )
-                                                      (get_local $22)
+                                                      (get_local $21)
                                                     )
                                                   )
                                                 )
                                                 (i32.store
                                                   (get_local $7)
-                                                  (tee_local $11
+                                                  (tee_local $10
                                                     (i32.sub
-                                                      (get_local $11)
-                                                      (get_local $31)
+                                                      (get_local $22)
+                                                      (get_local $10)
                                                     )
                                                   )
                                                 )
                                                 (br_if $do-once81
                                                   (f64.eq
                                                     (f64.add
-                                                      (get_local $22)
+                                                      (get_local $21)
                                                       (get_local $14)
                                                     )
-                                                    (get_local $22)
+                                                    (get_local $21)
                                                   )
                                                 )
                                                 (i32.store
                                                   (get_local $7)
                                                   (tee_local $6
                                                     (i32.add
-                                                      (get_local $11)
-                                                      (get_local $12)
+                                                      (get_local $10)
+                                                      (get_local $16)
                                                     )
                                                   )
                                                 )
@@ -5480,7 +5469,7 @@
                                                   (i32.mul
                                                     (i32.shr_s
                                                       (i32.sub
-                                                        (get_local $40)
+                                                        (get_local $31)
                                                         (get_local $5)
                                                       )
                                                       (i32.const 2)
@@ -5490,7 +5479,7 @@
                                                 )
                                                 (br_if $do-once81
                                                   (i32.lt_u
-                                                    (tee_local $12
+                                                    (tee_local $16
                                                       (i32.load
                                                         (get_local $5)
                                                       )
@@ -5498,7 +5487,7 @@
                                                     (i32.const 10)
                                                   )
                                                 )
-                                                (set_local $11
+                                                (set_local $10
                                                   (i32.const 10)
                                                 )
                                                 (loop $while-in88
@@ -5510,10 +5499,10 @@
                                                   )
                                                   (br_if $while-in88
                                                     (i32.ge_u
-                                                      (get_local $12)
-                                                      (tee_local $11
+                                                      (get_local $16)
+                                                      (tee_local $10
                                                         (i32.mul
-                                                          (get_local $11)
+                                                          (get_local $10)
                                                           (i32.const 10)
                                                         )
                                                       )
@@ -5523,7 +5512,7 @@
                                               )
                                             )
                                           )
-                                          (set_local $11
+                                          (set_local $10
                                             (get_local $6)
                                           )
                                           (set_local $9
@@ -5544,17 +5533,17 @@
                                           (get_local $5)
                                         )
                                         (block i32
-                                          (set_local $11
+                                          (set_local $10
                                             (get_local $6)
                                           )
                                           (get_local $5)
                                         )
                                       )
                                     )
-                                    (set_local $25
+                                    (set_local $36
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $11)
+                                        (get_local $10)
                                       )
                                     )
                                     (set_local $5
@@ -5565,13 +5554,13 @@
                                         (if
                                           (i32.le_u
                                             (get_local $5)
-                                            (get_local $12)
+                                            (get_local $16)
                                           )
                                           (block
-                                            (set_local $26
+                                            (set_local $22
                                               (i32.const 0)
                                             )
-                                            (set_local $9
+                                            (set_local $7
                                               (get_local $5)
                                             )
                                             (br $while-out89)
@@ -5587,10 +5576,10 @@
                                             )
                                           )
                                           (block
-                                            (set_local $26
+                                            (set_local $22
                                               (i32.const 1)
                                             )
-                                            (set_local $9
+                                            (set_local $7
                                               (get_local $5)
                                             )
                                           )
@@ -5603,12 +5592,12 @@
                                         )
                                       )
                                     )
-                                    (set_local $19
+                                    (set_local $12
                                       (block $do-once91 i32
                                         (if i32
-                                          (get_local $21)
+                                          (get_local $43)
                                           (block i32
-                                            (set_local $16
+                                            (set_local $9
                                               (if i32
                                                 (i32.and
                                                   (i32.gt_s
@@ -5616,25 +5605,25 @@
                                                       (i32.add
                                                         (i32.xor
                                                           (i32.and
-                                                            (get_local $44)
+                                                            (get_local $29)
                                                             (i32.const 1)
                                                           )
                                                           (i32.const 1)
                                                         )
-                                                        (get_local $19)
+                                                        (get_local $18)
                                                       )
                                                     )
-                                                    (get_local $11)
+                                                    (get_local $10)
                                                   )
                                                   (i32.gt_s
-                                                    (get_local $11)
+                                                    (get_local $10)
                                                     (i32.const -5)
                                                   )
                                                 )
                                                 (block i32
                                                   (set_local $6
                                                     (i32.add
-                                                      (get_local $16)
+                                                      (get_local $12)
                                                       (i32.const -1)
                                                     )
                                                   )
@@ -5643,13 +5632,13 @@
                                                       (get_local $5)
                                                       (i32.const -1)
                                                     )
-                                                    (get_local $11)
+                                                    (get_local $10)
                                                   )
                                                 )
                                                 (block i32
                                                   (set_local $6
                                                     (i32.add
-                                                      (get_local $16)
+                                                      (get_local $12)
                                                       (i32.const -2)
                                                     )
                                                   )
@@ -5661,31 +5650,31 @@
                                               )
                                             )
                                             (if
-                                              (tee_local $7
+                                              (tee_local $12
                                                 (i32.and
-                                                  (get_local $10)
+                                                  (get_local $11)
                                                   (i32.const 8)
                                                 )
                                               )
                                               (block
                                                 (set_local $5
-                                                  (get_local $16)
+                                                  (get_local $9)
                                                 )
                                                 (br $do-once91
-                                                  (get_local $7)
+                                                  (get_local $12)
                                                 )
                                               )
                                             )
                                             (block $do-once93
                                               (if
-                                                (get_local $26)
+                                                (get_local $22)
                                                 (block
                                                   (if
                                                     (i32.eqz
-                                                      (tee_local $19
+                                                      (tee_local $18
                                                         (i32.load
                                                           (i32.add
-                                                            (get_local $9)
+                                                            (get_local $7)
                                                             (i32.const -4)
                                                           )
                                                         )
@@ -5700,7 +5689,7 @@
                                                   )
                                                   (if
                                                     (call $i32u-rem
-                                                      (get_local $19)
+                                                      (get_local $18)
                                                       (i32.const 10)
                                                     )
                                                     (block
@@ -5710,7 +5699,7 @@
                                                       (br $do-once93)
                                                     )
                                                     (block
-                                                      (set_local $7
+                                                      (set_local $12
                                                         (i32.const 10)
                                                       )
                                                       (set_local $5
@@ -5728,10 +5717,10 @@
                                                     (br_if $while-in96
                                                       (i32.eqz
                                                         (call $i32u-rem
-                                                          (get_local $19)
-                                                          (tee_local $7
+                                                          (get_local $18)
+                                                          (tee_local $12
                                                             (i32.mul
-                                                              (get_local $7)
+                                                              (get_local $12)
                                                               (i32.const 10)
                                                             )
                                                           )
@@ -5745,13 +5734,13 @@
                                                 )
                                               )
                                             )
-                                            (set_local $7
+                                            (set_local $12
                                               (i32.add
                                                 (i32.mul
                                                   (i32.shr_s
                                                     (i32.sub
-                                                      (get_local $9)
-                                                      (get_local $40)
+                                                      (get_local $7)
+                                                      (get_local $31)
                                                     )
                                                     (i32.const 2)
                                                   )
@@ -5771,13 +5760,13 @@
                                               (block i32
                                                 (set_local $5
                                                   (select
-                                                    (get_local $16)
+                                                    (get_local $9)
                                                     (tee_local $5
                                                       (select
                                                         (i32.const 0)
                                                         (tee_local $5
                                                           (i32.sub
-                                                            (get_local $7)
+                                                            (get_local $12)
                                                             (get_local $5)
                                                           )
                                                         )
@@ -5788,7 +5777,7 @@
                                                       )
                                                     )
                                                     (i32.lt_s
-                                                      (get_local $16)
+                                                      (get_local $9)
                                                       (get_local $5)
                                                     )
                                                   )
@@ -5798,15 +5787,15 @@
                                               (block i32
                                                 (set_local $5
                                                   (select
-                                                    (get_local $16)
+                                                    (get_local $9)
                                                     (tee_local $5
                                                       (select
                                                         (i32.const 0)
                                                         (tee_local $5
                                                           (i32.sub
                                                             (i32.add
-                                                              (get_local $7)
-                                                              (get_local $11)
+                                                              (get_local $12)
+                                                              (get_local $10)
                                                             )
                                                             (get_local $5)
                                                           )
@@ -5818,7 +5807,7 @@
                                                       )
                                                     )
                                                     (i32.lt_s
-                                                      (get_local $16)
+                                                      (get_local $9)
                                                       (get_local $5)
                                                     )
                                                   )
@@ -5829,13 +5818,13 @@
                                           )
                                           (block i32
                                             (set_local $5
-                                              (get_local $19)
+                                              (get_local $18)
                                             )
                                             (set_local $6
-                                              (get_local $16)
+                                              (get_local $12)
                                             )
                                             (i32.and
-                                              (get_local $10)
+                                              (get_local $11)
                                               (i32.const 8)
                                             )
                                           )
@@ -5845,10 +5834,10 @@
                                     (set_local $31
                                       (i32.and
                                         (i32.ne
-                                          (tee_local $16
+                                          (tee_local $18
                                             (i32.or
                                               (get_local $5)
-                                              (get_local $19)
+                                              (get_local $12)
                                             )
                                           )
                                           (i32.const 0)
@@ -5856,9 +5845,9 @@
                                         (i32.const 1)
                                       )
                                     )
-                                    (set_local $25
+                                    (set_local $9
                                       (if i32
-                                        (tee_local $21
+                                        (tee_local $29
                                           (i32.eq
                                             (i32.or
                                               (get_local $6)
@@ -5870,10 +5859,10 @@
                                         (block i32
                                           (set_local $6
                                             (select
-                                              (get_local $11)
+                                              (get_local $10)
                                               (i32.const 0)
                                               (i32.gt_s
-                                                (get_local $11)
+                                                (get_local $10)
                                                 (i32.const 0)
                                               )
                                             )
@@ -5884,15 +5873,15 @@
                                           (if
                                             (i32.lt_s
                                               (i32.sub
-                                                (get_local $32)
-                                                (tee_local $7
+                                                (get_local $30)
+                                                (tee_local $9
                                                   (call $_fmt_u
-                                                    (tee_local $7
+                                                    (tee_local $9
                                                       (select
-                                                        (get_local $25)
-                                                        (get_local $11)
+                                                        (get_local $36)
+                                                        (get_local $10)
                                                         (i32.lt_s
-                                                          (get_local $11)
+                                                          (get_local $10)
                                                           (i32.const 0)
                                                         )
                                                       )
@@ -5900,7 +5889,7 @@
                                                     (i32.shr_s
                                                       (i32.shl
                                                         (i32.lt_s
-                                                          (get_local $7)
+                                                          (get_local $9)
                                                           (i32.const 0)
                                                         )
                                                         (i32.const 31)
@@ -5915,9 +5904,9 @@
                                             )
                                             (loop $while-in98
                                               (i32.store8
-                                                (tee_local $7
+                                                (tee_local $9
                                                   (i32.add
-                                                    (get_local $7)
+                                                    (get_local $9)
                                                     (i32.const -1)
                                                   )
                                                 )
@@ -5926,8 +5915,8 @@
                                               (br_if $while-in98
                                                 (i32.lt_s
                                                   (i32.sub
-                                                    (get_local $32)
-                                                    (get_local $7)
+                                                    (get_local $30)
+                                                    (get_local $9)
                                                   )
                                                   (i32.const 2)
                                                 )
@@ -5936,13 +5925,13 @@
                                           )
                                           (i32.store8
                                             (i32.add
-                                              (get_local $7)
+                                              (get_local $9)
                                               (i32.const -1)
                                             )
                                             (i32.add
                                               (i32.and
                                                 (i32.shr_s
-                                                  (get_local $11)
+                                                  (get_local $10)
                                                   (i32.const 31)
                                                 )
                                                 (i32.const 2)
@@ -5951,9 +5940,9 @@
                                             )
                                           )
                                           (i32.store8
-                                            (tee_local $7
+                                            (tee_local $9
                                               (i32.add
-                                                (get_local $7)
+                                                (get_local $9)
                                                 (i32.const -2)
                                               )
                                             )
@@ -5961,24 +5950,24 @@
                                           )
                                           (set_local $6
                                             (i32.sub
-                                              (get_local $32)
-                                              (get_local $7)
+                                              (get_local $30)
+                                              (get_local $9)
                                             )
                                           )
-                                          (get_local $7)
+                                          (get_local $9)
                                         )
                                       )
                                     )
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $17)
-                                      (tee_local $11
+                                      (get_local $13)
+                                      (tee_local $10
                                         (i32.add
                                           (i32.add
                                             (i32.add
                                               (i32.add
-                                                (get_local $30)
+                                                (get_local $28)
                                                 (i32.const 1)
                                               )
                                               (get_local $5)
@@ -5988,7 +5977,7 @@
                                           (get_local $6)
                                         )
                                       )
-                                      (get_local $10)
+                                      (get_local $11)
                                     )
                                     (if
                                       (i32.eqz
@@ -6001,8 +5990,8 @@
                                       )
                                       (drop
                                         (call $___fwritex
-                                          (get_local $36)
-                                          (get_local $30)
+                                          (get_local $35)
+                                          (get_local $28)
                                           (get_local $0)
                                         )
                                       )
@@ -6010,24 +5999,24 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 48)
-                                      (get_local $17)
-                                      (get_local $11)
+                                      (get_local $13)
+                                      (get_local $10)
                                       (i32.xor
-                                        (get_local $10)
+                                        (get_local $11)
                                         (i32.const 65536)
                                       )
                                     )
                                     (block $do-once99
                                       (if
-                                        (get_local $21)
+                                        (get_local $29)
                                         (block
-                                          (set_local $7
+                                          (set_local $9
                                             (tee_local $12
                                               (select
                                                 (get_local $8)
-                                                (get_local $12)
+                                                (get_local $16)
                                                 (i32.gt_u
-                                                  (get_local $12)
+                                                  (get_local $16)
                                                   (get_local $8)
                                                 )
                                               )
@@ -6037,23 +6026,23 @@
                                             (set_local $6
                                               (call $_fmt_u
                                                 (i32.load
-                                                  (get_local $7)
+                                                  (get_local $9)
                                                 )
                                                 (i32.const 0)
-                                                (get_local $34)
+                                                (get_local $33)
                                               )
                                             )
                                             (block $do-once103
                                               (if
                                                 (i32.eq
-                                                  (get_local $7)
+                                                  (get_local $9)
                                                   (get_local $12)
                                                 )
                                                 (block
                                                   (br_if $do-once103
                                                     (i32.ne
                                                       (get_local $6)
-                                                      (get_local $34)
+                                                      (get_local $33)
                                                     )
                                                   )
                                                   (i32.store8
@@ -6115,14 +6104,14 @@
                                               (i32.le_u
                                                 (tee_local $6
                                                   (i32.add
-                                                    (get_local $7)
+                                                    (get_local $9)
                                                     (i32.const 4)
                                                   )
                                                 )
                                                 (get_local $8)
                                               )
                                               (block
-                                                (set_local $7
+                                                (set_local $9
                                                   (get_local $6)
                                                 )
                                                 (br $while-in102)
@@ -6131,7 +6120,7 @@
                                           )
                                           (block $do-once107
                                             (if
-                                              (get_local $16)
+                                              (get_local $18)
                                               (block
                                                 (br_if $do-once107
                                                   (i32.and
@@ -6159,97 +6148,95 @@
                                               )
                                               (i32.lt_u
                                                 (get_local $6)
-                                                (get_local $9)
+                                                (get_local $7)
                                               )
                                             )
-                                            (block
-                                              (set_local $7
-                                                (get_local $5)
-                                              )
-                                              (loop $while-in110
-                                                (if
-                                                  (i32.gt_u
-                                                    (tee_local $5
-                                                      (call $_fmt_u
-                                                        (i32.load
-                                                          (get_local $6)
-                                                        )
-                                                        (i32.const 0)
-                                                        (get_local $34)
+                                            (loop $while-in110
+                                              (if
+                                                (i32.gt_u
+                                                  (tee_local $8
+                                                    (call $_fmt_u
+                                                      (i32.load
+                                                        (get_local $6)
                                                       )
+                                                      (i32.const 0)
+                                                      (get_local $33)
                                                     )
-                                                    (get_local $24)
                                                   )
-                                                  (loop $while-in112
-                                                    (i32.store8
-                                                      (tee_local $5
-                                                        (i32.add
-                                                          (get_local $5)
-                                                          (i32.const -1)
-                                                        )
+                                                  (get_local $24)
+                                                )
+                                                (loop $while-in112
+                                                  (i32.store8
+                                                    (tee_local $8
+                                                      (i32.add
+                                                        (get_local $8)
+                                                        (i32.const -1)
                                                       )
-                                                      (i32.const 48)
                                                     )
-                                                    (br_if $while-in112
-                                                      (i32.gt_u
-                                                        (get_local $5)
-                                                        (get_local $24)
-                                                      )
+                                                    (i32.const 48)
+                                                  )
+                                                  (br_if $while-in112
+                                                    (i32.gt_u
+                                                      (get_local $8)
+                                                      (get_local $24)
                                                     )
                                                   )
                                                 )
-                                                (if
-                                                  (i32.eqz
-                                                    (i32.and
-                                                      (i32.load
-                                                        (get_local $0)
-                                                      )
-                                                      (i32.const 32)
-                                                    )
-                                                  )
-                                                  (drop
-                                                    (call $___fwritex
-                                                      (get_local $5)
-                                                      (select
-                                                        (i32.const 9)
-                                                        (get_local $7)
-                                                        (i32.gt_s
-                                                          (get_local $7)
-                                                          (i32.const 9)
-                                                        )
-                                                      )
+                                              )
+                                              (if
+                                                (i32.eqz
+                                                  (i32.and
+                                                    (i32.load
                                                       (get_local $0)
                                                     )
+                                                    (i32.const 32)
                                                   )
+                                                )
+                                                (drop
+                                                  (call $___fwritex
+                                                    (get_local $8)
+                                                    (select
+                                                      (i32.const 9)
+                                                      (get_local $5)
+                                                      (i32.gt_s
+                                                        (get_local $5)
+                                                        (i32.const 9)
+                                                      )
+                                                    )
+                                                    (get_local $0)
+                                                  )
+                                                )
+                                              )
+                                              (set_local $8
+                                                (i32.add
+                                                  (get_local $5)
+                                                  (i32.const -9)
+                                                )
+                                              )
+                                              (if
+                                                (i32.and
+                                                  (i32.gt_s
+                                                    (get_local $5)
+                                                    (i32.const 9)
+                                                  )
+                                                  (i32.lt_u
+                                                    (tee_local $6
+                                                      (i32.add
+                                                        (get_local $6)
+                                                        (i32.const 4)
+                                                      )
+                                                    )
+                                                    (get_local $7)
+                                                  )
+                                                )
+                                                (block
+                                                  (set_local $5
+                                                    (get_local $8)
+                                                  )
+                                                  (br $while-in110)
                                                 )
                                                 (set_local $5
-                                                  (i32.add
-                                                    (get_local $7)
-                                                    (i32.const -9)
-                                                  )
-                                                )
-                                                (if
-                                                  (i32.and
-                                                    (i32.gt_s
-                                                      (get_local $7)
-                                                      (i32.const 9)
-                                                    )
-                                                    (i32.lt_u
-                                                      (tee_local $6
-                                                        (i32.add
-                                                          (get_local $6)
-                                                          (i32.const 4)
-                                                        )
-                                                      )
-                                                      (get_local $9)
-                                                    )
-                                                  )
-                                                  (block
-                                                    (set_local $7
-                                                      (get_local $5)
-                                                    )
-                                                    (br $while-in110)
-                                                  )
+                                                  (get_local $8)
                                                 )
                                               )
                                             )
@@ -6266,14 +6253,14 @@
                                           )
                                         )
                                         (block
-                                          (set_local $16
+                                          (set_local $18
                                             (select
-                                              (get_local $9)
+                                              (get_local $7)
                                               (i32.add
-                                                (get_local $12)
+                                                (get_local $16)
                                                 (i32.const 4)
                                               )
-                                              (get_local $26)
+                                              (get_local $22)
                                             )
                                           )
                                           (if
@@ -6282,31 +6269,31 @@
                                               (i32.const -1)
                                             )
                                             (block
-                                              (set_local $9
+                                              (set_local $12
                                                 (i32.eqz
-                                                  (get_local $19)
+                                                  (get_local $12)
                                                 )
                                               )
-                                              (set_local $6
-                                                (get_local $12)
+                                              (set_local $8
+                                                (get_local $16)
                                               )
-                                              (set_local $7
+                                              (set_local $6
                                                 (get_local $5)
                                               )
                                               (loop $while-in114
-                                                (set_local $8
+                                                (set_local $7
                                                   (if i32
                                                     (i32.eq
                                                       (tee_local $5
                                                         (call $_fmt_u
                                                           (i32.load
-                                                            (get_local $6)
+                                                            (get_local $8)
                                                           )
                                                           (i32.const 0)
-                                                          (get_local $34)
+                                                          (get_local $33)
                                                         )
                                                       )
-                                                      (get_local $34)
+                                                      (get_local $33)
                                                     )
                                                     (block i32
                                                       (i32.store8
@@ -6321,13 +6308,13 @@
                                                 (block $do-once115
                                                   (if
                                                     (i32.eq
-                                                      (get_local $6)
-                                                      (get_local $12)
+                                                      (get_local $8)
+                                                      (get_local $16)
                                                     )
                                                     (block
                                                       (set_local $5
                                                         (i32.add
-                                                          (get_local $8)
+                                                          (get_local $7)
                                                           (i32.const 1)
                                                         )
                                                       )
@@ -6342,7 +6329,7 @@
                                                         )
                                                         (drop
                                                           (call $___fwritex
-                                                            (get_local $8)
+                                                            (get_local $7)
                                                             (i32.const 1)
                                                             (get_local $0)
                                                           )
@@ -6350,9 +6337,9 @@
                                                       )
                                                       (br_if $do-once115
                                                         (i32.and
-                                                          (get_local $9)
+                                                          (get_local $12)
                                                           (i32.lt_s
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                             (i32.const 1)
                                                           )
                                                         )
@@ -6376,15 +6363,15 @@
                                                     (block
                                                       (if
                                                         (i32.gt_u
-                                                          (get_local $8)
+                                                          (get_local $7)
                                                           (get_local $24)
                                                         )
                                                         (set_local $5
-                                                          (get_local $8)
+                                                          (get_local $7)
                                                         )
                                                         (block
                                                           (set_local $5
-                                                            (get_local $8)
+                                                            (get_local $7)
                                                           )
                                                           (br $do-once115)
                                                         )
@@ -6409,7 +6396,7 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $8
+                                                (set_local $7
                                                   (i32.sub
                                                     (get_local $49)
                                                     (get_local $5)
@@ -6428,44 +6415,41 @@
                                                     (call $___fwritex
                                                       (get_local $5)
                                                       (select
-                                                        (get_local $8)
                                                         (get_local $7)
+                                                        (get_local $6)
                                                         (i32.gt_s
+                                                          (get_local $6)
                                                           (get_local $7)
-                                                          (get_local $8)
                                                         )
                                                       )
                                                       (get_local $0)
                                                     )
                                                   )
                                                 )
-                                                (if
+                                                (br_if $while-in114
                                                   (i32.and
                                                     (i32.lt_u
-                                                      (tee_local $6
+                                                      (tee_local $8
                                                         (i32.add
-                                                          (get_local $6)
+                                                          (get_local $8)
                                                           (i32.const 4)
                                                         )
                                                       )
-                                                      (get_local $16)
+                                                      (get_local $18)
                                                     )
                                                     (i32.gt_s
-                                                      (tee_local $5
+                                                      (tee_local $6
                                                         (i32.sub
+                                                          (get_local $6)
                                                           (get_local $7)
-                                                          (get_local $8)
                                                         )
                                                       )
                                                       (i32.const -1)
                                                     )
                                                   )
-                                                  (block
-                                                    (set_local $7
-                                                      (get_local $5)
-                                                    )
-                                                    (br $while-in114)
-                                                  )
+                                                )
+                                                (set_local $5
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -6490,10 +6474,10 @@
                                           )
                                           (drop
                                             (call $___fwritex
-                                              (get_local $25)
+                                              (get_local $9)
                                               (i32.sub
-                                                (get_local $32)
-                                                (get_local $25)
+                                                (get_local $30)
+                                                (get_local $9)
                                               )
                                               (get_local $0)
                                             )
@@ -6504,27 +6488,27 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $17)
-                                      (get_local $11)
+                                      (get_local $13)
+                                      (get_local $10)
                                       (i32.xor
-                                        (get_local $10)
+                                        (get_local $11)
                                         (i32.const 8192)
                                       )
                                     )
                                     (select
-                                      (get_local $17)
-                                      (get_local $11)
+                                      (get_local $13)
+                                      (get_local $10)
                                       (i32.lt_s
-                                        (get_local $11)
-                                        (get_local $17)
+                                        (get_local $10)
+                                        (get_local $13)
                                       )
                                     )
                                   )
                                   (block i32
-                                    (set_local $7
+                                    (set_local $6
                                       (select
                                         (i32.const 0)
-                                        (get_local $30)
+                                        (get_local $28)
                                         (tee_local $5
                                           (i32.or
                                             (f64.ne
@@ -6536,15 +6520,15 @@
                                         )
                                       )
                                     )
-                                    (set_local $8
+                                    (set_local $7
                                       (select
                                         (select
                                           (i32.const 4135)
                                           (i32.const 4139)
-                                          (tee_local $6
+                                          (tee_local $7
                                             (i32.ne
                                               (i32.and
-                                                (get_local $16)
+                                                (get_local $12)
                                                 (i32.const 32)
                                               )
                                               (i32.const 0)
@@ -6554,7 +6538,7 @@
                                         (select
                                           (i32.const 4127)
                                           (i32.const 4131)
-                                          (get_local $6)
+                                          (get_local $7)
                                         )
                                         (get_local $5)
                                       )
@@ -6562,33 +6546,33 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $17)
-                                      (tee_local $6
+                                      (get_local $13)
+                                      (tee_local $5
                                         (i32.add
-                                          (get_local $7)
+                                          (get_local $6)
                                           (i32.const 3)
                                         )
                                       )
-                                      (get_local $9)
+                                      (get_local $8)
                                     )
                                     (if
                                       (i32.eqz
                                         (i32.and
                                           (if i32
                                             (i32.and
-                                              (tee_local $5
+                                              (tee_local $8
                                                 (i32.load
                                                   (get_local $0)
                                                 )
                                               )
                                               (i32.const 32)
                                             )
-                                            (get_local $5)
+                                            (get_local $8)
                                             (block i32
                                               (drop
                                                 (call $___fwritex
-                                                  (get_local $36)
-                                                  (get_local $7)
+                                                  (get_local $35)
+                                                  (get_local $6)
                                                   (get_local $0)
                                                 )
                                               )
@@ -6602,7 +6586,7 @@
                                       )
                                       (drop
                                         (call $___fwritex
-                                          (get_local $8)
+                                          (get_local $7)
                                           (i32.const 3)
                                           (get_local $0)
                                         )
@@ -6611,19 +6595,19 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $17)
-                                      (get_local $6)
+                                      (get_local $13)
+                                      (get_local $5)
                                       (i32.xor
-                                        (get_local $10)
+                                        (get_local $11)
                                         (i32.const 8192)
                                       )
                                     )
                                     (select
-                                      (get_local $17)
-                                      (get_local $6)
+                                      (get_local $13)
+                                      (get_local $5)
                                       (i32.lt_s
-                                        (get_local $6)
-                                        (get_local $17)
+                                        (get_local $5)
+                                        (get_local $13)
                                       )
                                     )
                                   )
@@ -6635,7 +6619,7 @@
                           (set_local $6
                             (get_local $1)
                           )
-                          (set_local $11
+                          (set_local $10
                             (get_local $7)
                           )
                           (set_local $8
@@ -6651,23 +6635,23 @@
                         )
                         (set_local $9
                           (i32.and
-                            (get_local $16)
+                            (get_local $12)
                             (i32.const 32)
                           )
                         )
                         (if
                           (i32.and
                             (i32.eqz
-                              (tee_local $10
+                              (tee_local $8
                                 (i32.load
                                   (tee_local $6
-                                    (get_local $18)
+                                    (get_local $17)
                                   )
                                 )
                               )
                             )
                             (i32.eqz
-                              (tee_local $6
+                              (tee_local $11
                                 (i32.load offset=4
                                   (get_local $6)
                                 )
@@ -6687,6 +6671,9 @@
                             (br $jumpthreading$inner$7)
                           )
                           (block
+                            (set_local $6
+                              (get_local $8)
+                            )
                             (set_local $8
                               (get_local $23)
                             )
@@ -6702,7 +6689,7 @@
                                   (i32.load8_u
                                     (i32.add
                                       (i32.and
-                                        (get_local $10)
+                                        (get_local $6)
                                         (i32.const 15)
                                       )
                                       (i32.const 4075)
@@ -6715,16 +6702,16 @@
                                 (i32.eqz
                                   (i32.and
                                     (i32.eqz
-                                      (tee_local $10
+                                      (tee_local $6
                                         (call $_bitshift64Lshr
-                                          (get_local $10)
                                           (get_local $6)
+                                          (get_local $11)
                                           (i32.const 4)
                                         )
                                       )
                                     )
                                     (i32.eqz
-                                      (tee_local $6
+                                      (tee_local $11
                                         (get_global $tempRet0)
                                       )
                                     )
@@ -6746,14 +6733,14 @@
                                 (i32.and
                                   (i32.eqz
                                     (i32.load
-                                      (tee_local $10
-                                        (get_local $18)
+                                      (tee_local $11
+                                        (get_local $17)
                                       )
                                     )
                                   )
                                   (i32.eqz
                                     (i32.load offset=4
-                                      (get_local $10)
+                                      (get_local $11)
                                     )
                                   )
                                 )
@@ -6775,7 +6762,7 @@
                                   (i32.add
                                     (i32.const 4091)
                                     (i32.shr_s
-                                      (get_local $16)
+                                      (get_local $12)
                                       (i32.const 4)
                                     )
                                   )
@@ -6795,11 +6782,11 @@
                         )
                       )
                       (set_local $1
-                        (get_local $10)
+                        (get_local $11)
                       )
                       (br $jumpthreading$inner$7)
                     )
-                    (set_local $28
+                    (set_local $26
                       (i32.const 0)
                     )
                     (set_local $16
@@ -6816,10 +6803,10 @@
                     (set_local $6
                       (get_local $1)
                     )
-                    (set_local $10
-                      (get_local $9)
-                    )
                     (set_local $11
+                      (get_local $8)
+                    )
+                    (set_local $10
                       (select
                         (get_local $7)
                         (i32.sub
@@ -6853,9 +6840,9 @@
                   (set_local $6
                     (i32.const 0)
                   )
-                  (set_local $7
+                  (set_local $8
                     (i32.load
-                      (get_local $18)
+                      (get_local $17)
                     )
                   )
                   (loop $while-in125
@@ -6864,7 +6851,7 @@
                         (i32.eqz
                           (tee_local $9
                             (i32.load
-                              (get_local $7)
+                              (get_local $8)
                             )
                           )
                         )
@@ -6874,7 +6861,7 @@
                           (i32.lt_s
                             (tee_local $6
                               (call $_wctomb
-                                (get_local $41)
+                                (get_local $40)
                                 (get_local $9)
                               )
                             )
@@ -6883,21 +6870,21 @@
                           (i32.gt_u
                             (get_local $6)
                             (i32.sub
-                              (get_local $8)
+                              (get_local $7)
                               (get_local $1)
                             )
                           )
                         )
                       )
-                      (set_local $7
+                      (set_local $8
                         (i32.add
-                          (get_local $7)
+                          (get_local $8)
                           (i32.const 4)
                         )
                       )
                       (br_if $while-in125
                         (i32.gt_u
-                          (get_local $8)
+                          (get_local $7)
                           (tee_local $1
                             (i32.add
                               (get_local $6)
@@ -6923,19 +6910,19 @@
                   (call $_pad
                     (get_local $0)
                     (i32.const 32)
-                    (get_local $17)
+                    (get_local $13)
                     (get_local $1)
-                    (get_local $10)
+                    (get_local $11)
                   )
                   (if
                     (get_local $1)
                     (block
-                      (set_local $6
+                      (set_local $7
                         (i32.const 0)
                       )
-                      (set_local $7
+                      (set_local $6
                         (i32.load
-                          (get_local $18)
+                          (get_local $17)
                         )
                       )
                       (loop $while-in127
@@ -6943,7 +6930,7 @@
                           (i32.eqz
                             (tee_local $8
                               (i32.load
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                           )
@@ -6954,23 +6941,23 @@
                             (br $jumpthreading$inner$6)
                           )
                         )
-                        (set_local $7
+                        (set_local $6
                           (i32.add
-                            (get_local $7)
+                            (get_local $6)
                             (i32.const 4)
                           )
                         )
                         (if
                           (i32.gt_s
-                            (tee_local $6
+                            (tee_local $7
                               (i32.add
                                 (tee_local $8
                                   (call $_wctomb
-                                    (get_local $41)
+                                    (get_local $40)
                                     (get_local $8)
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $7)
                               )
                             )
                             (get_local $1)
@@ -6993,7 +6980,7 @@
                           )
                           (drop
                             (call $___fwritex
-                              (get_local $41)
+                              (get_local $40)
                               (get_local $8)
                               (get_local $0)
                             )
@@ -7001,7 +6988,7 @@
                         )
                         (br_if $while-in127
                           (i32.lt_u
-                            (get_local $6)
+                            (get_local $7)
                             (get_local $1)
                           )
                         )
@@ -7022,16 +7009,16 @@
                   )
                   (br $jumpthreading$outer$7)
                 )
-                (set_local $28
+                (set_local $26
                   (i32.const 0)
                 )
                 (call $_pad
                   (get_local $0)
                   (i32.const 32)
-                  (get_local $17)
+                  (get_local $13)
                   (get_local $6)
                   (i32.xor
-                    (get_local $10)
+                    (get_local $11)
                     (i32.const 8192)
                   )
                 )
@@ -7040,20 +7027,20 @@
                 )
                 (set_local $5
                   (select
-                    (get_local $17)
+                    (get_local $13)
                     (get_local $6)
                     (i32.gt_s
-                      (get_local $17)
+                      (get_local $13)
                       (get_local $6)
                     )
                   )
                 )
                 (br $label$continue$L1)
               )
-              (set_local $28
+              (set_local $26
                 (i32.const 0)
               )
-              (set_local $10
+              (set_local $11
                 (select
                   (i32.and
                     (get_local $1)
@@ -7078,7 +7065,7 @@
                         (i32.ne
                           (i32.load
                             (tee_local $1
-                              (get_local $18)
+                              (get_local $17)
                             )
                           )
                           (i32.const 0)
@@ -7093,7 +7080,7 @@
                     )
                   )
                   (block i32
-                    (set_local $11
+                    (set_local $10
                       (select
                         (get_local $7)
                         (tee_local $1
@@ -7123,7 +7110,7 @@
                     (get_local $6)
                   )
                   (block i32
-                    (set_local $11
+                    (set_local $10
                       (i32.const 0)
                     )
                     (set_local $1
@@ -7142,7 +7129,7 @@
                   (tee_local $1
                     (i32.add
                       (get_local $8)
-                      (tee_local $11
+                      (tee_local $10
                         (select
                           (tee_local $12
                             (i32.sub
@@ -7150,24 +7137,24 @@
                               (get_local $6)
                             )
                           )
-                          (get_local $11)
+                          (get_local $10)
                           (i32.lt_s
-                            (get_local $11)
+                            (get_local $10)
                             (get_local $12)
                           )
                         )
                       )
                     )
                   )
-                  (get_local $17)
+                  (get_local $13)
                   (i32.lt_s
-                    (get_local $17)
+                    (get_local $13)
                     (get_local $1)
                   )
                 )
               )
               (get_local $1)
-              (get_local $10)
+              (get_local $11)
             )
             (if
               (i32.eqz
@@ -7192,14 +7179,14 @@
               (get_local $7)
               (get_local $1)
               (i32.xor
-                (get_local $10)
+                (get_local $11)
                 (i32.const 65536)
               )
             )
             (call $_pad
               (get_local $0)
               (i32.const 48)
-              (get_local $11)
+              (get_local $10)
               (get_local $12)
               (i32.const 0)
             )
@@ -7226,7 +7213,7 @@
               (get_local $7)
               (get_local $1)
               (i32.xor
-                (get_local $10)
+                (get_local $11)
                 (i32.const 8192)
               )
             )
@@ -7246,7 +7233,7 @@
           (get_local $0)
         )
         (if
-          (get_local $13)
+          (get_local $19)
           (block
             (set_local $0
               (i32.const 1)
@@ -7355,7 +7342,7 @@
       )
     )
     (set_global $STACKTOP
-      (get_local $27)
+      (get_local $25)
     )
     (get_local $15)
   )
@@ -7415,9 +7402,9 @@
                             )
                             (br $label$break$L1)
                           )
-                          (set_local $3
+                          (set_local $1
                             (i32.load
-                              (tee_local $1
+                              (tee_local $3
                                 (i32.and
                                   (i32.add
                                     (i32.load
@@ -7433,20 +7420,20 @@
                           (i32.store
                             (get_local $2)
                             (i32.add
-                              (get_local $1)
+                              (get_local $3)
                               (i32.const 4)
                             )
                           )
                           (i32.store
                             (get_local $0)
-                            (get_local $3)
+                            (get_local $1)
                           )
                           (i32.store offset=4
                             (get_local $0)
                             (i32.shr_s
                               (i32.shl
                                 (i32.lt_s
-                                  (get_local $3)
+                                  (get_local $1)
                                   (i32.const 0)
                                 )
                                 (i32.const 31)
@@ -7873,12 +7860,9 @@
           )
         )
         (if
-          (i32.lt_u
+          (i32.ge_u
             (get_local $0)
             (i32.const 10)
-          )
-          (set_local $0
-            (get_local $1)
           )
           (block
             (set_local $0
@@ -7888,11 +7872,8 @@
           )
         )
       )
-      (set_local $0
-        (get_local $1)
-      )
     )
-    (get_local $0)
+    (get_local $1)
   )
   (func $_pad (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
     (local $5 i32)
@@ -7939,23 +7920,23 @@
               (get_local $1)
               (select
                 (i32.const 256)
-                (tee_local $4
+                (tee_local $1
                   (i32.sub
                     (get_local $2)
                     (get_local $3)
                   )
                 )
                 (i32.gt_u
-                  (get_local $4)
+                  (get_local $1)
                   (i32.const 256)
                 )
               )
             )
           )
-          (set_local $7
+          (set_local $4
             (i32.eqz
               (i32.and
-                (tee_local $1
+                (tee_local $7
                   (i32.load
                     (get_local $0)
                   )
@@ -7966,7 +7947,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $4)
+              (get_local $1)
               (i32.const 255)
             )
             (block
@@ -7977,16 +7958,16 @@
                 )
               )
               (set_local $2
-                (get_local $4)
+                (get_local $7)
               )
               (set_local $3
-                (get_local $7)
+                (get_local $4)
               )
               (loop $while-in
                 (set_local $3
                   (i32.eqz
                     (i32.and
-                      (tee_local $1
+                      (tee_local $2
                         (if i32
                           (get_local $3)
                           (block i32
@@ -8001,7 +7982,7 @@
                               (get_local $0)
                             )
                           )
-                          (get_local $1)
+                          (get_local $2)
                         )
                       )
                       (i32.const 32)
@@ -8010,9 +7991,9 @@
                 )
                 (br_if $while-in
                   (i32.gt_u
-                    (tee_local $2
+                    (tee_local $1
                       (i32.add
-                        (get_local $2)
+                        (get_local $1)
                         (i32.const -256)
                       )
                     )
@@ -8032,12 +8013,10 @@
                 )
               )
             )
-            (if
-              (get_local $7)
-              (set_local $1
+            (br_if $do-once
+              (i32.eqz
                 (get_local $4)
               )
-              (br $do-once)
             )
           )
           (drop
@@ -8088,16 +8067,16 @@
         (block
           (if
             (i32.and
-              (tee_local $1
+              (tee_local $2
                 (i32.shr_u
                   (tee_local $10
                     (i32.load
                       (i32.const 176)
                     )
                   )
-                  (tee_local $4
+                  (tee_local $7
                     (i32.shr_u
-                      (tee_local $3
+                      (tee_local $4
                         (select
                           (i32.const 16)
                           (i32.and
@@ -8121,29 +8100,29 @@
               (i32.const 3)
             )
             (block
-              (set_local $4
+              (set_local $6
                 (i32.load
                   (tee_local $1
                     (i32.add
-                      (tee_local $5
+                      (tee_local $7
                         (i32.load
-                          (tee_local $9
+                          (tee_local $3
                             (i32.add
                               (tee_local $2
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (tee_local $3
+                                      (tee_local $4
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $1)
+                                              (get_local $2)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $4)
+                                          (get_local $7)
                                         )
                                       )
                                       (i32.const 1)
@@ -8165,7 +8144,7 @@
               (if
                 (i32.eq
                   (get_local $2)
-                  (get_local $4)
+                  (get_local $6)
                 )
                 (i32.store
                   (i32.const 176)
@@ -8174,7 +8153,7 @@
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $3)
+                        (get_local $4)
                       )
                       (i32.const -1)
                     )
@@ -8183,7 +8162,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $4)
+                      (get_local $6)
                       (i32.load
                         (i32.const 192)
                       )
@@ -8195,12 +8174,12 @@
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $4)
+                            (get_local $6)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $5)
+                      (get_local $7)
                     )
                     (block
                       (i32.store
@@ -8208,8 +8187,8 @@
                         (get_local $2)
                       )
                       (i32.store
-                        (get_local $9)
-                        (get_local $4)
+                        (get_local $3)
+                        (get_local $6)
                       )
                     )
                     (call $_abort)
@@ -8217,11 +8196,11 @@
                 )
               )
               (i32.store offset=4
-                (get_local $5)
+                (get_local $7)
                 (i32.or
                   (tee_local $0
                     (i32.shl
-                      (get_local $3)
+                      (get_local $4)
                       (i32.const 3)
                     )
                   )
@@ -8232,7 +8211,7 @@
                 (tee_local $0
                   (i32.add
                     (i32.add
-                      (get_local $5)
+                      (get_local $7)
                       (get_local $0)
                     )
                     (i32.const 4)
@@ -8252,7 +8231,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $3)
+              (get_local $4)
               (tee_local $0
                 (i32.load
                   (i32.const 184)
@@ -8261,37 +8240,37 @@
             )
             (block
               (if
-                (get_local $1)
+                (get_local $2)
                 (block
-                  (set_local $5
+                  (set_local $7
                     (i32.and
                       (i32.shr_u
-                        (tee_local $1
+                        (tee_local $3
                           (i32.add
                             (i32.and
-                              (tee_local $1
+                              (tee_local $3
                                 (i32.and
                                   (i32.shl
-                                    (get_local $1)
-                                    (get_local $4)
+                                    (get_local $2)
+                                    (get_local $7)
                                   )
                                   (i32.or
-                                    (tee_local $1
+                                    (tee_local $3
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $4)
+                                        (get_local $7)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $1)
+                                      (get_local $3)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $1)
+                                (get_local $3)
                               )
                             )
                             (i32.const -1)
@@ -8302,32 +8281,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $7
+                  (set_local $12
                     (i32.load
-                      (tee_local $5
+                      (tee_local $7
                         (i32.add
-                          (tee_local $9
+                          (tee_local $6
                             (i32.load
-                              (tee_local $6
+                              (tee_local $3
                                 (i32.add
-                                  (tee_local $1
+                                  (tee_local $2
                                     (i32.add
                                       (i32.const 216)
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $4
+                                          (tee_local $5
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $4
+                                                      (tee_local $3
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $1
+                                                            (tee_local $2
                                                               (i32.shr_u
-                                                                (get_local $1)
-                                                                (get_local $5)
+                                                                (get_local $3)
+                                                                (get_local $7)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -8335,15 +8314,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $5)
+                                                      (get_local $7)
                                                     )
-                                                    (tee_local $4
+                                                    (tee_local $3
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (tee_local $1
+                                                          (tee_local $2
                                                             (i32.shr_u
-                                                              (get_local $1)
-                                                              (get_local $4)
+                                                              (get_local $2)
+                                                              (get_local $3)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -8352,13 +8331,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (tee_local $4
+                                                  (tee_local $3
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (tee_local $1
+                                                        (tee_local $2
                                                           (i32.shr_u
-                                                            (get_local $1)
-                                                            (get_local $4)
+                                                            (get_local $2)
+                                                            (get_local $3)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -8367,13 +8346,13 @@
                                                     )
                                                   )
                                                 )
-                                                (tee_local $4
+                                                (tee_local $3
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (tee_local $1
+                                                      (tee_local $2
                                                         (i32.shr_u
-                                                          (get_local $1)
-                                                          (get_local $4)
+                                                          (get_local $2)
+                                                          (get_local $3)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -8383,8 +8362,8 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $1)
-                                                (get_local $4)
+                                                (get_local $2)
+                                                (get_local $3)
                                               )
                                             )
                                           )
@@ -8406,8 +8385,8 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $1)
-                      (get_local $7)
+                      (get_local $2)
+                      (get_local $12)
                     )
                     (block
                       (i32.store
@@ -8417,20 +8396,20 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $4)
+                              (get_local $5)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $8
+                      (set_local $16
                         (get_local $0)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $7)
+                          (get_local $12)
                           (i32.load
                             (i32.const 192)
                           )
@@ -8442,23 +8421,23 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $7)
+                                (get_local $12)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $9)
+                          (get_local $6)
                         )
                         (block
                           (i32.store
                             (get_local $0)
-                            (get_local $1)
+                            (get_local $2)
                           )
                           (i32.store
-                            (get_local $6)
-                            (get_local $7)
+                            (get_local $3)
+                            (get_local $12)
                           )
-                          (set_local $8
+                          (set_local $16
                             (i32.load
                               (i32.const 184)
                             )
@@ -8469,27 +8448,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $9)
+                    (get_local $6)
                     (i32.or
-                      (get_local $3)
+                      (get_local $4)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $9
+                    (tee_local $6
                       (i32.add
-                        (get_local $9)
-                        (get_local $3)
+                        (get_local $6)
+                        (get_local $4)
                       )
                     )
                     (i32.or
                       (tee_local $4
                         (i32.sub
                           (i32.shl
-                            (get_local $4)
+                            (get_local $5)
                             (i32.const 3)
                           )
-                          (get_local $3)
+                          (get_local $4)
                         )
                       )
                       (i32.const 1)
@@ -8497,27 +8476,27 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $9)
+                      (get_local $6)
                       (get_local $4)
                     )
                     (get_local $4)
                   )
                   (if
-                    (get_local $8)
+                    (get_local $16)
                     (block
-                      (set_local $6
+                      (set_local $5
                         (i32.load
                           (i32.const 196)
                         )
                       )
-                      (set_local $0
+                      (set_local $2
                         (i32.add
                           (i32.const 216)
                           (i32.shl
                             (i32.shl
-                              (tee_local $1
+                              (tee_local $0
                                 (i32.shr_u
-                                  (get_local $8)
+                                  (get_local $16)
                                   (i32.const 3)
                                 )
                               )
@@ -8534,20 +8513,20 @@
                               (i32.const 176)
                             )
                           )
-                          (tee_local $1
+                          (tee_local $0
                             (i32.shl
                               (i32.const 1)
-                              (get_local $1)
+                              (get_local $0)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $1
+                            (tee_local $0
                               (i32.load
                                 (tee_local $3
                                   (i32.add
-                                    (get_local $0)
+                                    (get_local $2)
                                     (i32.const 8)
                                   )
                                 )
@@ -8559,11 +8538,11 @@
                           )
                           (call $_abort)
                           (block
-                            (set_local $12
+                            (set_local $15
                               (get_local $3)
                             )
-                            (set_local $2
-                              (get_local $1)
+                            (set_local $1
+                              (get_local $0)
                             )
                           )
                         )
@@ -8572,35 +8551,35 @@
                             (i32.const 176)
                             (i32.or
                               (get_local $3)
-                              (get_local $1)
+                              (get_local $0)
                             )
                           )
-                          (set_local $12
+                          (set_local $15
                             (i32.add
-                              (get_local $0)
+                              (get_local $2)
                               (i32.const 8)
                             )
                           )
-                          (set_local $2
-                            (get_local $0)
+                          (set_local $1
+                            (get_local $2)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $12)
-                        (get_local $6)
+                        (get_local $15)
+                        (get_local $5)
                       )
                       (i32.store offset=12
-                        (get_local $2)
-                        (get_local $6)
+                        (get_local $1)
+                        (get_local $5)
                       )
                       (i32.store offset=8
-                        (get_local $6)
-                        (get_local $2)
+                        (get_local $5)
+                        (get_local $1)
                       )
                       (i32.store offset=12
-                        (get_local $6)
-                        (get_local $0)
+                        (get_local $5)
+                        (get_local $2)
                       )
                     )
                   )
@@ -8610,10 +8589,10 @@
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $9)
+                    (get_local $6)
                   )
                   (return
-                    (get_local $5)
+                    (get_local $7)
                   )
                 )
               )
@@ -8644,11 +8623,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $4
+                  (set_local $7
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (tee_local $1
+                          (tee_local $0
                             (i32.load offset=480
                               (i32.shl
                                 (i32.add
@@ -8656,10 +8635,10 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (tee_local $1
+                                          (tee_local $0
                                             (i32.and
                                               (i32.shr_u
-                                                (tee_local $0
+                                                (tee_local $1
                                                   (i32.shr_u
                                                     (get_local $0)
                                                     (get_local $2)
@@ -8672,13 +8651,13 @@
                                           )
                                           (get_local $2)
                                         )
-                                        (tee_local $1
+                                        (tee_local $0
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $0
+                                              (tee_local $1
                                                 (i32.shr_u
-                                                  (get_local $0)
                                                   (get_local $1)
+                                                  (get_local $0)
                                                 )
                                               )
                                               (i32.const 2)
@@ -8687,13 +8666,13 @@
                                           )
                                         )
                                       )
-                                      (tee_local $1
+                                      (tee_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $0
+                                            (tee_local $1
                                               (i32.shr_u
-                                                (get_local $0)
                                                 (get_local $1)
+                                                (get_local $0)
                                               )
                                             )
                                             (i32.const 1)
@@ -8702,13 +8681,13 @@
                                         )
                                       )
                                     )
-                                    (tee_local $1
+                                    (tee_local $0
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $0
+                                          (tee_local $1
                                             (i32.shr_u
-                                              (get_local $0)
                                               (get_local $1)
+                                              (get_local $0)
                                             )
                                           )
                                           (i32.const 1)
@@ -8718,8 +8697,8 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $0)
                                     (get_local $1)
+                                    (get_local $0)
                                   )
                                 )
                                 (i32.const 2)
@@ -8729,11 +8708,14 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $3)
+                      (get_local $4)
                     )
                   )
                   (set_local $2
-                    (get_local $1)
+                    (get_local $0)
+                  )
+                  (set_local $1
+                    (get_local $0)
                   )
                   (loop $while-in
                     (block $while-out
@@ -8754,14 +8736,17 @@
                             )
                           )
                           (block
-                            (set_local $2
+                            (set_local $12
+                              (get_local $7)
+                            )
+                            (set_local $11
                               (get_local $1)
                             )
                             (br $while-out)
                           )
                         )
                       )
-                      (set_local $6
+                      (set_local $12
                         (i32.lt_u
                           (tee_local $2
                             (i32.sub
@@ -8771,17 +8756,17 @@
                                 )
                                 (i32.const -8)
                               )
-                              (get_local $3)
+                              (get_local $4)
                             )
                           )
-                          (get_local $4)
+                          (get_local $7)
                         )
                       )
-                      (set_local $4
+                      (set_local $7
                         (select
                           (get_local $2)
-                          (get_local $4)
-                          (get_local $6)
+                          (get_local $7)
+                          (get_local $12)
                         )
                       )
                       (set_local $2
@@ -8791,7 +8776,7 @@
                         (select
                           (get_local $0)
                           (get_local $1)
-                          (get_local $6)
+                          (get_local $12)
                         )
                       )
                       (br $while-in)
@@ -8799,7 +8784,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $2)
+                      (get_local $11)
                       (tee_local $10
                         (i32.load
                           (i32.const 192)
@@ -8810,19 +8795,19 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $2)
-                      (tee_local $7
+                      (get_local $11)
+                      (tee_local $14
                         (i32.add
-                          (get_local $2)
-                          (get_local $3)
+                          (get_local $11)
+                          (get_local $4)
                         )
                       )
                     )
                     (call $_abort)
                   )
-                  (set_local $11
+                  (set_local $8
                     (i32.load offset=24
-                      (get_local $2)
+                      (get_local $11)
                     )
                   )
                   (block $do-once4
@@ -8830,10 +8815,10 @@
                       (i32.eq
                         (tee_local $0
                           (i32.load offset=12
-                            (get_local $2)
+                            (get_local $11)
                           )
                         )
-                        (get_local $2)
+                        (get_local $11)
                       )
                       (block
                         (if
@@ -8842,7 +8827,7 @@
                               (i32.load
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $2)
+                                    (get_local $11)
                                     (i32.const 20)
                                   )
                                 )
@@ -8855,7 +8840,7 @@
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
-                                      (get_local $2)
+                                      (get_local $11)
                                       (i32.const 16)
                                     )
                                   )
@@ -8863,7 +8848,7 @@
                               )
                             )
                             (block
-                              (set_local $5
+                              (set_local $6
                                 (i32.const 0)
                               )
                               (br $do-once4)
@@ -8872,9 +8857,9 @@
                         )
                         (loop $while-in7
                           (if
-                            (tee_local $8
+                            (tee_local $2
                               (i32.load
-                                (tee_local $6
+                                (tee_local $7
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 20)
@@ -8884,18 +8869,18 @@
                             )
                             (block
                               (set_local $1
-                                (get_local $8)
+                                (get_local $2)
                               )
                               (set_local $0
-                                (get_local $6)
+                                (get_local $7)
                               )
                               (br $while-in7)
                             )
                           )
                           (if
-                            (tee_local $8
+                            (tee_local $2
                               (i32.load
-                                (tee_local $6
+                                (tee_local $7
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 16)
@@ -8905,10 +8890,10 @@
                             )
                             (block
                               (set_local $1
-                                (get_local $8)
+                                (get_local $2)
                               )
                               (set_local $0
-                                (get_local $6)
+                                (get_local $7)
                               )
                               (br $while-in7)
                             )
@@ -8925,7 +8910,7 @@
                               (get_local $0)
                               (i32.const 0)
                             )
-                            (set_local $5
+                            (set_local $6
                               (get_local $1)
                             )
                           )
@@ -8934,9 +8919,9 @@
                       (block
                         (if
                           (i32.lt_u
-                            (tee_local $8
+                            (tee_local $7
                               (i32.load offset=8
-                                (get_local $2)
+                                (get_local $11)
                               )
                             )
                             (get_local $10)
@@ -8946,14 +8931,14 @@
                         (if
                           (i32.ne
                             (i32.load
-                              (tee_local $6
+                              (tee_local $2
                                 (i32.add
-                                  (get_local $8)
+                                  (get_local $7)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $2)
+                            (get_local $11)
                           )
                           (call $_abort)
                         )
@@ -8967,18 +8952,18 @@
                                 )
                               )
                             )
-                            (get_local $2)
+                            (get_local $11)
                           )
                           (block
                             (i32.store
-                              (get_local $6)
+                              (get_local $2)
                               (get_local $0)
                             )
                             (i32.store
                               (get_local $1)
-                              (get_local $8)
+                              (get_local $7)
                             )
-                            (set_local $5
+                            (set_local $6
                               (get_local $0)
                             )
                           )
@@ -8989,11 +8974,11 @@
                   )
                   (block $do-once8
                     (if
-                      (get_local $11)
+                      (get_local $8)
                       (block
                         (if
                           (i32.eq
-                            (get_local $2)
+                            (get_local $11)
                             (i32.load
                               (tee_local $0
                                 (i32.add
@@ -9001,7 +8986,7 @@
                                   (i32.shl
                                     (tee_local $1
                                       (i32.load offset=28
-                                        (get_local $2)
+                                        (get_local $11)
                                       )
                                     )
                                     (i32.const 2)
@@ -9013,11 +8998,11 @@
                           (block
                             (i32.store
                               (get_local $0)
-                              (get_local $5)
+                              (get_local $6)
                             )
                             (if
                               (i32.eqz
-                                (get_local $5)
+                                (get_local $6)
                               )
                               (block
                                 (i32.store
@@ -9042,7 +9027,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $11)
+                                (get_local $8)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -9054,33 +9039,33 @@
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
-                                      (get_local $11)
+                                      (get_local $8)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $2)
+                                (get_local $11)
                               )
                               (i32.store
                                 (get_local $0)
-                                (get_local $5)
+                                (get_local $6)
                               )
                               (i32.store offset=20
-                                (get_local $11)
-                                (get_local $5)
+                                (get_local $8)
+                                (get_local $6)
                               )
                             )
                             (br_if $do-once8
                               (i32.eqz
-                                (get_local $5)
+                                (get_local $6)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $5)
-                            (tee_local $1
+                            (get_local $6)
+                            (tee_local $0
                               (i32.load
                                 (i32.const 192)
                               )
@@ -9089,29 +9074,29 @@
                           (call $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $5)
-                          (get_local $11)
+                          (get_local $6)
+                          (get_local $8)
                         )
                         (if
-                          (tee_local $0
+                          (tee_local $1
                             (i32.load offset=16
-                              (get_local $2)
+                              (get_local $11)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $0)
                               (get_local $1)
+                              (get_local $0)
                             )
                             (call $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $5)
-                                (get_local $0)
+                                (get_local $6)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $0)
-                                (get_local $5)
+                                (get_local $1)
+                                (get_local $6)
                               )
                             )
                           )
@@ -9119,7 +9104,7 @@
                         (if
                           (tee_local $0
                             (i32.load offset=20
-                              (get_local $2)
+                              (get_local $11)
                             )
                           )
                           (if
@@ -9132,12 +9117,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $5)
+                                (get_local $6)
                                 (get_local $0)
                               )
                               (i32.store offset=24
                                 (get_local $0)
-                                (get_local $5)
+                                (get_local $6)
                               )
                             )
                           )
@@ -9147,17 +9132,17 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $4)
+                      (get_local $12)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $2)
+                        (get_local $11)
                         (i32.or
                           (tee_local $0
                             (i32.add
+                              (get_local $12)
                               (get_local $4)
-                              (get_local $3)
                             )
                           )
                           (i32.const 3)
@@ -9167,7 +9152,7 @@
                         (tee_local $0
                           (i32.add
                             (i32.add
-                              (get_local $2)
+                              (get_local $11)
                               (get_local $0)
                             )
                             (i32.const 4)
@@ -9183,25 +9168,25 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $2)
+                        (get_local $11)
                         (i32.or
-                          (get_local $3)
+                          (get_local $4)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $7)
+                        (get_local $14)
                         (i32.or
-                          (get_local $4)
+                          (get_local $12)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $7)
-                          (get_local $4)
+                          (get_local $14)
+                          (get_local $12)
                         )
-                        (get_local $4)
+                        (get_local $12)
                       )
                       (if
                         (tee_local $0
@@ -9210,17 +9195,17 @@
                           )
                         )
                         (block
-                          (set_local $5
+                          (set_local $4
                             (i32.load
                               (i32.const 196)
                             )
                           )
-                          (set_local $0
+                          (set_local $2
                             (i32.add
                               (i32.const 216)
                               (i32.shl
                                 (i32.shl
-                                  (tee_local $1
+                                  (tee_local $0
                                     (i32.shr_u
                                       (get_local $0)
                                       (i32.const 3)
@@ -9234,25 +9219,25 @@
                           )
                           (if
                             (i32.and
-                              (tee_local $3
+                              (tee_local $1
                                 (i32.load
                                   (i32.const 176)
                                 )
                               )
-                              (tee_local $1
+                              (tee_local $0
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $1)
+                                  (get_local $0)
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (tee_local $1
+                                (tee_local $0
                                   (i32.load
-                                    (tee_local $3
+                                    (tee_local $1
                                       (i32.add
-                                        (get_local $0)
+                                        (get_local $2)
                                         (i32.const 8)
                                       )
                                     )
@@ -9264,11 +9249,11 @@
                               )
                               (call $_abort)
                               (block
-                                (set_local $13
-                                  (get_local $3)
-                                )
-                                (set_local $9
+                                (set_local $5
                                   (get_local $1)
+                                )
+                                (set_local $3
+                                  (get_local $0)
                                 )
                               )
                             )
@@ -9276,63 +9261,63 @@
                               (i32.store
                                 (i32.const 176)
                                 (i32.or
-                                  (get_local $3)
                                   (get_local $1)
+                                  (get_local $0)
                                 )
                               )
-                              (set_local $13
+                              (set_local $5
                                 (i32.add
-                                  (get_local $0)
+                                  (get_local $2)
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $9
-                                (get_local $0)
+                              (set_local $3
+                                (get_local $2)
                               )
                             )
                           )
                           (i32.store
-                            (get_local $13)
                             (get_local $5)
+                            (get_local $4)
                           )
                           (i32.store offset=12
-                            (get_local $9)
-                            (get_local $5)
+                            (get_local $3)
+                            (get_local $4)
                           )
                           (i32.store offset=8
-                            (get_local $5)
-                            (get_local $9)
+                            (get_local $4)
+                            (get_local $3)
                           )
                           (i32.store offset=12
-                            (get_local $5)
-                            (get_local $0)
+                            (get_local $4)
+                            (get_local $2)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $4)
+                        (get_local $12)
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $7)
+                        (get_local $14)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $2)
+                      (get_local $11)
                       (i32.const 8)
                     )
                   )
                 )
                 (set_local $0
-                  (get_local $3)
+                  (get_local $4)
                 )
               )
             )
             (set_local $0
-              (get_local $3)
+              (get_local $4)
             )
           )
         )
@@ -9345,9 +9330,9 @@
             (i32.const -1)
           )
           (block
-            (set_local $9
+            (set_local $6
               (i32.and
-                (tee_local $2
+                (tee_local $0
                   (i32.add
                     (get_local $0)
                     (i32.const 11)
@@ -9363,55 +9348,55 @@
                 )
               )
               (block
-                (set_local $0
+                (set_local $3
                   (i32.sub
                     (i32.const 0)
-                    (get_local $9)
+                    (get_local $6)
                   )
                 )
                 (block $jumpthreading$outer$2
                   (block $jumpthreading$inner$2
                     (if
-                      (tee_local $2
+                      (tee_local $0
                         (i32.load offset=480
                           (i32.shl
-                            (tee_local $15
+                            (tee_local $17
                               (if i32
-                                (tee_local $2
+                                (tee_local $0
                                   (i32.shr_u
-                                    (get_local $2)
+                                    (get_local $0)
                                     (i32.const 8)
                                   )
                                 )
                                 (if i32
                                   (i32.gt_u
-                                    (get_local $9)
+                                    (get_local $6)
                                     (i32.const 16777215)
                                   )
                                   (i32.const 31)
                                   (i32.or
                                     (i32.and
                                       (i32.shr_u
-                                        (get_local $9)
+                                        (get_local $6)
                                         (i32.add
-                                          (tee_local $2
+                                          (tee_local $0
                                             (i32.add
                                               (i32.sub
                                                 (i32.const 14)
                                                 (i32.or
                                                   (i32.or
-                                                    (tee_local $5
+                                                    (tee_local $0
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (tee_local $2
+                                                            (tee_local $1
                                                               (i32.shl
-                                                                (get_local $2)
-                                                                (tee_local $8
+                                                                (get_local $0)
+                                                                (tee_local $5
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
-                                                                        (get_local $2)
+                                                                        (get_local $0)
                                                                         (i32.const 1048320)
                                                                       )
                                                                       (i32.const 16)
@@ -9428,16 +9413,16 @@
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $8)
+                                                    (get_local $5)
                                                   )
-                                                  (tee_local $5
+                                                  (tee_local $0
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $2
+                                                          (tee_local $1
                                                             (i32.shl
-                                                              (get_local $2)
-                                                              (get_local $5)
+                                                              (get_local $1)
+                                                              (get_local $0)
                                                             )
                                                           )
                                                           (i32.const 245760)
@@ -9451,8 +9436,8 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $2)
-                                                  (get_local $5)
+                                                  (get_local $1)
+                                                  (get_local $0)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -9464,7 +9449,7 @@
                                       (i32.const 1)
                                     )
                                     (i32.shl
-                                      (get_local $2)
+                                      (get_local $0)
                                       (i32.const 1)
                                     )
                                   )
@@ -9477,43 +9462,37 @@
                         )
                       )
                       (block
-                        (set_local $5
-                          (get_local $0)
-                        )
-                        (set_local $13
+                        (set_local $16
                           (i32.const 0)
                         )
-                        (set_local $12
+                        (set_local $18
                           (i32.shl
-                            (get_local $9)
+                            (get_local $6)
                             (select
                               (i32.const 0)
                               (i32.sub
                                 (i32.const 25)
                                 (i32.shr_u
-                                  (get_local $15)
+                                  (get_local $17)
                                   (i32.const 1)
                                 )
                               )
                               (i32.eq
-                                (get_local $15)
+                                (get_local $17)
                                 (i32.const 31)
                               )
                             )
                           )
                         )
-                        (set_local $0
-                          (get_local $2)
-                        )
-                        (set_local $2
+                        (set_local $5
                           (i32.const 0)
                         )
                         (loop $while-in14
                           (if
                             (i32.lt_u
-                              (tee_local $8
+                              (tee_local $1
                                 (i32.sub
-                                  (tee_local $14
+                                  (tee_local $15
                                     (i32.and
                                       (i32.load offset=4
                                         (get_local $0)
@@ -9521,24 +9500,24 @@
                                       (i32.const -8)
                                     )
                                   )
-                                  (get_local $9)
+                                  (get_local $6)
                                 )
                               )
-                              (get_local $5)
+                              (get_local $3)
                             )
                             (if
                               (i32.eq
-                                (get_local $14)
-                                (get_local $9)
+                                (get_local $15)
+                                (get_local $6)
                               )
                               (block
                                 (set_local $4
-                                  (get_local $8)
+                                  (get_local $1)
                                 )
-                                (set_local $3
+                                (set_local $7
                                   (get_local $0)
                                 )
-                                (set_local $1
+                                (set_local $2
                                   (get_local $0)
                                 )
                                 (set_local $19
@@ -9547,30 +9526,33 @@
                                 (br $jumpthreading$outer$2)
                               )
                               (block
-                                (set_local $5
-                                  (get_local $8)
+                                (set_local $3
+                                  (get_local $1)
                                 )
-                                (set_local $2
+                                (set_local $1
                                   (get_local $0)
                                 )
                               )
                             )
+                            (set_local $1
+                              (get_local $5)
+                            )
                           )
-                          (set_local $8
+                          (set_local $0
                             (select
-                              (get_local $13)
-                              (tee_local $8
+                              (get_local $16)
+                              (tee_local $5
                                 (i32.load offset=20
                                   (get_local $0)
                                 )
                               )
                               (i32.or
                                 (i32.eqz
-                                  (get_local $8)
+                                  (get_local $5)
                                 )
                                 (i32.eq
-                                  (get_local $8)
-                                  (tee_local $14
+                                  (get_local $5)
+                                  (tee_local $15
                                     (i32.load
                                       (i32.add
                                         (i32.add
@@ -9579,7 +9561,7 @@
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $12)
+                                            (get_local $18)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -9591,14 +9573,14 @@
                               )
                             )
                           )
-                          (set_local $0
+                          (set_local $5
                             (i32.shl
-                              (get_local $12)
+                              (get_local $18)
                               (i32.xor
                                 (i32.and
-                                  (tee_local $12
+                                  (tee_local $16
                                     (i32.eqz
-                                      (get_local $14)
+                                      (get_local $15)
                                     )
                                   )
                                   (i32.const 1)
@@ -9607,34 +9589,31 @@
                               )
                             )
                           )
-                          (if
-                            (get_local $12)
-                            (block
-                              (set_local $0
-                                (get_local $5)
-                              )
-                              (br $jumpthreading$inner$2)
+                          (br_if $jumpthreading$inner$2
+                            (get_local $16)
+                          )
+                          (block
+                            (set_local $16
+                              (get_local $0)
                             )
-                            (block
-                              (set_local $13
-                                (get_local $8)
-                              )
-                              (set_local $12
-                                (get_local $0)
-                              )
-                              (set_local $0
-                                (get_local $14)
-                              )
-                              (br $while-in14)
+                            (set_local $18
+                              (get_local $5)
                             )
+                            (set_local $0
+                              (get_local $15)
+                            )
+                            (set_local $5
+                              (get_local $1)
+                            )
+                            (br $while-in14)
                           )
                         )
                       )
                       (block
-                        (set_local $8
+                        (set_local $0
                           (i32.const 0)
                         )
-                        (set_local $2
+                        (set_local $1
                           (i32.const 0)
                         )
                         (br $jumpthreading$inner$2)
@@ -9643,32 +9622,32 @@
                     (br $jumpthreading$outer$2)
                   )
                   (if
-                    (tee_local $5
+                    (tee_local $0
                       (if i32
                         (i32.and
                           (i32.eqz
-                            (get_local $8)
+                            (get_local $0)
                           )
                           (i32.eqz
-                            (get_local $2)
+                            (get_local $1)
                           )
                         )
                         (block i32
                           (if
                             (i32.eqz
-                              (tee_local $5
+                              (tee_local $0
                                 (i32.and
                                   (get_local $24)
                                   (i32.or
-                                    (tee_local $5
+                                    (tee_local $0
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $15)
+                                        (get_local $17)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $5)
+                                      (get_local $0)
                                     )
                                   )
                                 )
@@ -9676,21 +9655,21 @@
                             )
                             (block
                               (set_local $0
-                                (get_local $9)
+                                (get_local $6)
                               )
                               (br $do-once)
                             )
                           )
-                          (set_local $12
+                          (set_local $15
                             (i32.and
                               (i32.shr_u
-                                (tee_local $5
+                                (tee_local $0
                                   (i32.add
                                     (i32.and
-                                      (get_local $5)
+                                      (get_local $0)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $5)
+                                        (get_local $0)
                                       )
                                     )
                                     (i32.const -1)
@@ -9708,13 +9687,13 @@
                                   (i32.or
                                     (i32.or
                                       (i32.or
-                                        (tee_local $8
+                                        (tee_local $0
                                           (i32.and
                                             (i32.shr_u
                                               (tee_local $5
                                                 (i32.shr_u
-                                                  (get_local $5)
-                                                  (get_local $12)
+                                                  (get_local $0)
+                                                  (get_local $15)
                                                 )
                                               )
                                               (i32.const 5)
@@ -9722,15 +9701,15 @@
                                             (i32.const 8)
                                           )
                                         )
-                                        (get_local $12)
+                                        (get_local $15)
                                       )
-                                      (tee_local $8
+                                      (tee_local $0
                                         (i32.and
                                           (i32.shr_u
                                             (tee_local $5
                                               (i32.shr_u
                                                 (get_local $5)
-                                                (get_local $8)
+                                                (get_local $0)
                                               )
                                             )
                                             (i32.const 2)
@@ -9739,13 +9718,13 @@
                                         )
                                       )
                                     )
-                                    (tee_local $8
+                                    (tee_local $0
                                       (i32.and
                                         (i32.shr_u
                                           (tee_local $5
                                             (i32.shr_u
                                               (get_local $5)
-                                              (get_local $8)
+                                              (get_local $0)
                                             )
                                           )
                                           (i32.const 1)
@@ -9754,13 +9733,13 @@
                                       )
                                     )
                                   )
-                                  (tee_local $8
+                                  (tee_local $0
                                     (i32.and
                                       (i32.shr_u
                                         (tee_local $5
                                           (i32.shr_u
                                             (get_local $5)
-                                            (get_local $8)
+                                            (get_local $0)
                                           )
                                         )
                                         (i32.const 1)
@@ -9771,36 +9750,36 @@
                                 )
                                 (i32.shr_u
                                   (get_local $5)
-                                  (get_local $8)
+                                  (get_local $0)
                                 )
                               )
                               (i32.const 2)
                             )
                           )
                         )
-                        (get_local $8)
+                        (get_local $0)
                       )
                     )
                     (block
                       (set_local $4
+                        (get_local $3)
+                      )
+                      (set_local $7
                         (get_local $0)
                       )
-                      (set_local $3
-                        (get_local $5)
-                      )
-                      (set_local $1
-                        (get_local $2)
+                      (set_local $2
+                        (get_local $1)
                       )
                       (set_local $19
                         (i32.const 90)
                       )
                     )
                     (block
-                      (set_local $7
-                        (get_local $0)
+                      (set_local $9
+                        (get_local $3)
                       )
-                      (set_local $6
-                        (get_local $2)
+                      (set_local $13
+                        (get_local $1)
                       )
                     )
                   )
@@ -9811,17 +9790,17 @@
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $2
+                    (set_local $1
                       (i32.lt_u
                         (tee_local $0
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $3)
+                                (get_local $7)
                               )
                               (i32.const -8)
                             )
-                            (get_local $9)
+                            (get_local $6)
                           )
                         )
                         (get_local $4)
@@ -9831,63 +9810,63 @@
                       (select
                         (get_local $0)
                         (get_local $4)
-                        (get_local $2)
+                        (get_local $1)
                       )
                     )
-                    (set_local $1
+                    (set_local $2
                       (select
-                        (get_local $3)
-                        (get_local $1)
+                        (get_local $7)
                         (get_local $2)
+                        (get_local $1)
                       )
                     )
                     (if
                       (tee_local $0
                         (i32.load offset=16
-                          (get_local $3)
+                          (get_local $7)
                         )
                       )
                       (block
-                        (set_local $3
+                        (set_local $7
                           (get_local $0)
                         )
                         (br $while-in16)
                       )
                     )
                     (br_if $while-in16
-                      (tee_local $3
+                      (tee_local $7
                         (i32.load offset=20
-                          (get_local $3)
+                          (get_local $7)
                         )
                       )
                     )
                     (block
-                      (set_local $7
+                      (set_local $9
                         (get_local $4)
                       )
-                      (set_local $6
-                        (get_local $1)
+                      (set_local $13
+                        (get_local $2)
                       )
                     )
                   )
                 )
                 (if
-                  (get_local $6)
+                  (get_local $13)
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $9)
                       (i32.sub
                         (i32.load
                           (i32.const 184)
                         )
-                        (get_local $9)
+                        (get_local $6)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $6)
-                          (tee_local $8
+                          (get_local $13)
+                          (tee_local $4
                             (i32.load
                               (i32.const 192)
                             )
@@ -9897,19 +9876,19 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $6)
-                          (tee_local $4
+                          (get_local $13)
+                          (tee_local $5
                             (i32.add
+                              (get_local $13)
                               (get_local $6)
-                              (get_local $9)
                             )
                           )
                         )
                         (call $_abort)
                       )
-                      (set_local $5
+                      (set_local $7
                         (i32.load offset=24
-                          (get_local $6)
+                          (get_local $13)
                         )
                       )
                       (block $do-once17
@@ -9917,10 +9896,10 @@
                           (i32.eq
                             (tee_local $0
                               (i32.load offset=12
-                                (get_local $6)
+                                (get_local $13)
                               )
                             )
-                            (get_local $6)
+                            (get_local $13)
                           )
                           (block
                             (if
@@ -9929,7 +9908,7 @@
                                   (i32.load
                                     (tee_local $0
                                       (i32.add
-                                        (get_local $6)
+                                        (get_local $13)
                                         (i32.const 20)
                                       )
                                     )
@@ -9942,7 +9921,7 @@
                                     (i32.load
                                       (tee_local $0
                                         (i32.add
-                                          (get_local $6)
+                                          (get_local $13)
                                           (i32.const 16)
                                         )
                                       )
@@ -9950,7 +9929,7 @@
                                   )
                                 )
                                 (block
-                                  (set_local $10
+                                  (set_local $8
                                     (i32.const 0)
                                   )
                                   (br $do-once17)
@@ -10004,7 +9983,7 @@
                             (if
                               (i32.lt_u
                                 (get_local $0)
-                                (get_local $8)
+                                (get_local $4)
                               )
                               (call $_abort)
                               (block
@@ -10012,7 +9991,7 @@
                                   (get_local $0)
                                   (i32.const 0)
                                 )
-                                (set_local $10
+                                (set_local $8
                                   (get_local $1)
                                 )
                               )
@@ -10021,26 +10000,26 @@
                           (block
                             (if
                               (i32.lt_u
-                                (tee_local $3
+                                (tee_local $2
                                   (i32.load offset=8
-                                    (get_local $6)
+                                    (get_local $13)
                                   )
                                 )
-                                (get_local $8)
+                                (get_local $4)
                               )
                               (call $_abort)
                             )
                             (if
                               (i32.ne
                                 (i32.load
-                                  (tee_local $2
+                                  (tee_local $3
                                     (i32.add
-                                      (get_local $3)
+                                      (get_local $2)
                                       (i32.const 12)
                                     )
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $13)
                               )
                               (call $_abort)
                             )
@@ -10054,18 +10033,18 @@
                                     )
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $13)
                               )
                               (block
                                 (i32.store
-                                  (get_local $2)
+                                  (get_local $3)
                                   (get_local $0)
                                 )
                                 (i32.store
                                   (get_local $1)
-                                  (get_local $3)
+                                  (get_local $2)
                                 )
-                                (set_local $10
+                                (set_local $8
                                   (get_local $0)
                                 )
                               )
@@ -10076,11 +10055,11 @@
                       )
                       (block $do-once21
                         (if
-                          (get_local $5)
+                          (get_local $7)
                           (block
                             (if
                               (i32.eq
-                                (get_local $6)
+                                (get_local $13)
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
@@ -10088,7 +10067,7 @@
                                       (i32.shl
                                         (tee_local $1
                                           (i32.load offset=28
-                                            (get_local $6)
+                                            (get_local $13)
                                           )
                                         )
                                         (i32.const 2)
@@ -10100,11 +10079,11 @@
                               (block
                                 (i32.store
                                   (get_local $0)
-                                  (get_local $10)
+                                  (get_local $8)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $10)
+                                    (get_local $8)
                                   )
                                   (block
                                     (i32.store
@@ -10129,7 +10108,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $5)
+                                    (get_local $7)
                                     (i32.load
                                       (i32.const 192)
                                     )
@@ -10141,33 +10120,33 @@
                                     (i32.load
                                       (tee_local $0
                                         (i32.add
-                                          (get_local $5)
+                                          (get_local $7)
                                           (i32.const 16)
                                         )
                                       )
                                     )
-                                    (get_local $6)
+                                    (get_local $13)
                                   )
                                   (i32.store
                                     (get_local $0)
-                                    (get_local $10)
+                                    (get_local $8)
                                   )
                                   (i32.store offset=20
-                                    (get_local $5)
-                                    (get_local $10)
+                                    (get_local $7)
+                                    (get_local $8)
                                   )
                                 )
                                 (br_if $do-once21
                                   (i32.eqz
-                                    (get_local $10)
+                                    (get_local $8)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $10)
-                                (tee_local $1
+                                (get_local $8)
+                                (tee_local $0
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -10176,29 +10155,29 @@
                               (call $_abort)
                             )
                             (i32.store offset=24
-                              (get_local $10)
-                              (get_local $5)
+                              (get_local $8)
+                              (get_local $7)
                             )
                             (if
-                              (tee_local $0
+                              (tee_local $1
                                 (i32.load offset=16
-                                  (get_local $6)
+                                  (get_local $13)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $0)
                                   (get_local $1)
+                                  (get_local $0)
                                 )
                                 (call $_abort)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $10)
-                                    (get_local $0)
+                                    (get_local $8)
+                                    (get_local $1)
                                   )
                                   (i32.store offset=24
-                                    (get_local $0)
-                                    (get_local $10)
+                                    (get_local $1)
+                                    (get_local $8)
                                   )
                                 )
                               )
@@ -10206,7 +10185,7 @@
                             (if
                               (tee_local $0
                                 (i32.load offset=20
-                                  (get_local $6)
+                                  (get_local $13)
                                 )
                               )
                               (if
@@ -10219,12 +10198,12 @@
                                 (call $_abort)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $10)
+                                    (get_local $8)
                                     (get_local $0)
                                   )
                                   (i32.store offset=24
                                     (get_local $0)
-                                    (get_local $10)
+                                    (get_local $8)
                                   )
                                 )
                               )
@@ -10235,17 +10214,17 @@
                       (block $do-once25
                         (if
                           (i32.lt_u
-                            (get_local $7)
+                            (get_local $9)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $6)
+                              (get_local $13)
                               (i32.or
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $7)
                                     (get_local $9)
+                                    (get_local $6)
                                   )
                                 )
                                 (i32.const 3)
@@ -10255,7 +10234,7 @@
                               (tee_local $0
                                 (i32.add
                                   (i32.add
-                                    (get_local $6)
+                                    (get_local $13)
                                     (get_local $0)
                                   )
                                   (i32.const 4)
@@ -10271,44 +10250,44 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $6)
+                              (get_local $13)
                               (i32.or
-                                (get_local $9)
+                                (get_local $6)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
-                              (get_local $4)
+                              (get_local $5)
                               (i32.or
-                                (get_local $7)
+                                (get_local $9)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
-                                (get_local $4)
-                                (get_local $7)
+                                (get_local $5)
+                                (get_local $9)
                               )
-                              (get_local $7)
+                              (get_local $9)
                             )
-                            (set_local $1
+                            (set_local $0
                               (i32.shr_u
-                                (get_local $7)
+                                (get_local $9)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $7)
+                                (get_local $9)
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $0
+                                (set_local $3
                                   (i32.add
                                     (i32.const 216)
                                     (i32.shl
                                       (i32.shl
-                                        (get_local $1)
+                                        (get_local $0)
                                         (i32.const 1)
                                       )
                                       (i32.const 2)
@@ -10317,25 +10296,25 @@
                                 )
                                 (if
                                   (i32.and
-                                    (tee_local $2
+                                    (tee_local $1
                                       (i32.load
                                         (i32.const 176)
                                       )
                                     )
-                                    (tee_local $1
+                                    (tee_local $0
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $1)
+                                        (get_local $0)
                                       )
                                     )
                                   )
                                   (if
                                     (i32.lt_u
-                                      (tee_local $1
+                                      (tee_local $0
                                         (i32.load
-                                          (tee_local $2
+                                          (tee_local $1
                                             (i32.add
-                                              (get_local $0)
+                                              (get_local $3)
                                               (i32.const 8)
                                             )
                                           )
@@ -10348,10 +10327,10 @@
                                     (call $_abort)
                                     (block
                                       (set_local $20
-                                        (get_local $2)
-                                      )
-                                      (set_local $16
                                         (get_local $1)
+                                      )
+                                      (set_local $10
+                                        (get_local $0)
                                       )
                                     )
                                   )
@@ -10359,62 +10338,62 @@
                                     (i32.store
                                       (i32.const 176)
                                       (i32.or
-                                        (get_local $2)
                                         (get_local $1)
+                                        (get_local $0)
                                       )
                                     )
                                     (set_local $20
                                       (i32.add
-                                        (get_local $0)
+                                        (get_local $3)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $16
-                                      (get_local $0)
+                                    (set_local $10
+                                      (get_local $3)
                                     )
                                   )
                                 )
                                 (i32.store
                                   (get_local $20)
-                                  (get_local $4)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=12
-                                  (get_local $16)
-                                  (get_local $4)
+                                  (get_local $10)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=8
-                                  (get_local $4)
-                                  (get_local $16)
+                                  (get_local $5)
+                                  (get_local $10)
                                 )
                                 (i32.store offset=12
-                                  (get_local $4)
-                                  (get_local $0)
+                                  (get_local $5)
+                                  (get_local $3)
                                 )
                                 (br $do-once25)
                               )
                             )
-                            (set_local $1
+                            (set_local $2
                               (i32.add
                                 (i32.const 480)
                                 (i32.shl
-                                  (tee_local $2
+                                  (tee_local $3
                                     (if i32
                                       (tee_local $0
                                         (i32.shr_u
-                                          (get_local $7)
+                                          (get_local $9)
                                           (i32.const 8)
                                         )
                                       )
                                       (if i32
                                         (i32.gt_u
-                                          (get_local $7)
+                                          (get_local $9)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $7)
+                                              (get_local $9)
                                               (i32.add
                                                 (tee_local $0
                                                   (i32.add
@@ -10422,14 +10401,14 @@
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (tee_local $1
+                                                          (tee_local $0
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (tee_local $0
+                                                                  (tee_local $1
                                                                     (i32.shl
                                                                       (get_local $0)
-                                                                      (tee_local $2
+                                                                      (tee_local $3
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
@@ -10450,16 +10429,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $2)
+                                                          (get_local $3)
                                                         )
-                                                        (tee_local $1
+                                                        (tee_local $0
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $0
+                                                                (tee_local $1
                                                                   (i32.shl
-                                                                    (get_local $0)
                                                                     (get_local $1)
+                                                                    (get_local $0)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -10473,8 +10452,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $0)
                                                         (get_local $1)
+                                                        (get_local $0)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -10499,13 +10478,13 @@
                               )
                             )
                             (i32.store offset=28
-                              (get_local $4)
-                              (get_local $2)
+                              (get_local $5)
+                              (get_local $3)
                             )
                             (i32.store offset=4
                               (tee_local $0
                                 (i32.add
-                                  (get_local $4)
+                                  (get_local $5)
                                   (i32.const 16)
                                 )
                               )
@@ -10518,7 +10497,7 @@
                             (if
                               (i32.eqz
                                 (i32.and
-                                  (tee_local $3
+                                  (tee_local $1
                                     (i32.load
                                       (i32.const 180)
                                     )
@@ -10526,7 +10505,7 @@
                                   (tee_local $0
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $2)
+                                      (get_local $3)
                                     )
                                   )
                                 )
@@ -10535,43 +10514,43 @@
                                 (i32.store
                                   (i32.const 180)
                                   (i32.or
-                                    (get_local $3)
+                                    (get_local $1)
                                     (get_local $0)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $1)
-                                  (get_local $4)
+                                  (get_local $2)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=24
-                                  (get_local $4)
-                                  (get_local $1)
+                                  (get_local $5)
+                                  (get_local $2)
                                 )
                                 (i32.store offset=12
-                                  (get_local $4)
-                                  (get_local $4)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=8
-                                  (get_local $4)
-                                  (get_local $4)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                                 (br $do-once25)
                               )
                             )
-                            (set_local $2
+                            (set_local $3
                               (i32.shl
-                                (get_local $7)
+                                (get_local $9)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $2)
+                                      (get_local $3)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $2)
+                                    (get_local $3)
                                     (i32.const 31)
                                   )
                                 )
@@ -10579,7 +10558,7 @@
                             )
                             (set_local $0
                               (i32.load
-                                (get_local $1)
+                                (get_local $2)
                               )
                             )
                             (block $jumpthreading$outer$1
@@ -10594,59 +10573,52 @@
                                           )
                                           (i32.const -8)
                                         )
-                                        (get_local $7)
+                                        (get_local $9)
                                       )
                                     )
-                                    (set_local $1
+                                    (set_local $2
                                       (i32.shl
-                                        (get_local $2)
+                                        (get_local $3)
                                         (i32.const 1)
                                       )
                                     )
-                                    (if
-                                      (tee_local $3
-                                        (i32.load
-                                          (tee_local $2
-                                            (i32.add
+                                    (br_if $jumpthreading$inner$0
+                                      (i32.eqz
+                                        (tee_local $1
+                                          (i32.load
+                                            (tee_local $3
                                               (i32.add
-                                                (get_local $0)
-                                                (i32.const 16)
-                                              )
-                                              (i32.shl
-                                                (i32.shr_u
-                                                  (get_local $2)
-                                                  (i32.const 31)
+                                                (i32.add
+                                                  (get_local $0)
+                                                  (i32.const 16)
                                                 )
-                                                (i32.const 2)
+                                                (i32.shl
+                                                  (i32.shr_u
+                                                    (get_local $3)
+                                                    (i32.const 31)
+                                                  )
+                                                  (i32.const 2)
+                                                )
                                               )
                                             )
                                           )
                                         )
                                       )
-                                      (block
-                                        (set_local $2
-                                          (get_local $1)
-                                        )
-                                        (set_local $0
-                                          (get_local $3)
-                                        )
-                                        (br $while-in28)
+                                    )
+                                    (block
+                                      (set_local $3
+                                        (get_local $2)
                                       )
-                                      (block
-                                        (set_local $1
-                                          (get_local $0)
-                                        )
-                                        (set_local $0
-                                          (get_local $2)
-                                        )
-                                        (br $jumpthreading$inner$0)
+                                      (set_local $0
+                                        (get_local $1)
                                       )
+                                      (br $while-in28)
                                     )
                                   )
                                 )
                                 (if
                                   (i32.lt_u
-                                    (get_local $0)
+                                    (get_local $3)
                                     (i32.load
                                       (i32.const 192)
                                     )
@@ -10654,20 +10626,20 @@
                                   (call $_abort)
                                   (block
                                     (i32.store
-                                      (get_local $0)
-                                      (get_local $4)
+                                      (get_local $3)
+                                      (get_local $5)
                                     )
                                     (i32.store offset=24
-                                      (get_local $4)
-                                      (get_local $1)
+                                      (get_local $5)
+                                      (get_local $0)
                                     )
                                     (i32.store offset=12
-                                      (get_local $4)
-                                      (get_local $4)
+                                      (get_local $5)
+                                      (get_local $5)
                                     )
                                     (i32.store offset=8
-                                      (get_local $4)
-                                      (get_local $4)
+                                      (get_local $5)
+                                      (get_local $5)
                                     )
                                     (br $do-once25)
                                   )
@@ -10677,9 +10649,9 @@
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (tee_local $3
+                                    (tee_local $2
                                       (i32.load
-                                        (tee_local $1
+                                        (tee_local $3
                                           (i32.add
                                             (get_local $0)
                                             (i32.const 8)
@@ -10687,7 +10659,7 @@
                                         )
                                       )
                                     )
-                                    (tee_local $2
+                                    (tee_local $1
                                       (i32.load
                                         (i32.const 192)
                                       )
@@ -10695,28 +10667,28 @@
                                   )
                                   (i32.ge_u
                                     (get_local $0)
-                                    (get_local $2)
+                                    (get_local $1)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $3)
-                                    (get_local $4)
+                                    (get_local $2)
+                                    (get_local $5)
                                   )
                                   (i32.store
-                                    (get_local $1)
-                                    (get_local $4)
+                                    (get_local $3)
+                                    (get_local $5)
                                   )
                                   (i32.store offset=8
-                                    (get_local $4)
-                                    (get_local $3)
+                                    (get_local $5)
+                                    (get_local $2)
                                   )
                                   (i32.store offset=12
-                                    (get_local $4)
+                                    (get_local $5)
                                     (get_local $0)
                                   )
                                   (i32.store offset=24
-                                    (get_local $4)
+                                    (get_local $5)
                                     (i32.const 0)
                                   )
                                 )
@@ -10728,22 +10700,22 @@
                       )
                       (return
                         (i32.add
-                          (get_local $6)
+                          (get_local $13)
                           (i32.const 8)
                         )
                       )
                     )
                     (set_local $0
-                      (get_local $9)
+                      (get_local $6)
                     )
                   )
                   (set_local $0
-                    (get_local $9)
+                    (get_local $6)
                   )
                 )
               )
               (set_local $0
-                (get_local $9)
+                (get_local $6)
               )
             )
           )
@@ -10752,7 +10724,7 @@
     )
     (if
       (i32.ge_u
-        (tee_local $2
+        (tee_local $1
           (i32.load
             (i32.const 184)
           )
@@ -10760,16 +10732,16 @@
         (get_local $0)
       )
       (block
-        (set_local $3
+        (set_local $2
           (i32.load
             (i32.const 196)
           )
         )
         (if
           (i32.gt_u
-            (tee_local $1
+            (tee_local $3
               (i32.sub
-                (get_local $2)
+                (get_local $1)
                 (get_local $0)
               )
             )
@@ -10778,33 +10750,33 @@
           (block
             (i32.store
               (i32.const 196)
-              (tee_local $2
+              (tee_local $1
                 (i32.add
-                  (get_local $3)
+                  (get_local $2)
                   (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 184)
-              (get_local $1)
+              (get_local $3)
             )
             (i32.store offset=4
-              (get_local $2)
+              (get_local $1)
               (i32.or
-                (get_local $1)
+                (get_local $3)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $2)
                 (get_local $1)
+                (get_local $3)
               )
-              (get_local $1)
+              (get_local $3)
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
                 (get_local $0)
                 (i32.const 3)
@@ -10821,9 +10793,9 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
-                (get_local $2)
+                (get_local $1)
                 (i32.const 3)
               )
             )
@@ -10831,8 +10803,8 @@
               (tee_local $0
                 (i32.add
                   (i32.add
-                    (get_local $3)
                     (get_local $2)
+                    (get_local $1)
                   )
                   (i32.const 4)
                 )
@@ -10848,7 +10820,7 @@
         )
         (return
           (i32.add
-            (get_local $3)
+            (get_local $2)
             (i32.const 8)
           )
         )
@@ -10866,7 +10838,7 @@
       (block
         (i32.store
           (i32.const 188)
-          (tee_local $1
+          (tee_local $3
             (i32.sub
               (get_local $1)
               (get_local $0)
@@ -10875,9 +10847,9 @@
         )
         (i32.store
           (i32.const 200)
-          (tee_local $2
+          (tee_local $1
             (i32.add
-              (tee_local $3
+              (tee_local $2
                 (i32.load
                   (i32.const 200)
                 )
@@ -10887,14 +10859,14 @@
           )
         )
         (i32.store offset=4
-          (get_local $2)
+          (get_local $1)
           (i32.or
-            (get_local $1)
+            (get_local $3)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $3)
+          (get_local $2)
           (i32.or
             (get_local $0)
             (i32.const 3)
@@ -10902,7 +10874,7 @@
         )
         (return
           (i32.add
-            (get_local $3)
+            (get_local $2)
             (i32.const 8)
           )
         )
@@ -10967,7 +10939,7 @@
         )
       )
     )
-    (set_local $8
+    (set_local $10
       (i32.add
         (get_local $0)
         (i32.const 48)
@@ -10975,7 +10947,7 @@
     )
     (if
       (i32.le_u
-        (tee_local $9
+        (tee_local $8
           (i32.and
             (tee_local $6
               (i32.add
@@ -10992,7 +10964,7 @@
                 )
               )
             )
-            (tee_local $2
+            (tee_local $7
               (i32.sub
                 (i32.const 0)
                 (get_local $1)
@@ -11007,7 +10979,7 @@
       )
     )
     (if
-      (tee_local $4
+      (tee_local $2
         (i32.load
           (i32.const 616)
         )
@@ -11022,14 +10994,14 @@
                     (i32.const 608)
                   )
                 )
-                (get_local $9)
+                (get_local $8)
               )
             )
             (get_local $3)
           )
           (i32.gt_u
             (get_local $1)
-            (get_local $4)
+            (get_local $2)
           )
         )
         (return
@@ -11080,7 +11052,7 @@
                             (i32.add
                               (get_local $3)
                               (i32.load
-                                (tee_local $3
+                                (tee_local $2
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 4)
@@ -11118,14 +11090,14 @@
                               (i32.const 188)
                             )
                           )
-                          (get_local $2)
+                          (get_local $7)
                         )
                       )
                       (i32.const 2147483647)
                     )
                     (if
                       (i32.eq
-                        (tee_local $2
+                        (tee_local $3
                           (call $_sbrk
                             (get_local $1)
                           )
@@ -11135,13 +11107,13 @@
                             (get_local $4)
                           )
                           (i32.load
-                            (get_local $3)
+                            (get_local $2)
                           )
                         )
                       )
                       (br_if $jumpthreading$inner$12
                         (i32.ne
-                          (get_local $2)
+                          (get_local $3)
                           (i32.const -1)
                         )
                       )
@@ -11152,7 +11124,7 @@
                 )
                 (if
                   (i32.ne
-                    (tee_local $2
+                    (tee_local $3
                       (call $_sbrk
                         (i32.const 0)
                       )
@@ -11160,9 +11132,9 @@
                     (i32.const -1)
                   )
                   (block
-                    (set_local $3
+                    (set_local $4
                       (i32.add
-                        (tee_local $6
+                        (tee_local $7
                           (i32.load
                             (i32.const 608)
                           )
@@ -11170,7 +11142,7 @@
                         (tee_local $1
                           (if i32
                             (i32.and
-                              (tee_local $3
+                              (tee_local $2
                                 (i32.add
                                   (tee_local $4
                                     (i32.load
@@ -11181,17 +11153,17 @@
                                 )
                               )
                               (tee_local $1
-                                (get_local $2)
+                                (get_local $3)
                               )
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $9)
+                                (get_local $8)
                                 (get_local $1)
                               )
                               (i32.and
                                 (i32.add
-                                  (get_local $3)
+                                  (get_local $2)
                                   (get_local $1)
                                 )
                                 (i32.sub
@@ -11200,7 +11172,7 @@
                                 )
                               )
                             )
-                            (get_local $9)
+                            (get_local $8)
                           )
                         )
                       )
@@ -11218,7 +11190,7 @@
                       )
                       (block
                         (if
-                          (tee_local $4
+                          (tee_local $2
                             (i32.load
                               (i32.const 616)
                             )
@@ -11226,29 +11198,29 @@
                           (br_if $label$break$L279
                             (i32.or
                               (i32.le_u
-                                (get_local $3)
-                                (get_local $6)
+                                (get_local $4)
+                                (get_local $7)
                               )
                               (i32.gt_u
-                                (get_local $3)
                                 (get_local $4)
+                                (get_local $2)
                               )
                             )
                           )
                         )
                         (br_if $jumpthreading$inner$12
                           (i32.eq
-                            (tee_local $3
+                            (tee_local $2
                               (call $_sbrk
                                 (get_local $1)
                               )
                             )
-                            (get_local $2)
+                            (get_local $3)
                           )
                         )
                         (block
-                          (set_local $2
-                            (get_local $3)
+                          (set_local $3
+                            (get_local $2)
                           )
                           (br $jumpthreading$inner$4)
                         )
@@ -11258,7 +11230,7 @@
                 )
                 (br $label$break$L279)
               )
-              (set_local $3
+              (set_local $4
                 (i32.sub
                   (i32.const 0)
                   (get_local $1)
@@ -11267,7 +11239,7 @@
               (if
                 (i32.and
                   (i32.gt_u
-                    (get_local $8)
+                    (get_local $10)
                     (get_local $1)
                   )
                   (i32.and
@@ -11276,21 +11248,21 @@
                       (i32.const 2147483647)
                     )
                     (i32.ne
-                      (get_local $2)
+                      (get_local $3)
                       (i32.const -1)
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (tee_local $4
+                    (tee_local $2
                       (i32.and
                         (i32.add
                           (i32.sub
                             (get_local $5)
                             (get_local $1)
                           )
-                          (tee_local $4
+                          (tee_local $2
                             (i32.load
                               (i32.const 656)
                             )
@@ -11298,7 +11270,7 @@
                         )
                         (i32.sub
                           (i32.const 0)
-                          (get_local $4)
+                          (get_local $2)
                         )
                       )
                     )
@@ -11307,21 +11279,21 @@
                   (if
                     (i32.eq
                       (call $_sbrk
-                        (get_local $4)
+                        (get_local $2)
                       )
                       (i32.const -1)
                     )
                     (block
                       (drop
                         (call $_sbrk
-                          (get_local $3)
+                          (get_local $4)
                         )
                       )
                       (br $label$break$L279)
                     )
                     (set_local $1
                       (i32.add
-                        (get_local $4)
+                        (get_local $2)
                         (get_local $1)
                       )
                     )
@@ -11330,7 +11302,7 @@
               )
               (br_if $jumpthreading$inner$12
                 (i32.ne
-                  (get_local $2)
+                  (get_local $3)
                   (i32.const -1)
                 )
               )
@@ -11348,15 +11320,15 @@
         )
         (if
           (i32.lt_u
-            (get_local $9)
+            (get_local $8)
             (i32.const 2147483647)
           )
           (if
             (i32.and
               (i32.lt_u
-                (tee_local $2
+                (tee_local $3
                   (call $_sbrk
-                    (get_local $9)
+                    (get_local $8)
                   )
                 )
                 (tee_local $1
@@ -11367,7 +11339,7 @@
               )
               (i32.and
                 (i32.ne
-                  (get_local $2)
+                  (get_local $3)
                   (i32.const -1)
                 )
                 (i32.ne
@@ -11381,7 +11353,7 @@
                 (tee_local $1
                   (i32.sub
                     (get_local $1)
-                    (get_local $2)
+                    (get_local $3)
                   )
                 )
                 (i32.add
@@ -11396,7 +11368,7 @@
       )
       (i32.store
         (i32.const 608)
-        (tee_local $3
+        (tee_local $2
           (i32.add
             (i32.load
               (i32.const 608)
@@ -11407,25 +11379,25 @@
       )
       (if
         (i32.gt_u
-          (get_local $3)
+          (get_local $2)
           (i32.load
             (i32.const 612)
           )
         )
         (i32.store
           (i32.const 612)
-          (get_local $3)
+          (get_local $2)
         )
       )
       (block $do-once40
         (if
-          (tee_local $7
+          (tee_local $9
             (i32.load
               (i32.const 200)
             )
           )
           (block
-            (set_local $3
+            (set_local $2
               (i32.const 624)
             )
             (block $jumpthreading$outer$9
@@ -11433,18 +11405,18 @@
                 (loop $while-in45
                   (br_if $jumpthreading$inner$9
                     (i32.eq
-                      (get_local $2)
+                      (get_local $3)
                       (i32.add
-                        (tee_local $9
+                        (tee_local $6
                           (i32.load
-                            (get_local $3)
+                            (get_local $2)
                           )
                         )
-                        (tee_local $5
+                        (tee_local $7
                           (i32.load
                             (tee_local $4
                               (i32.add
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 4)
                               )
                             )
@@ -11454,9 +11426,9 @@
                     )
                   )
                   (br_if $while-in45
-                    (tee_local $3
+                    (tee_local $2
                       (i32.load offset=8
-                        (get_local $3)
+                        (get_local $2)
                       )
                     )
                   )
@@ -11467,7 +11439,7 @@
                 (i32.eqz
                   (i32.and
                     (i32.load offset=12
-                      (get_local $3)
+                      (get_local $2)
                     )
                     (i32.const 8)
                   )
@@ -11475,33 +11447,33 @@
                 (if
                   (i32.and
                     (i32.lt_u
-                      (get_local $7)
-                      (get_local $2)
+                      (get_local $9)
+                      (get_local $3)
                     )
                     (i32.ge_u
-                      (get_local $7)
                       (get_local $9)
+                      (get_local $6)
                     )
                   )
                   (block
                     (i32.store
                       (get_local $4)
                       (i32.add
-                        (get_local $5)
+                        (get_local $7)
                         (get_local $1)
                       )
                     )
-                    (set_local $3
+                    (set_local $2
                       (i32.add
-                        (get_local $7)
-                        (tee_local $2
+                        (get_local $9)
+                        (tee_local $3
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (tee_local $2
+                                (tee_local $3
                                   (i32.add
-                                    (get_local $7)
+                                    (get_local $9)
                                     (i32.const 8)
                                   )
                                 )
@@ -11510,7 +11482,7 @@
                             )
                             (i32.const 0)
                             (i32.and
-                              (get_local $2)
+                              (get_local $3)
                               (i32.const 7)
                             )
                           )
@@ -11521,7 +11493,7 @@
                       (i32.add
                         (i32.sub
                           (get_local $1)
-                          (get_local $2)
+                          (get_local $3)
                         )
                         (i32.load
                           (i32.const 188)
@@ -11530,14 +11502,14 @@
                     )
                     (i32.store
                       (i32.const 200)
-                      (get_local $3)
+                      (get_local $2)
                     )
                     (i32.store
                       (i32.const 188)
                       (get_local $1)
                     )
                     (i32.store offset=4
-                      (get_local $3)
+                      (get_local $2)
                       (i32.or
                         (get_local $1)
                         (i32.const 1)
@@ -11545,7 +11517,7 @@
                     )
                     (i32.store offset=4
                       (i32.add
-                        (get_local $3)
+                        (get_local $2)
                         (get_local $1)
                       )
                       (i32.const 40)
@@ -11561,11 +11533,11 @@
                 )
               )
             )
-            (set_local $10
+            (set_local $5
               (if i32
                 (i32.lt_u
-                  (get_local $2)
-                  (tee_local $3
+                  (get_local $3)
+                  (tee_local $2
                     (i32.load
                       (i32.const 192)
                     )
@@ -11574,20 +11546,20 @@
                 (block i32
                   (i32.store
                     (i32.const 192)
-                    (get_local $2)
+                    (get_local $3)
                   )
-                  (get_local $2)
+                  (get_local $3)
                 )
-                (get_local $3)
+                (get_local $2)
               )
             )
-            (set_local $5
+            (set_local $7
               (i32.add
-                (get_local $2)
+                (get_local $3)
                 (get_local $1)
               )
             )
-            (set_local $3
+            (set_local $2
               (i32.const 624)
             )
             (block $jumpthreading$outer$10
@@ -11596,21 +11568,21 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $3)
+                        (get_local $2)
                       )
-                      (get_local $5)
+                      (get_local $7)
                     )
                     (block
                       (set_local $4
-                        (get_local $3)
+                        (get_local $2)
                       )
                       (br $jumpthreading$inner$10)
                     )
                   )
                   (br_if $while-in47
-                    (tee_local $3
+                    (tee_local $2
                       (i32.load offset=8
-                        (get_local $3)
+                        (get_local $2)
                       )
                     )
                   )
@@ -11623,7 +11595,7 @@
               (if
                 (i32.and
                   (i32.load offset=12
-                    (get_local $3)
+                    (get_local $2)
                   )
                   (i32.const 8)
                 )
@@ -11633,34 +11605,34 @@
                 (block
                   (i32.store
                     (get_local $4)
-                    (get_local $2)
+                    (get_local $3)
                   )
                   (i32.store
-                    (tee_local $3
+                    (tee_local $2
                       (i32.add
-                        (get_local $3)
+                        (get_local $2)
                         (i32.const 4)
                       )
                     )
                     (i32.add
                       (i32.load
-                        (get_local $3)
+                        (get_local $2)
                       )
                       (get_local $1)
                     )
                   )
-                  (set_local $6
+                  (set_local $8
                     (i32.add
-                      (tee_local $9
+                      (tee_local $6
                         (i32.add
-                          (get_local $2)
+                          (get_local $3)
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
                                 (tee_local $1
                                   (i32.add
-                                    (get_local $2)
+                                    (get_local $3)
                                     (i32.const 8)
                                   )
                                 )
@@ -11678,19 +11650,19 @@
                       (get_local $0)
                     )
                   )
-                  (set_local $2
+                  (set_local $4
                     (i32.sub
                       (i32.sub
-                        (tee_local $8
+                        (tee_local $10
                           (i32.add
-                            (get_local $5)
+                            (get_local $7)
                             (select
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
                                   (tee_local $1
                                     (i32.add
-                                      (get_local $5)
+                                      (get_local $7)
                                       (i32.const 8)
                                     )
                                   )
@@ -11705,13 +11677,13 @@
                             )
                           )
                         )
-                        (get_local $9)
+                        (get_local $6)
                       )
                       (get_local $0)
                     )
                   )
                   (i32.store offset=4
-                    (get_local $9)
+                    (get_local $6)
                     (i32.or
                       (get_local $0)
                       (i32.const 3)
@@ -11720,8 +11692,8 @@
                   (block $do-once48
                     (if
                       (i32.eq
-                        (get_local $8)
-                        (get_local $7)
+                        (get_local $10)
+                        (get_local $9)
                       )
                       (block
                         (i32.store
@@ -11731,16 +11703,16 @@
                               (i32.load
                                 (i32.const 188)
                               )
-                              (get_local $2)
+                              (get_local $4)
                             )
                           )
                         )
                         (i32.store
                           (i32.const 200)
-                          (get_local $6)
+                          (get_local $8)
                         )
                         (i32.store offset=4
-                          (get_local $6)
+                          (get_local $8)
                           (i32.or
                             (get_local $0)
                             (i32.const 1)
@@ -11750,7 +11722,7 @@
                       (block
                         (if
                           (i32.eq
-                            (get_local $8)
+                            (get_local $10)
                             (i32.load
                               (i32.const 196)
                             )
@@ -11763,16 +11735,16 @@
                                   (i32.load
                                     (i32.const 184)
                                   )
-                                  (get_local $2)
+                                  (get_local $4)
                                 )
                               )
                             )
                             (i32.store
                               (i32.const 196)
-                              (get_local $6)
+                              (get_local $8)
                             )
                             (i32.store offset=4
-                              (get_local $6)
+                              (get_local $8)
                               (i32.or
                                 (get_local $0)
                                 (i32.const 1)
@@ -11780,7 +11752,7 @@
                             )
                             (i32.store
                               (i32.add
-                                (get_local $6)
+                                (get_local $8)
                                 (get_local $0)
                               )
                               (get_local $0)
@@ -11794,9 +11766,9 @@
                               (if i32
                                 (i32.eq
                                   (i32.and
-                                    (tee_local $1
+                                    (tee_local $0
                                       (i32.load offset=4
-                                        (get_local $8)
+                                        (get_local $10)
                                       )
                                     )
                                     (i32.const 3)
@@ -11804,44 +11776,44 @@
                                   (i32.const 1)
                                 )
                                 (block i32
-                                  (set_local $5
+                                  (set_local $7
                                     (i32.and
-                                      (get_local $1)
+                                      (get_local $0)
                                       (i32.const -8)
                                     )
                                   )
-                                  (set_local $0
+                                  (set_local $1
                                     (i32.shr_u
-                                      (get_local $1)
+                                      (get_local $0)
                                       (i32.const 3)
                                     )
                                   )
                                   (block $label$break$L331
                                     (if
                                       (i32.lt_u
-                                        (get_local $1)
+                                        (get_local $0)
                                         (i32.const 256)
                                       )
                                       (block
-                                        (set_local $3
+                                        (set_local $2
                                           (i32.load offset=12
-                                            (get_local $8)
+                                            (get_local $10)
                                           )
                                         )
                                         (block $do-once51
                                           (if
                                             (i32.ne
-                                              (tee_local $4
+                                              (tee_local $3
                                                 (i32.load offset=8
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                 )
                                               )
-                                              (tee_local $1
+                                              (tee_local $0
                                                 (i32.add
                                                   (i32.const 216)
                                                   (i32.shl
                                                     (i32.shl
-                                                      (get_local $0)
+                                                      (get_local $1)
                                                       (i32.const 1)
                                                     )
                                                     (i32.const 2)
@@ -11852,17 +11824,17 @@
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $4)
-                                                  (get_local $10)
+                                                  (get_local $3)
+                                                  (get_local $5)
                                                 )
                                                 (call $_abort)
                                               )
                                               (br_if $do-once51
                                                 (i32.eq
                                                   (i32.load offset=12
-                                                    (get_local $4)
+                                                    (get_local $3)
                                                   )
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                 )
                                               )
                                               (call $_abort)
@@ -11871,8 +11843,8 @@
                                         )
                                         (if
                                           (i32.eq
+                                            (get_local $2)
                                             (get_local $3)
-                                            (get_local $4)
                                           )
                                           (block
                                             (i32.store
@@ -11884,7 +11856,7 @@
                                                 (i32.xor
                                                   (i32.shl
                                                     (i32.const 1)
-                                                    (get_local $0)
+                                                    (get_local $1)
                                                   )
                                                   (i32.const -1)
                                                 )
@@ -11896,20 +11868,20 @@
                                         (block $do-once53
                                           (if
                                             (i32.eq
-                                              (get_local $3)
-                                              (get_local $1)
+                                              (get_local $2)
+                                              (get_local $0)
                                             )
                                             (set_local $21
                                               (i32.add
-                                                (get_local $3)
+                                                (get_local $2)
                                                 (i32.const 8)
                                               )
                                             )
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $3)
-                                                  (get_local $10)
+                                                  (get_local $2)
+                                                  (get_local $5)
                                                 )
                                                 (call $_abort)
                                               )
@@ -11918,12 +11890,12 @@
                                                   (i32.load
                                                     (tee_local $0
                                                       (i32.add
-                                                        (get_local $3)
+                                                        (get_local $2)
                                                         (i32.const 8)
                                                       )
                                                     )
                                                   )
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                 )
                                                 (block
                                                   (set_local $21
@@ -11937,18 +11909,18 @@
                                           )
                                         )
                                         (i32.store offset=12
-                                          (get_local $4)
                                           (get_local $3)
+                                          (get_local $2)
                                         )
                                         (i32.store
                                           (get_local $21)
-                                          (get_local $4)
+                                          (get_local $3)
                                         )
                                       )
                                       (block
-                                        (set_local $7
+                                        (set_local $12
                                           (i32.load offset=24
-                                            (get_local $8)
+                                            (get_local $10)
                                           )
                                         )
                                         (block $do-once55
@@ -11956,41 +11928,41 @@
                                             (i32.eq
                                               (tee_local $0
                                                 (i32.load offset=12
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                 )
                                               )
-                                              (get_local $8)
+                                              (get_local $10)
                                             )
                                             (block
                                               (if
-                                                (tee_local $1
-                                                  (i32.load
-                                                    (tee_local $3
-                                                      (i32.add
-                                                        (tee_local $0
-                                                          (i32.add
-                                                            (get_local $8)
-                                                            (i32.const 16)
+                                                (i32.eqz
+                                                  (tee_local $1
+                                                    (i32.load
+                                                      (tee_local $0
+                                                        (i32.add
+                                                          (tee_local $3
+                                                            (i32.add
+                                                              (get_local $10)
+                                                              (i32.const 16)
+                                                            )
                                                           )
+                                                          (i32.const 4)
                                                         )
-                                                        (i32.const 4)
                                                       )
                                                     )
                                                   )
-                                                )
-                                                (set_local $0
-                                                  (get_local $3)
                                                 )
                                                 (if
-                                                  (i32.eqz
-                                                    (tee_local $1
-                                                      (i32.load
-                                                        (get_local $0)
-                                                      )
+                                                  (tee_local $1
+                                                    (i32.load
+                                                      (get_local $3)
                                                     )
                                                   )
+                                                  (set_local $0
+                                                    (get_local $3)
+                                                  )
                                                   (block
-                                                    (set_local $11
+                                                    (set_local $14
                                                       (i32.const 0)
                                                     )
                                                     (br $do-once55)
@@ -11999,9 +11971,9 @@
                                               )
                                               (loop $while-in58
                                                 (if
-                                                  (tee_local $4
+                                                  (tee_local $3
                                                     (i32.load
-                                                      (tee_local $3
+                                                      (tee_local $2
                                                         (i32.add
                                                           (get_local $1)
                                                           (i32.const 20)
@@ -12011,18 +11983,18 @@
                                                   )
                                                   (block
                                                     (set_local $1
-                                                      (get_local $4)
+                                                      (get_local $3)
                                                     )
                                                     (set_local $0
-                                                      (get_local $3)
+                                                      (get_local $2)
                                                     )
                                                     (br $while-in58)
                                                   )
                                                 )
                                                 (if
-                                                  (tee_local $4
+                                                  (tee_local $3
                                                     (i32.load
-                                                      (tee_local $3
+                                                      (tee_local $2
                                                         (i32.add
                                                           (get_local $1)
                                                           (i32.const 16)
@@ -12032,10 +12004,10 @@
                                                   )
                                                   (block
                                                     (set_local $1
-                                                      (get_local $4)
+                                                      (get_local $3)
                                                     )
                                                     (set_local $0
-                                                      (get_local $3)
+                                                      (get_local $2)
                                                     )
                                                     (br $while-in58)
                                                   )
@@ -12044,7 +12016,7 @@
                                               (if
                                                 (i32.lt_u
                                                   (get_local $0)
-                                                  (get_local $10)
+                                                  (get_local $5)
                                                 )
                                                 (call $_abort)
                                                 (block
@@ -12052,7 +12024,7 @@
                                                     (get_local $0)
                                                     (i32.const 0)
                                                   )
-                                                  (set_local $11
+                                                  (set_local $14
                                                     (get_local $1)
                                                   )
                                                 )
@@ -12061,12 +12033,12 @@
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (tee_local $4
+                                                  (tee_local $2
                                                     (i32.load offset=8
-                                                      (get_local $8)
+                                                      (get_local $10)
                                                     )
                                                   )
-                                                  (get_local $10)
+                                                  (get_local $5)
                                                 )
                                                 (call $_abort)
                                               )
@@ -12075,12 +12047,12 @@
                                                   (i32.load
                                                     (tee_local $3
                                                       (i32.add
-                                                        (get_local $4)
+                                                        (get_local $2)
                                                         (i32.const 12)
                                                       )
                                                     )
                                                   )
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                 )
                                                 (call $_abort)
                                               )
@@ -12094,7 +12066,7 @@
                                                       )
                                                     )
                                                   )
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                 )
                                                 (block
                                                   (i32.store
@@ -12103,9 +12075,9 @@
                                                   )
                                                   (i32.store
                                                     (get_local $1)
-                                                    (get_local $4)
+                                                    (get_local $2)
                                                   )
-                                                  (set_local $11
+                                                  (set_local $14
                                                     (get_local $0)
                                                   )
                                                 )
@@ -12116,13 +12088,13 @@
                                         )
                                         (br_if $label$break$L331
                                           (i32.eqz
-                                            (get_local $7)
+                                            (get_local $12)
                                           )
                                         )
                                         (block $do-once59
                                           (if
                                             (i32.eq
-                                              (get_local $8)
+                                              (get_local $10)
                                               (i32.load
                                                 (tee_local $0
                                                   (i32.add
@@ -12130,7 +12102,7 @@
                                                     (i32.shl
                                                       (tee_local $1
                                                         (i32.load offset=28
-                                                          (get_local $8)
+                                                          (get_local $10)
                                                         )
                                                       )
                                                       (i32.const 2)
@@ -12142,10 +12114,10 @@
                                             (block
                                               (i32.store
                                                 (get_local $0)
-                                                (get_local $11)
+                                                (get_local $14)
                                               )
                                               (br_if $do-once59
-                                                (get_local $11)
+                                                (get_local $14)
                                               )
                                               (i32.store
                                                 (i32.const 180)
@@ -12167,7 +12139,7 @@
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $7)
+                                                  (get_local $12)
                                                   (i32.load
                                                     (i32.const 192)
                                                   )
@@ -12179,25 +12151,25 @@
                                                   (i32.load
                                                     (tee_local $0
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $12)
                                                         (i32.const 16)
                                                       )
                                                     )
                                                   )
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                 )
                                                 (i32.store
                                                   (get_local $0)
-                                                  (get_local $11)
+                                                  (get_local $14)
                                                 )
                                                 (i32.store offset=20
-                                                  (get_local $7)
-                                                  (get_local $11)
+                                                  (get_local $12)
+                                                  (get_local $14)
                                                 )
                                               )
                                               (br_if $label$break$L331
                                                 (i32.eqz
-                                                  (get_local $11)
+                                                  (get_local $14)
                                                 )
                                               )
                                             )
@@ -12205,8 +12177,8 @@
                                         )
                                         (if
                                           (i32.lt_u
-                                            (get_local $11)
-                                            (tee_local $3
+                                            (get_local $14)
+                                            (tee_local $1
                                               (i32.load
                                                 (i32.const 192)
                                               )
@@ -12215,15 +12187,15 @@
                                           (call $_abort)
                                         )
                                         (i32.store offset=24
-                                          (get_local $11)
-                                          (get_local $7)
+                                          (get_local $14)
+                                          (get_local $12)
                                         )
                                         (if
-                                          (tee_local $1
+                                          (tee_local $3
                                             (i32.load
                                               (tee_local $0
                                                 (i32.add
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                   (i32.const 16)
                                                 )
                                               )
@@ -12231,18 +12203,18 @@
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $1)
                                               (get_local $3)
+                                              (get_local $1)
                                             )
                                             (call $_abort)
                                             (block
                                               (i32.store offset=16
-                                                (get_local $11)
-                                                (get_local $1)
+                                                (get_local $14)
+                                                (get_local $3)
                                               )
                                               (i32.store offset=24
-                                                (get_local $1)
-                                                (get_local $11)
+                                                (get_local $3)
+                                                (get_local $14)
                                               )
                                             )
                                           )
@@ -12266,30 +12238,30 @@
                                           (call $_abort)
                                           (block
                                             (i32.store offset=20
-                                              (get_local $11)
+                                              (get_local $14)
                                               (get_local $0)
                                             )
                                             (i32.store offset=24
                                               (get_local $0)
-                                              (get_local $11)
+                                              (get_local $14)
                                             )
                                           )
                                         )
                                       )
                                     )
                                   )
-                                  (set_local $2
+                                  (set_local $4
                                     (i32.add
-                                      (get_local $5)
-                                      (get_local $2)
+                                      (get_local $7)
+                                      (get_local $4)
                                     )
                                   )
                                   (i32.add
-                                    (get_local $8)
-                                    (get_local $5)
+                                    (get_local $10)
+                                    (get_local $7)
                                   )
                                 )
-                                (get_local $8)
+                                (get_local $10)
                               )
                               (i32.const 4)
                             )
@@ -12302,37 +12274,37 @@
                           )
                         )
                         (i32.store offset=4
-                          (get_local $6)
+                          (get_local $8)
                           (i32.or
-                            (get_local $2)
+                            (get_local $4)
                             (i32.const 1)
                           )
                         )
                         (i32.store
                           (i32.add
-                            (get_local $6)
-                            (get_local $2)
+                            (get_local $8)
+                            (get_local $4)
                           )
-                          (get_local $2)
+                          (get_local $4)
                         )
-                        (set_local $1
+                        (set_local $0
                           (i32.shr_u
-                            (get_local $2)
+                            (get_local $4)
                             (i32.const 3)
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $2)
+                            (get_local $4)
                             (i32.const 256)
                           )
                           (block
-                            (set_local $0
+                            (set_local $3
                               (i32.add
                                 (i32.const 216)
                                 (i32.shl
                                   (i32.shl
-                                    (get_local $1)
+                                    (get_local $0)
                                     (i32.const 1)
                                   )
                                   (i32.const 2)
@@ -12342,26 +12314,26 @@
                             (block $do-once63
                               (if
                                 (i32.and
-                                  (tee_local $2
+                                  (tee_local $1
                                     (i32.load
                                       (i32.const 176)
                                     )
                                   )
-                                  (tee_local $1
+                                  (tee_local $0
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $1)
+                                      (get_local $0)
                                     )
                                   )
                                 )
                                 (block
                                   (if
                                     (i32.ge_u
-                                      (tee_local $1
+                                      (tee_local $0
                                         (i32.load
-                                          (tee_local $2
+                                          (tee_local $1
                                             (i32.add
-                                              (get_local $0)
+                                              (get_local $3)
                                               (i32.const 8)
                                             )
                                           )
@@ -12373,10 +12345,10 @@
                                     )
                                     (block
                                       (set_local $22
-                                        (get_local $2)
-                                      )
-                                      (set_local $17
                                         (get_local $1)
+                                      )
+                                      (set_local $11
+                                        (get_local $0)
                                       )
                                       (br $do-once63)
                                     )
@@ -12387,42 +12359,42 @@
                                   (i32.store
                                     (i32.const 176)
                                     (i32.or
-                                      (get_local $2)
                                       (get_local $1)
+                                      (get_local $0)
                                     )
                                   )
                                   (set_local $22
                                     (i32.add
-                                      (get_local $0)
+                                      (get_local $3)
                                       (i32.const 8)
                                     )
                                   )
-                                  (set_local $17
-                                    (get_local $0)
+                                  (set_local $11
+                                    (get_local $3)
                                   )
                                 )
                               )
                             )
                             (i32.store
                               (get_local $22)
-                              (get_local $6)
+                              (get_local $8)
                             )
                             (i32.store offset=12
-                              (get_local $17)
-                              (get_local $6)
+                              (get_local $11)
+                              (get_local $8)
                             )
                             (i32.store offset=8
-                              (get_local $6)
-                              (get_local $17)
+                              (get_local $8)
+                              (get_local $11)
                             )
                             (i32.store offset=12
-                              (get_local $6)
-                              (get_local $0)
+                              (get_local $8)
+                              (get_local $3)
                             )
                             (br $do-once48)
                           )
                         )
-                        (set_local $1
+                        (set_local $2
                           (i32.add
                             (i32.const 480)
                             (i32.shl
@@ -12431,7 +12403,7 @@
                                   (if i32
                                     (tee_local $0
                                       (i32.shr_u
-                                        (get_local $2)
+                                        (get_local $4)
                                         (i32.const 8)
                                       )
                                     )
@@ -12440,7 +12412,7 @@
                                         (br_if $do-once65
                                           (i32.const 31)
                                           (i32.gt_u
-                                            (get_local $2)
+                                            (get_local $4)
                                             (i32.const 16777215)
                                           )
                                         )
@@ -12448,7 +12420,7 @@
                                       (i32.or
                                         (i32.and
                                           (i32.shr_u
-                                            (get_local $2)
+                                            (get_local $4)
                                             (i32.add
                                               (tee_local $0
                                                 (i32.add
@@ -12456,11 +12428,11 @@
                                                     (i32.const 14)
                                                     (i32.or
                                                       (i32.or
-                                                        (tee_local $1
+                                                        (tee_local $0
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $0
+                                                                (tee_local $1
                                                                   (i32.shl
                                                                     (get_local $0)
                                                                     (tee_local $3
@@ -12486,14 +12458,14 @@
                                                         )
                                                         (get_local $3)
                                                       )
-                                                      (tee_local $1
+                                                      (tee_local $0
                                                         (i32.and
                                                           (i32.shr_u
                                                             (i32.add
-                                                              (tee_local $0
+                                                              (tee_local $1
                                                                 (i32.shl
-                                                                  (get_local $0)
                                                                   (get_local $1)
+                                                                  (get_local $0)
                                                                 )
                                                               )
                                                               (i32.const 245760)
@@ -12507,8 +12479,8 @@
                                                   )
                                                   (i32.shr_u
                                                     (i32.shl
-                                                      (get_local $0)
                                                       (get_local $1)
+                                                      (get_local $0)
                                                     )
                                                     (i32.const 15)
                                                   )
@@ -12534,13 +12506,13 @@
                           )
                         )
                         (i32.store offset=28
-                          (get_local $6)
+                          (get_local $8)
                           (get_local $3)
                         )
                         (i32.store offset=4
                           (tee_local $0
                             (i32.add
-                              (get_local $6)
+                              (get_local $8)
                               (i32.const 16)
                             )
                           )
@@ -12553,7 +12525,7 @@
                         (if
                           (i32.eqz
                             (i32.and
-                              (tee_local $4
+                              (tee_local $1
                                 (i32.load
                                   (i32.const 180)
                                 )
@@ -12570,32 +12542,32 @@
                             (i32.store
                               (i32.const 180)
                               (i32.or
-                                (get_local $4)
+                                (get_local $1)
                                 (get_local $0)
                               )
                             )
                             (i32.store
-                              (get_local $1)
-                              (get_local $6)
+                              (get_local $2)
+                              (get_local $8)
                             )
                             (i32.store offset=24
-                              (get_local $6)
-                              (get_local $1)
+                              (get_local $8)
+                              (get_local $2)
                             )
                             (i32.store offset=12
-                              (get_local $6)
-                              (get_local $6)
+                              (get_local $8)
+                              (get_local $8)
                             )
                             (i32.store offset=8
-                              (get_local $6)
-                              (get_local $6)
+                              (get_local $8)
+                              (get_local $8)
                             )
                             (br $do-once48)
                           )
                         )
                         (set_local $3
                           (i32.shl
-                            (get_local $2)
+                            (get_local $4)
                             (select
                               (i32.const 0)
                               (i32.sub
@@ -12614,7 +12586,7 @@
                         )
                         (set_local $0
                           (i32.load
-                            (get_local $1)
+                            (get_local $2)
                           )
                         )
                         (block $jumpthreading$outer$6
@@ -12629,59 +12601,52 @@
                                       )
                                       (i32.const -8)
                                     )
-                                    (get_local $2)
+                                    (get_local $4)
                                   )
                                 )
-                                (set_local $1
+                                (set_local $2
                                   (i32.shl
                                     (get_local $3)
                                     (i32.const 1)
                                   )
                                 )
-                                (if
-                                  (tee_local $4
-                                    (i32.load
-                                      (tee_local $3
-                                        (i32.add
+                                (br_if $jumpthreading$inner$5
+                                  (i32.eqz
+                                    (tee_local $1
+                                      (i32.load
+                                        (tee_local $3
                                           (i32.add
-                                            (get_local $0)
-                                            (i32.const 16)
-                                          )
-                                          (i32.shl
-                                            (i32.shr_u
-                                              (get_local $3)
-                                              (i32.const 31)
+                                            (i32.add
+                                              (get_local $0)
+                                              (i32.const 16)
                                             )
-                                            (i32.const 2)
+                                            (i32.shl
+                                              (i32.shr_u
+                                                (get_local $3)
+                                                (i32.const 31)
+                                              )
+                                              (i32.const 2)
+                                            )
                                           )
                                         )
                                       )
                                     )
                                   )
-                                  (block
-                                    (set_local $3
-                                      (get_local $1)
-                                    )
-                                    (set_local $0
-                                      (get_local $4)
-                                    )
-                                    (br $while-in68)
+                                )
+                                (block
+                                  (set_local $3
+                                    (get_local $2)
                                   )
-                                  (block
-                                    (set_local $1
-                                      (get_local $0)
-                                    )
-                                    (set_local $0
-                                      (get_local $3)
-                                    )
-                                    (br $jumpthreading$inner$5)
+                                  (set_local $0
+                                    (get_local $1)
                                   )
+                                  (br $while-in68)
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $0)
+                                (get_local $3)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -12689,20 +12654,20 @@
                               (call $_abort)
                               (block
                                 (i32.store
-                                  (get_local $0)
-                                  (get_local $6)
+                                  (get_local $3)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=24
-                                  (get_local $6)
-                                  (get_local $1)
+                                  (get_local $8)
+                                  (get_local $0)
                                 )
                                 (i32.store offset=12
-                                  (get_local $6)
-                                  (get_local $6)
+                                  (get_local $8)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=8
-                                  (get_local $6)
-                                  (get_local $6)
+                                  (get_local $8)
+                                  (get_local $8)
                                 )
                                 (br $do-once48)
                               )
@@ -12712,9 +12677,9 @@
                           (if
                             (i32.and
                               (i32.ge_u
-                                (tee_local $3
+                                (tee_local $2
                                   (i32.load
-                                    (tee_local $1
+                                    (tee_local $3
                                       (i32.add
                                         (get_local $0)
                                         (i32.const 8)
@@ -12722,7 +12687,7 @@
                                     )
                                   )
                                 )
-                                (tee_local $2
+                                (tee_local $1
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -12730,28 +12695,28 @@
                               )
                               (i32.ge_u
                                 (get_local $0)
-                                (get_local $2)
+                                (get_local $1)
                               )
                             )
                             (block
                               (i32.store offset=12
-                                (get_local $3)
-                                (get_local $6)
+                                (get_local $2)
+                                (get_local $8)
                               )
                               (i32.store
-                                (get_local $1)
-                                (get_local $6)
+                                (get_local $3)
+                                (get_local $8)
                               )
                               (i32.store offset=8
-                                (get_local $6)
-                                (get_local $3)
+                                (get_local $8)
+                                (get_local $2)
                               )
                               (i32.store offset=12
-                                (get_local $6)
+                                (get_local $8)
                                 (get_local $0)
                               )
                               (i32.store offset=24
-                                (get_local $6)
+                                (get_local $8)
                                 (i32.const 0)
                               )
                             )
@@ -12763,7 +12728,7 @@
                   )
                   (return
                     (i32.add
-                      (get_local $9)
+                      (get_local $6)
                       (i32.const 8)
                     )
                   )
@@ -12774,24 +12739,24 @@
               (block $while-out69
                 (if
                   (i32.le_u
-                    (tee_local $3
+                    (tee_local $2
                       (i32.load
                         (get_local $4)
                       )
                     )
-                    (get_local $7)
+                    (get_local $9)
                   )
                   (br_if $while-out69
                     (i32.gt_u
-                      (tee_local $3
+                      (tee_local $2
                         (i32.add
-                          (get_local $3)
+                          (get_local $2)
                           (i32.load offset=4
                             (get_local $4)
                           )
                         )
                       )
-                      (get_local $7)
+                      (get_local $9)
                     )
                   )
                 )
@@ -12803,22 +12768,22 @@
                 (br $while-in70)
               )
             )
-            (set_local $5
+            (set_local $7
               (i32.add
                 (tee_local $4
                   (i32.add
-                    (get_local $3)
+                    (get_local $2)
                     (i32.const -47)
                   )
                 )
                 (i32.const 8)
               )
             )
-            (set_local $8
+            (set_local $5
               (i32.add
-                (tee_local $9
+                (tee_local $11
                   (select
-                    (get_local $7)
+                    (get_local $9)
                     (tee_local $4
                       (i32.add
                         (get_local $4)
@@ -12826,13 +12791,13 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (get_local $5)
+                              (get_local $7)
                             )
                             (i32.const 7)
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $5)
+                            (get_local $7)
                             (i32.const 7)
                           )
                         )
@@ -12840,9 +12805,9 @@
                     )
                     (i32.lt_u
                       (get_local $4)
-                      (tee_local $6
+                      (tee_local $7
                         (i32.add
-                          (get_local $7)
+                          (get_local $9)
                           (i32.const 16)
                         )
                       )
@@ -12854,9 +12819,9 @@
             )
             (i32.store
               (i32.const 200)
-              (tee_local $5
+              (tee_local $6
                 (i32.add
-                  (get_local $2)
+                  (get_local $3)
                   (tee_local $4
                     (select
                       (i32.and
@@ -12864,7 +12829,7 @@
                           (i32.const 0)
                           (tee_local $4
                             (i32.add
-                              (get_local $2)
+                              (get_local $3)
                               (i32.const 8)
                             )
                           )
@@ -12894,7 +12859,7 @@
               )
             )
             (i32.store offset=4
-              (get_local $5)
+              (get_local $6)
               (i32.or
                 (get_local $4)
                 (i32.const 1)
@@ -12902,7 +12867,7 @@
             )
             (i32.store offset=4
               (i32.add
-                (get_local $5)
+                (get_local $6)
                 (get_local $4)
               )
               (i32.const 40)
@@ -12916,39 +12881,39 @@
             (i32.store
               (tee_local $4
                 (i32.add
-                  (get_local $9)
+                  (get_local $11)
                   (i32.const 4)
                 )
               )
               (i32.const 27)
             )
             (i32.store
-              (get_local $8)
+              (get_local $5)
               (i32.load
                 (i32.const 624)
               )
             )
             (i32.store offset=4
-              (get_local $8)
+              (get_local $5)
               (i32.load
                 (i32.const 628)
               )
             )
             (i32.store offset=8
-              (get_local $8)
+              (get_local $5)
               (i32.load
                 (i32.const 632)
               )
             )
             (i32.store offset=12
-              (get_local $8)
+              (get_local $5)
               (i32.load
                 (i32.const 636)
               )
             )
             (i32.store
               (i32.const 624)
-              (get_local $2)
+              (get_local $3)
             )
             (i32.store
               (i32.const 628)
@@ -12960,11 +12925,11 @@
             )
             (i32.store
               (i32.const 632)
-              (get_local $8)
+              (get_local $5)
             )
             (set_local $1
               (i32.add
-                (get_local $9)
+                (get_local $11)
                 (i32.const 24)
               )
             )
@@ -12984,14 +12949,14 @@
                     (get_local $1)
                     (i32.const 4)
                   )
-                  (get_local $3)
+                  (get_local $2)
                 )
               )
             )
             (if
               (i32.ne
+                (get_local $11)
                 (get_local $9)
-                (get_local $7)
               )
               (block
                 (i32.store
@@ -13004,39 +12969,39 @@
                   )
                 )
                 (i32.store offset=4
-                  (get_local $7)
+                  (get_local $9)
                   (i32.or
-                    (tee_local $5
+                    (tee_local $6
                       (i32.sub
+                        (get_local $11)
                         (get_local $9)
-                        (get_local $7)
                       )
                     )
                     (i32.const 1)
                   )
                 )
                 (i32.store
-                  (get_local $9)
-                  (get_local $5)
+                  (get_local $11)
+                  (get_local $6)
                 )
-                (set_local $2
+                (set_local $1
                   (i32.shr_u
-                    (get_local $5)
+                    (get_local $6)
                     (i32.const 3)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $5)
+                    (get_local $6)
                     (i32.const 256)
                   )
                   (block
-                    (set_local $1
+                    (set_local $2
                       (i32.add
                         (i32.const 216)
                         (i32.shl
                           (i32.shl
-                            (get_local $2)
+                            (get_local $1)
                             (i32.const 1)
                           )
                           (i32.const 2)
@@ -13050,20 +13015,20 @@
                             (i32.const 176)
                           )
                         )
-                        (tee_local $2
+                        (tee_local $1
                           (i32.shl
                             (i32.const 1)
-                            (get_local $2)
+                            (get_local $1)
                           )
                         )
                       )
                       (if
                         (i32.lt_u
-                          (tee_local $2
+                          (tee_local $1
                             (i32.load
                               (tee_local $3
                                 (i32.add
-                                  (get_local $1)
+                                  (get_local $2)
                                   (i32.const 8)
                                 )
                               )
@@ -13078,8 +13043,8 @@
                           (set_local $23
                             (get_local $3)
                           )
-                          (set_local $18
-                            (get_local $2)
+                          (set_local $12
+                            (get_local $1)
                           )
                         )
                       )
@@ -13088,61 +13053,61 @@
                           (i32.const 176)
                           (i32.or
                             (get_local $3)
-                            (get_local $2)
+                            (get_local $1)
                           )
                         )
                         (set_local $23
                           (i32.add
-                            (get_local $1)
+                            (get_local $2)
                             (i32.const 8)
                           )
                         )
-                        (set_local $18
-                          (get_local $1)
+                        (set_local $12
+                          (get_local $2)
                         )
                       )
                     )
                     (i32.store
                       (get_local $23)
-                      (get_local $7)
+                      (get_local $9)
                     )
                     (i32.store offset=12
-                      (get_local $18)
-                      (get_local $7)
+                      (get_local $12)
+                      (get_local $9)
                     )
                     (i32.store offset=8
-                      (get_local $7)
-                      (get_local $18)
+                      (get_local $9)
+                      (get_local $12)
                     )
                     (i32.store offset=12
-                      (get_local $7)
-                      (get_local $1)
+                      (get_local $9)
+                      (get_local $2)
                     )
                     (br $do-once40)
                   )
                 )
-                (set_local $2
+                (set_local $4
                   (i32.add
                     (i32.const 480)
                     (i32.shl
-                      (tee_local $3
+                      (tee_local $2
                         (if i32
                           (tee_local $1
                             (i32.shr_u
-                              (get_local $5)
+                              (get_local $6)
                               (i32.const 8)
                             )
                           )
                           (if i32
                             (i32.gt_u
-                              (get_local $5)
+                              (get_local $6)
                               (i32.const 16777215)
                             )
                             (i32.const 31)
                             (i32.or
                               (i32.and
                                 (i32.shr_u
-                                  (get_local $5)
+                                  (get_local $6)
                                   (i32.add
                                     (tee_local $1
                                       (i32.add
@@ -13150,14 +13115,14 @@
                                           (i32.const 14)
                                           (i32.or
                                             (i32.or
-                                              (tee_local $2
+                                              (tee_local $1
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (tee_local $1
+                                                      (tee_local $3
                                                         (i32.shl
                                                           (get_local $1)
-                                                          (tee_local $3
+                                                          (tee_local $2
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
@@ -13178,16 +13143,16 @@
                                                   (i32.const 4)
                                                 )
                                               )
-                                              (get_local $3)
+                                              (get_local $2)
                                             )
-                                            (tee_local $2
+                                            (tee_local $1
                                               (i32.and
                                                 (i32.shr_u
                                                   (i32.add
-                                                    (tee_local $1
+                                                    (tee_local $3
                                                       (i32.shl
+                                                        (get_local $3)
                                                         (get_local $1)
-                                                        (get_local $2)
                                                       )
                                                     )
                                                     (i32.const 245760)
@@ -13201,8 +13166,8 @@
                                         )
                                         (i32.shr_u
                                           (i32.shl
+                                            (get_local $3)
                                             (get_local $1)
-                                            (get_local $2)
                                           )
                                           (i32.const 15)
                                         )
@@ -13227,21 +13192,21 @@
                   )
                 )
                 (i32.store offset=28
-                  (get_local $7)
-                  (get_local $3)
+                  (get_local $9)
+                  (get_local $2)
                 )
                 (i32.store offset=20
-                  (get_local $7)
+                  (get_local $9)
                   (i32.const 0)
                 )
                 (i32.store
-                  (get_local $6)
+                  (get_local $7)
                   (i32.const 0)
                 )
                 (if
                   (i32.eqz
                     (i32.and
-                      (tee_local $4
+                      (tee_local $3
                         (i32.load
                           (i32.const 180)
                         )
@@ -13249,7 +13214,7 @@
                       (tee_local $1
                         (i32.shl
                           (i32.const 1)
-                          (get_local $3)
+                          (get_local $2)
                         )
                       )
                     )
@@ -13258,43 +13223,43 @@
                     (i32.store
                       (i32.const 180)
                       (i32.or
-                        (get_local $4)
+                        (get_local $3)
                         (get_local $1)
                       )
                     )
                     (i32.store
-                      (get_local $2)
-                      (get_local $7)
+                      (get_local $4)
+                      (get_local $9)
                     )
                     (i32.store offset=24
-                      (get_local $7)
-                      (get_local $2)
+                      (get_local $9)
+                      (get_local $4)
                     )
                     (i32.store offset=12
-                      (get_local $7)
-                      (get_local $7)
+                      (get_local $9)
+                      (get_local $9)
                     )
                     (i32.store offset=8
-                      (get_local $7)
-                      (get_local $7)
+                      (get_local $9)
+                      (get_local $9)
                     )
                     (br $do-once40)
                   )
                 )
-                (set_local $3
+                (set_local $2
                   (i32.shl
-                    (get_local $5)
+                    (get_local $6)
                     (select
                       (i32.const 0)
                       (i32.sub
                         (i32.const 25)
                         (i32.shr_u
-                          (get_local $3)
+                          (get_local $2)
                           (i32.const 1)
                         )
                       )
                       (i32.eq
-                        (get_local $3)
+                        (get_local $2)
                         (i32.const 31)
                       )
                     )
@@ -13302,7 +13267,7 @@
                 )
                 (set_local $1
                   (i32.load
-                    (get_local $2)
+                    (get_local $4)
                   )
                 )
                 (block $jumpthreading$outer$8
@@ -13317,59 +13282,52 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $5)
+                            (get_local $6)
                           )
                         )
-                        (set_local $2
+                        (set_local $4
                           (i32.shl
-                            (get_local $3)
+                            (get_local $2)
                             (i32.const 1)
                           )
                         )
-                        (if
-                          (tee_local $4
-                            (i32.load
-                              (tee_local $3
-                                (i32.add
+                        (br_if $jumpthreading$inner$7
+                          (i32.eqz
+                            (tee_local $3
+                              (i32.load
+                                (tee_local $2
                                   (i32.add
-                                    (get_local $1)
-                                    (i32.const 16)
-                                  )
-                                  (i32.shl
-                                    (i32.shr_u
-                                      (get_local $3)
-                                      (i32.const 31)
+                                    (i32.add
+                                      (get_local $1)
+                                      (i32.const 16)
                                     )
-                                    (i32.const 2)
+                                    (i32.shl
+                                      (i32.shr_u
+                                        (get_local $2)
+                                        (i32.const 31)
+                                      )
+                                      (i32.const 2)
+                                    )
                                   )
                                 )
                               )
                             )
                           )
-                          (block
-                            (set_local $3
-                              (get_local $2)
-                            )
-                            (set_local $1
-                              (get_local $4)
-                            )
-                            (br $while-in74)
+                        )
+                        (block
+                          (set_local $2
+                            (get_local $4)
                           )
-                          (block
-                            (set_local $2
-                              (get_local $1)
-                            )
-                            (set_local $1
-                              (get_local $3)
-                            )
-                            (br $jumpthreading$inner$7)
+                          (set_local $1
+                            (get_local $3)
                           )
+                          (br $while-in74)
                         )
                       )
                     )
                     (if
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $2)
                         (i32.load
                           (i32.const 192)
                         )
@@ -13377,20 +13335,20 @@
                       (call $_abort)
                       (block
                         (i32.store
-                          (get_local $1)
-                          (get_local $7)
+                          (get_local $2)
+                          (get_local $9)
                         )
                         (i32.store offset=24
-                          (get_local $7)
-                          (get_local $2)
+                          (get_local $9)
+                          (get_local $1)
                         )
                         (i32.store offset=12
-                          (get_local $7)
-                          (get_local $7)
+                          (get_local $9)
+                          (get_local $9)
                         )
                         (i32.store offset=8
-                          (get_local $7)
-                          (get_local $7)
+                          (get_local $9)
+                          (get_local $9)
                         )
                         (br $do-once40)
                       )
@@ -13424,22 +13382,22 @@
                     (block
                       (i32.store offset=12
                         (get_local $4)
-                        (get_local $7)
+                        (get_local $9)
                       )
                       (i32.store
                         (get_local $2)
-                        (get_local $7)
+                        (get_local $9)
                       )
                       (i32.store offset=8
-                        (get_local $7)
+                        (get_local $9)
                         (get_local $4)
                       )
                       (i32.store offset=12
-                        (get_local $7)
+                        (get_local $9)
                         (get_local $1)
                       )
                       (i32.store offset=24
-                        (get_local $7)
+                        (get_local $9)
                         (i32.const 0)
                       )
                     )
@@ -13453,25 +13411,25 @@
             (if
               (i32.or
                 (i32.eqz
-                  (tee_local $3
+                  (tee_local $2
                     (i32.load
                       (i32.const 192)
                     )
                   )
                 )
                 (i32.lt_u
-                  (get_local $2)
                   (get_local $3)
+                  (get_local $2)
                 )
               )
               (i32.store
                 (i32.const 192)
-                (get_local $2)
+                (get_local $3)
               )
             )
             (i32.store
               (i32.const 624)
-              (get_local $2)
+              (get_local $3)
             )
             (i32.store
               (i32.const 628)
@@ -13491,7 +13449,7 @@
               (i32.const 208)
               (i32.const -1)
             )
-            (set_local $3
+            (set_local $2
               (i32.const 0)
             )
             (loop $while-in43
@@ -13501,7 +13459,7 @@
                     (i32.const 216)
                     (i32.shl
                       (i32.shl
-                        (get_local $3)
+                        (get_local $2)
                         (i32.const 1)
                       )
                       (i32.const 2)
@@ -13516,9 +13474,9 @@
               )
               (br_if $while-in43
                 (i32.ne
-                  (tee_local $3
+                  (tee_local $2
                     (i32.add
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const 1)
                     )
                   )
@@ -13528,17 +13486,17 @@
             )
             (i32.store
               (i32.const 200)
-              (tee_local $3
+              (tee_local $2
                 (i32.add
-                  (get_local $2)
-                  (tee_local $2
+                  (get_local $3)
+                  (tee_local $3
                     (select
                       (i32.and
                         (i32.sub
                           (i32.const 0)
-                          (tee_local $2
+                          (tee_local $3
                             (i32.add
-                              (get_local $2)
+                              (get_local $3)
                               (i32.const 8)
                             )
                           )
@@ -13547,7 +13505,7 @@
                       )
                       (i32.const 0)
                       (i32.and
-                        (get_local $2)
+                        (get_local $3)
                         (i32.const 7)
                       )
                     )
@@ -13563,12 +13521,12 @@
                     (get_local $1)
                     (i32.const -40)
                   )
-                  (get_local $2)
+                  (get_local $3)
                 )
               )
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
                 (get_local $1)
                 (i32.const 1)
@@ -13576,7 +13534,7 @@
             )
             (i32.store offset=4
               (i32.add
-                (get_local $3)
+                (get_local $2)
                 (get_local $1)
               )
               (i32.const 40)
@@ -13602,7 +13560,7 @@
         (block
           (i32.store
             (i32.const 188)
-            (tee_local $1
+            (tee_local $3
               (i32.sub
                 (get_local $1)
                 (get_local $0)
@@ -13611,9 +13569,9 @@
           )
           (i32.store
             (i32.const 200)
-            (tee_local $2
+            (tee_local $1
               (i32.add
-                (tee_local $3
+                (tee_local $2
                   (i32.load
                     (i32.const 200)
                   )
@@ -13623,14 +13581,14 @@
             )
           )
           (i32.store offset=4
-            (get_local $2)
+            (get_local $1)
             (i32.or
-              (get_local $1)
+              (get_local $3)
               (i32.const 1)
             )
           )
           (i32.store offset=4
-            (get_local $3)
+            (get_local $2)
             (i32.or
               (get_local $0)
               (i32.const 3)
@@ -13638,7 +13596,7 @@
           )
           (return
             (i32.add
-              (get_local $3)
+              (get_local $2)
               (i32.const 8)
             )
           )
@@ -13675,7 +13633,7 @@
     )
     (if
       (i32.lt_u
-        (tee_local $2
+        (tee_local $1
           (i32.add
             (get_local $0)
             (i32.const -8)
@@ -13691,9 +13649,9 @@
     )
     (if
       (i32.eq
-        (tee_local $10
+        (tee_local $5
           (i32.and
-            (tee_local $3
+            (tee_local $7
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -13708,12 +13666,12 @@
       )
       (call $_abort)
     )
-    (set_local $6
+    (set_local $8
       (i32.add
-        (get_local $2)
+        (get_local $1)
         (tee_local $0
           (i32.and
-            (get_local $3)
+            (get_local $7)
             (i32.const -8)
           )
         )
@@ -13722,43 +13680,43 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $3)
+          (get_local $7)
           (i32.const 1)
         )
         (block
-          (set_local $4
-            (get_local $2)
+          (set_local $3
+            (get_local $1)
           )
-          (set_local $1
+          (set_local $4
             (get_local $0)
           )
         )
         (block
-          (set_local $8
+          (set_local $7
             (i32.load
-              (get_local $2)
+              (get_local $1)
             )
           )
           (if
             (i32.eqz
-              (get_local $10)
+              (get_local $5)
             )
             (return)
           )
-          (set_local $3
+          (set_local $0
             (i32.add
-              (get_local $8)
+              (get_local $7)
               (get_local $0)
             )
           )
           (if
             (i32.lt_u
-              (tee_local $0
+              (tee_local $1
                 (i32.add
-                  (get_local $2)
+                  (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $8)
+                    (get_local $7)
                   )
                 )
               )
@@ -13768,7 +13726,7 @@
           )
           (if
             (i32.eq
-              (get_local $0)
+              (get_local $1)
               (i32.load
                 (i32.const 196)
               )
@@ -13777,11 +13735,11 @@
               (if
                 (i32.ne
                   (i32.and
-                    (tee_local $1
+                    (tee_local $4
                       (i32.load
-                        (tee_local $4
+                        (tee_local $3
                           (i32.add
-                            (get_local $6)
+                            (get_local $8)
                             (i32.const 4)
                           )
                         )
@@ -13792,73 +13750,73 @@
                   (i32.const 3)
                 )
                 (block
+                  (set_local $3
+                    (get_local $1)
+                  )
                   (set_local $4
                     (get_local $0)
-                  )
-                  (set_local $1
-                    (get_local $3)
                   )
                   (br $do-once)
                 )
               )
               (i32.store
                 (i32.const 184)
-                (get_local $3)
+                (get_local $0)
               )
               (i32.store
-                (get_local $4)
+                (get_local $3)
                 (i32.and
-                  (get_local $1)
+                  (get_local $4)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $0)
+                (get_local $1)
                 (i32.or
-                  (get_local $3)
+                  (get_local $0)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
+                  (get_local $1)
                   (get_local $0)
-                  (get_local $3)
                 )
-                (get_local $3)
+                (get_local $0)
               )
               (return)
             )
           )
-          (set_local $10
+          (set_local $5
             (i32.shr_u
-              (get_local $8)
+              (get_local $7)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $8)
+              (get_local $7)
               (i32.const 256)
             )
             (block
-              (set_local $2
+              (set_local $6
                 (i32.load offset=12
-                  (get_local $0)
+                  (get_local $1)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $4
+                  (tee_local $3
                     (i32.load offset=8
-                      (get_local $0)
+                      (get_local $1)
                     )
                   )
-                  (tee_local $1
+                  (tee_local $4
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $10)
+                          (get_local $5)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -13869,7 +13827,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $4)
+                      (get_local $3)
                       (get_local $11)
                     )
                     (call $_abort)
@@ -13877,9 +13835,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $4)
+                        (get_local $3)
                       )
-                      (get_local $0)
+                      (get_local $1)
                     )
                     (call $_abort)
                   )
@@ -13887,8 +13845,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $2)
-                  (get_local $4)
+                  (get_local $6)
+                  (get_local $3)
                 )
                 (block
                   (i32.store
@@ -13900,36 +13858,36 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $10)
+                          (get_local $5)
                         )
                         (i32.const -1)
                       )
                     )
                   )
+                  (set_local $3
+                    (get_local $1)
+                  )
                   (set_local $4
                     (get_local $0)
-                  )
-                  (set_local $1
-                    (get_local $3)
                   )
                   (br $do-once)
                 )
               )
               (if
                 (i32.eq
-                  (get_local $2)
-                  (get_local $1)
+                  (get_local $6)
+                  (get_local $4)
                 )
-                (set_local $5
+                (set_local $2
                   (i32.add
-                    (get_local $2)
+                    (get_local $6)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $2)
+                      (get_local $6)
                       (get_local $11)
                     )
                     (call $_abort)
@@ -13937,42 +13895,42 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $1
+                        (tee_local $4
                           (i32.add
-                            (get_local $2)
+                            (get_local $6)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $0)
-                    )
-                    (set_local $5
                       (get_local $1)
+                    )
+                    (set_local $2
+                      (get_local $4)
                     )
                     (call $_abort)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $4)
-                (get_local $2)
+                (get_local $3)
+                (get_local $6)
               )
               (i32.store
-                (get_local $5)
-                (get_local $4)
+                (get_local $2)
+                (get_local $3)
+              )
+              (set_local $3
+                (get_local $1)
               )
               (set_local $4
                 (get_local $0)
-              )
-              (set_local $1
-                (get_local $3)
               )
               (br $do-once)
             )
           )
           (set_local $12
             (i32.load offset=24
-              (get_local $0)
+              (get_local $1)
             )
           )
           (block $do-once0
@@ -13980,21 +13938,21 @@
               (i32.eq
                 (tee_local $2
                   (i32.load offset=12
-                    (get_local $0)
+                    (get_local $1)
                   )
                 )
-                (get_local $0)
+                (get_local $1)
               )
               (block
                 (if
                   (i32.eqz
-                    (tee_local $2
+                    (tee_local $5
                       (i32.load
-                        (tee_local $5
+                        (tee_local $2
                           (i32.add
-                            (tee_local $8
+                            (tee_local $7
                               (i32.add
-                                (get_local $0)
+                                (get_local $1)
                                 (i32.const 16)
                               )
                             )
@@ -14005,16 +13963,16 @@
                     )
                   )
                   (if
-                    (tee_local $2
+                    (tee_local $5
                       (i32.load
-                        (get_local $8)
+                        (get_local $7)
                       )
                     )
-                    (set_local $5
-                      (get_local $8)
+                    (set_local $2
+                      (get_local $7)
                     )
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.const 0)
                       )
                       (br $do-once0)
@@ -14023,42 +13981,42 @@
                 )
                 (loop $while-in
                   (if
-                    (tee_local $8
+                    (tee_local $7
                       (i32.load
                         (tee_local $10
                           (i32.add
-                            (get_local $2)
+                            (get_local $5)
                             (i32.const 20)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $2
-                        (get_local $8)
-                      )
                       (set_local $5
+                        (get_local $7)
+                      )
+                      (set_local $2
                         (get_local $10)
                       )
                       (br $while-in)
                     )
                   )
                   (if
-                    (tee_local $8
+                    (tee_local $7
                       (i32.load
                         (tee_local $10
                           (i32.add
-                            (get_local $2)
+                            (get_local $5)
                             (i32.const 16)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $2
-                        (get_local $8)
-                      )
                       (set_local $5
+                        (get_local $7)
+                      )
+                      (set_local $2
                         (get_local $10)
                       )
                       (br $while-in)
@@ -14067,17 +14025,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $5)
+                    (get_local $2)
                     (get_local $11)
                   )
                   (call $_abort)
                   (block
                     (i32.store
-                      (get_local $5)
+                      (get_local $2)
                       (i32.const 0)
                     )
-                    (set_local $7
-                      (get_local $2)
+                    (set_local $6
+                      (get_local $5)
                     )
                   )
                 )
@@ -14085,9 +14043,9 @@
               (block
                 (if
                   (i32.lt_u
-                    (tee_local $5
+                    (tee_local $10
                       (i32.load offset=8
-                        (get_local $0)
+                        (get_local $1)
                       )
                     )
                     (get_local $11)
@@ -14097,39 +14055,39 @@
                 (if
                   (i32.ne
                     (i32.load
-                      (tee_local $8
+                      (tee_local $7
                         (i32.add
-                          (get_local $5)
+                          (get_local $10)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $1)
                   )
                   (call $_abort)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $10
+                      (tee_local $5
                         (i32.add
                           (get_local $2)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $1)
                   )
                   (block
                     (i32.store
-                      (get_local $8)
+                      (get_local $7)
                       (get_local $2)
                     )
                     (i32.store
-                      (get_local $10)
                       (get_local $5)
+                      (get_local $10)
                     )
-                    (set_local $7
+                    (set_local $6
                       (get_local $2)
                     )
                   )
@@ -14143,15 +14101,15 @@
             (block
               (if
                 (i32.eq
-                  (get_local $0)
+                  (get_local $1)
                   (i32.load
-                    (tee_local $5
+                    (tee_local $2
                       (i32.add
                         (i32.const 480)
                         (i32.shl
-                          (tee_local $2
+                          (tee_local $5
                             (i32.load offset=28
-                              (get_local $0)
+                              (get_local $1)
                             )
                           )
                           (i32.const 2)
@@ -14162,12 +14120,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $5)
-                    (get_local $7)
+                    (get_local $2)
+                    (get_local $6)
                   )
                   (if
                     (i32.eqz
-                      (get_local $7)
+                      (get_local $6)
                     )
                     (block
                       (i32.store
@@ -14179,17 +14137,17 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $2)
+                              (get_local $5)
                             )
                             (i32.const -1)
                           )
                         )
                       )
+                      (set_local $3
+                        (get_local $1)
+                      )
                       (set_local $4
                         (get_local $0)
-                      )
-                      (set_local $1
-                        (get_local $3)
                       )
                       (br $do-once)
                     )
@@ -14215,27 +14173,27 @@
                           )
                         )
                       )
-                      (get_local $0)
+                      (get_local $1)
                     )
                     (i32.store
                       (get_local $2)
-                      (get_local $7)
+                      (get_local $6)
                     )
                     (i32.store offset=20
                       (get_local $12)
-                      (get_local $7)
+                      (get_local $6)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $7)
+                      (get_local $6)
                     )
                     (block
+                      (set_local $3
+                        (get_local $1)
+                      )
                       (set_local $4
                         (get_local $0)
-                      )
-                      (set_local $1
-                        (get_local $3)
                       )
                       (br $do-once)
                     )
@@ -14244,8 +14202,8 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $7)
-                  (tee_local $2
+                  (get_local $6)
+                  (tee_local $5
                     (i32.load
                       (i32.const 192)
                     )
@@ -14254,15 +14212,15 @@
                 (call $_abort)
               )
               (i32.store offset=24
-                (get_local $7)
+                (get_local $6)
                 (get_local $12)
               )
               (if
-                (tee_local $5
+                (tee_local $7
                   (i32.load
-                    (tee_local $8
+                    (tee_local $2
                       (i32.add
-                        (get_local $0)
+                        (get_local $1)
                         (i32.const 16)
                       )
                     )
@@ -14270,18 +14228,18 @@
                 )
                 (if
                   (i32.lt_u
+                    (get_local $7)
                     (get_local $5)
-                    (get_local $2)
                   )
                   (call $_abort)
                   (block
                     (i32.store offset=16
+                      (get_local $6)
                       (get_local $7)
-                      (get_local $5)
                     )
                     (i32.store offset=24
-                      (get_local $5)
                       (get_local $7)
+                      (get_local $6)
                     )
                   )
                 )
@@ -14289,7 +14247,7 @@
               (if
                 (tee_local $2
                   (i32.load offset=4
-                    (get_local $8)
+                    (get_local $2)
                   )
                 )
                 (if
@@ -14302,37 +14260,37 @@
                   (call $_abort)
                   (block
                     (i32.store offset=20
-                      (get_local $7)
+                      (get_local $6)
                       (get_local $2)
                     )
                     (i32.store offset=24
                       (get_local $2)
-                      (get_local $7)
+                      (get_local $6)
+                    )
+                    (set_local $3
+                      (get_local $1)
                     )
                     (set_local $4
                       (get_local $0)
                     )
-                    (set_local $1
-                      (get_local $3)
-                    )
                   )
                 )
                 (block
+                  (set_local $3
+                    (get_local $1)
+                  )
                   (set_local $4
                     (get_local $0)
-                  )
-                  (set_local $1
-                    (get_local $3)
                   )
                 )
               )
             )
             (block
+              (set_local $3
+                (get_local $1)
+              )
               (set_local $4
                 (get_local $0)
-              )
-              (set_local $1
-                (get_local $3)
               )
             )
           )
@@ -14341,19 +14299,19 @@
     )
     (if
       (i32.ge_u
-        (get_local $4)
-        (get_local $6)
+        (get_local $3)
+        (get_local $8)
       )
       (call $_abort)
     )
     (if
       (i32.eqz
         (i32.and
-          (tee_local $0
+          (tee_local $1
             (i32.load
-              (tee_local $3
+              (tee_local $0
                 (i32.add
-                  (get_local $6)
+                  (get_local $8)
                   (i32.const 4)
                 )
               )
@@ -14366,36 +14324,36 @@
     )
     (if
       (i32.and
-        (get_local $0)
+        (get_local $1)
         (i32.const 2)
       )
       (block
         (i32.store
-          (get_local $3)
+          (get_local $0)
           (i32.and
-            (get_local $0)
+            (get_local $1)
             (i32.const -2)
           )
         )
         (i32.store offset=4
-          (get_local $4)
+          (get_local $3)
           (i32.or
-            (get_local $1)
+            (get_local $4)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
+            (get_local $3)
             (get_local $4)
-            (get_local $1)
           )
-          (get_local $1)
+          (get_local $4)
         )
       )
       (block
         (if
           (i32.eq
-            (get_local $6)
+            (get_local $8)
             (i32.load
               (i32.const 200)
             )
@@ -14408,16 +14366,16 @@
                   (i32.load
                     (i32.const 188)
                   )
-                  (get_local $1)
+                  (get_local $4)
                 )
               )
             )
             (i32.store
               (i32.const 200)
-              (get_local $4)
+              (get_local $3)
             )
             (i32.store offset=4
-              (get_local $4)
+              (get_local $3)
               (i32.or
                 (get_local $0)
                 (i32.const 1)
@@ -14425,7 +14383,7 @@
             )
             (if
               (i32.ne
-                (get_local $4)
+                (get_local $3)
                 (i32.load
                   (i32.const 196)
                 )
@@ -14445,7 +14403,7 @@
         )
         (if
           (i32.eq
-            (get_local $6)
+            (get_local $8)
             (i32.load
               (i32.const 196)
             )
@@ -14458,16 +14416,16 @@
                   (i32.load
                     (i32.const 184)
                   )
-                  (get_local $1)
+                  (get_local $4)
                 )
               )
             )
             (i32.store
               (i32.const 196)
-              (get_local $4)
+              (get_local $3)
             )
             (i32.store offset=4
-              (get_local $4)
+              (get_local $3)
               (i32.or
                 (get_local $0)
                 (i32.const 1)
@@ -14475,7 +14433,7 @@
             )
             (i32.store
               (i32.add
-                (get_local $4)
+                (get_local $3)
                 (get_local $0)
               )
               (get_local $0)
@@ -14483,38 +14441,38 @@
             (return)
           )
         )
-        (set_local $2
+        (set_local $5
           (i32.add
             (i32.and
-              (get_local $0)
+              (get_local $1)
               (i32.const -8)
             )
-            (get_local $1)
+            (get_local $4)
           )
         )
-        (set_local $5
+        (set_local $4
           (i32.shr_u
-            (get_local $0)
+            (get_local $1)
             (i32.const 3)
           )
         )
         (block $do-once4
           (if
             (i32.lt_u
-              (get_local $0)
+              (get_local $1)
               (i32.const 256)
             )
             (block
-              (set_local $3
+              (set_local $2
                 (i32.load offset=12
-                  (get_local $6)
+                  (get_local $8)
                 )
               )
               (if
                 (i32.ne
                   (tee_local $1
                     (i32.load offset=8
-                      (get_local $6)
+                      (get_local $8)
                     )
                   )
                   (tee_local $0
@@ -14522,7 +14480,7 @@
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $5)
+                          (get_local $4)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -14545,7 +14503,7 @@
                       (i32.load offset=12
                         (get_local $1)
                       )
-                      (get_local $6)
+                      (get_local $8)
                     )
                     (call $_abort)
                   )
@@ -14553,7 +14511,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $3)
+                  (get_local $2)
                   (get_local $1)
                 )
                 (block
@@ -14566,7 +14524,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $5)
+                          (get_local $4)
                         )
                         (i32.const -1)
                       )
@@ -14577,19 +14535,19 @@
               )
               (if
                 (i32.eq
-                  (get_local $3)
+                  (get_local $2)
                   (get_local $0)
                 )
                 (set_local $14
                   (i32.add
-                    (get_local $3)
+                    (get_local $2)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $3)
+                      (get_local $2)
                       (i32.load
                         (i32.const 192)
                       )
@@ -14601,12 +14559,12 @@
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $3)
+                            (get_local $2)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $6)
+                      (get_local $8)
                     )
                     (set_local $14
                       (get_local $0)
@@ -14617,7 +14575,7 @@
               )
               (i32.store offset=12
                 (get_local $1)
-                (get_local $3)
+                (get_local $2)
               )
               (i32.store
                 (get_local $14)
@@ -14625,9 +14583,9 @@
               )
             )
             (block
-              (set_local $7
+              (set_local $6
                 (i32.load offset=24
-                  (get_local $6)
+                  (get_local $8)
                 )
               )
               (block $do-once6
@@ -14635,21 +14593,21 @@
                   (i32.eq
                     (tee_local $0
                       (i32.load offset=12
-                        (get_local $6)
+                        (get_local $8)
                       )
                     )
-                    (get_local $6)
+                    (get_local $8)
                   )
                   (block
                     (if
                       (i32.eqz
-                        (tee_local $0
+                        (tee_local $4
                           (i32.load
-                            (tee_local $1
+                            (tee_local $0
                               (i32.add
-                                (tee_local $3
+                                (tee_local $1
                                   (i32.add
-                                    (get_local $6)
+                                    (get_local $8)
                                     (i32.const 16)
                                   )
                                 )
@@ -14660,13 +14618,13 @@
                         )
                       )
                       (if
-                        (tee_local $0
+                        (tee_local $4
                           (i32.load
-                            (get_local $3)
+                            (get_local $1)
                           )
                         )
-                        (set_local $1
-                          (get_local $3)
+                        (set_local $0
+                          (get_local $1)
                         )
                         (block
                           (set_local $9
@@ -14678,43 +14636,43 @@
                     )
                     (loop $while-in9
                       (if
-                        (tee_local $3
+                        (tee_local $1
                           (i32.load
-                            (tee_local $5
+                            (tee_local $2
                               (i32.add
-                                (get_local $0)
+                                (get_local $4)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $0
-                            (get_local $3)
+                          (set_local $4
+                            (get_local $1)
                           )
-                          (set_local $1
-                            (get_local $5)
+                          (set_local $0
+                            (get_local $2)
                           )
                           (br $while-in9)
                         )
                       )
                       (if
-                        (tee_local $3
+                        (tee_local $1
                           (i32.load
-                            (tee_local $5
+                            (tee_local $2
                               (i32.add
-                                (get_local $0)
+                                (get_local $4)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $0
-                            (get_local $3)
+                          (set_local $4
+                            (get_local $1)
                           )
-                          (set_local $1
-                            (get_local $5)
+                          (set_local $0
+                            (get_local $2)
                           )
                           (br $while-in9)
                         )
@@ -14722,7 +14680,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $0)
                         (i32.load
                           (i32.const 192)
                         )
@@ -14730,11 +14688,11 @@
                       (call $_abort)
                       (block
                         (i32.store
-                          (get_local $1)
+                          (get_local $0)
                           (i32.const 0)
                         )
                         (set_local $9
-                          (get_local $0)
+                          (get_local $4)
                         )
                       )
                     )
@@ -14742,9 +14700,9 @@
                   (block
                     (if
                       (i32.lt_u
-                        (tee_local $1
+                        (tee_local $2
                           (i32.load offset=8
-                            (get_local $6)
+                            (get_local $8)
                           )
                         )
                         (i32.load
@@ -14756,37 +14714,37 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (tee_local $3
+                          (tee_local $1
                             (i32.add
-                              (get_local $1)
+                              (get_local $2)
                               (i32.const 12)
                             )
                           )
                         )
-                        (get_local $6)
+                        (get_local $8)
                       )
                       (call $_abort)
                     )
                     (if
                       (i32.eq
                         (i32.load
-                          (tee_local $5
+                          (tee_local $4
                             (i32.add
                               (get_local $0)
                               (i32.const 8)
                             )
                           )
                         )
-                        (get_local $6)
+                        (get_local $8)
                       )
                       (block
                         (i32.store
-                          (get_local $3)
+                          (get_local $1)
                           (get_local $0)
                         )
                         (i32.store
-                          (get_local $5)
-                          (get_local $1)
+                          (get_local $4)
+                          (get_local $2)
                         )
                         (set_local $9
                           (get_local $0)
@@ -14798,19 +14756,19 @@
                 )
               )
               (if
-                (get_local $7)
+                (get_local $6)
                 (block
                   (if
                     (i32.eq
-                      (get_local $6)
+                      (get_local $8)
                       (i32.load
-                        (tee_local $1
+                        (tee_local $0
                           (i32.add
                             (i32.const 480)
                             (i32.shl
-                              (tee_local $0
+                              (tee_local $4
                                 (i32.load offset=28
-                                  (get_local $6)
+                                  (get_local $8)
                                 )
                               )
                               (i32.const 2)
@@ -14821,7 +14779,7 @@
                     )
                     (block
                       (i32.store
-                        (get_local $1)
+                        (get_local $0)
                         (get_local $9)
                       )
                       (if
@@ -14838,7 +14796,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $0)
+                                  (get_local $4)
                                 )
                                 (i32.const -1)
                               )
@@ -14851,7 +14809,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $7)
+                          (get_local $6)
                           (i32.load
                             (i32.const 192)
                           )
@@ -14863,19 +14821,19 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $7)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                             )
                           )
-                          (get_local $6)
+                          (get_local $8)
                         )
                         (i32.store
                           (get_local $0)
                           (get_local $9)
                         )
                         (i32.store offset=20
-                          (get_local $7)
+                          (get_local $6)
                           (get_local $9)
                         )
                       )
@@ -14889,7 +14847,7 @@
                   (if
                     (i32.lt_u
                       (get_local $9)
-                      (tee_local $0
+                      (tee_local $4
                         (i32.load
                           (i32.const 192)
                         )
@@ -14899,14 +14857,14 @@
                   )
                   (i32.store offset=24
                     (get_local $9)
-                    (get_local $7)
+                    (get_local $6)
                   )
                   (if
                     (tee_local $1
                       (i32.load
-                        (tee_local $3
+                        (tee_local $0
                           (i32.add
-                            (get_local $6)
+                            (get_local $8)
                             (i32.const 16)
                           )
                         )
@@ -14915,7 +14873,7 @@
                     (if
                       (i32.lt_u
                         (get_local $1)
-                        (get_local $0)
+                        (get_local $4)
                       )
                       (call $_abort)
                       (block
@@ -14933,7 +14891,7 @@
                   (if
                     (tee_local $0
                       (i32.load offset=4
-                        (get_local $3)
+                        (get_local $0)
                       )
                     )
                     (if
@@ -14962,22 +14920,22 @@
           )
         )
         (i32.store offset=4
-          (get_local $4)
+          (get_local $3)
           (i32.or
-            (get_local $2)
+            (get_local $5)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
-            (get_local $4)
-            (get_local $2)
+            (get_local $3)
+            (get_local $5)
           )
-          (get_local $2)
+          (get_local $5)
         )
         (if
           (i32.eq
-            (get_local $4)
+            (get_local $3)
             (i32.load
               (i32.const 196)
             )
@@ -14985,34 +14943,34 @@
           (block
             (i32.store
               (i32.const 184)
-              (get_local $2)
+              (get_local $5)
             )
             (return)
           )
-          (set_local $1
-            (get_local $2)
+          (set_local $4
+            (get_local $5)
           )
         )
       )
     )
-    (set_local $2
+    (set_local $0
       (i32.shr_u
-        (get_local $1)
+        (get_local $4)
         (i32.const 3)
       )
     )
     (if
       (i32.lt_u
-        (get_local $1)
+        (get_local $4)
         (i32.const 256)
       )
       (block
-        (set_local $3
+        (set_local $1
           (i32.add
             (i32.const 216)
             (i32.shl
               (i32.shl
-                (get_local $2)
+                (get_local $0)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -15021,25 +14979,25 @@
         )
         (if
           (i32.and
-            (tee_local $0
+            (tee_local $4
               (i32.load
                 (i32.const 176)
               )
             )
-            (tee_local $1
+            (tee_local $0
               (i32.shl
                 (i32.const 1)
-                (get_local $2)
+                (get_local $0)
               )
             )
           )
           (if
             (i32.lt_u
-              (tee_local $1
+              (tee_local $0
                 (i32.load
-                  (tee_local $0
+                  (tee_local $4
                     (i32.add
-                      (get_local $3)
+                      (get_local $1)
                       (i32.const 8)
                     )
                   )
@@ -15052,10 +15010,10 @@
             (call $_abort)
             (block
               (set_local $15
-                (get_local $0)
+                (get_local $4)
               )
               (set_local $13
-                (get_local $1)
+                (get_local $0)
               )
             )
           )
@@ -15063,36 +15021,36 @@
             (i32.store
               (i32.const 176)
               (i32.or
+                (get_local $4)
                 (get_local $0)
-                (get_local $1)
               )
             )
             (set_local $15
               (i32.add
-                (get_local $3)
+                (get_local $1)
                 (i32.const 8)
               )
             )
             (set_local $13
-              (get_local $3)
+              (get_local $1)
             )
           )
         )
         (i32.store
           (get_local $15)
-          (get_local $4)
+          (get_local $3)
         )
         (i32.store offset=12
           (get_local $13)
-          (get_local $4)
+          (get_local $3)
         )
         (i32.store offset=8
-          (get_local $4)
+          (get_local $3)
           (get_local $13)
         )
         (i32.store offset=12
-          (get_local $4)
           (get_local $3)
+          (get_local $1)
         )
         (return)
       )
@@ -15101,24 +15059,24 @@
       (i32.add
         (i32.const 480)
         (i32.shl
-          (tee_local $3
+          (tee_local $2
             (if i32
               (tee_local $0
                 (i32.shr_u
-                  (get_local $1)
+                  (get_local $4)
                   (i32.const 8)
                 )
               )
               (if i32
                 (i32.gt_u
-                  (get_local $1)
+                  (get_local $4)
                   (i32.const 16777215)
                 )
                 (i32.const 31)
                 (i32.or
                   (i32.and
                     (i32.shr_u
-                      (get_local $1)
+                      (get_local $4)
                       (i32.add
                         (tee_local $0
                           (i32.add
@@ -15126,14 +15084,14 @@
                               (i32.const 14)
                               (i32.or
                                 (i32.or
-                                  (tee_local $3
+                                  (tee_local $0
                                     (i32.and
                                       (i32.shr_u
                                         (i32.add
-                                          (tee_local $2
+                                          (tee_local $1
                                             (i32.shl
                                               (get_local $0)
-                                              (tee_local $0
+                                              (tee_local $2
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
@@ -15154,16 +15112,16 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $0)
+                                  (get_local $2)
                                 )
                                 (tee_local $0
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (tee_local $3
+                                        (tee_local $1
                                           (i32.shl
-                                            (get_local $2)
-                                            (get_local $3)
+                                            (get_local $1)
+                                            (get_local $0)
                                           )
                                         )
                                         (i32.const 245760)
@@ -15177,7 +15135,7 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $3)
+                                (get_local $1)
                                 (get_local $0)
                               )
                               (i32.const 15)
@@ -15203,47 +15161,47 @@
       )
     )
     (i32.store offset=28
-      (get_local $4)
       (get_local $3)
+      (get_local $2)
     )
     (i32.store offset=20
-      (get_local $4)
+      (get_local $3)
       (i32.const 0)
     )
     (i32.store offset=16
-      (get_local $4)
+      (get_local $3)
       (i32.const 0)
     )
     (block $do-once12
       (if
         (i32.and
-          (tee_local $0
+          (tee_local $1
             (i32.load
               (i32.const 180)
             )
           )
-          (tee_local $2
+          (tee_local $0
             (i32.shl
               (i32.const 1)
-              (get_local $3)
+              (get_local $2)
             )
           )
         )
         (block
           (set_local $2
             (i32.shl
-              (get_local $1)
+              (get_local $4)
               (select
                 (i32.const 0)
                 (i32.sub
                   (i32.const 25)
                   (i32.shr_u
-                    (get_local $3)
+                    (get_local $2)
                     (i32.const 1)
                   )
                 )
                 (i32.eq
-                  (get_local $3)
+                  (get_local $2)
                   (i32.const 31)
                 )
               )
@@ -15266,7 +15224,7 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $1)
+                      (get_local $4)
                     )
                   )
                   (set_local $5
@@ -15277,7 +15235,7 @@
                   )
                   (br_if $jumpthreading$inner$0
                     (i32.eqz
-                      (tee_local $3
+                      (tee_local $1
                         (i32.load
                           (tee_local $2
                             (i32.add
@@ -15303,7 +15261,7 @@
                       (get_local $5)
                     )
                     (set_local $0
-                      (get_local $3)
+                      (get_local $1)
                     )
                     (br $while-in15)
                   )
@@ -15320,19 +15278,19 @@
                 (block
                   (i32.store
                     (get_local $2)
-                    (get_local $4)
+                    (get_local $3)
                   )
                   (i32.store offset=24
-                    (get_local $4)
+                    (get_local $3)
                     (get_local $0)
                   )
                   (i32.store offset=12
-                    (get_local $4)
-                    (get_local $4)
+                    (get_local $3)
+                    (get_local $3)
                   )
                   (i32.store offset=8
-                    (get_local $4)
-                    (get_local $4)
+                    (get_local $3)
+                    (get_local $3)
                   )
                   (br $do-once12)
                 )
@@ -15342,9 +15300,9 @@
             (if
               (i32.and
                 (i32.ge_u
-                  (tee_local $1
+                  (tee_local $2
                     (i32.load
-                      (tee_local $2
+                      (tee_local $1
                         (i32.add
                           (get_local $0)
                           (i32.const 8)
@@ -15352,7 +15310,7 @@
                       )
                     )
                   )
-                  (tee_local $3
+                  (tee_local $4
                     (i32.load
                       (i32.const 192)
                     )
@@ -15360,28 +15318,28 @@
                 )
                 (i32.ge_u
                   (get_local $0)
-                  (get_local $3)
+                  (get_local $4)
                 )
               )
               (block
                 (i32.store offset=12
-                  (get_local $1)
-                  (get_local $4)
+                  (get_local $2)
+                  (get_local $3)
                 )
                 (i32.store
-                  (get_local $2)
-                  (get_local $4)
+                  (get_local $1)
+                  (get_local $3)
                 )
                 (i32.store offset=8
-                  (get_local $4)
-                  (get_local $1)
+                  (get_local $3)
+                  (get_local $2)
                 )
                 (i32.store offset=12
-                  (get_local $4)
+                  (get_local $3)
                   (get_local $0)
                 )
                 (i32.store offset=24
-                  (get_local $4)
+                  (get_local $3)
                   (i32.const 0)
                 )
               )
@@ -15393,25 +15351,25 @@
           (i32.store
             (i32.const 180)
             (i32.or
+              (get_local $1)
               (get_local $0)
-              (get_local $2)
             )
           )
           (i32.store
             (get_local $5)
-            (get_local $4)
+            (get_local $3)
           )
           (i32.store offset=24
-            (get_local $4)
+            (get_local $3)
             (get_local $5)
           )
           (i32.store offset=12
-            (get_local $4)
-            (get_local $4)
+            (get_local $3)
+            (get_local $3)
           )
           (i32.store offset=8
-            (get_local $4)
-            (get_local $4)
+            (get_local $3)
+            (get_local $3)
           )
         )
       )
@@ -15437,7 +15395,7 @@
     (loop $while-in17
       (set_local $0
         (i32.add
-          (tee_local $1
+          (tee_local $4
             (i32.load
               (get_local $0)
             )
@@ -15446,7 +15404,7 @@
         )
       )
       (br_if $while-in17
-        (get_local $1)
+        (get_local $4)
       )
     )
     (i32.store
@@ -15476,6 +15434,7 @@
     )
   )
   (func $_i64Add (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+    (local $4 i32)
     (set_global $tempRet0
       (i32.add
         (i32.add
@@ -15483,7 +15442,7 @@
           (get_local $3)
         )
         (i32.lt_u
-          (tee_local $1
+          (tee_local $4
             (i32.add
               (get_local $0)
               (get_local $2)
@@ -15493,7 +15452,7 @@
         )
       )
     )
-    (get_local $1)
+    (get_local $4)
   )
   (func $_memset (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (local $3 i32)

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -654,7 +654,7 @@
           )
         )
         (block i32
-          (set_local $0
+          (set_local $1
             (if i32
               (i32.load
                 (i32.const 12)
@@ -671,7 +671,7 @@
             (i32.const 44)
           )
           (if
-            (tee_local $1
+            (tee_local $0
               (i32.load
                 (i32.const 40)
               )
@@ -681,45 +681,45 @@
                 (if i32
                   (i32.gt_s
                     (i32.load offset=76
-                      (get_local $1)
+                      (get_local $0)
                     )
                     (i32.const -1)
                   )
                   (call $___lockfile
-                    (get_local $1)
+                    (get_local $0)
                   )
                   (i32.const 0)
                 )
               )
-              (set_local $0
+              (set_local $1
                 (if i32
                   (i32.gt_u
                     (i32.load offset=20
-                      (get_local $1)
+                      (get_local $0)
                     )
                     (i32.load offset=28
-                      (get_local $1)
+                      (get_local $0)
                     )
                   )
                   (i32.or
                     (call $___fflush_unlocked
-                      (get_local $1)
+                      (get_local $0)
                     )
-                    (get_local $0)
+                    (get_local $1)
                   )
-                  (get_local $0)
+                  (get_local $1)
                 )
               )
               (if
                 (get_local $2)
                 (call $___unlockfile
-                  (get_local $1)
+                  (get_local $0)
                 )
               )
               (br_if $while-in
-                (tee_local $1
+                (tee_local $0
                   (i32.load offset=56
-                    (get_local $1)
+                    (get_local $0)
                   )
                 )
               )
@@ -728,7 +728,7 @@
           (call $___unlock
             (i32.const 44)
           )
-          (get_local $0)
+          (get_local $1)
         )
       )
     )
@@ -817,13 +817,13 @@
       (get_local $7)
     )
     (i32.store
-      (tee_local $4
+      (tee_local $3
         (i32.add
           (get_local $7)
           (i32.const 32)
         )
       )
-      (tee_local $3
+      (tee_local $5
         (i32.load
           (tee_local $6
             (i32.add
@@ -835,8 +835,8 @@
       )
     )
     (i32.store offset=4
-      (get_local $4)
-      (tee_local $3
+      (get_local $3)
+      (tee_local $4
         (i32.sub
           (i32.load
             (tee_local $10
@@ -846,16 +846,16 @@
               )
             )
           )
-          (get_local $3)
+          (get_local $5)
         )
       )
     )
     (i32.store offset=8
-      (get_local $4)
+      (get_local $3)
       (get_local $1)
     )
     (i32.store offset=12
-      (get_local $4)
+      (get_local $3)
       (get_local $2)
     )
     (set_local $13
@@ -871,14 +871,14 @@
       )
     )
     (set_local $1
-      (get_local $4)
+      (get_local $3)
     )
-    (set_local $4
+    (set_local $5
       (i32.const 2)
     )
     (set_local $11
       (i32.add
-        (get_local $3)
+        (get_local $4)
         (get_local $2)
       )
     )
@@ -890,7 +890,7 @@
               (br_if $jumpthreading$inner$0
                 (i32.eq
                   (get_local $11)
-                  (tee_local $5
+                  (tee_local $4
                     (if i32
                       (i32.load
                         (i32.const 16)
@@ -912,7 +912,7 @@
                         )
                         (i32.store offset=8
                           (get_local $9)
-                          (get_local $4)
+                          (get_local $5)
                         )
                         (set_local $3
                           (call $___syscall_ret
@@ -940,7 +940,7 @@
                         )
                         (i32.store offset=8
                           (get_local $8)
-                          (get_local $4)
+                          (get_local $5)
                         )
                         (call $___syscall_ret
                           (call $___syscall146
@@ -955,7 +955,7 @@
               )
               (br_if $jumpthreading$inner$1
                 (i32.lt_s
-                  (get_local $5)
+                  (get_local $4)
                   (i32.const 0)
                 )
               )
@@ -963,13 +963,13 @@
                 (set_local $11
                   (i32.sub
                     (get_local $11)
-                    (get_local $5)
+                    (get_local $4)
                   )
                 )
                 (set_local $1
                   (if i32
                     (i32.gt_u
-                      (get_local $5)
+                      (get_local $4)
                       (tee_local $12
                         (i32.load offset=4
                           (get_local $1)
@@ -989,9 +989,9 @@
                         (get_local $10)
                         (get_local $3)
                       )
-                      (set_local $5
+                      (set_local $4
                         (i32.sub
-                          (get_local $5)
+                          (get_local $4)
                           (get_local $12)
                         )
                       )
@@ -1001,9 +1001,9 @@
                           (i32.const 8)
                         )
                       )
-                      (set_local $4
+                      (set_local $5
                         (i32.add
-                          (get_local $4)
+                          (get_local $5)
                           (i32.const -1)
                         )
                       )
@@ -1013,7 +1013,7 @@
                     )
                     (if i32
                       (i32.eq
-                        (get_local $4)
+                        (get_local $5)
                         (i32.const 2)
                       )
                       (block i32
@@ -1023,13 +1023,13 @@
                             (i32.load
                               (get_local $6)
                             )
-                            (get_local $5)
+                            (get_local $4)
                           )
                         )
                         (set_local $3
                           (get_local $1)
                         )
-                        (set_local $4
+                        (set_local $5
                           (i32.const 2)
                         )
                         (get_local $12)
@@ -1049,14 +1049,14 @@
                     (i32.load
                       (get_local $3)
                     )
-                    (get_local $5)
+                    (get_local $4)
                   )
                 )
                 (i32.store offset=4
                   (get_local $3)
                   (i32.sub
                     (get_local $1)
-                    (get_local $5)
+                    (get_local $4)
                   )
                 )
                 (set_local $1
@@ -1123,7 +1123,7 @@
             )
           )
           (i32.eq
-            (get_local $4)
+            (get_local $5)
             (i32.const 2)
           )
         )
@@ -1169,7 +1169,7 @@
         (i32.const 120)
       )
     )
-    (set_local $8
+    (set_local $7
       (get_local $3)
     )
     (set_local $6
@@ -1178,10 +1178,10 @@
         (i32.const 136)
       )
     )
-    (set_local $7
+    (set_local $9
       (i32.add
         (tee_local $4
-          (tee_local $9
+          (tee_local $8
             (i32.add
               (get_local $3)
               (i32.const 80)
@@ -1204,7 +1204,7 @@
               (i32.const 4)
             )
           )
-          (get_local $7)
+          (get_local $9)
         )
       )
     )
@@ -1221,14 +1221,14 @@
             (i32.const 0)
             (get_local $1)
             (get_local $5)
+            (get_local $7)
             (get_local $8)
-            (get_local $9)
           )
           (i32.const 0)
         )
         (i32.const -1)
         (block i32
-          (set_local $12
+          (set_local $14
             (if i32
               (i32.gt_s
                 (i32.load offset=76
@@ -1267,7 +1267,7 @@
               )
             )
           )
-          (set_local $2
+          (set_local $1
             (select
               (i32.const -1)
               (if i32
@@ -1283,13 +1283,13 @@
                   (get_local $0)
                   (get_local $1)
                   (get_local $5)
+                  (get_local $7)
                   (get_local $8)
-                  (get_local $9)
                 )
                 (block i32
-                  (set_local $2
+                  (set_local $12
                     (i32.load
-                      (tee_local $7
+                      (tee_local $11
                         (i32.add
                           (get_local $0)
                           (i32.const 44)
@@ -1298,11 +1298,11 @@
                     )
                   )
                   (i32.store
-                    (get_local $7)
+                    (get_local $11)
                     (get_local $6)
                   )
                   (i32.store
-                    (tee_local $13
+                    (tee_local $9
                       (i32.add
                         (get_local $0)
                         (i32.const 28)
@@ -1311,7 +1311,7 @@
                     (get_local $6)
                   )
                   (i32.store
-                    (tee_local $11
+                    (tee_local $13
                       (i32.add
                         (get_local $0)
                         (i32.const 20)
@@ -1324,7 +1324,7 @@
                     (i32.const 80)
                   )
                   (i32.store
-                    (tee_local $14
+                    (tee_local $2
                       (i32.add
                         (get_local $0)
                         (i32.const 16)
@@ -1340,12 +1340,12 @@
                       (get_local $0)
                       (get_local $1)
                       (get_local $5)
+                      (get_local $7)
                       (get_local $8)
-                      (get_local $9)
                     )
                   )
                   (if i32
-                    (get_local $2)
+                    (get_local $12)
                     (block i32
                       (drop
                         (call_indirect $FUNCSIG$iiii
@@ -1368,28 +1368,28 @@
                           (get_local $1)
                           (i32.const -1)
                           (i32.load
-                            (get_local $11)
+                            (get_local $13)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $7)
-                        (get_local $2)
+                        (get_local $11)
+                        (get_local $12)
                       )
                       (i32.store
                         (get_local $10)
                         (i32.const 0)
                       )
                       (i32.store
-                        (get_local $14)
+                        (get_local $2)
+                        (i32.const 0)
+                      )
+                      (i32.store
+                        (get_local $9)
                         (i32.const 0)
                       )
                       (i32.store
                         (get_local $13)
-                        (i32.const 0)
-                      )
-                      (i32.store
-                        (get_local $11)
                         (i32.const 0)
                       )
                       (get_local $1)
@@ -1399,7 +1399,7 @@
                 )
               )
               (i32.and
-                (tee_local $1
+                (tee_local $2
                   (i32.load
                     (get_local $0)
                   )
@@ -1411,17 +1411,17 @@
           (i32.store
             (get_local $0)
             (i32.or
-              (get_local $1)
+              (get_local $2)
               (get_local $4)
             )
           )
           (if
-            (get_local $12)
+            (get_local $14)
             (call $___unlockfile
               (get_local $0)
             )
           )
-          (get_local $2)
+          (get_local $1)
         )
       )
     )
@@ -2302,8 +2302,8 @@
     (local $18 i32)
     (local $19 i32)
     (local $20 i32)
-    (local $21 i32)
-    (local $22 f64)
+    (local $21 f64)
+    (local $22 i32)
     (local $23 i32)
     (local $24 i32)
     (local $25 i32)
@@ -2337,7 +2337,7 @@
     (local $53 i32)
     (local $54 i32)
     (local $55 i32)
-    (set_local $27
+    (set_local $25
       (get_global $STACKTOP)
     )
     (set_global $STACKTOP
@@ -2355,20 +2355,20 @@
     )
     (set_local $20
       (i32.add
-        (get_local $27)
+        (get_local $25)
         (i32.const 16)
       )
     )
-    (set_local $18
-      (get_local $27)
+    (set_local $17
+      (get_local $25)
     )
-    (set_local $41
+    (set_local $40
       (i32.add
-        (get_local $27)
+        (get_local $25)
         (i32.const 528)
       )
     )
-    (set_local $33
+    (set_local $32
       (i32.ne
         (get_local $0)
         (i32.const 0)
@@ -2377,9 +2377,9 @@
     (set_local $45
       (tee_local $23
         (i32.add
-          (tee_local $13
+          (tee_local $19
             (i32.add
-              (get_local $27)
+              (get_local $25)
               (i32.const 536)
             )
           )
@@ -2389,7 +2389,7 @@
     )
     (set_local $46
       (i32.add
-        (get_local $13)
+        (get_local $19)
         (i32.const 39)
       )
     )
@@ -2397,7 +2397,7 @@
       (i32.add
         (tee_local $47
           (i32.add
-            (get_local $27)
+            (get_local $25)
             (i32.const 8)
           )
         )
@@ -2406,9 +2406,9 @@
     )
     (set_local $37
       (i32.add
-        (tee_local $13
+        (tee_local $19
           (i32.add
-            (get_local $27)
+            (get_local $25)
             (i32.const 576)
           )
         )
@@ -2417,19 +2417,19 @@
     )
     (set_local $48
       (i32.add
-        (get_local $13)
+        (get_local $19)
         (i32.const 11)
       )
     )
     (set_local $51
       (i32.sub
-        (tee_local $32
+        (tee_local $30
           (get_local $37)
         )
-        (tee_local $42
+        (tee_local $41
           (tee_local $24
             (i32.add
-              (get_local $27)
+              (get_local $25)
               (i32.const 588)
             )
           )
@@ -2439,12 +2439,12 @@
     (set_local $52
       (i32.sub
         (i32.const -2)
-        (get_local $42)
+        (get_local $41)
       )
     )
     (set_local $53
       (i32.add
-        (get_local $32)
+        (get_local $30)
         (i32.const 2)
       )
     )
@@ -2452,7 +2452,7 @@
       (i32.add
         (tee_local $54
           (i32.add
-            (get_local $27)
+            (get_local $25)
             (i32.const 24)
           )
         )
@@ -2460,7 +2460,7 @@
       )
     )
     (set_local $49
-      (tee_local $34
+      (tee_local $33
         (i32.add
           (get_local $24)
           (i32.const 9)
@@ -2479,7 +2479,7 @@
     (set_local $5
       (i32.const 0)
     )
-    (set_local $13
+    (set_local $19
       (i32.const 0)
     )
     (block $label$break$L343
@@ -2519,7 +2519,7 @@
               (i32.eqz
                 (i32.shr_s
                   (i32.shl
-                    (tee_local $5
+                    (tee_local $6
                       (i32.load8_s
                         (get_local $1)
                       )
@@ -2530,13 +2530,8 @@
                 )
               )
             )
-            (block
-              (set_local $6
-                (get_local $5)
-              )
-              (set_local $5
-                (get_local $1)
-              )
+            (set_local $5
+              (get_local $1)
             )
             (loop $label$continue$L9
               (block $label$break$L9
@@ -2559,18 +2554,18 @@
                     (set_local $39
                       (get_local $5)
                     )
-                    (set_local $43
+                    (set_local $42
                       (get_local $5)
                     )
-                    (set_local $28
+                    (set_local $26
                       (i32.const 9)
                     )
                     (br $label$break$L9)
                   )
-                  (set_local $29
+                  (set_local $27
                     (get_local $5)
                   )
-                  (set_local $35
+                  (set_local $34
                     (get_local $5)
                   )
                   (br $label$break$L9)
@@ -2591,11 +2586,11 @@
             (block $label$break$L12
               (if
                 (i32.eq
-                  (get_local $28)
+                  (get_local $26)
                   (i32.const 9)
                 )
                 (loop $while-in
-                  (set_local $28
+                  (set_local $26
                     (i32.const 0)
                   )
                   (if
@@ -2606,25 +2601,25 @@
                       (i32.const 37)
                     )
                     (block
-                      (set_local $29
+                      (set_local $27
                         (get_local $39)
                       )
-                      (set_local $35
-                        (get_local $43)
+                      (set_local $34
+                        (get_local $42)
                       )
                       (br $label$break$L12)
                     )
                   )
-                  (set_local $35
+                  (set_local $34
                     (i32.add
-                      (get_local $43)
+                      (get_local $42)
                       (i32.const 1)
                     )
                   )
                   (if
                     (i32.eq
                       (i32.load8_s
-                        (tee_local $29
+                        (tee_local $27
                           (i32.add
                             (get_local $39)
                             (i32.const 2)
@@ -2635,10 +2630,10 @@
                     )
                     (block
                       (set_local $39
-                        (get_local $29)
+                        (get_local $27)
                       )
-                      (set_local $43
-                        (get_local $35)
+                      (set_local $42
+                        (get_local $34)
                       )
                       (br $while-in)
                     )
@@ -2648,12 +2643,12 @@
             )
             (set_local $6
               (i32.sub
-                (get_local $35)
+                (get_local $34)
                 (get_local $1)
               )
             )
             (if
-              (get_local $33)
+              (get_local $32)
               (if
                 (i32.eqz
                   (i32.and
@@ -2674,12 +2669,12 @@
             )
             (if
               (i32.ne
-                (get_local $35)
+                (get_local $34)
                 (get_local $1)
               )
               (block
                 (set_local $1
-                  (get_local $29)
+                  (get_local $27)
                 )
                 (set_local $5
                   (get_local $6)
@@ -2687,18 +2682,18 @@
                 (br $label$continue$L1)
               )
             )
-            (set_local $21
+            (set_local $18
               (if i32
                 (i32.lt_u
-                  (tee_local $9
+                  (tee_local $8
                     (i32.add
                       (i32.shr_s
                         (i32.shl
-                          (tee_local $5
+                          (tee_local $7
                             (i32.load8_s
-                              (tee_local $10
+                              (tee_local $5
                                 (i32.add
-                                  (get_local $29)
+                                  (get_local $27)
                                   (i32.const 1)
                                 )
                               )
@@ -2714,19 +2709,19 @@
                   (i32.const 10)
                 )
                 (block i32
-                  (set_local $5
+                  (set_local $7
                     (i32.load8_s
-                      (tee_local $10
+                      (tee_local $5
                         (select
                           (i32.add
-                            (get_local $29)
+                            (get_local $27)
                             (i32.const 3)
                           )
-                          (get_local $10)
-                          (tee_local $8
+                          (get_local $5)
+                          (tee_local $11
                             (i32.eq
                               (i32.load8_s offset=2
-                                (get_local $29)
+                                (get_local $27)
                               )
                               (i32.const 36)
                             )
@@ -2735,35 +2730,30 @@
                       )
                     )
                   )
-                  (set_local $7
+                  (set_local $19
                     (select
                       (i32.const 1)
-                      (get_local $13)
-                      (get_local $8)
+                      (get_local $19)
+                      (get_local $11)
                     )
                   )
                   (select
-                    (get_local $9)
-                    (i32.const -1)
                     (get_local $8)
+                    (i32.const -1)
+                    (get_local $11)
                   )
                 )
-                (block i32
-                  (set_local $7
-                    (get_local $13)
-                  )
-                  (i32.const -1)
-                )
+                (i32.const -1)
               )
             )
             (block $label$break$L25
               (if
                 (i32.eq
                   (i32.and
-                    (tee_local $8
+                    (tee_local $11
                       (i32.shr_s
                         (i32.shl
-                          (get_local $5)
+                          (get_local $7)
                           (i32.const 24)
                         )
                         (i32.const 24)
@@ -2774,12 +2764,6 @@
                   (i32.const 32)
                 )
                 (block
-                  (set_local $13
-                    (get_local $5)
-                  )
-                  (set_local $5
-                    (get_local $8)
-                  )
                   (set_local $8
                     (i32.const 0)
                   )
@@ -2790,7 +2774,7 @@
                           (i32.shl
                             (i32.const 1)
                             (i32.add
-                              (get_local $5)
+                              (get_local $11)
                               (i32.const -32)
                             )
                           )
@@ -2798,7 +2782,10 @@
                         )
                       )
                       (block
-                        (set_local $5
+                        (set_local $11
+                          (get_local $7)
+                        )
+                        (set_local $7
                           (get_local $8)
                         )
                         (br $label$break$L25)
@@ -2811,7 +2798,7 @@
                           (i32.add
                             (i32.shr_s
                               (i32.shl
-                                (get_local $13)
+                                (get_local $7)
                                 (i32.const 24)
                               )
                               (i32.const 24)
@@ -2825,14 +2812,14 @@
                     (br_if $while-in4
                       (i32.eq
                         (i32.and
-                          (tee_local $5
+                          (tee_local $11
                             (i32.shr_s
                               (i32.shl
-                                (tee_local $13
+                                (tee_local $7
                                   (i32.load8_s
-                                    (tee_local $10
+                                    (tee_local $5
                                       (i32.add
-                                        (get_local $10)
+                                        (get_local $5)
                                         (i32.const 1)
                                       )
                                     )
@@ -2848,16 +2835,21 @@
                         (i32.const 32)
                       )
                     )
-                    (set_local $5
-                      (get_local $8)
+                    (block
+                      (set_local $11
+                        (get_local $7)
+                      )
+                      (set_local $7
+                        (get_local $8)
+                      )
                     )
                   )
                 )
                 (block
-                  (set_local $13
-                    (get_local $5)
+                  (set_local $11
+                    (get_local $7)
                   )
-                  (set_local $5
+                  (set_local $7
                     (i32.const 0)
                   )
                 )
@@ -2868,7 +2860,7 @@
                 (i32.eq
                   (i32.shr_s
                     (i32.shl
-                      (get_local $13)
+                      (get_local $11)
                       (i32.const 24)
                     )
                     (i32.const 24)
@@ -2876,17 +2868,17 @@
                   (i32.const 42)
                 )
                 (block
-                  (set_local $13
+                  (set_local $19
                     (block $jumpthreading$outer$0 i32
                       (block $jumpthreading$inner$0
                         (br_if $jumpthreading$inner$0
                           (i32.ge_u
-                            (tee_local $8
+                            (tee_local $11
                               (i32.add
                                 (i32.load8_s
-                                  (tee_local $13
+                                  (tee_local $8
                                     (i32.add
-                                      (get_local $10)
+                                      (get_local $5)
                                       (i32.const 1)
                                     )
                                   )
@@ -2900,7 +2892,7 @@
                         (br_if $jumpthreading$inner$0
                           (i32.ne
                             (i32.load8_s offset=2
-                              (get_local $10)
+                              (get_local $5)
                             )
                             (i32.const 36)
                           )
@@ -2909,19 +2901,19 @@
                           (i32.add
                             (get_local $4)
                             (i32.shl
-                              (get_local $8)
+                              (get_local $11)
                               (i32.const 2)
                             )
                           )
                           (i32.const 10)
                         )
-                        (set_local $13
+                        (set_local $19
                           (i32.add
                             (get_local $3)
                             (i32.shl
                               (i32.add
                                 (i32.load8_s
-                                  (get_local $13)
+                                  (get_local $8)
                                 )
                                 (i32.const -48)
                               )
@@ -2929,26 +2921,26 @@
                             )
                           )
                         )
-                        (set_local $10
+                        (set_local $5
                           (i32.add
-                            (get_local $10)
+                            (get_local $5)
                             (i32.const 3)
                           )
                         )
-                        (set_local $7
+                        (set_local $13
                           (i32.load
-                            (get_local $13)
+                            (get_local $19)
                           )
                         )
                         (br $jumpthreading$outer$0
                           (i32.const 1)
                         )
                       )
-                      (set_local $28
+                      (set_local $26
                         (i32.const 0)
                       )
                       (if
-                        (get_local $7)
+                        (get_local $19)
                         (block
                           (set_local $15
                             (i32.const -1)
@@ -2958,27 +2950,27 @@
                       )
                       (if
                         (i32.eqz
-                          (get_local $33)
+                          (get_local $32)
                         )
                         (block
-                          (set_local $8
-                            (get_local $5)
+                          (set_local $11
+                            (get_local $7)
                           )
-                          (set_local $10
-                            (get_local $13)
+                          (set_local $5
+                            (get_local $8)
                           )
-                          (set_local $13
+                          (set_local $19
                             (i32.const 0)
                           )
-                          (set_local $17
+                          (set_local $13
                             (i32.const 0)
                           )
                           (br $do-once5)
                         )
                       )
-                      (set_local $7
+                      (set_local $13
                         (i32.load
-                          (tee_local $10
+                          (tee_local $19
                             (i32.and
                               (i32.add
                                 (i32.load
@@ -2994,50 +2986,45 @@
                       (i32.store
                         (get_local $2)
                         (i32.add
-                          (get_local $10)
+                          (get_local $19)
                           (i32.const 4)
                         )
                       )
-                      (set_local $10
-                        (get_local $13)
+                      (set_local $5
+                        (get_local $8)
                       )
                       (i32.const 0)
                     )
                   )
-                  (set_local $8
+                  (set_local $11
                     (if i32
                       (i32.lt_s
-                        (get_local $7)
+                        (get_local $13)
                         (i32.const 0)
                       )
                       (block i32
-                        (set_local $17
+                        (set_local $13
                           (i32.sub
                             (i32.const 0)
-                            (get_local $7)
+                            (get_local $13)
                           )
                         )
                         (i32.or
-                          (get_local $5)
+                          (get_local $7)
                           (i32.const 8192)
                         )
                       )
-                      (block i32
-                        (set_local $17
-                          (get_local $7)
-                        )
-                        (get_local $5)
-                      )
+                      (get_local $7)
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (tee_local $13
+                    (tee_local $11
                       (i32.add
                         (i32.shr_s
                           (i32.shl
-                            (get_local $13)
+                            (get_local $11)
                             (i32.const 24)
                           )
                           (i32.const 24)
@@ -3052,13 +3039,13 @@
                       (i32.const 0)
                     )
                     (loop $while-in8
-                      (set_local $13
+                      (set_local $11
                         (i32.add
                           (i32.mul
                             (get_local $8)
                             (i32.const 10)
                           )
-                          (get_local $13)
+                          (get_local $11)
                         )
                       )
                       (if
@@ -3066,9 +3053,9 @@
                           (tee_local $9
                             (i32.add
                               (i32.load8_s
-                                (tee_local $10
+                                (tee_local $5
                                   (i32.add
-                                    (get_local $10)
+                                    (get_local $5)
                                     (i32.const 1)
                                   )
                                 )
@@ -3080,21 +3067,21 @@
                         )
                         (block
                           (set_local $8
-                            (get_local $13)
+                            (get_local $11)
                           )
-                          (set_local $13
+                          (set_local $11
                             (get_local $9)
                           )
                           (br $while-in8)
                         )
-                        (set_local $9
-                          (get_local $13)
+                        (set_local $13
+                          (get_local $11)
                         )
                       )
                     )
                     (if
                       (i32.lt_s
-                        (get_local $9)
+                        (get_local $13)
                         (i32.const 0)
                       )
                       (block
@@ -3103,39 +3090,28 @@
                         )
                         (br $label$break$L1)
                       )
-                      (block
-                        (set_local $8
-                          (get_local $5)
-                        )
-                        (set_local $13
-                          (get_local $7)
-                        )
-                        (set_local $17
-                          (get_local $9)
-                        )
+                      (set_local $11
+                        (get_local $7)
                       )
                     )
                   )
                   (block
-                    (set_local $8
-                      (get_local $5)
-                    )
-                    (set_local $13
+                    (set_local $11
                       (get_local $7)
                     )
-                    (set_local $17
+                    (set_local $13
                       (i32.const 0)
                     )
                   )
                 )
               )
             )
-            (set_local $9
+            (set_local $8
               (block $label$break$L46 i32
                 (if i32
                   (i32.eq
                     (i32.load8_s
-                      (get_local $10)
+                      (get_local $5)
                     )
                     (i32.const 46)
                   )
@@ -3146,9 +3122,9 @@
                           (i32.shl
                             (tee_local $7
                               (i32.load8_s
-                                (tee_local $5
+                                (tee_local $8
                                   (i32.add
-                                    (get_local $10)
+                                    (get_local $5)
                                     (i32.const 1)
                                   )
                                 )
@@ -3177,15 +3153,20 @@
                             )
                             (i32.const 10)
                           )
-                          (set_local $10
-                            (i32.const 0)
+                          (block
+                            (set_local $5
+                              (get_local $8)
+                            )
+                            (set_local $8
+                              (i32.const 0)
+                            )
                           )
                           (block
                             (set_local $7
                               (i32.const 0)
                             )
                             (br $label$break$L46
-                              (get_local $5)
+                              (get_local $8)
                             )
                           )
                         )
@@ -3193,7 +3174,7 @@
                           (set_local $7
                             (i32.add
                               (i32.mul
-                                (get_local $10)
+                                (get_local $8)
                                 (i32.const 10)
                               )
                               (get_local $7)
@@ -3217,7 +3198,7 @@
                               (i32.const 10)
                             )
                             (block
-                              (set_local $10
+                              (set_local $8
                                 (get_local $7)
                               )
                               (set_local $7
@@ -3234,12 +3215,12 @@
                     )
                     (if
                       (i32.lt_u
-                        (tee_local $5
+                        (tee_local $7
                           (i32.add
                             (i32.load8_s
-                              (tee_local $9
+                              (tee_local $8
                                 (i32.add
-                                  (get_local $10)
+                                  (get_local $5)
                                   (i32.const 2)
                                 )
                               )
@@ -3252,7 +3233,7 @@
                       (if
                         (i32.eq
                           (i32.load8_s offset=3
-                            (get_local $10)
+                            (get_local $5)
                           )
                           (i32.const 36)
                         )
@@ -3261,19 +3242,19 @@
                             (i32.add
                               (get_local $4)
                               (i32.shl
-                                (get_local $5)
+                                (get_local $7)
                                 (i32.const 2)
                               )
                             )
                             (i32.const 10)
                           )
-                          (set_local $5
+                          (set_local $7
                             (i32.add
                               (get_local $3)
                               (i32.shl
                                 (i32.add
                                   (i32.load8_s
-                                    (get_local $9)
+                                    (get_local $8)
                                   )
                                   (i32.const -48)
                                 )
@@ -3283,12 +3264,12 @@
                           )
                           (set_local $7
                             (i32.load
-                              (get_local $5)
+                              (get_local $7)
                             )
                           )
                           (br $label$break$L46
                             (i32.add
-                              (get_local $10)
+                              (get_local $5)
                               (i32.const 4)
                             )
                           )
@@ -3296,7 +3277,7 @@
                       )
                     )
                     (if
-                      (get_local $13)
+                      (get_local $19)
                       (block
                         (set_local $15
                           (i32.const -1)
@@ -3305,7 +3286,7 @@
                       )
                     )
                     (if i32
-                      (get_local $33)
+                      (get_local $32)
                       (block i32
                         (set_local $7
                           (i32.load
@@ -3329,13 +3310,13 @@
                             (i32.const 4)
                           )
                         )
-                        (get_local $9)
+                        (get_local $8)
                       )
                       (block i32
                         (set_local $7
                           (i32.const 0)
                         )
-                        (get_local $9)
+                        (get_local $8)
                       )
                     )
                   )
@@ -3343,21 +3324,21 @@
                     (set_local $7
                       (i32.const -1)
                     )
-                    (get_local $10)
+                    (get_local $5)
                   )
                 )
               )
             )
-            (set_local $11
+            (set_local $9
               (i32.const 0)
             )
             (loop $while-in13
               (if
                 (i32.gt_u
-                  (tee_local $5
+                  (tee_local $10
                     (i32.add
                       (i32.load8_s
-                        (get_local $9)
+                        (get_local $8)
                       )
                       (i32.const -65)
                     )
@@ -3371,16 +3352,16 @@
                   (br $label$break$L1)
                 )
               )
-              (set_local $10
+              (set_local $5
                 (i32.add
-                  (get_local $9)
+                  (get_local $8)
                   (i32.const 1)
                 )
               )
               (if
                 (i32.lt_u
                   (i32.add
-                    (tee_local $5
+                    (tee_local $10
                       (i32.and
                         (tee_local $12
                           (i32.load8_s
@@ -3388,11 +3369,11 @@
                               (i32.add
                                 (i32.const 3611)
                                 (i32.mul
-                                  (get_local $11)
+                                  (get_local $9)
                                   (i32.const 58)
                                 )
                               )
-                              (get_local $5)
+                              (get_local $10)
                             )
                           )
                         )
@@ -3404,24 +3385,16 @@
                   (i32.const 8)
                 )
                 (block
+                  (set_local $8
+                    (get_local $5)
+                  )
                   (set_local $9
                     (get_local $10)
                   )
-                  (set_local $11
-                    (get_local $5)
-                  )
                   (br $while-in13)
                 )
-                (block
-                  (set_local $16
-                    (get_local $5)
-                  )
-                  (set_local $5
-                    (get_local $10)
-                  )
-                  (set_local $19
-                    (get_local $9)
-                  )
+                (set_local $16
+                  (get_local $8)
                 )
               )
             )
@@ -3442,9 +3415,9 @@
                 (br $label$break$L1)
               )
             )
-            (set_local $10
+            (set_local $8
               (i32.gt_s
-                (get_local $21)
+                (get_local $18)
                 (i32.const -1)
               )
             )
@@ -3462,7 +3435,7 @@
                     (i32.const 19)
                   )
                   (if
-                    (get_local $10)
+                    (get_local $8)
                     (block
                       (set_local $15
                         (i32.const -1)
@@ -3473,25 +3446,25 @@
                   )
                   (block
                     (if
-                      (get_local $10)
+                      (get_local $8)
                       (block
                         (i32.store
                           (i32.add
                             (get_local $4)
                             (i32.shl
-                              (get_local $21)
+                              (get_local $18)
                               (i32.const 2)
                             )
                           )
-                          (get_local $16)
+                          (get_local $10)
                         )
                         (set_local $12
                           (i32.load offset=4
-                            (tee_local $9
+                            (tee_local $10
                               (i32.add
                                 (get_local $3)
                                 (i32.shl
-                                  (get_local $21)
+                                  (get_local $18)
                                   (i32.const 3)
                                 )
                               )
@@ -3499,15 +3472,15 @@
                           )
                         )
                         (i32.store
-                          (tee_local $10
-                            (get_local $18)
+                          (tee_local $8
+                            (get_local $17)
                           )
                           (i32.load
-                            (get_local $9)
+                            (get_local $10)
                           )
                         )
                         (i32.store offset=4
-                          (get_local $10)
+                          (get_local $8)
                           (get_local $12)
                         )
                         (br $jumpthreading$inner$1)
@@ -3515,7 +3488,7 @@
                     )
                     (if
                       (i32.eqz
-                        (get_local $33)
+                        (get_local $32)
                       )
                       (block
                         (set_local $15
@@ -3525,20 +3498,20 @@
                       )
                     )
                     (call $_pop_arg_336
-                      (get_local $18)
-                      (get_local $16)
+                      (get_local $17)
+                      (get_local $10)
                       (get_local $2)
                     )
                   )
                 )
                 (br $jumpthreading$outer$1)
               )
-              (set_local $28
+              (set_local $26
                 (i32.const 0)
               )
               (if
                 (i32.eqz
-                  (get_local $33)
+                  (get_local $32)
                 )
                 (block
                   (set_local $1
@@ -3551,17 +3524,17 @@
                 )
               )
             )
-            (set_local $10
+            (set_local $11
               (select
-                (tee_local $9
+                (tee_local $8
                   (i32.and
-                    (get_local $8)
+                    (get_local $11)
                     (i32.const -65537)
                   )
                 )
-                (get_local $8)
+                (get_local $11)
                 (i32.and
-                  (get_local $8)
+                  (get_local $11)
                   (i32.const 8192)
                 )
               )
@@ -3588,25 +3561,25 @@
                                                   (block $switch-case27
                                                     (br_table $switch-case42 $switch-default120 $switch-case40 $switch-default120 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case29 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case42 $switch-default120 $switch-case37 $switch-case34 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-case34 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case29 $switch-default120
                                                       (i32.sub
-                                                        (tee_local $16
+                                                        (tee_local $12
                                                           (select
                                                             (i32.and
-                                                              (tee_local $8
+                                                              (tee_local $10
                                                                 (i32.load8_s
-                                                                  (get_local $19)
+                                                                  (get_local $16)
                                                                 )
                                                               )
                                                               (i32.const -33)
                                                             )
-                                                            (get_local $8)
+                                                            (get_local $10)
                                                             (i32.and
                                                               (i32.ne
-                                                                (get_local $11)
+                                                                (get_local $9)
                                                                 (i32.const 0)
                                                               )
                                                               (i32.eq
                                                                 (i32.and
-                                                                  (get_local $8)
+                                                                  (get_local $10)
                                                                   (i32.const 15)
                                                                 )
                                                                 (i32.const 3)
@@ -3628,14 +3601,14 @@
                                                                 (block $switch-case19
                                                                   (br_table $switch-case19 $switch-case20 $switch-case21 $switch-case22 $switch-case23 $switch-default26 $switch-case24 $switch-case25 $switch-default26
                                                                     (i32.sub
-                                                                      (get_local $11)
+                                                                      (get_local $9)
                                                                       (i32.const 0)
                                                                     )
                                                                   )
                                                                 )
                                                                 (i32.store
                                                                   (i32.load
-                                                                    (get_local $18)
+                                                                    (get_local $17)
                                                                   )
                                                                   (get_local $15)
                                                                 )
@@ -3649,7 +3622,7 @@
                                                               )
                                                               (i32.store
                                                                 (i32.load
-                                                                  (get_local $18)
+                                                                  (get_local $17)
                                                                 )
                                                                 (get_local $15)
                                                               )
@@ -3664,7 +3637,7 @@
                                                             (i32.store
                                                               (tee_local $1
                                                                 (i32.load
-                                                                  (get_local $18)
+                                                                  (get_local $17)
                                                                 )
                                                               )
                                                               (get_local $15)
@@ -3692,7 +3665,7 @@
                                                           )
                                                           (i32.store16
                                                             (i32.load
-                                                              (get_local $18)
+                                                              (get_local $17)
                                                             )
                                                             (get_local $15)
                                                           )
@@ -3706,7 +3679,7 @@
                                                         )
                                                         (i32.store8
                                                           (i32.load
-                                                            (get_local $18)
+                                                            (get_local $17)
                                                           )
                                                           (get_local $15)
                                                         )
@@ -3720,7 +3693,7 @@
                                                       )
                                                       (i32.store
                                                         (i32.load
-                                                          (get_local $18)
+                                                          (get_local $17)
                                                         )
                                                         (get_local $15)
                                                       )
@@ -3735,7 +3708,7 @@
                                                     (i32.store
                                                       (tee_local $1
                                                         (i32.load
-                                                          (get_local $18)
+                                                          (get_local $17)
                                                         )
                                                       )
                                                       (get_local $15)
@@ -3771,7 +3744,7 @@
                                                 )
                                                 (set_local $1
                                                   (i32.or
-                                                    (get_local $10)
+                                                    (get_local $11)
                                                     (i32.const 8)
                                                   )
                                                 )
@@ -3785,13 +3758,13 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $16
+                                                (set_local $12
                                                   (i32.const 120)
                                                 )
                                                 (br $jumpthreading$inner$2)
                                               )
                                               (set_local $1
-                                                (get_local $10)
+                                                (get_local $11)
                                               )
                                               (br $jumpthreading$inner$2)
                                             )
@@ -3801,7 +3774,7 @@
                                                   (tee_local $6
                                                     (i32.load
                                                       (tee_local $1
-                                                        (get_local $18)
+                                                        (get_local $17)
                                                       )
                                                     )
                                                   )
@@ -3868,7 +3841,7 @@
                                             )
                                             (if
                                               (i32.and
-                                                (get_local $10)
+                                                (get_local $11)
                                                 (i32.const 8)
                                               )
                                               (block
@@ -3876,11 +3849,11 @@
                                                   (get_local $8)
                                                 )
                                                 (set_local $1
-                                                  (get_local $10)
+                                                  (get_local $11)
                                                 )
                                                 (set_local $7
                                                   (select
-                                                    (tee_local $10
+                                                    (tee_local $11
                                                       (i32.add
                                                         (i32.sub
                                                           (get_local $45)
@@ -3892,7 +3865,7 @@
                                                     (get_local $7)
                                                     (i32.lt_s
                                                       (get_local $7)
-                                                      (get_local $10)
+                                                      (get_local $11)
                                                     )
                                                   )
                                                 )
@@ -3909,7 +3882,7 @@
                                                   (get_local $8)
                                                 )
                                                 (set_local $1
-                                                  (get_local $10)
+                                                  (get_local $11)
                                                 )
                                                 (set_local $8
                                                   (i32.const 0)
@@ -3924,7 +3897,7 @@
                                           (set_local $1
                                             (i32.load
                                               (tee_local $6
-                                                (get_local $18)
+                                                (get_local $17)
                                               )
                                             )
                                           )
@@ -3940,7 +3913,7 @@
                                             (block
                                               (i32.store
                                                 (tee_local $8
-                                                  (get_local $18)
+                                                  (get_local $17)
                                                 )
                                                 (tee_local $1
                                                   (call $_i64Subtract
@@ -3968,7 +3941,7 @@
                                           )
                                           (if
                                             (i32.and
-                                              (get_local $10)
+                                              (get_local $11)
                                               (i32.const 2048)
                                             )
                                             (block
@@ -3984,7 +3957,7 @@
                                               (set_local $8
                                                 (tee_local $9
                                                   (i32.and
-                                                    (get_local $10)
+                                                    (get_local $11)
                                                     (i32.const 1)
                                                   )
                                                 )
@@ -4003,7 +3976,7 @@
                                         (set_local $1
                                           (i32.load
                                             (tee_local $6
-                                              (get_local $18)
+                                              (get_local $17)
                                             )
                                           )
                                         )
@@ -4021,7 +3994,7 @@
                                         (br $jumpthreading$inner$3)
                                       )
                                       (set_local $1
-                                        (get_local $18)
+                                        (get_local $17)
                                       )
                                       (i32.store8
                                         (get_local $46)
@@ -4032,10 +4005,10 @@
                                       (set_local $6
                                         (get_local $46)
                                       )
-                                      (set_local $10
-                                        (get_local $9)
-                                      )
                                       (set_local $11
+                                        (get_local $8)
+                                      )
+                                      (set_local $10
                                         (i32.const 1)
                                       )
                                       (set_local $8
@@ -4062,7 +4035,7 @@
                                     (select
                                       (tee_local $1
                                         (i32.load
-                                          (get_local $18)
+                                          (get_local $17)
                                         )
                                       )
                                       (i32.const 4101)
@@ -4075,7 +4048,7 @@
                                   (br $jumpthreading$inner$4)
                                 )
                                 (set_local $1
-                                  (get_local $18)
+                                  (get_local $17)
                                 )
                                 (i32.store
                                   (get_local $47)
@@ -4088,40 +4061,34 @@
                                   (i32.const 0)
                                 )
                                 (i32.store
-                                  (get_local $18)
+                                  (get_local $17)
                                   (get_local $47)
                                 )
-                                (set_local $8
+                                (set_local $7
                                   (i32.const -1)
                                 )
                                 (br $jumpthreading$inner$5)
                               )
-                              (if
+                              (br_if $jumpthreading$inner$5
                                 (get_local $7)
-                                (block
-                                  (set_local $8
-                                    (get_local $7)
-                                  )
-                                  (br $jumpthreading$inner$5)
+                              )
+                              (block
+                                (call $_pad
+                                  (get_local $0)
+                                  (i32.const 32)
+                                  (get_local $13)
+                                  (i32.const 0)
+                                  (get_local $11)
                                 )
-                                (block
-                                  (call $_pad
-                                    (get_local $0)
-                                    (i32.const 32)
-                                    (get_local $17)
-                                    (i32.const 0)
-                                    (get_local $10)
-                                  )
-                                  (set_local $6
-                                    (i32.const 0)
-                                  )
-                                  (br $jumpthreading$inner$6)
+                                (set_local $6
+                                  (i32.const 0)
                                 )
+                                (br $jumpthreading$inner$6)
                               )
                             )
                             (set_local $14
                               (f64.load
-                                (get_local $18)
+                                (get_local $17)
                               )
                             )
                             (i32.store
@@ -4132,7 +4099,7 @@
                               (get_global $tempDoublePtr)
                               (get_local $14)
                             )
-                            (set_local $36
+                            (set_local $35
                               (if i32
                                 (i32.lt_s
                                   (i32.load offset=4
@@ -4141,7 +4108,7 @@
                                   (i32.const 0)
                                 )
                                 (block i32
-                                  (set_local $30
+                                  (set_local $28
                                     (i32.const 1)
                                   )
                                   (set_local $14
@@ -4153,20 +4120,20 @@
                                 )
                                 (if i32
                                   (i32.and
-                                    (get_local $10)
+                                    (get_local $11)
                                     (i32.const 2048)
                                   )
                                   (block i32
-                                    (set_local $30
+                                    (set_local $28
                                       (i32.const 1)
                                     )
                                     (i32.const 4111)
                                   )
                                   (block i32
-                                    (set_local $30
+                                    (set_local $28
                                       (tee_local $1
                                         (i32.and
-                                          (get_local $10)
+                                          (get_local $11)
                                           (i32.const 1)
                                         )
                                       )
@@ -4214,7 +4181,7 @@
                                     (if
                                       (tee_local $5
                                         (f64.ne
-                                          (tee_local $22
+                                          (tee_local $21
                                             (f64.mul
                                               (call $_frexpl
                                                 (get_local $14)
@@ -4238,33 +4205,33 @@
                                     )
                                     (if
                                       (i32.eq
-                                        (tee_local $25
+                                        (tee_local $16
                                           (i32.or
-                                            (get_local $16)
+                                            (get_local $12)
                                             (i32.const 32)
                                           )
                                         )
                                         (i32.const 97)
                                       )
                                       (block
-                                        (set_local $19
+                                        (set_local $9
                                           (select
                                             (i32.add
-                                              (get_local $36)
+                                              (get_local $35)
                                               (i32.const 9)
                                             )
-                                            (get_local $36)
-                                            (tee_local $9
+                                            (get_local $35)
+                                            (tee_local $16
                                               (i32.and
-                                                (get_local $16)
+                                                (get_local $12)
                                                 (i32.const 32)
                                               )
                                             )
                                           )
                                         )
-                                        (set_local $8
+                                        (set_local $10
                                           (i32.or
-                                            (get_local $30)
+                                            (get_local $28)
                                             (i32.const 2)
                                           )
                                         )
@@ -4284,7 +4251,7 @@
                                                 )
                                               )
                                             )
-                                            (get_local $22)
+                                            (get_local $21)
                                             (block f64
                                               (set_local $14
                                                 (f64.const 8)
@@ -4311,7 +4278,7 @@
                                                     (get_local $14)
                                                     (f64.sub
                                                       (f64.neg
-                                                        (get_local $22)
+                                                        (get_local $21)
                                                       )
                                                       (get_local $14)
                                                     )
@@ -4319,14 +4286,14 @@
                                                 )
                                                 (f64.sub
                                                   (f64.add
-                                                    (get_local $22)
+                                                    (get_local $21)
                                                     (get_local $14)
                                                   )
                                                   (get_local $14)
                                                 )
                                                 (i32.eq
                                                   (i32.load8_s
-                                                    (get_local $19)
+                                                    (get_local $9)
                                                   )
                                                   (i32.const 45)
                                                 )
@@ -4397,14 +4364,14 @@
                                           )
                                         )
                                         (i32.store8
-                                          (tee_local $11
+                                          (tee_local $6
                                             (i32.add
                                               (get_local $6)
                                               (i32.const -2)
                                             )
                                           )
                                           (i32.add
-                                            (get_local $16)
+                                            (get_local $12)
                                             (i32.const 15)
                                           )
                                         )
@@ -4414,10 +4381,10 @@
                                             (i32.const 1)
                                           )
                                         )
-                                        (set_local $16
+                                        (set_local $18
                                           (i32.eqz
                                             (i32.and
-                                              (get_local $10)
+                                              (get_local $11)
                                               (i32.const 8)
                                             )
                                           )
@@ -4431,7 +4398,7 @@
                                             (i32.or
                                               (i32.load8_u
                                                 (i32.add
-                                                  (tee_local $6
+                                                  (tee_local $8
                                                     (i32.trunc_s/f64
                                                       (get_local $14)
                                                     )
@@ -4439,7 +4406,7 @@
                                                   (i32.const 4075)
                                                 )
                                               )
-                                              (get_local $9)
+                                              (get_local $16)
                                             )
                                           )
                                           (set_local $14
@@ -4447,7 +4414,7 @@
                                               (f64.sub
                                                 (get_local $14)
                                                 (f64.convert_s/i32
-                                                  (get_local $6)
+                                                  (get_local $8)
                                                 )
                                               )
                                               (f64.const 16)
@@ -4458,22 +4425,22 @@
                                               (if i32
                                                 (i32.eq
                                                   (i32.sub
-                                                    (tee_local $6
+                                                    (tee_local $8
                                                       (i32.add
                                                         (get_local $5)
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (get_local $42)
+                                                    (get_local $41)
                                                   )
                                                   (i32.const 1)
                                                 )
                                                 (block i32
                                                   (drop
                                                     (br_if $do-once57
-                                                      (get_local $6)
+                                                      (get_local $8)
                                                       (i32.and
-                                                        (get_local $16)
+                                                        (get_local $18)
                                                         (i32.and
                                                           (get_local $12)
                                                           (f64.eq
@@ -4485,7 +4452,7 @@
                                                     )
                                                   )
                                                   (i32.store8
-                                                    (get_local $6)
+                                                    (get_local $8)
                                                     (i32.const 46)
                                                   )
                                                   (i32.add
@@ -4493,7 +4460,7 @@
                                                     (i32.const 2)
                                                   )
                                                 )
-                                                (get_local $6)
+                                                (get_local $8)
                                               )
                                             )
                                           )
@@ -4507,22 +4474,22 @@
                                         (call $_pad
                                           (get_local $0)
                                           (i32.const 32)
-                                          (get_local $17)
-                                          (tee_local $6
+                                          (get_local $13)
+                                          (tee_local $7
                                             (i32.add
-                                              (tee_local $7
+                                              (tee_local $8
                                                 (select
                                                   (i32.sub
                                                     (i32.add
                                                       (get_local $53)
                                                       (get_local $7)
                                                     )
-                                                    (get_local $11)
+                                                    (get_local $6)
                                                   )
                                                   (i32.add
                                                     (i32.sub
                                                       (get_local $51)
-                                                      (get_local $11)
+                                                      (get_local $6)
                                                     )
                                                     (get_local $5)
                                                   )
@@ -4541,10 +4508,10 @@
                                                   )
                                                 )
                                               )
-                                              (get_local $8)
+                                              (get_local $10)
                                             )
                                           )
-                                          (get_local $10)
+                                          (get_local $11)
                                         )
                                         (if
                                           (i32.eqz
@@ -4557,8 +4524,8 @@
                                           )
                                           (drop
                                             (call $___fwritex
-                                              (get_local $19)
-                                              (get_local $8)
+                                              (get_local $9)
+                                              (get_local $10)
                                               (get_local $0)
                                             )
                                           )
@@ -4566,17 +4533,17 @@
                                         (call $_pad
                                           (get_local $0)
                                           (i32.const 48)
-                                          (get_local $17)
-                                          (get_local $6)
+                                          (get_local $13)
+                                          (get_local $7)
                                           (i32.xor
-                                            (get_local $10)
+                                            (get_local $11)
                                             (i32.const 65536)
                                           )
                                         )
                                         (set_local $5
                                           (i32.sub
                                             (get_local $5)
-                                            (get_local $42)
+                                            (get_local $41)
                                           )
                                         )
                                         (if
@@ -4600,13 +4567,13 @@
                                           (get_local $0)
                                           (i32.const 48)
                                           (i32.sub
-                                            (get_local $7)
+                                            (get_local $8)
                                             (i32.add
                                               (get_local $5)
                                               (tee_local $5
                                                 (i32.sub
-                                                  (get_local $32)
-                                                  (get_local $11)
+                                                  (get_local $30)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -4625,7 +4592,7 @@
                                           )
                                           (drop
                                             (call $___fwritex
-                                              (get_local $11)
+                                              (get_local $6)
                                               (get_local $5)
                                               (get_local $0)
                                             )
@@ -4634,26 +4601,26 @@
                                         (call $_pad
                                           (get_local $0)
                                           (i32.const 32)
-                                          (get_local $17)
-                                          (get_local $6)
+                                          (get_local $13)
+                                          (get_local $7)
                                           (i32.xor
-                                            (get_local $10)
+                                            (get_local $11)
                                             (i32.const 8192)
                                           )
                                         )
                                         (br $do-once49
                                           (select
-                                            (get_local $17)
-                                            (get_local $6)
+                                            (get_local $13)
+                                            (get_local $7)
                                             (i32.lt_s
-                                              (get_local $6)
-                                              (get_local $17)
+                                              (get_local $7)
+                                              (get_local $13)
                                             )
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $19
+                                    (set_local $18
                                       (select
                                         (i32.const 6)
                                         (get_local $7)
@@ -4663,7 +4630,7 @@
                                         )
                                       )
                                     )
-                                    (set_local $40
+                                    (set_local $31
                                       (tee_local $8
                                         (select
                                           (get_local $54)
@@ -4685,7 +4652,7 @@
                                                 )
                                                 (set_local $14
                                                   (f64.mul
-                                                    (get_local $22)
+                                                    (get_local $21)
                                                     (f64.const 268435456)
                                                   )
                                                 )
@@ -4693,7 +4660,7 @@
                                               )
                                               (block i32
                                                 (set_local $14
-                                                  (get_local $22)
+                                                  (get_local $21)
                                                 )
                                                 (i32.load
                                                   (get_local $20)
@@ -4705,21 +4672,21 @@
                                         )
                                       )
                                     )
-                                    (set_local $6
+                                    (set_local $5
                                       (get_local $8)
                                     )
                                     (loop $while-in60
                                       (i32.store
-                                        (get_local $6)
-                                        (tee_local $5
+                                        (get_local $5)
+                                        (tee_local $6
                                           (i32.trunc_s/f64
                                             (get_local $14)
                                           )
                                         )
                                       )
-                                      (set_local $6
+                                      (set_local $5
                                         (i32.add
-                                          (get_local $6)
+                                          (get_local $5)
                                           (i32.const 4)
                                         )
                                       )
@@ -4730,7 +4697,7 @@
                                               (f64.sub
                                                 (get_local $14)
                                                 (f64.convert_u/i32
-                                                  (get_local $5)
+                                                  (get_local $6)
                                                 )
                                               )
                                               (f64.const 1e9)
@@ -4750,11 +4717,11 @@
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $9
+                                        (set_local $6
                                           (get_local $8)
                                         )
                                         (loop $while-in62
-                                          (set_local $21
+                                          (set_local $10
                                             (select
                                               (i32.const 29)
                                               (get_local $7)
@@ -4764,41 +4731,41 @@
                                               )
                                             )
                                           )
-                                          (set_local $9
+                                          (set_local $6
                                             (block $do-once63 i32
                                               (if i32
                                                 (i32.lt_u
                                                   (tee_local $7
                                                     (i32.add
-                                                      (get_local $6)
+                                                      (get_local $5)
                                                       (i32.const -4)
                                                     )
                                                   )
-                                                  (get_local $9)
+                                                  (get_local $6)
                                                 )
-                                                (get_local $9)
+                                                (get_local $6)
                                                 (block i32
-                                                  (set_local $5
+                                                  (set_local $9
                                                     (i32.const 0)
                                                   )
                                                   (loop $while-in66
-                                                    (set_local $12
+                                                    (set_local $29
                                                       (call $___uremdi3
-                                                        (tee_local $5
+                                                        (tee_local $9
                                                           (call $_i64Add
                                                             (call $_bitshift64Shl
                                                               (i32.load
                                                                 (get_local $7)
                                                               )
                                                               (i32.const 0)
-                                                              (get_local $21)
+                                                              (get_local $10)
                                                             )
                                                             (get_global $tempRet0)
-                                                            (get_local $5)
+                                                            (get_local $9)
                                                             (i32.const 0)
                                                           )
                                                         )
-                                                        (tee_local $11
+                                                        (tee_local $22
                                                           (get_global $tempRet0)
                                                         )
                                                         (i32.const 1000000000)
@@ -4807,12 +4774,12 @@
                                                     )
                                                     (i32.store
                                                       (get_local $7)
-                                                      (get_local $12)
+                                                      (get_local $29)
                                                     )
-                                                    (set_local $5
+                                                    (set_local $9
                                                       (call $___udivdi3
-                                                        (get_local $5)
-                                                        (get_local $11)
+                                                        (get_local $9)
+                                                        (get_local $22)
                                                         (i32.const 1000000000)
                                                         (i32.const 0)
                                                       )
@@ -4825,64 +4792,54 @@
                                                             (i32.const -4)
                                                           )
                                                         )
-                                                        (get_local $9)
+                                                        (get_local $6)
                                                       )
                                                     )
                                                   )
                                                   (drop
                                                     (br_if $do-once63
-                                                      (get_local $9)
+                                                      (get_local $6)
                                                       (i32.eqz
-                                                        (get_local $5)
+                                                        (get_local $9)
                                                       )
                                                     )
                                                   )
                                                   (i32.store
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.add
-                                                        (get_local $9)
+                                                        (get_local $6)
                                                         (i32.const -4)
                                                       )
                                                     )
-                                                    (get_local $5)
+                                                    (get_local $9)
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
                                           )
-                                          (set_local $5
-                                            (get_local $6)
-                                          )
                                           (loop $while-in68
                                             (block $while-out67
-                                              (if
+                                              (br_if $while-out67
                                                 (i32.le_u
                                                   (get_local $5)
-                                                  (get_local $9)
-                                                )
-                                                (block
-                                                  (set_local $6
-                                                    (get_local $5)
-                                                  )
-                                                  (br $while-out67)
+                                                  (get_local $6)
                                                 )
                                               )
                                               (if
-                                                (i32.load
-                                                  (tee_local $6
-                                                    (i32.add
-                                                      (get_local $5)
-                                                      (i32.const -4)
+                                                (i32.eqz
+                                                  (i32.load
+                                                    (tee_local $7
+                                                      (i32.add
+                                                        (get_local $5)
+                                                        (i32.const -4)
+                                                      )
                                                     )
                                                   )
                                                 )
-                                                (set_local $6
-                                                  (get_local $5)
-                                                )
                                                 (block
                                                   (set_local $5
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (br $while-in68)
                                                 )
@@ -4896,7 +4853,7 @@
                                                 (i32.load
                                                   (get_local $20)
                                                 )
-                                                (get_local $21)
+                                                (get_local $10)
                                               )
                                             )
                                           )
@@ -4906,26 +4863,39 @@
                                               (i32.const 0)
                                             )
                                           )
-                                          (set_local $5
-                                            (get_local $9)
+                                          (block
+                                            (set_local $9
+                                              (get_local $7)
+                                            )
+                                            (set_local $7
+                                              (get_local $5)
+                                            )
                                           )
                                         )
                                       )
-                                      (set_local $5
-                                        (get_local $8)
+                                      (block
+                                        (set_local $9
+                                          (get_local $7)
+                                        )
+                                        (set_local $6
+                                          (get_local $8)
+                                        )
+                                        (set_local $7
+                                          (get_local $5)
+                                        )
                                       )
                                     )
                                     (if
                                       (i32.lt_s
-                                        (get_local $7)
+                                        (get_local $9)
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $12
+                                        (set_local $22
                                           (i32.add
                                             (i32.div_s
                                               (i32.add
-                                                (get_local $19)
+                                                (get_local $18)
                                                 (i32.const 25)
                                               )
                                               (i32.const 9)
@@ -4933,20 +4903,23 @@
                                             (i32.const 1)
                                           )
                                         )
-                                        (set_local $21
+                                        (set_local $29
                                           (i32.eq
-                                            (get_local $25)
+                                            (get_local $16)
                                             (i32.const 102)
                                           )
                                         )
+                                        (set_local $5
+                                          (get_local $7)
+                                        )
                                         (loop $while-in70
-                                          (set_local $26
+                                          (set_local $10
                                             (select
                                               (i32.const 9)
                                               (tee_local $7
                                                 (i32.sub
                                                   (i32.const 0)
-                                                  (get_local $7)
+                                                  (get_local $9)
                                                 )
                                               )
                                               (i32.gt_s
@@ -4955,52 +4928,52 @@
                                               )
                                             )
                                           )
-                                          (set_local $6
+                                          (set_local $7
                                             (select
                                               (i32.add
                                                 (tee_local $7
                                                   (select
                                                     (get_local $8)
-                                                    (tee_local $5
+                                                    (tee_local $6
                                                       (block $do-once71 i32
                                                         (if i32
                                                           (i32.lt_u
-                                                            (get_local $5)
                                                             (get_local $6)
+                                                            (get_local $5)
                                                           )
                                                           (block i32
-                                                            (set_local $44
+                                                            (set_local $43
                                                               (i32.add
                                                                 (i32.shl
                                                                   (i32.const 1)
-                                                                  (get_local $26)
+                                                                  (get_local $10)
                                                                 )
                                                                 (i32.const -1)
                                                               )
                                                             )
-                                                            (set_local $31
+                                                            (set_local $36
                                                               (i32.shr_u
                                                                 (i32.const 1000000000)
-                                                                (get_local $26)
+                                                                (get_local $10)
                                                               )
                                                             )
                                                             (set_local $9
                                                               (i32.const 0)
                                                             )
                                                             (set_local $7
-                                                              (get_local $5)
+                                                              (get_local $6)
                                                             )
                                                             (loop $while-in74
                                                               (i32.store
                                                                 (get_local $7)
                                                                 (i32.add
                                                                   (i32.shr_u
-                                                                    (tee_local $11
+                                                                    (tee_local $44
                                                                       (i32.load
                                                                         (get_local $7)
                                                                       )
                                                                     )
-                                                                    (get_local $26)
+                                                                    (get_local $10)
                                                                   )
                                                                   (get_local $9)
                                                                 )
@@ -5008,10 +4981,10 @@
                                                               (set_local $9
                                                                 (i32.mul
                                                                   (i32.and
-                                                                    (get_local $11)
                                                                     (get_local $44)
+                                                                    (get_local $43)
                                                                   )
-                                                                  (get_local $31)
+                                                                  (get_local $36)
                                                                 )
                                                               )
                                                               (br_if $while-in74
@@ -5022,100 +4995,116 @@
                                                                       (i32.const 4)
                                                                     )
                                                                   )
-                                                                  (get_local $6)
+                                                                  (get_local $5)
                                                                 )
                                                               )
                                                             )
-                                                            (set_local $5
+                                                            (set_local $6
                                                               (select
-                                                                (get_local $5)
+                                                                (get_local $6)
                                                                 (i32.add
-                                                                  (get_local $5)
+                                                                  (get_local $6)
                                                                   (i32.const 4)
                                                                 )
                                                                 (i32.load
-                                                                  (get_local $5)
+                                                                  (get_local $6)
                                                                 )
                                                               )
                                                             )
                                                             (drop
                                                               (br_if $do-once71
-                                                                (get_local $5)
+                                                                (get_local $6)
                                                                 (i32.eqz
                                                                   (get_local $9)
                                                                 )
                                                               )
                                                             )
                                                             (i32.store
-                                                              (get_local $6)
+                                                              (get_local $5)
                                                               (get_local $9)
                                                             )
-                                                            (set_local $6
+                                                            (set_local $5
                                                               (i32.add
-                                                                (get_local $6)
+                                                                (get_local $5)
                                                                 (i32.const 4)
                                                               )
                                                             )
-                                                            (get_local $5)
+                                                            (get_local $6)
                                                           )
                                                           (select
-                                                            (get_local $5)
+                                                            (get_local $6)
                                                             (i32.add
-                                                              (get_local $5)
+                                                              (get_local $6)
                                                               (i32.const 4)
                                                             )
                                                             (i32.load
-                                                              (get_local $5)
+                                                              (get_local $6)
                                                             )
                                                           )
                                                         )
                                                       )
                                                     )
-                                                    (get_local $21)
+                                                    (get_local $29)
                                                   )
                                                 )
                                                 (i32.shl
-                                                  (get_local $12)
+                                                  (get_local $22)
                                                   (i32.const 2)
                                                 )
                                               )
-                                              (get_local $6)
+                                              (get_local $5)
                                               (i32.gt_s
                                                 (i32.shr_s
                                                   (i32.sub
-                                                    (get_local $6)
+                                                    (get_local $5)
                                                     (get_local $7)
                                                   )
                                                   (i32.const 2)
                                                 )
-                                                (get_local $12)
+                                                (get_local $22)
                                               )
                                             )
                                           )
                                           (i32.store
                                             (get_local $20)
-                                            (tee_local $7
+                                            (tee_local $9
                                               (i32.add
                                                 (i32.load
                                                   (get_local $20)
                                                 )
-                                                (get_local $26)
+                                                (get_local $10)
                                               )
                                             )
                                           )
-                                          (br_if $while-in70
+                                          (if
                                             (i32.lt_s
-                                              (get_local $7)
+                                              (get_local $9)
                                               (i32.const 0)
                                             )
-                                          )
-                                          (set_local $9
-                                            (get_local $6)
+                                            (block
+                                              (set_local $5
+                                                (get_local $7)
+                                              )
+                                              (br $while-in70)
+                                            )
+                                            (block
+                                              (set_local $5
+                                                (get_local $6)
+                                              )
+                                              (set_local $9
+                                                (get_local $7)
+                                              )
+                                            )
                                           )
                                         )
                                       )
-                                      (set_local $9
-                                        (get_local $6)
+                                      (block
+                                        (set_local $5
+                                          (get_local $6)
+                                        )
+                                        (set_local $9
+                                          (get_local $7)
+                                        )
                                       )
                                     )
                                     (block $do-once75
@@ -5129,7 +5118,7 @@
                                             (i32.mul
                                               (i32.shr_s
                                                 (i32.sub
-                                                  (get_local $40)
+                                                  (get_local $31)
                                                   (get_local $5)
                                                 )
                                                 (i32.const 2)
@@ -5139,7 +5128,7 @@
                                           )
                                           (br_if $do-once75
                                             (i32.lt_u
-                                              (tee_local $11
+                                              (tee_local $10
                                                 (i32.load
                                                   (get_local $5)
                                                 )
@@ -5159,7 +5148,7 @@
                                             )
                                             (br_if $while-in78
                                               (i32.ge_u
-                                                (get_local $11)
+                                                (get_local $10)
                                                 (tee_local $7
                                                   (i32.mul
                                                     (get_local $7)
@@ -5175,18 +5164,18 @@
                                         )
                                       )
                                     )
-                                    (set_local $12
+                                    (set_local $16
                                       (if i32
                                         (i32.lt_s
                                           (tee_local $7
                                             (i32.add
                                               (i32.sub
-                                                (get_local $19)
+                                                (get_local $18)
                                                 (select
                                                   (get_local $6)
                                                   (i32.const 0)
                                                   (i32.ne
-                                                    (get_local $25)
+                                                    (get_local $16)
                                                     (i32.const 102)
                                                   )
                                                 )
@@ -5194,15 +5183,15 @@
                                               (i32.shr_s
                                                 (i32.shl
                                                   (i32.and
-                                                    (tee_local $44
+                                                    (tee_local $29
                                                       (i32.ne
-                                                        (get_local $19)
+                                                        (get_local $18)
                                                         (i32.const 0)
                                                       )
                                                     )
-                                                    (tee_local $21
+                                                    (tee_local $43
                                                       (i32.eq
-                                                        (get_local $25)
+                                                        (get_local $16)
                                                         (i32.const 103)
                                                       )
                                                     )
@@ -5218,7 +5207,7 @@
                                               (i32.shr_s
                                                 (i32.sub
                                                   (get_local $9)
-                                                  (get_local $40)
+                                                  (get_local $31)
                                                 )
                                                 (i32.const 2)
                                               )
@@ -5237,7 +5226,7 @@
                                               (i32.shl
                                                 (i32.add
                                                   (i32.div_s
-                                                    (tee_local $11
+                                                    (tee_local $10
                                                       (i32.add
                                                         (get_local $7)
                                                         (i32.const 9216)
@@ -5253,10 +5242,10 @@
                                           )
                                           (if
                                             (i32.lt_s
-                                              (tee_local $11
+                                              (tee_local $10
                                                 (i32.add
                                                   (i32.rem_s
-                                                    (get_local $11)
+                                                    (get_local $10)
                                                     (i32.const 9)
                                                   )
                                                   (i32.const 1)
@@ -5265,21 +5254,21 @@
                                               (i32.const 9)
                                             )
                                             (block
-                                              (set_local $12
+                                              (set_local $16
                                                 (i32.const 10)
                                               )
                                               (loop $while-in80
-                                                (set_local $12
+                                                (set_local $16
                                                   (i32.mul
-                                                    (get_local $12)
+                                                    (get_local $16)
                                                     (i32.const 10)
                                                   )
                                                 )
                                                 (br_if $while-in80
                                                   (i32.ne
-                                                    (tee_local $11
+                                                    (tee_local $10
                                                       (i32.add
-                                                        (get_local $11)
+                                                        (get_local $10)
                                                         (i32.const 1)
                                                       )
                                                     )
@@ -5288,7 +5277,7 @@
                                                 )
                                               )
                                             )
-                                            (set_local $12
+                                            (set_local $16
                                               (i32.const 10)
                                             )
                                           )
@@ -5296,7 +5285,7 @@
                                             (if
                                               (i32.eqz
                                                 (i32.and
-                                                  (tee_local $26
+                                                  (tee_local $36
                                                     (i32.eq
                                                       (i32.add
                                                         (get_local $7)
@@ -5306,28 +5295,28 @@
                                                     )
                                                   )
                                                   (i32.eqz
-                                                    (tee_local $31
+                                                    (tee_local $10
                                                       (i32.rem_u
-                                                        (tee_local $11
+                                                        (tee_local $22
                                                           (i32.load
                                                             (get_local $7)
                                                           )
                                                         )
-                                                        (get_local $12)
+                                                        (get_local $16)
                                                       )
                                                     )
                                                   )
                                                 )
                                               )
                                               (block
-                                                (set_local $22
+                                                (set_local $21
                                                   (select
                                                     (f64.const 9007199254740994)
                                                     (f64.const 9007199254740992)
                                                     (i32.and
                                                       (i32.div_u
-                                                        (get_local $11)
-                                                        (get_local $12)
+                                                        (get_local $22)
+                                                        (get_local $16)
                                                       )
                                                       (i32.const 1)
                                                     )
@@ -5336,10 +5325,10 @@
                                                 (set_local $14
                                                   (if f64
                                                     (i32.lt_u
-                                                      (get_local $31)
-                                                      (tee_local $25
+                                                      (get_local $10)
+                                                      (tee_local $44
                                                         (i32.div_s
-                                                          (get_local $12)
+                                                          (get_local $16)
                                                           (i32.const 2)
                                                         )
                                                       )
@@ -5349,26 +5338,26 @@
                                                       (f64.const 1)
                                                       (f64.const 1.5)
                                                       (i32.and
-                                                        (get_local $26)
+                                                        (get_local $36)
                                                         (i32.eq
-                                                          (get_local $31)
-                                                          (get_local $25)
+                                                          (get_local $10)
+                                                          (get_local $44)
                                                         )
                                                       )
                                                     )
                                                   )
                                                 )
-                                                (set_local $22
+                                                (set_local $21
                                                   (block $do-once83 f64
                                                     (if f64
-                                                      (get_local $30)
+                                                      (get_local $28)
                                                       (block f64
                                                         (drop
                                                           (br_if $do-once83
-                                                            (get_local $22)
+                                                            (get_local $21)
                                                             (i32.ne
                                                               (i32.load8_s
-                                                                (get_local $36)
+                                                                (get_local $35)
                                                               )
                                                               (i32.const 45)
                                                             )
@@ -5380,37 +5369,37 @@
                                                           )
                                                         )
                                                         (f64.neg
-                                                          (get_local $22)
+                                                          (get_local $21)
                                                         )
                                                       )
-                                                      (get_local $22)
+                                                      (get_local $21)
                                                     )
                                                   )
                                                 )
                                                 (i32.store
                                                   (get_local $7)
-                                                  (tee_local $11
+                                                  (tee_local $10
                                                     (i32.sub
-                                                      (get_local $11)
-                                                      (get_local $31)
+                                                      (get_local $22)
+                                                      (get_local $10)
                                                     )
                                                   )
                                                 )
                                                 (br_if $do-once81
                                                   (f64.eq
                                                     (f64.add
-                                                      (get_local $22)
+                                                      (get_local $21)
                                                       (get_local $14)
                                                     )
-                                                    (get_local $22)
+                                                    (get_local $21)
                                                   )
                                                 )
                                                 (i32.store
                                                   (get_local $7)
                                                   (tee_local $6
                                                     (i32.add
-                                                      (get_local $11)
-                                                      (get_local $12)
+                                                      (get_local $10)
+                                                      (get_local $16)
                                                     )
                                                   )
                                                 )
@@ -5473,7 +5462,7 @@
                                                   (i32.mul
                                                     (i32.shr_s
                                                       (i32.sub
-                                                        (get_local $40)
+                                                        (get_local $31)
                                                         (get_local $5)
                                                       )
                                                       (i32.const 2)
@@ -5483,7 +5472,7 @@
                                                 )
                                                 (br_if $do-once81
                                                   (i32.lt_u
-                                                    (tee_local $12
+                                                    (tee_local $16
                                                       (i32.load
                                                         (get_local $5)
                                                       )
@@ -5491,7 +5480,7 @@
                                                     (i32.const 10)
                                                   )
                                                 )
-                                                (set_local $11
+                                                (set_local $10
                                                   (i32.const 10)
                                                 )
                                                 (loop $while-in88
@@ -5503,10 +5492,10 @@
                                                   )
                                                   (br_if $while-in88
                                                     (i32.ge_u
-                                                      (get_local $12)
-                                                      (tee_local $11
+                                                      (get_local $16)
+                                                      (tee_local $10
                                                         (i32.mul
-                                                          (get_local $11)
+                                                          (get_local $10)
                                                           (i32.const 10)
                                                         )
                                                       )
@@ -5516,7 +5505,7 @@
                                               )
                                             )
                                           )
-                                          (set_local $11
+                                          (set_local $10
                                             (get_local $6)
                                           )
                                           (set_local $9
@@ -5537,17 +5526,17 @@
                                           (get_local $5)
                                         )
                                         (block i32
-                                          (set_local $11
+                                          (set_local $10
                                             (get_local $6)
                                           )
                                           (get_local $5)
                                         )
                                       )
                                     )
-                                    (set_local $25
+                                    (set_local $36
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $11)
+                                        (get_local $10)
                                       )
                                     )
                                     (set_local $5
@@ -5558,13 +5547,13 @@
                                         (if
                                           (i32.le_u
                                             (get_local $5)
-                                            (get_local $12)
+                                            (get_local $16)
                                           )
                                           (block
-                                            (set_local $26
+                                            (set_local $22
                                               (i32.const 0)
                                             )
-                                            (set_local $9
+                                            (set_local $7
                                               (get_local $5)
                                             )
                                             (br $while-out89)
@@ -5580,10 +5569,10 @@
                                             )
                                           )
                                           (block
-                                            (set_local $26
+                                            (set_local $22
                                               (i32.const 1)
                                             )
-                                            (set_local $9
+                                            (set_local $7
                                               (get_local $5)
                                             )
                                           )
@@ -5596,12 +5585,12 @@
                                         )
                                       )
                                     )
-                                    (set_local $19
+                                    (set_local $12
                                       (block $do-once91 i32
                                         (if i32
-                                          (get_local $21)
+                                          (get_local $43)
                                           (block i32
-                                            (set_local $16
+                                            (set_local $9
                                               (if i32
                                                 (i32.and
                                                   (i32.gt_s
@@ -5609,25 +5598,25 @@
                                                       (i32.add
                                                         (i32.xor
                                                           (i32.and
-                                                            (get_local $44)
+                                                            (get_local $29)
                                                             (i32.const 1)
                                                           )
                                                           (i32.const 1)
                                                         )
-                                                        (get_local $19)
+                                                        (get_local $18)
                                                       )
                                                     )
-                                                    (get_local $11)
+                                                    (get_local $10)
                                                   )
                                                   (i32.gt_s
-                                                    (get_local $11)
+                                                    (get_local $10)
                                                     (i32.const -5)
                                                   )
                                                 )
                                                 (block i32
                                                   (set_local $6
                                                     (i32.add
-                                                      (get_local $16)
+                                                      (get_local $12)
                                                       (i32.const -1)
                                                     )
                                                   )
@@ -5636,13 +5625,13 @@
                                                       (get_local $5)
                                                       (i32.const -1)
                                                     )
-                                                    (get_local $11)
+                                                    (get_local $10)
                                                   )
                                                 )
                                                 (block i32
                                                   (set_local $6
                                                     (i32.add
-                                                      (get_local $16)
+                                                      (get_local $12)
                                                       (i32.const -2)
                                                     )
                                                   )
@@ -5654,31 +5643,31 @@
                                               )
                                             )
                                             (if
-                                              (tee_local $7
+                                              (tee_local $12
                                                 (i32.and
-                                                  (get_local $10)
+                                                  (get_local $11)
                                                   (i32.const 8)
                                                 )
                                               )
                                               (block
                                                 (set_local $5
-                                                  (get_local $16)
+                                                  (get_local $9)
                                                 )
                                                 (br $do-once91
-                                                  (get_local $7)
+                                                  (get_local $12)
                                                 )
                                               )
                                             )
                                             (block $do-once93
                                               (if
-                                                (get_local $26)
+                                                (get_local $22)
                                                 (block
                                                   (if
                                                     (i32.eqz
-                                                      (tee_local $19
+                                                      (tee_local $18
                                                         (i32.load
                                                           (i32.add
-                                                            (get_local $9)
+                                                            (get_local $7)
                                                             (i32.const -4)
                                                           )
                                                         )
@@ -5693,7 +5682,7 @@
                                                   )
                                                   (if
                                                     (i32.rem_u
-                                                      (get_local $19)
+                                                      (get_local $18)
                                                       (i32.const 10)
                                                     )
                                                     (block
@@ -5703,7 +5692,7 @@
                                                       (br $do-once93)
                                                     )
                                                     (block
-                                                      (set_local $7
+                                                      (set_local $12
                                                         (i32.const 10)
                                                       )
                                                       (set_local $5
@@ -5721,10 +5710,10 @@
                                                     (br_if $while-in96
                                                       (i32.eqz
                                                         (i32.rem_u
-                                                          (get_local $19)
-                                                          (tee_local $7
+                                                          (get_local $18)
+                                                          (tee_local $12
                                                             (i32.mul
-                                                              (get_local $7)
+                                                              (get_local $12)
                                                               (i32.const 10)
                                                             )
                                                           )
@@ -5738,13 +5727,13 @@
                                                 )
                                               )
                                             )
-                                            (set_local $7
+                                            (set_local $12
                                               (i32.add
                                                 (i32.mul
                                                   (i32.shr_s
                                                     (i32.sub
-                                                      (get_local $9)
-                                                      (get_local $40)
+                                                      (get_local $7)
+                                                      (get_local $31)
                                                     )
                                                     (i32.const 2)
                                                   )
@@ -5764,13 +5753,13 @@
                                               (block i32
                                                 (set_local $5
                                                   (select
-                                                    (get_local $16)
+                                                    (get_local $9)
                                                     (tee_local $5
                                                       (select
                                                         (i32.const 0)
                                                         (tee_local $5
                                                           (i32.sub
-                                                            (get_local $7)
+                                                            (get_local $12)
                                                             (get_local $5)
                                                           )
                                                         )
@@ -5781,7 +5770,7 @@
                                                       )
                                                     )
                                                     (i32.lt_s
-                                                      (get_local $16)
+                                                      (get_local $9)
                                                       (get_local $5)
                                                     )
                                                   )
@@ -5791,15 +5780,15 @@
                                               (block i32
                                                 (set_local $5
                                                   (select
-                                                    (get_local $16)
+                                                    (get_local $9)
                                                     (tee_local $5
                                                       (select
                                                         (i32.const 0)
                                                         (tee_local $5
                                                           (i32.sub
                                                             (i32.add
-                                                              (get_local $7)
-                                                              (get_local $11)
+                                                              (get_local $12)
+                                                              (get_local $10)
                                                             )
                                                             (get_local $5)
                                                           )
@@ -5811,7 +5800,7 @@
                                                       )
                                                     )
                                                     (i32.lt_s
-                                                      (get_local $16)
+                                                      (get_local $9)
                                                       (get_local $5)
                                                     )
                                                   )
@@ -5822,13 +5811,13 @@
                                           )
                                           (block i32
                                             (set_local $5
-                                              (get_local $19)
+                                              (get_local $18)
                                             )
                                             (set_local $6
-                                              (get_local $16)
+                                              (get_local $12)
                                             )
                                             (i32.and
-                                              (get_local $10)
+                                              (get_local $11)
                                               (i32.const 8)
                                             )
                                           )
@@ -5838,10 +5827,10 @@
                                     (set_local $31
                                       (i32.and
                                         (i32.ne
-                                          (tee_local $16
+                                          (tee_local $18
                                             (i32.or
                                               (get_local $5)
-                                              (get_local $19)
+                                              (get_local $12)
                                             )
                                           )
                                           (i32.const 0)
@@ -5849,9 +5838,9 @@
                                         (i32.const 1)
                                       )
                                     )
-                                    (set_local $25
+                                    (set_local $9
                                       (if i32
-                                        (tee_local $21
+                                        (tee_local $29
                                           (i32.eq
                                             (i32.or
                                               (get_local $6)
@@ -5863,10 +5852,10 @@
                                         (block i32
                                           (set_local $6
                                             (select
-                                              (get_local $11)
+                                              (get_local $10)
                                               (i32.const 0)
                                               (i32.gt_s
-                                                (get_local $11)
+                                                (get_local $10)
                                                 (i32.const 0)
                                               )
                                             )
@@ -5877,15 +5866,15 @@
                                           (if
                                             (i32.lt_s
                                               (i32.sub
-                                                (get_local $32)
-                                                (tee_local $7
+                                                (get_local $30)
+                                                (tee_local $9
                                                   (call $_fmt_u
-                                                    (tee_local $7
+                                                    (tee_local $9
                                                       (select
-                                                        (get_local $25)
-                                                        (get_local $11)
+                                                        (get_local $36)
+                                                        (get_local $10)
                                                         (i32.lt_s
-                                                          (get_local $11)
+                                                          (get_local $10)
                                                           (i32.const 0)
                                                         )
                                                       )
@@ -5893,7 +5882,7 @@
                                                     (i32.shr_s
                                                       (i32.shl
                                                         (i32.lt_s
-                                                          (get_local $7)
+                                                          (get_local $9)
                                                           (i32.const 0)
                                                         )
                                                         (i32.const 31)
@@ -5908,9 +5897,9 @@
                                             )
                                             (loop $while-in98
                                               (i32.store8
-                                                (tee_local $7
+                                                (tee_local $9
                                                   (i32.add
-                                                    (get_local $7)
+                                                    (get_local $9)
                                                     (i32.const -1)
                                                   )
                                                 )
@@ -5919,8 +5908,8 @@
                                               (br_if $while-in98
                                                 (i32.lt_s
                                                   (i32.sub
-                                                    (get_local $32)
-                                                    (get_local $7)
+                                                    (get_local $30)
+                                                    (get_local $9)
                                                   )
                                                   (i32.const 2)
                                                 )
@@ -5929,13 +5918,13 @@
                                           )
                                           (i32.store8
                                             (i32.add
-                                              (get_local $7)
+                                              (get_local $9)
                                               (i32.const -1)
                                             )
                                             (i32.add
                                               (i32.and
                                                 (i32.shr_s
-                                                  (get_local $11)
+                                                  (get_local $10)
                                                   (i32.const 31)
                                                 )
                                                 (i32.const 2)
@@ -5944,9 +5933,9 @@
                                             )
                                           )
                                           (i32.store8
-                                            (tee_local $7
+                                            (tee_local $9
                                               (i32.add
-                                                (get_local $7)
+                                                (get_local $9)
                                                 (i32.const -2)
                                               )
                                             )
@@ -5954,24 +5943,24 @@
                                           )
                                           (set_local $6
                                             (i32.sub
-                                              (get_local $32)
-                                              (get_local $7)
+                                              (get_local $30)
+                                              (get_local $9)
                                             )
                                           )
-                                          (get_local $7)
+                                          (get_local $9)
                                         )
                                       )
                                     )
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $17)
-                                      (tee_local $11
+                                      (get_local $13)
+                                      (tee_local $10
                                         (i32.add
                                           (i32.add
                                             (i32.add
                                               (i32.add
-                                                (get_local $30)
+                                                (get_local $28)
                                                 (i32.const 1)
                                               )
                                               (get_local $5)
@@ -5981,7 +5970,7 @@
                                           (get_local $6)
                                         )
                                       )
-                                      (get_local $10)
+                                      (get_local $11)
                                     )
                                     (if
                                       (i32.eqz
@@ -5994,8 +5983,8 @@
                                       )
                                       (drop
                                         (call $___fwritex
-                                          (get_local $36)
-                                          (get_local $30)
+                                          (get_local $35)
+                                          (get_local $28)
                                           (get_local $0)
                                         )
                                       )
@@ -6003,24 +5992,24 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 48)
-                                      (get_local $17)
-                                      (get_local $11)
+                                      (get_local $13)
+                                      (get_local $10)
                                       (i32.xor
-                                        (get_local $10)
+                                        (get_local $11)
                                         (i32.const 65536)
                                       )
                                     )
                                     (block $do-once99
                                       (if
-                                        (get_local $21)
+                                        (get_local $29)
                                         (block
-                                          (set_local $7
+                                          (set_local $9
                                             (tee_local $12
                                               (select
                                                 (get_local $8)
-                                                (get_local $12)
+                                                (get_local $16)
                                                 (i32.gt_u
-                                                  (get_local $12)
+                                                  (get_local $16)
                                                   (get_local $8)
                                                 )
                                               )
@@ -6030,23 +6019,23 @@
                                             (set_local $6
                                               (call $_fmt_u
                                                 (i32.load
-                                                  (get_local $7)
+                                                  (get_local $9)
                                                 )
                                                 (i32.const 0)
-                                                (get_local $34)
+                                                (get_local $33)
                                               )
                                             )
                                             (block $do-once103
                                               (if
                                                 (i32.eq
-                                                  (get_local $7)
+                                                  (get_local $9)
                                                   (get_local $12)
                                                 )
                                                 (block
                                                   (br_if $do-once103
                                                     (i32.ne
                                                       (get_local $6)
-                                                      (get_local $34)
+                                                      (get_local $33)
                                                     )
                                                   )
                                                   (i32.store8
@@ -6108,14 +6097,14 @@
                                               (i32.le_u
                                                 (tee_local $6
                                                   (i32.add
-                                                    (get_local $7)
+                                                    (get_local $9)
                                                     (i32.const 4)
                                                   )
                                                 )
                                                 (get_local $8)
                                               )
                                               (block
-                                                (set_local $7
+                                                (set_local $9
                                                   (get_local $6)
                                                 )
                                                 (br $while-in102)
@@ -6124,7 +6113,7 @@
                                           )
                                           (block $do-once107
                                             (if
-                                              (get_local $16)
+                                              (get_local $18)
                                               (block
                                                 (br_if $do-once107
                                                   (i32.and
@@ -6152,97 +6141,95 @@
                                               )
                                               (i32.lt_u
                                                 (get_local $6)
-                                                (get_local $9)
+                                                (get_local $7)
                                               )
                                             )
-                                            (block
-                                              (set_local $7
-                                                (get_local $5)
-                                              )
-                                              (loop $while-in110
-                                                (if
-                                                  (i32.gt_u
-                                                    (tee_local $5
-                                                      (call $_fmt_u
-                                                        (i32.load
-                                                          (get_local $6)
-                                                        )
-                                                        (i32.const 0)
-                                                        (get_local $34)
+                                            (loop $while-in110
+                                              (if
+                                                (i32.gt_u
+                                                  (tee_local $8
+                                                    (call $_fmt_u
+                                                      (i32.load
+                                                        (get_local $6)
                                                       )
+                                                      (i32.const 0)
+                                                      (get_local $33)
                                                     )
-                                                    (get_local $24)
                                                   )
-                                                  (loop $while-in112
-                                                    (i32.store8
-                                                      (tee_local $5
-                                                        (i32.add
-                                                          (get_local $5)
-                                                          (i32.const -1)
-                                                        )
+                                                  (get_local $24)
+                                                )
+                                                (loop $while-in112
+                                                  (i32.store8
+                                                    (tee_local $8
+                                                      (i32.add
+                                                        (get_local $8)
+                                                        (i32.const -1)
                                                       )
-                                                      (i32.const 48)
                                                     )
-                                                    (br_if $while-in112
-                                                      (i32.gt_u
-                                                        (get_local $5)
-                                                        (get_local $24)
-                                                      )
+                                                    (i32.const 48)
+                                                  )
+                                                  (br_if $while-in112
+                                                    (i32.gt_u
+                                                      (get_local $8)
+                                                      (get_local $24)
                                                     )
                                                   )
                                                 )
-                                                (if
-                                                  (i32.eqz
-                                                    (i32.and
-                                                      (i32.load
-                                                        (get_local $0)
-                                                      )
-                                                      (i32.const 32)
-                                                    )
-                                                  )
-                                                  (drop
-                                                    (call $___fwritex
-                                                      (get_local $5)
-                                                      (select
-                                                        (i32.const 9)
-                                                        (get_local $7)
-                                                        (i32.gt_s
-                                                          (get_local $7)
-                                                          (i32.const 9)
-                                                        )
-                                                      )
+                                              )
+                                              (if
+                                                (i32.eqz
+                                                  (i32.and
+                                                    (i32.load
                                                       (get_local $0)
                                                     )
+                                                    (i32.const 32)
                                                   )
+                                                )
+                                                (drop
+                                                  (call $___fwritex
+                                                    (get_local $8)
+                                                    (select
+                                                      (i32.const 9)
+                                                      (get_local $5)
+                                                      (i32.gt_s
+                                                        (get_local $5)
+                                                        (i32.const 9)
+                                                      )
+                                                    )
+                                                    (get_local $0)
+                                                  )
+                                                )
+                                              )
+                                              (set_local $8
+                                                (i32.add
+                                                  (get_local $5)
+                                                  (i32.const -9)
+                                                )
+                                              )
+                                              (if
+                                                (i32.and
+                                                  (i32.gt_s
+                                                    (get_local $5)
+                                                    (i32.const 9)
+                                                  )
+                                                  (i32.lt_u
+                                                    (tee_local $6
+                                                      (i32.add
+                                                        (get_local $6)
+                                                        (i32.const 4)
+                                                      )
+                                                    )
+                                                    (get_local $7)
+                                                  )
+                                                )
+                                                (block
+                                                  (set_local $5
+                                                    (get_local $8)
+                                                  )
+                                                  (br $while-in110)
                                                 )
                                                 (set_local $5
-                                                  (i32.add
-                                                    (get_local $7)
-                                                    (i32.const -9)
-                                                  )
-                                                )
-                                                (if
-                                                  (i32.and
-                                                    (i32.gt_s
-                                                      (get_local $7)
-                                                      (i32.const 9)
-                                                    )
-                                                    (i32.lt_u
-                                                      (tee_local $6
-                                                        (i32.add
-                                                          (get_local $6)
-                                                          (i32.const 4)
-                                                        )
-                                                      )
-                                                      (get_local $9)
-                                                    )
-                                                  )
-                                                  (block
-                                                    (set_local $7
-                                                      (get_local $5)
-                                                    )
-                                                    (br $while-in110)
-                                                  )
+                                                  (get_local $8)
                                                 )
                                               )
                                             )
@@ -6259,14 +6246,14 @@
                                           )
                                         )
                                         (block
-                                          (set_local $16
+                                          (set_local $18
                                             (select
-                                              (get_local $9)
+                                              (get_local $7)
                                               (i32.add
-                                                (get_local $12)
+                                                (get_local $16)
                                                 (i32.const 4)
                                               )
-                                              (get_local $26)
+                                              (get_local $22)
                                             )
                                           )
                                           (if
@@ -6275,31 +6262,31 @@
                                               (i32.const -1)
                                             )
                                             (block
-                                              (set_local $9
+                                              (set_local $12
                                                 (i32.eqz
-                                                  (get_local $19)
+                                                  (get_local $12)
                                                 )
                                               )
-                                              (set_local $6
-                                                (get_local $12)
+                                              (set_local $8
+                                                (get_local $16)
                                               )
-                                              (set_local $7
+                                              (set_local $6
                                                 (get_local $5)
                                               )
                                               (loop $while-in114
-                                                (set_local $8
+                                                (set_local $7
                                                   (if i32
                                                     (i32.eq
                                                       (tee_local $5
                                                         (call $_fmt_u
                                                           (i32.load
-                                                            (get_local $6)
+                                                            (get_local $8)
                                                           )
                                                           (i32.const 0)
-                                                          (get_local $34)
+                                                          (get_local $33)
                                                         )
                                                       )
-                                                      (get_local $34)
+                                                      (get_local $33)
                                                     )
                                                     (block i32
                                                       (i32.store8
@@ -6314,13 +6301,13 @@
                                                 (block $do-once115
                                                   (if
                                                     (i32.eq
-                                                      (get_local $6)
-                                                      (get_local $12)
+                                                      (get_local $8)
+                                                      (get_local $16)
                                                     )
                                                     (block
                                                       (set_local $5
                                                         (i32.add
-                                                          (get_local $8)
+                                                          (get_local $7)
                                                           (i32.const 1)
                                                         )
                                                       )
@@ -6335,7 +6322,7 @@
                                                         )
                                                         (drop
                                                           (call $___fwritex
-                                                            (get_local $8)
+                                                            (get_local $7)
                                                             (i32.const 1)
                                                             (get_local $0)
                                                           )
@@ -6343,9 +6330,9 @@
                                                       )
                                                       (br_if $do-once115
                                                         (i32.and
-                                                          (get_local $9)
+                                                          (get_local $12)
                                                           (i32.lt_s
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                             (i32.const 1)
                                                           )
                                                         )
@@ -6369,15 +6356,15 @@
                                                     (block
                                                       (if
                                                         (i32.gt_u
-                                                          (get_local $8)
+                                                          (get_local $7)
                                                           (get_local $24)
                                                         )
                                                         (set_local $5
-                                                          (get_local $8)
+                                                          (get_local $7)
                                                         )
                                                         (block
                                                           (set_local $5
-                                                            (get_local $8)
+                                                            (get_local $7)
                                                           )
                                                           (br $do-once115)
                                                         )
@@ -6402,7 +6389,7 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $8
+                                                (set_local $7
                                                   (i32.sub
                                                     (get_local $49)
                                                     (get_local $5)
@@ -6421,44 +6408,41 @@
                                                     (call $___fwritex
                                                       (get_local $5)
                                                       (select
-                                                        (get_local $8)
                                                         (get_local $7)
+                                                        (get_local $6)
                                                         (i32.gt_s
+                                                          (get_local $6)
                                                           (get_local $7)
-                                                          (get_local $8)
                                                         )
                                                       )
                                                       (get_local $0)
                                                     )
                                                   )
                                                 )
-                                                (if
+                                                (br_if $while-in114
                                                   (i32.and
                                                     (i32.lt_u
-                                                      (tee_local $6
+                                                      (tee_local $8
                                                         (i32.add
-                                                          (get_local $6)
+                                                          (get_local $8)
                                                           (i32.const 4)
                                                         )
                                                       )
-                                                      (get_local $16)
+                                                      (get_local $18)
                                                     )
                                                     (i32.gt_s
-                                                      (tee_local $5
+                                                      (tee_local $6
                                                         (i32.sub
+                                                          (get_local $6)
                                                           (get_local $7)
-                                                          (get_local $8)
                                                         )
                                                       )
                                                       (i32.const -1)
                                                     )
                                                   )
-                                                  (block
-                                                    (set_local $7
-                                                      (get_local $5)
-                                                    )
-                                                    (br $while-in114)
-                                                  )
+                                                )
+                                                (set_local $5
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -6483,10 +6467,10 @@
                                           )
                                           (drop
                                             (call $___fwritex
-                                              (get_local $25)
+                                              (get_local $9)
                                               (i32.sub
-                                                (get_local $32)
-                                                (get_local $25)
+                                                (get_local $30)
+                                                (get_local $9)
                                               )
                                               (get_local $0)
                                             )
@@ -6497,27 +6481,27 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $17)
-                                      (get_local $11)
+                                      (get_local $13)
+                                      (get_local $10)
                                       (i32.xor
-                                        (get_local $10)
+                                        (get_local $11)
                                         (i32.const 8192)
                                       )
                                     )
                                     (select
-                                      (get_local $17)
-                                      (get_local $11)
+                                      (get_local $13)
+                                      (get_local $10)
                                       (i32.lt_s
-                                        (get_local $11)
-                                        (get_local $17)
+                                        (get_local $10)
+                                        (get_local $13)
                                       )
                                     )
                                   )
                                   (block i32
-                                    (set_local $7
+                                    (set_local $6
                                       (select
                                         (i32.const 0)
-                                        (get_local $30)
+                                        (get_local $28)
                                         (tee_local $5
                                           (i32.or
                                             (f64.ne
@@ -6529,15 +6513,15 @@
                                         )
                                       )
                                     )
-                                    (set_local $8
+                                    (set_local $7
                                       (select
                                         (select
                                           (i32.const 4135)
                                           (i32.const 4139)
-                                          (tee_local $6
+                                          (tee_local $7
                                             (i32.ne
                                               (i32.and
-                                                (get_local $16)
+                                                (get_local $12)
                                                 (i32.const 32)
                                               )
                                               (i32.const 0)
@@ -6547,7 +6531,7 @@
                                         (select
                                           (i32.const 4127)
                                           (i32.const 4131)
-                                          (get_local $6)
+                                          (get_local $7)
                                         )
                                         (get_local $5)
                                       )
@@ -6555,33 +6539,33 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $17)
-                                      (tee_local $6
+                                      (get_local $13)
+                                      (tee_local $5
                                         (i32.add
-                                          (get_local $7)
+                                          (get_local $6)
                                           (i32.const 3)
                                         )
                                       )
-                                      (get_local $9)
+                                      (get_local $8)
                                     )
                                     (if
                                       (i32.eqz
                                         (i32.and
                                           (if i32
                                             (i32.and
-                                              (tee_local $5
+                                              (tee_local $8
                                                 (i32.load
                                                   (get_local $0)
                                                 )
                                               )
                                               (i32.const 32)
                                             )
-                                            (get_local $5)
+                                            (get_local $8)
                                             (block i32
                                               (drop
                                                 (call $___fwritex
-                                                  (get_local $36)
-                                                  (get_local $7)
+                                                  (get_local $35)
+                                                  (get_local $6)
                                                   (get_local $0)
                                                 )
                                               )
@@ -6595,7 +6579,7 @@
                                       )
                                       (drop
                                         (call $___fwritex
-                                          (get_local $8)
+                                          (get_local $7)
                                           (i32.const 3)
                                           (get_local $0)
                                         )
@@ -6604,19 +6588,19 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $17)
-                                      (get_local $6)
+                                      (get_local $13)
+                                      (get_local $5)
                                       (i32.xor
-                                        (get_local $10)
+                                        (get_local $11)
                                         (i32.const 8192)
                                       )
                                     )
                                     (select
-                                      (get_local $17)
-                                      (get_local $6)
+                                      (get_local $13)
+                                      (get_local $5)
                                       (i32.lt_s
-                                        (get_local $6)
-                                        (get_local $17)
+                                        (get_local $5)
+                                        (get_local $13)
                                       )
                                     )
                                   )
@@ -6628,7 +6612,7 @@
                           (set_local $6
                             (get_local $1)
                           )
-                          (set_local $11
+                          (set_local $10
                             (get_local $7)
                           )
                           (set_local $8
@@ -6644,23 +6628,23 @@
                         )
                         (set_local $9
                           (i32.and
-                            (get_local $16)
+                            (get_local $12)
                             (i32.const 32)
                           )
                         )
                         (if
                           (i32.and
                             (i32.eqz
-                              (tee_local $10
+                              (tee_local $8
                                 (i32.load
                                   (tee_local $6
-                                    (get_local $18)
+                                    (get_local $17)
                                   )
                                 )
                               )
                             )
                             (i32.eqz
-                              (tee_local $6
+                              (tee_local $11
                                 (i32.load offset=4
                                   (get_local $6)
                                 )
@@ -6680,6 +6664,9 @@
                             (br $jumpthreading$inner$7)
                           )
                           (block
+                            (set_local $6
+                              (get_local $8)
+                            )
                             (set_local $8
                               (get_local $23)
                             )
@@ -6695,7 +6682,7 @@
                                   (i32.load8_u
                                     (i32.add
                                       (i32.and
-                                        (get_local $10)
+                                        (get_local $6)
                                         (i32.const 15)
                                       )
                                       (i32.const 4075)
@@ -6708,16 +6695,16 @@
                                 (i32.eqz
                                   (i32.and
                                     (i32.eqz
-                                      (tee_local $10
+                                      (tee_local $6
                                         (call $_bitshift64Lshr
-                                          (get_local $10)
                                           (get_local $6)
+                                          (get_local $11)
                                           (i32.const 4)
                                         )
                                       )
                                     )
                                     (i32.eqz
-                                      (tee_local $6
+                                      (tee_local $11
                                         (get_global $tempRet0)
                                       )
                                     )
@@ -6739,14 +6726,14 @@
                                 (i32.and
                                   (i32.eqz
                                     (i32.load
-                                      (tee_local $10
-                                        (get_local $18)
+                                      (tee_local $11
+                                        (get_local $17)
                                       )
                                     )
                                   )
                                   (i32.eqz
                                     (i32.load offset=4
-                                      (get_local $10)
+                                      (get_local $11)
                                     )
                                   )
                                 )
@@ -6768,7 +6755,7 @@
                                   (i32.add
                                     (i32.const 4091)
                                     (i32.shr_s
-                                      (get_local $16)
+                                      (get_local $12)
                                       (i32.const 4)
                                     )
                                   )
@@ -6788,11 +6775,11 @@
                         )
                       )
                       (set_local $1
-                        (get_local $10)
+                        (get_local $11)
                       )
                       (br $jumpthreading$inner$7)
                     )
-                    (set_local $28
+                    (set_local $26
                       (i32.const 0)
                     )
                     (set_local $16
@@ -6809,10 +6796,10 @@
                     (set_local $6
                       (get_local $1)
                     )
-                    (set_local $10
-                      (get_local $9)
-                    )
                     (set_local $11
+                      (get_local $8)
+                    )
+                    (set_local $10
                       (select
                         (get_local $7)
                         (i32.sub
@@ -6846,9 +6833,9 @@
                   (set_local $6
                     (i32.const 0)
                   )
-                  (set_local $7
+                  (set_local $8
                     (i32.load
-                      (get_local $18)
+                      (get_local $17)
                     )
                   )
                   (loop $while-in125
@@ -6857,7 +6844,7 @@
                         (i32.eqz
                           (tee_local $9
                             (i32.load
-                              (get_local $7)
+                              (get_local $8)
                             )
                           )
                         )
@@ -6867,7 +6854,7 @@
                           (i32.lt_s
                             (tee_local $6
                               (call $_wctomb
-                                (get_local $41)
+                                (get_local $40)
                                 (get_local $9)
                               )
                             )
@@ -6876,21 +6863,21 @@
                           (i32.gt_u
                             (get_local $6)
                             (i32.sub
-                              (get_local $8)
+                              (get_local $7)
                               (get_local $1)
                             )
                           )
                         )
                       )
-                      (set_local $7
+                      (set_local $8
                         (i32.add
-                          (get_local $7)
+                          (get_local $8)
                           (i32.const 4)
                         )
                       )
                       (br_if $while-in125
                         (i32.gt_u
-                          (get_local $8)
+                          (get_local $7)
                           (tee_local $1
                             (i32.add
                               (get_local $6)
@@ -6916,19 +6903,19 @@
                   (call $_pad
                     (get_local $0)
                     (i32.const 32)
-                    (get_local $17)
+                    (get_local $13)
                     (get_local $1)
-                    (get_local $10)
+                    (get_local $11)
                   )
                   (if
                     (get_local $1)
                     (block
-                      (set_local $6
+                      (set_local $7
                         (i32.const 0)
                       )
-                      (set_local $7
+                      (set_local $6
                         (i32.load
-                          (get_local $18)
+                          (get_local $17)
                         )
                       )
                       (loop $while-in127
@@ -6936,7 +6923,7 @@
                           (i32.eqz
                             (tee_local $8
                               (i32.load
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                           )
@@ -6947,23 +6934,23 @@
                             (br $jumpthreading$inner$6)
                           )
                         )
-                        (set_local $7
+                        (set_local $6
                           (i32.add
-                            (get_local $7)
+                            (get_local $6)
                             (i32.const 4)
                           )
                         )
                         (if
                           (i32.gt_s
-                            (tee_local $6
+                            (tee_local $7
                               (i32.add
                                 (tee_local $8
                                   (call $_wctomb
-                                    (get_local $41)
+                                    (get_local $40)
                                     (get_local $8)
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $7)
                               )
                             )
                             (get_local $1)
@@ -6986,7 +6973,7 @@
                           )
                           (drop
                             (call $___fwritex
-                              (get_local $41)
+                              (get_local $40)
                               (get_local $8)
                               (get_local $0)
                             )
@@ -6994,7 +6981,7 @@
                         )
                         (br_if $while-in127
                           (i32.lt_u
-                            (get_local $6)
+                            (get_local $7)
                             (get_local $1)
                           )
                         )
@@ -7015,16 +7002,16 @@
                   )
                   (br $jumpthreading$outer$7)
                 )
-                (set_local $28
+                (set_local $26
                   (i32.const 0)
                 )
                 (call $_pad
                   (get_local $0)
                   (i32.const 32)
-                  (get_local $17)
+                  (get_local $13)
                   (get_local $6)
                   (i32.xor
-                    (get_local $10)
+                    (get_local $11)
                     (i32.const 8192)
                   )
                 )
@@ -7033,20 +7020,20 @@
                 )
                 (set_local $5
                   (select
-                    (get_local $17)
+                    (get_local $13)
                     (get_local $6)
                     (i32.gt_s
-                      (get_local $17)
+                      (get_local $13)
                       (get_local $6)
                     )
                   )
                 )
                 (br $label$continue$L1)
               )
-              (set_local $28
+              (set_local $26
                 (i32.const 0)
               )
-              (set_local $10
+              (set_local $11
                 (select
                   (i32.and
                     (get_local $1)
@@ -7071,7 +7058,7 @@
                         (i32.ne
                           (i32.load
                             (tee_local $1
-                              (get_local $18)
+                              (get_local $17)
                             )
                           )
                           (i32.const 0)
@@ -7086,7 +7073,7 @@
                     )
                   )
                   (block i32
-                    (set_local $11
+                    (set_local $10
                       (select
                         (get_local $7)
                         (tee_local $1
@@ -7116,7 +7103,7 @@
                     (get_local $6)
                   )
                   (block i32
-                    (set_local $11
+                    (set_local $10
                       (i32.const 0)
                     )
                     (set_local $1
@@ -7135,7 +7122,7 @@
                   (tee_local $1
                     (i32.add
                       (get_local $8)
-                      (tee_local $11
+                      (tee_local $10
                         (select
                           (tee_local $12
                             (i32.sub
@@ -7143,24 +7130,24 @@
                               (get_local $6)
                             )
                           )
-                          (get_local $11)
+                          (get_local $10)
                           (i32.lt_s
-                            (get_local $11)
+                            (get_local $10)
                             (get_local $12)
                           )
                         )
                       )
                     )
                   )
-                  (get_local $17)
+                  (get_local $13)
                   (i32.lt_s
-                    (get_local $17)
+                    (get_local $13)
                     (get_local $1)
                   )
                 )
               )
               (get_local $1)
-              (get_local $10)
+              (get_local $11)
             )
             (if
               (i32.eqz
@@ -7185,14 +7172,14 @@
               (get_local $7)
               (get_local $1)
               (i32.xor
-                (get_local $10)
+                (get_local $11)
                 (i32.const 65536)
               )
             )
             (call $_pad
               (get_local $0)
               (i32.const 48)
-              (get_local $11)
+              (get_local $10)
               (get_local $12)
               (i32.const 0)
             )
@@ -7219,7 +7206,7 @@
               (get_local $7)
               (get_local $1)
               (i32.xor
-                (get_local $10)
+                (get_local $11)
                 (i32.const 8192)
               )
             )
@@ -7239,7 +7226,7 @@
           (get_local $0)
         )
         (if
-          (get_local $13)
+          (get_local $19)
           (block
             (set_local $0
               (i32.const 1)
@@ -7348,7 +7335,7 @@
       )
     )
     (set_global $STACKTOP
-      (get_local $27)
+      (get_local $25)
     )
     (get_local $15)
   )
@@ -7408,9 +7395,9 @@
                             )
                             (br $label$break$L1)
                           )
-                          (set_local $3
+                          (set_local $1
                             (i32.load
-                              (tee_local $1
+                              (tee_local $3
                                 (i32.and
                                   (i32.add
                                     (i32.load
@@ -7426,20 +7413,20 @@
                           (i32.store
                             (get_local $2)
                             (i32.add
-                              (get_local $1)
+                              (get_local $3)
                               (i32.const 4)
                             )
                           )
                           (i32.store
                             (get_local $0)
-                            (get_local $3)
+                            (get_local $1)
                           )
                           (i32.store offset=4
                             (get_local $0)
                             (i32.shr_s
                               (i32.shl
                                 (i32.lt_s
-                                  (get_local $3)
+                                  (get_local $1)
                                   (i32.const 0)
                                 )
                                 (i32.const 31)
@@ -7866,12 +7853,9 @@
           )
         )
         (if
-          (i32.lt_u
+          (i32.ge_u
             (get_local $0)
             (i32.const 10)
-          )
-          (set_local $0
-            (get_local $1)
           )
           (block
             (set_local $0
@@ -7881,11 +7865,8 @@
           )
         )
       )
-      (set_local $0
-        (get_local $1)
-      )
     )
-    (get_local $0)
+    (get_local $1)
   )
   (func $_pad (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
     (local $5 i32)
@@ -7932,23 +7913,23 @@
               (get_local $1)
               (select
                 (i32.const 256)
-                (tee_local $4
+                (tee_local $1
                   (i32.sub
                     (get_local $2)
                     (get_local $3)
                   )
                 )
                 (i32.gt_u
-                  (get_local $4)
+                  (get_local $1)
                   (i32.const 256)
                 )
               )
             )
           )
-          (set_local $7
+          (set_local $4
             (i32.eqz
               (i32.and
-                (tee_local $1
+                (tee_local $7
                   (i32.load
                     (get_local $0)
                   )
@@ -7959,7 +7940,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $4)
+              (get_local $1)
               (i32.const 255)
             )
             (block
@@ -7970,16 +7951,16 @@
                 )
               )
               (set_local $2
-                (get_local $4)
+                (get_local $7)
               )
               (set_local $3
-                (get_local $7)
+                (get_local $4)
               )
               (loop $while-in
                 (set_local $3
                   (i32.eqz
                     (i32.and
-                      (tee_local $1
+                      (tee_local $2
                         (if i32
                           (get_local $3)
                           (block i32
@@ -7994,7 +7975,7 @@
                               (get_local $0)
                             )
                           )
-                          (get_local $1)
+                          (get_local $2)
                         )
                       )
                       (i32.const 32)
@@ -8003,9 +7984,9 @@
                 )
                 (br_if $while-in
                   (i32.gt_u
-                    (tee_local $2
+                    (tee_local $1
                       (i32.add
-                        (get_local $2)
+                        (get_local $1)
                         (i32.const -256)
                       )
                     )
@@ -8025,12 +8006,10 @@
                 )
               )
             )
-            (if
-              (get_local $7)
-              (set_local $1
+            (br_if $do-once
+              (i32.eqz
                 (get_local $4)
               )
-              (br $do-once)
             )
           )
           (drop
@@ -8081,16 +8060,16 @@
         (block
           (if
             (i32.and
-              (tee_local $1
+              (tee_local $2
                 (i32.shr_u
                   (tee_local $10
                     (i32.load
                       (i32.const 176)
                     )
                   )
-                  (tee_local $4
+                  (tee_local $7
                     (i32.shr_u
-                      (tee_local $3
+                      (tee_local $4
                         (select
                           (i32.const 16)
                           (i32.and
@@ -8114,29 +8093,29 @@
               (i32.const 3)
             )
             (block
-              (set_local $4
+              (set_local $6
                 (i32.load
                   (tee_local $1
                     (i32.add
-                      (tee_local $5
+                      (tee_local $7
                         (i32.load
-                          (tee_local $9
+                          (tee_local $3
                             (i32.add
                               (tee_local $2
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (tee_local $3
+                                      (tee_local $4
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $1)
+                                              (get_local $2)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $4)
+                                          (get_local $7)
                                         )
                                       )
                                       (i32.const 1)
@@ -8158,7 +8137,7 @@
               (if
                 (i32.eq
                   (get_local $2)
-                  (get_local $4)
+                  (get_local $6)
                 )
                 (i32.store
                   (i32.const 176)
@@ -8167,7 +8146,7 @@
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $3)
+                        (get_local $4)
                       )
                       (i32.const -1)
                     )
@@ -8176,7 +8155,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $4)
+                      (get_local $6)
                       (i32.load
                         (i32.const 192)
                       )
@@ -8188,12 +8167,12 @@
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $4)
+                            (get_local $6)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $5)
+                      (get_local $7)
                     )
                     (block
                       (i32.store
@@ -8201,8 +8180,8 @@
                         (get_local $2)
                       )
                       (i32.store
-                        (get_local $9)
-                        (get_local $4)
+                        (get_local $3)
+                        (get_local $6)
                       )
                     )
                     (call $_abort)
@@ -8210,11 +8189,11 @@
                 )
               )
               (i32.store offset=4
-                (get_local $5)
+                (get_local $7)
                 (i32.or
                   (tee_local $0
                     (i32.shl
-                      (get_local $3)
+                      (get_local $4)
                       (i32.const 3)
                     )
                   )
@@ -8225,7 +8204,7 @@
                 (tee_local $0
                   (i32.add
                     (i32.add
-                      (get_local $5)
+                      (get_local $7)
                       (get_local $0)
                     )
                     (i32.const 4)
@@ -8245,7 +8224,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $3)
+              (get_local $4)
               (tee_local $0
                 (i32.load
                   (i32.const 184)
@@ -8254,37 +8233,37 @@
             )
             (block
               (if
-                (get_local $1)
+                (get_local $2)
                 (block
-                  (set_local $5
+                  (set_local $7
                     (i32.and
                       (i32.shr_u
-                        (tee_local $1
+                        (tee_local $3
                           (i32.add
                             (i32.and
-                              (tee_local $1
+                              (tee_local $3
                                 (i32.and
                                   (i32.shl
-                                    (get_local $1)
-                                    (get_local $4)
+                                    (get_local $2)
+                                    (get_local $7)
                                   )
                                   (i32.or
-                                    (tee_local $1
+                                    (tee_local $3
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $4)
+                                        (get_local $7)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $1)
+                                      (get_local $3)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $1)
+                                (get_local $3)
                               )
                             )
                             (i32.const -1)
@@ -8295,32 +8274,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $7
+                  (set_local $12
                     (i32.load
-                      (tee_local $5
+                      (tee_local $7
                         (i32.add
-                          (tee_local $9
+                          (tee_local $6
                             (i32.load
-                              (tee_local $6
+                              (tee_local $3
                                 (i32.add
-                                  (tee_local $1
+                                  (tee_local $2
                                     (i32.add
                                       (i32.const 216)
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $4
+                                          (tee_local $5
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $4
+                                                      (tee_local $3
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $1
+                                                            (tee_local $2
                                                               (i32.shr_u
-                                                                (get_local $1)
-                                                                (get_local $5)
+                                                                (get_local $3)
+                                                                (get_local $7)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -8328,15 +8307,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $5)
+                                                      (get_local $7)
                                                     )
-                                                    (tee_local $4
+                                                    (tee_local $3
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (tee_local $1
+                                                          (tee_local $2
                                                             (i32.shr_u
-                                                              (get_local $1)
-                                                              (get_local $4)
+                                                              (get_local $2)
+                                                              (get_local $3)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -8345,13 +8324,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (tee_local $4
+                                                  (tee_local $3
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (tee_local $1
+                                                        (tee_local $2
                                                           (i32.shr_u
-                                                            (get_local $1)
-                                                            (get_local $4)
+                                                            (get_local $2)
+                                                            (get_local $3)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -8360,13 +8339,13 @@
                                                     )
                                                   )
                                                 )
-                                                (tee_local $4
+                                                (tee_local $3
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (tee_local $1
+                                                      (tee_local $2
                                                         (i32.shr_u
-                                                          (get_local $1)
-                                                          (get_local $4)
+                                                          (get_local $2)
+                                                          (get_local $3)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -8376,8 +8355,8 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $1)
-                                                (get_local $4)
+                                                (get_local $2)
+                                                (get_local $3)
                                               )
                                             )
                                           )
@@ -8399,8 +8378,8 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $1)
-                      (get_local $7)
+                      (get_local $2)
+                      (get_local $12)
                     )
                     (block
                       (i32.store
@@ -8410,20 +8389,20 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $4)
+                              (get_local $5)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $8
+                      (set_local $16
                         (get_local $0)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $7)
+                          (get_local $12)
                           (i32.load
                             (i32.const 192)
                           )
@@ -8435,23 +8414,23 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $7)
+                                (get_local $12)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $9)
+                          (get_local $6)
                         )
                         (block
                           (i32.store
                             (get_local $0)
-                            (get_local $1)
+                            (get_local $2)
                           )
                           (i32.store
-                            (get_local $6)
-                            (get_local $7)
+                            (get_local $3)
+                            (get_local $12)
                           )
-                          (set_local $8
+                          (set_local $16
                             (i32.load
                               (i32.const 184)
                             )
@@ -8462,27 +8441,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $9)
+                    (get_local $6)
                     (i32.or
-                      (get_local $3)
+                      (get_local $4)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $9
+                    (tee_local $6
                       (i32.add
-                        (get_local $9)
-                        (get_local $3)
+                        (get_local $6)
+                        (get_local $4)
                       )
                     )
                     (i32.or
                       (tee_local $4
                         (i32.sub
                           (i32.shl
-                            (get_local $4)
+                            (get_local $5)
                             (i32.const 3)
                           )
-                          (get_local $3)
+                          (get_local $4)
                         )
                       )
                       (i32.const 1)
@@ -8490,27 +8469,27 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $9)
+                      (get_local $6)
                       (get_local $4)
                     )
                     (get_local $4)
                   )
                   (if
-                    (get_local $8)
+                    (get_local $16)
                     (block
-                      (set_local $6
+                      (set_local $5
                         (i32.load
                           (i32.const 196)
                         )
                       )
-                      (set_local $0
+                      (set_local $2
                         (i32.add
                           (i32.const 216)
                           (i32.shl
                             (i32.shl
-                              (tee_local $1
+                              (tee_local $0
                                 (i32.shr_u
-                                  (get_local $8)
+                                  (get_local $16)
                                   (i32.const 3)
                                 )
                               )
@@ -8527,20 +8506,20 @@
                               (i32.const 176)
                             )
                           )
-                          (tee_local $1
+                          (tee_local $0
                             (i32.shl
                               (i32.const 1)
-                              (get_local $1)
+                              (get_local $0)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $1
+                            (tee_local $0
                               (i32.load
                                 (tee_local $3
                                   (i32.add
-                                    (get_local $0)
+                                    (get_local $2)
                                     (i32.const 8)
                                   )
                                 )
@@ -8552,11 +8531,11 @@
                           )
                           (call $_abort)
                           (block
-                            (set_local $12
+                            (set_local $15
                               (get_local $3)
                             )
-                            (set_local $2
-                              (get_local $1)
+                            (set_local $1
+                              (get_local $0)
                             )
                           )
                         )
@@ -8565,35 +8544,35 @@
                             (i32.const 176)
                             (i32.or
                               (get_local $3)
-                              (get_local $1)
+                              (get_local $0)
                             )
                           )
-                          (set_local $12
+                          (set_local $15
                             (i32.add
-                              (get_local $0)
+                              (get_local $2)
                               (i32.const 8)
                             )
                           )
-                          (set_local $2
-                            (get_local $0)
+                          (set_local $1
+                            (get_local $2)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $12)
-                        (get_local $6)
+                        (get_local $15)
+                        (get_local $5)
                       )
                       (i32.store offset=12
-                        (get_local $2)
-                        (get_local $6)
+                        (get_local $1)
+                        (get_local $5)
                       )
                       (i32.store offset=8
-                        (get_local $6)
-                        (get_local $2)
+                        (get_local $5)
+                        (get_local $1)
                       )
                       (i32.store offset=12
-                        (get_local $6)
-                        (get_local $0)
+                        (get_local $5)
+                        (get_local $2)
                       )
                     )
                   )
@@ -8603,10 +8582,10 @@
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $9)
+                    (get_local $6)
                   )
                   (return
-                    (get_local $5)
+                    (get_local $7)
                   )
                 )
               )
@@ -8637,11 +8616,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $4
+                  (set_local $7
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (tee_local $1
+                          (tee_local $0
                             (i32.load offset=480
                               (i32.shl
                                 (i32.add
@@ -8649,10 +8628,10 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (tee_local $1
+                                          (tee_local $0
                                             (i32.and
                                               (i32.shr_u
-                                                (tee_local $0
+                                                (tee_local $1
                                                   (i32.shr_u
                                                     (get_local $0)
                                                     (get_local $2)
@@ -8665,13 +8644,13 @@
                                           )
                                           (get_local $2)
                                         )
-                                        (tee_local $1
+                                        (tee_local $0
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $0
+                                              (tee_local $1
                                                 (i32.shr_u
-                                                  (get_local $0)
                                                   (get_local $1)
+                                                  (get_local $0)
                                                 )
                                               )
                                               (i32.const 2)
@@ -8680,13 +8659,13 @@
                                           )
                                         )
                                       )
-                                      (tee_local $1
+                                      (tee_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $0
+                                            (tee_local $1
                                               (i32.shr_u
-                                                (get_local $0)
                                                 (get_local $1)
+                                                (get_local $0)
                                               )
                                             )
                                             (i32.const 1)
@@ -8695,13 +8674,13 @@
                                         )
                                       )
                                     )
-                                    (tee_local $1
+                                    (tee_local $0
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $0
+                                          (tee_local $1
                                             (i32.shr_u
-                                              (get_local $0)
                                               (get_local $1)
+                                              (get_local $0)
                                             )
                                           )
                                           (i32.const 1)
@@ -8711,8 +8690,8 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $0)
                                     (get_local $1)
+                                    (get_local $0)
                                   )
                                 )
                                 (i32.const 2)
@@ -8722,11 +8701,14 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $3)
+                      (get_local $4)
                     )
                   )
                   (set_local $2
-                    (get_local $1)
+                    (get_local $0)
+                  )
+                  (set_local $1
+                    (get_local $0)
                   )
                   (loop $while-in
                     (block $while-out
@@ -8747,14 +8729,17 @@
                             )
                           )
                           (block
-                            (set_local $2
+                            (set_local $12
+                              (get_local $7)
+                            )
+                            (set_local $11
                               (get_local $1)
                             )
                             (br $while-out)
                           )
                         )
                       )
-                      (set_local $6
+                      (set_local $12
                         (i32.lt_u
                           (tee_local $2
                             (i32.sub
@@ -8764,17 +8749,17 @@
                                 )
                                 (i32.const -8)
                               )
-                              (get_local $3)
+                              (get_local $4)
                             )
                           )
-                          (get_local $4)
+                          (get_local $7)
                         )
                       )
-                      (set_local $4
+                      (set_local $7
                         (select
                           (get_local $2)
-                          (get_local $4)
-                          (get_local $6)
+                          (get_local $7)
+                          (get_local $12)
                         )
                       )
                       (set_local $2
@@ -8784,7 +8769,7 @@
                         (select
                           (get_local $0)
                           (get_local $1)
-                          (get_local $6)
+                          (get_local $12)
                         )
                       )
                       (br $while-in)
@@ -8792,7 +8777,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $2)
+                      (get_local $11)
                       (tee_local $10
                         (i32.load
                           (i32.const 192)
@@ -8803,19 +8788,19 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $2)
-                      (tee_local $7
+                      (get_local $11)
+                      (tee_local $14
                         (i32.add
-                          (get_local $2)
-                          (get_local $3)
+                          (get_local $11)
+                          (get_local $4)
                         )
                       )
                     )
                     (call $_abort)
                   )
-                  (set_local $11
+                  (set_local $8
                     (i32.load offset=24
-                      (get_local $2)
+                      (get_local $11)
                     )
                   )
                   (block $do-once4
@@ -8823,10 +8808,10 @@
                       (i32.eq
                         (tee_local $0
                           (i32.load offset=12
-                            (get_local $2)
+                            (get_local $11)
                           )
                         )
-                        (get_local $2)
+                        (get_local $11)
                       )
                       (block
                         (if
@@ -8835,7 +8820,7 @@
                               (i32.load
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $2)
+                                    (get_local $11)
                                     (i32.const 20)
                                   )
                                 )
@@ -8848,7 +8833,7 @@
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
-                                      (get_local $2)
+                                      (get_local $11)
                                       (i32.const 16)
                                     )
                                   )
@@ -8856,7 +8841,7 @@
                               )
                             )
                             (block
-                              (set_local $5
+                              (set_local $6
                                 (i32.const 0)
                               )
                               (br $do-once4)
@@ -8865,9 +8850,9 @@
                         )
                         (loop $while-in7
                           (if
-                            (tee_local $8
+                            (tee_local $2
                               (i32.load
-                                (tee_local $6
+                                (tee_local $7
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 20)
@@ -8877,18 +8862,18 @@
                             )
                             (block
                               (set_local $1
-                                (get_local $8)
+                                (get_local $2)
                               )
                               (set_local $0
-                                (get_local $6)
+                                (get_local $7)
                               )
                               (br $while-in7)
                             )
                           )
                           (if
-                            (tee_local $8
+                            (tee_local $2
                               (i32.load
-                                (tee_local $6
+                                (tee_local $7
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 16)
@@ -8898,10 +8883,10 @@
                             )
                             (block
                               (set_local $1
-                                (get_local $8)
+                                (get_local $2)
                               )
                               (set_local $0
-                                (get_local $6)
+                                (get_local $7)
                               )
                               (br $while-in7)
                             )
@@ -8918,7 +8903,7 @@
                               (get_local $0)
                               (i32.const 0)
                             )
-                            (set_local $5
+                            (set_local $6
                               (get_local $1)
                             )
                           )
@@ -8927,9 +8912,9 @@
                       (block
                         (if
                           (i32.lt_u
-                            (tee_local $8
+                            (tee_local $7
                               (i32.load offset=8
-                                (get_local $2)
+                                (get_local $11)
                               )
                             )
                             (get_local $10)
@@ -8939,14 +8924,14 @@
                         (if
                           (i32.ne
                             (i32.load
-                              (tee_local $6
+                              (tee_local $2
                                 (i32.add
-                                  (get_local $8)
+                                  (get_local $7)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $2)
+                            (get_local $11)
                           )
                           (call $_abort)
                         )
@@ -8960,18 +8945,18 @@
                                 )
                               )
                             )
-                            (get_local $2)
+                            (get_local $11)
                           )
                           (block
                             (i32.store
-                              (get_local $6)
+                              (get_local $2)
                               (get_local $0)
                             )
                             (i32.store
                               (get_local $1)
-                              (get_local $8)
+                              (get_local $7)
                             )
-                            (set_local $5
+                            (set_local $6
                               (get_local $0)
                             )
                           )
@@ -8982,11 +8967,11 @@
                   )
                   (block $do-once8
                     (if
-                      (get_local $11)
+                      (get_local $8)
                       (block
                         (if
                           (i32.eq
-                            (get_local $2)
+                            (get_local $11)
                             (i32.load
                               (tee_local $0
                                 (i32.add
@@ -8994,7 +8979,7 @@
                                   (i32.shl
                                     (tee_local $1
                                       (i32.load offset=28
-                                        (get_local $2)
+                                        (get_local $11)
                                       )
                                     )
                                     (i32.const 2)
@@ -9006,11 +8991,11 @@
                           (block
                             (i32.store
                               (get_local $0)
-                              (get_local $5)
+                              (get_local $6)
                             )
                             (if
                               (i32.eqz
-                                (get_local $5)
+                                (get_local $6)
                               )
                               (block
                                 (i32.store
@@ -9035,7 +9020,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $11)
+                                (get_local $8)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -9047,33 +9032,33 @@
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
-                                      (get_local $11)
+                                      (get_local $8)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $2)
+                                (get_local $11)
                               )
                               (i32.store
                                 (get_local $0)
-                                (get_local $5)
+                                (get_local $6)
                               )
                               (i32.store offset=20
-                                (get_local $11)
-                                (get_local $5)
+                                (get_local $8)
+                                (get_local $6)
                               )
                             )
                             (br_if $do-once8
                               (i32.eqz
-                                (get_local $5)
+                                (get_local $6)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $5)
-                            (tee_local $1
+                            (get_local $6)
+                            (tee_local $0
                               (i32.load
                                 (i32.const 192)
                               )
@@ -9082,29 +9067,29 @@
                           (call $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $5)
-                          (get_local $11)
+                          (get_local $6)
+                          (get_local $8)
                         )
                         (if
-                          (tee_local $0
+                          (tee_local $1
                             (i32.load offset=16
-                              (get_local $2)
+                              (get_local $11)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $0)
                               (get_local $1)
+                              (get_local $0)
                             )
                             (call $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $5)
-                                (get_local $0)
+                                (get_local $6)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $0)
-                                (get_local $5)
+                                (get_local $1)
+                                (get_local $6)
                               )
                             )
                           )
@@ -9112,7 +9097,7 @@
                         (if
                           (tee_local $0
                             (i32.load offset=20
-                              (get_local $2)
+                              (get_local $11)
                             )
                           )
                           (if
@@ -9125,12 +9110,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $5)
+                                (get_local $6)
                                 (get_local $0)
                               )
                               (i32.store offset=24
                                 (get_local $0)
-                                (get_local $5)
+                                (get_local $6)
                               )
                             )
                           )
@@ -9140,17 +9125,17 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $4)
+                      (get_local $12)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $2)
+                        (get_local $11)
                         (i32.or
                           (tee_local $0
                             (i32.add
+                              (get_local $12)
                               (get_local $4)
-                              (get_local $3)
                             )
                           )
                           (i32.const 3)
@@ -9160,7 +9145,7 @@
                         (tee_local $0
                           (i32.add
                             (i32.add
-                              (get_local $2)
+                              (get_local $11)
                               (get_local $0)
                             )
                             (i32.const 4)
@@ -9176,25 +9161,25 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $2)
+                        (get_local $11)
                         (i32.or
-                          (get_local $3)
+                          (get_local $4)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $7)
+                        (get_local $14)
                         (i32.or
-                          (get_local $4)
+                          (get_local $12)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $7)
-                          (get_local $4)
+                          (get_local $14)
+                          (get_local $12)
                         )
-                        (get_local $4)
+                        (get_local $12)
                       )
                       (if
                         (tee_local $0
@@ -9203,17 +9188,17 @@
                           )
                         )
                         (block
-                          (set_local $5
+                          (set_local $4
                             (i32.load
                               (i32.const 196)
                             )
                           )
-                          (set_local $0
+                          (set_local $2
                             (i32.add
                               (i32.const 216)
                               (i32.shl
                                 (i32.shl
-                                  (tee_local $1
+                                  (tee_local $0
                                     (i32.shr_u
                                       (get_local $0)
                                       (i32.const 3)
@@ -9227,25 +9212,25 @@
                           )
                           (if
                             (i32.and
-                              (tee_local $3
+                              (tee_local $1
                                 (i32.load
                                   (i32.const 176)
                                 )
                               )
-                              (tee_local $1
+                              (tee_local $0
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $1)
+                                  (get_local $0)
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (tee_local $1
+                                (tee_local $0
                                   (i32.load
-                                    (tee_local $3
+                                    (tee_local $1
                                       (i32.add
-                                        (get_local $0)
+                                        (get_local $2)
                                         (i32.const 8)
                                       )
                                     )
@@ -9257,11 +9242,11 @@
                               )
                               (call $_abort)
                               (block
-                                (set_local $13
-                                  (get_local $3)
-                                )
-                                (set_local $9
+                                (set_local $5
                                   (get_local $1)
+                                )
+                                (set_local $3
+                                  (get_local $0)
                                 )
                               )
                             )
@@ -9269,63 +9254,63 @@
                               (i32.store
                                 (i32.const 176)
                                 (i32.or
-                                  (get_local $3)
                                   (get_local $1)
+                                  (get_local $0)
                                 )
                               )
-                              (set_local $13
+                              (set_local $5
                                 (i32.add
-                                  (get_local $0)
+                                  (get_local $2)
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $9
-                                (get_local $0)
+                              (set_local $3
+                                (get_local $2)
                               )
                             )
                           )
                           (i32.store
-                            (get_local $13)
                             (get_local $5)
+                            (get_local $4)
                           )
                           (i32.store offset=12
-                            (get_local $9)
-                            (get_local $5)
+                            (get_local $3)
+                            (get_local $4)
                           )
                           (i32.store offset=8
-                            (get_local $5)
-                            (get_local $9)
+                            (get_local $4)
+                            (get_local $3)
                           )
                           (i32.store offset=12
-                            (get_local $5)
-                            (get_local $0)
+                            (get_local $4)
+                            (get_local $2)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $4)
+                        (get_local $12)
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $7)
+                        (get_local $14)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $2)
+                      (get_local $11)
                       (i32.const 8)
                     )
                   )
                 )
                 (set_local $0
-                  (get_local $3)
+                  (get_local $4)
                 )
               )
             )
             (set_local $0
-              (get_local $3)
+              (get_local $4)
             )
           )
         )
@@ -9338,9 +9323,9 @@
             (i32.const -1)
           )
           (block
-            (set_local $9
+            (set_local $6
               (i32.and
-                (tee_local $2
+                (tee_local $0
                   (i32.add
                     (get_local $0)
                     (i32.const 11)
@@ -9356,55 +9341,55 @@
                 )
               )
               (block
-                (set_local $0
+                (set_local $3
                   (i32.sub
                     (i32.const 0)
-                    (get_local $9)
+                    (get_local $6)
                   )
                 )
                 (block $jumpthreading$outer$2
                   (block $jumpthreading$inner$2
                     (if
-                      (tee_local $2
+                      (tee_local $0
                         (i32.load offset=480
                           (i32.shl
-                            (tee_local $15
+                            (tee_local $17
                               (if i32
-                                (tee_local $2
+                                (tee_local $0
                                   (i32.shr_u
-                                    (get_local $2)
+                                    (get_local $0)
                                     (i32.const 8)
                                   )
                                 )
                                 (if i32
                                   (i32.gt_u
-                                    (get_local $9)
+                                    (get_local $6)
                                     (i32.const 16777215)
                                   )
                                   (i32.const 31)
                                   (i32.or
                                     (i32.and
                                       (i32.shr_u
-                                        (get_local $9)
+                                        (get_local $6)
                                         (i32.add
-                                          (tee_local $2
+                                          (tee_local $0
                                             (i32.add
                                               (i32.sub
                                                 (i32.const 14)
                                                 (i32.or
                                                   (i32.or
-                                                    (tee_local $5
+                                                    (tee_local $0
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (tee_local $2
+                                                            (tee_local $1
                                                               (i32.shl
-                                                                (get_local $2)
-                                                                (tee_local $8
+                                                                (get_local $0)
+                                                                (tee_local $5
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
-                                                                        (get_local $2)
+                                                                        (get_local $0)
                                                                         (i32.const 1048320)
                                                                       )
                                                                       (i32.const 16)
@@ -9421,16 +9406,16 @@
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $8)
+                                                    (get_local $5)
                                                   )
-                                                  (tee_local $5
+                                                  (tee_local $0
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $2
+                                                          (tee_local $1
                                                             (i32.shl
-                                                              (get_local $2)
-                                                              (get_local $5)
+                                                              (get_local $1)
+                                                              (get_local $0)
                                                             )
                                                           )
                                                           (i32.const 245760)
@@ -9444,8 +9429,8 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $2)
-                                                  (get_local $5)
+                                                  (get_local $1)
+                                                  (get_local $0)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -9457,7 +9442,7 @@
                                       (i32.const 1)
                                     )
                                     (i32.shl
-                                      (get_local $2)
+                                      (get_local $0)
                                       (i32.const 1)
                                     )
                                   )
@@ -9470,43 +9455,37 @@
                         )
                       )
                       (block
-                        (set_local $5
-                          (get_local $0)
-                        )
-                        (set_local $13
+                        (set_local $16
                           (i32.const 0)
                         )
-                        (set_local $12
+                        (set_local $18
                           (i32.shl
-                            (get_local $9)
+                            (get_local $6)
                             (select
                               (i32.const 0)
                               (i32.sub
                                 (i32.const 25)
                                 (i32.shr_u
-                                  (get_local $15)
+                                  (get_local $17)
                                   (i32.const 1)
                                 )
                               )
                               (i32.eq
-                                (get_local $15)
+                                (get_local $17)
                                 (i32.const 31)
                               )
                             )
                           )
                         )
-                        (set_local $0
-                          (get_local $2)
-                        )
-                        (set_local $2
+                        (set_local $5
                           (i32.const 0)
                         )
                         (loop $while-in14
                           (if
                             (i32.lt_u
-                              (tee_local $8
+                              (tee_local $1
                                 (i32.sub
-                                  (tee_local $14
+                                  (tee_local $15
                                     (i32.and
                                       (i32.load offset=4
                                         (get_local $0)
@@ -9514,24 +9493,24 @@
                                       (i32.const -8)
                                     )
                                   )
-                                  (get_local $9)
+                                  (get_local $6)
                                 )
                               )
-                              (get_local $5)
+                              (get_local $3)
                             )
                             (if
                               (i32.eq
-                                (get_local $14)
-                                (get_local $9)
+                                (get_local $15)
+                                (get_local $6)
                               )
                               (block
                                 (set_local $4
-                                  (get_local $8)
+                                  (get_local $1)
                                 )
-                                (set_local $3
+                                (set_local $7
                                   (get_local $0)
                                 )
-                                (set_local $1
+                                (set_local $2
                                   (get_local $0)
                                 )
                                 (set_local $19
@@ -9540,30 +9519,33 @@
                                 (br $jumpthreading$outer$2)
                               )
                               (block
-                                (set_local $5
-                                  (get_local $8)
+                                (set_local $3
+                                  (get_local $1)
                                 )
-                                (set_local $2
+                                (set_local $1
                                   (get_local $0)
                                 )
                               )
                             )
+                            (set_local $1
+                              (get_local $5)
+                            )
                           )
-                          (set_local $8
+                          (set_local $0
                             (select
-                              (get_local $13)
-                              (tee_local $8
+                              (get_local $16)
+                              (tee_local $5
                                 (i32.load offset=20
                                   (get_local $0)
                                 )
                               )
                               (i32.or
                                 (i32.eqz
-                                  (get_local $8)
+                                  (get_local $5)
                                 )
                                 (i32.eq
-                                  (get_local $8)
-                                  (tee_local $14
+                                  (get_local $5)
+                                  (tee_local $15
                                     (i32.load
                                       (i32.add
                                         (i32.add
@@ -9572,7 +9554,7 @@
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $12)
+                                            (get_local $18)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -9584,14 +9566,14 @@
                               )
                             )
                           )
-                          (set_local $0
+                          (set_local $5
                             (i32.shl
-                              (get_local $12)
+                              (get_local $18)
                               (i32.xor
                                 (i32.and
-                                  (tee_local $12
+                                  (tee_local $16
                                     (i32.eqz
-                                      (get_local $14)
+                                      (get_local $15)
                                     )
                                   )
                                   (i32.const 1)
@@ -9600,34 +9582,31 @@
                               )
                             )
                           )
-                          (if
-                            (get_local $12)
-                            (block
-                              (set_local $0
-                                (get_local $5)
-                              )
-                              (br $jumpthreading$inner$2)
+                          (br_if $jumpthreading$inner$2
+                            (get_local $16)
+                          )
+                          (block
+                            (set_local $16
+                              (get_local $0)
                             )
-                            (block
-                              (set_local $13
-                                (get_local $8)
-                              )
-                              (set_local $12
-                                (get_local $0)
-                              )
-                              (set_local $0
-                                (get_local $14)
-                              )
-                              (br $while-in14)
+                            (set_local $18
+                              (get_local $5)
                             )
+                            (set_local $0
+                              (get_local $15)
+                            )
+                            (set_local $5
+                              (get_local $1)
+                            )
+                            (br $while-in14)
                           )
                         )
                       )
                       (block
-                        (set_local $8
+                        (set_local $0
                           (i32.const 0)
                         )
-                        (set_local $2
+                        (set_local $1
                           (i32.const 0)
                         )
                         (br $jumpthreading$inner$2)
@@ -9636,32 +9615,32 @@
                     (br $jumpthreading$outer$2)
                   )
                   (if
-                    (tee_local $5
+                    (tee_local $0
                       (if i32
                         (i32.and
                           (i32.eqz
-                            (get_local $8)
+                            (get_local $0)
                           )
                           (i32.eqz
-                            (get_local $2)
+                            (get_local $1)
                           )
                         )
                         (block i32
                           (if
                             (i32.eqz
-                              (tee_local $5
+                              (tee_local $0
                                 (i32.and
                                   (get_local $24)
                                   (i32.or
-                                    (tee_local $5
+                                    (tee_local $0
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $15)
+                                        (get_local $17)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $5)
+                                      (get_local $0)
                                     )
                                   )
                                 )
@@ -9669,21 +9648,21 @@
                             )
                             (block
                               (set_local $0
-                                (get_local $9)
+                                (get_local $6)
                               )
                               (br $do-once)
                             )
                           )
-                          (set_local $12
+                          (set_local $15
                             (i32.and
                               (i32.shr_u
-                                (tee_local $5
+                                (tee_local $0
                                   (i32.add
                                     (i32.and
-                                      (get_local $5)
+                                      (get_local $0)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $5)
+                                        (get_local $0)
                                       )
                                     )
                                     (i32.const -1)
@@ -9701,13 +9680,13 @@
                                   (i32.or
                                     (i32.or
                                       (i32.or
-                                        (tee_local $8
+                                        (tee_local $0
                                           (i32.and
                                             (i32.shr_u
                                               (tee_local $5
                                                 (i32.shr_u
-                                                  (get_local $5)
-                                                  (get_local $12)
+                                                  (get_local $0)
+                                                  (get_local $15)
                                                 )
                                               )
                                               (i32.const 5)
@@ -9715,15 +9694,15 @@
                                             (i32.const 8)
                                           )
                                         )
-                                        (get_local $12)
+                                        (get_local $15)
                                       )
-                                      (tee_local $8
+                                      (tee_local $0
                                         (i32.and
                                           (i32.shr_u
                                             (tee_local $5
                                               (i32.shr_u
                                                 (get_local $5)
-                                                (get_local $8)
+                                                (get_local $0)
                                               )
                                             )
                                             (i32.const 2)
@@ -9732,13 +9711,13 @@
                                         )
                                       )
                                     )
-                                    (tee_local $8
+                                    (tee_local $0
                                       (i32.and
                                         (i32.shr_u
                                           (tee_local $5
                                             (i32.shr_u
                                               (get_local $5)
-                                              (get_local $8)
+                                              (get_local $0)
                                             )
                                           )
                                           (i32.const 1)
@@ -9747,13 +9726,13 @@
                                       )
                                     )
                                   )
-                                  (tee_local $8
+                                  (tee_local $0
                                     (i32.and
                                       (i32.shr_u
                                         (tee_local $5
                                           (i32.shr_u
                                             (get_local $5)
-                                            (get_local $8)
+                                            (get_local $0)
                                           )
                                         )
                                         (i32.const 1)
@@ -9764,36 +9743,36 @@
                                 )
                                 (i32.shr_u
                                   (get_local $5)
-                                  (get_local $8)
+                                  (get_local $0)
                                 )
                               )
                               (i32.const 2)
                             )
                           )
                         )
-                        (get_local $8)
+                        (get_local $0)
                       )
                     )
                     (block
                       (set_local $4
+                        (get_local $3)
+                      )
+                      (set_local $7
                         (get_local $0)
                       )
-                      (set_local $3
-                        (get_local $5)
-                      )
-                      (set_local $1
-                        (get_local $2)
+                      (set_local $2
+                        (get_local $1)
                       )
                       (set_local $19
                         (i32.const 90)
                       )
                     )
                     (block
-                      (set_local $7
-                        (get_local $0)
+                      (set_local $9
+                        (get_local $3)
                       )
-                      (set_local $6
-                        (get_local $2)
+                      (set_local $13
+                        (get_local $1)
                       )
                     )
                   )
@@ -9804,17 +9783,17 @@
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $2
+                    (set_local $1
                       (i32.lt_u
                         (tee_local $0
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $3)
+                                (get_local $7)
                               )
                               (i32.const -8)
                             )
-                            (get_local $9)
+                            (get_local $6)
                           )
                         )
                         (get_local $4)
@@ -9824,63 +9803,63 @@
                       (select
                         (get_local $0)
                         (get_local $4)
-                        (get_local $2)
+                        (get_local $1)
                       )
                     )
-                    (set_local $1
+                    (set_local $2
                       (select
-                        (get_local $3)
-                        (get_local $1)
+                        (get_local $7)
                         (get_local $2)
+                        (get_local $1)
                       )
                     )
                     (if
                       (tee_local $0
                         (i32.load offset=16
-                          (get_local $3)
+                          (get_local $7)
                         )
                       )
                       (block
-                        (set_local $3
+                        (set_local $7
                           (get_local $0)
                         )
                         (br $while-in16)
                       )
                     )
                     (br_if $while-in16
-                      (tee_local $3
+                      (tee_local $7
                         (i32.load offset=20
-                          (get_local $3)
+                          (get_local $7)
                         )
                       )
                     )
                     (block
-                      (set_local $7
+                      (set_local $9
                         (get_local $4)
                       )
-                      (set_local $6
-                        (get_local $1)
+                      (set_local $13
+                        (get_local $2)
                       )
                     )
                   )
                 )
                 (if
-                  (get_local $6)
+                  (get_local $13)
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $9)
                       (i32.sub
                         (i32.load
                           (i32.const 184)
                         )
-                        (get_local $9)
+                        (get_local $6)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $6)
-                          (tee_local $8
+                          (get_local $13)
+                          (tee_local $4
                             (i32.load
                               (i32.const 192)
                             )
@@ -9890,19 +9869,19 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $6)
-                          (tee_local $4
+                          (get_local $13)
+                          (tee_local $5
                             (i32.add
+                              (get_local $13)
                               (get_local $6)
-                              (get_local $9)
                             )
                           )
                         )
                         (call $_abort)
                       )
-                      (set_local $5
+                      (set_local $7
                         (i32.load offset=24
-                          (get_local $6)
+                          (get_local $13)
                         )
                       )
                       (block $do-once17
@@ -9910,10 +9889,10 @@
                           (i32.eq
                             (tee_local $0
                               (i32.load offset=12
-                                (get_local $6)
+                                (get_local $13)
                               )
                             )
-                            (get_local $6)
+                            (get_local $13)
                           )
                           (block
                             (if
@@ -9922,7 +9901,7 @@
                                   (i32.load
                                     (tee_local $0
                                       (i32.add
-                                        (get_local $6)
+                                        (get_local $13)
                                         (i32.const 20)
                                       )
                                     )
@@ -9935,7 +9914,7 @@
                                     (i32.load
                                       (tee_local $0
                                         (i32.add
-                                          (get_local $6)
+                                          (get_local $13)
                                           (i32.const 16)
                                         )
                                       )
@@ -9943,7 +9922,7 @@
                                   )
                                 )
                                 (block
-                                  (set_local $10
+                                  (set_local $8
                                     (i32.const 0)
                                   )
                                   (br $do-once17)
@@ -9997,7 +9976,7 @@
                             (if
                               (i32.lt_u
                                 (get_local $0)
-                                (get_local $8)
+                                (get_local $4)
                               )
                               (call $_abort)
                               (block
@@ -10005,7 +9984,7 @@
                                   (get_local $0)
                                   (i32.const 0)
                                 )
-                                (set_local $10
+                                (set_local $8
                                   (get_local $1)
                                 )
                               )
@@ -10014,26 +9993,26 @@
                           (block
                             (if
                               (i32.lt_u
-                                (tee_local $3
+                                (tee_local $2
                                   (i32.load offset=8
-                                    (get_local $6)
+                                    (get_local $13)
                                   )
                                 )
-                                (get_local $8)
+                                (get_local $4)
                               )
                               (call $_abort)
                             )
                             (if
                               (i32.ne
                                 (i32.load
-                                  (tee_local $2
+                                  (tee_local $3
                                     (i32.add
-                                      (get_local $3)
+                                      (get_local $2)
                                       (i32.const 12)
                                     )
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $13)
                               )
                               (call $_abort)
                             )
@@ -10047,18 +10026,18 @@
                                     )
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $13)
                               )
                               (block
                                 (i32.store
-                                  (get_local $2)
+                                  (get_local $3)
                                   (get_local $0)
                                 )
                                 (i32.store
                                   (get_local $1)
-                                  (get_local $3)
+                                  (get_local $2)
                                 )
-                                (set_local $10
+                                (set_local $8
                                   (get_local $0)
                                 )
                               )
@@ -10069,11 +10048,11 @@
                       )
                       (block $do-once21
                         (if
-                          (get_local $5)
+                          (get_local $7)
                           (block
                             (if
                               (i32.eq
-                                (get_local $6)
+                                (get_local $13)
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
@@ -10081,7 +10060,7 @@
                                       (i32.shl
                                         (tee_local $1
                                           (i32.load offset=28
-                                            (get_local $6)
+                                            (get_local $13)
                                           )
                                         )
                                         (i32.const 2)
@@ -10093,11 +10072,11 @@
                               (block
                                 (i32.store
                                   (get_local $0)
-                                  (get_local $10)
+                                  (get_local $8)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $10)
+                                    (get_local $8)
                                   )
                                   (block
                                     (i32.store
@@ -10122,7 +10101,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $5)
+                                    (get_local $7)
                                     (i32.load
                                       (i32.const 192)
                                     )
@@ -10134,33 +10113,33 @@
                                     (i32.load
                                       (tee_local $0
                                         (i32.add
-                                          (get_local $5)
+                                          (get_local $7)
                                           (i32.const 16)
                                         )
                                       )
                                     )
-                                    (get_local $6)
+                                    (get_local $13)
                                   )
                                   (i32.store
                                     (get_local $0)
-                                    (get_local $10)
+                                    (get_local $8)
                                   )
                                   (i32.store offset=20
-                                    (get_local $5)
-                                    (get_local $10)
+                                    (get_local $7)
+                                    (get_local $8)
                                   )
                                 )
                                 (br_if $do-once21
                                   (i32.eqz
-                                    (get_local $10)
+                                    (get_local $8)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $10)
-                                (tee_local $1
+                                (get_local $8)
+                                (tee_local $0
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -10169,29 +10148,29 @@
                               (call $_abort)
                             )
                             (i32.store offset=24
-                              (get_local $10)
-                              (get_local $5)
+                              (get_local $8)
+                              (get_local $7)
                             )
                             (if
-                              (tee_local $0
+                              (tee_local $1
                                 (i32.load offset=16
-                                  (get_local $6)
+                                  (get_local $13)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $0)
                                   (get_local $1)
+                                  (get_local $0)
                                 )
                                 (call $_abort)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $10)
-                                    (get_local $0)
+                                    (get_local $8)
+                                    (get_local $1)
                                   )
                                   (i32.store offset=24
-                                    (get_local $0)
-                                    (get_local $10)
+                                    (get_local $1)
+                                    (get_local $8)
                                   )
                                 )
                               )
@@ -10199,7 +10178,7 @@
                             (if
                               (tee_local $0
                                 (i32.load offset=20
-                                  (get_local $6)
+                                  (get_local $13)
                                 )
                               )
                               (if
@@ -10212,12 +10191,12 @@
                                 (call $_abort)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $10)
+                                    (get_local $8)
                                     (get_local $0)
                                   )
                                   (i32.store offset=24
                                     (get_local $0)
-                                    (get_local $10)
+                                    (get_local $8)
                                   )
                                 )
                               )
@@ -10228,17 +10207,17 @@
                       (block $do-once25
                         (if
                           (i32.lt_u
-                            (get_local $7)
+                            (get_local $9)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $6)
+                              (get_local $13)
                               (i32.or
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $7)
                                     (get_local $9)
+                                    (get_local $6)
                                   )
                                 )
                                 (i32.const 3)
@@ -10248,7 +10227,7 @@
                               (tee_local $0
                                 (i32.add
                                   (i32.add
-                                    (get_local $6)
+                                    (get_local $13)
                                     (get_local $0)
                                   )
                                   (i32.const 4)
@@ -10264,44 +10243,44 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $6)
+                              (get_local $13)
                               (i32.or
-                                (get_local $9)
+                                (get_local $6)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
-                              (get_local $4)
+                              (get_local $5)
                               (i32.or
-                                (get_local $7)
+                                (get_local $9)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
-                                (get_local $4)
-                                (get_local $7)
+                                (get_local $5)
+                                (get_local $9)
                               )
-                              (get_local $7)
+                              (get_local $9)
                             )
-                            (set_local $1
+                            (set_local $0
                               (i32.shr_u
-                                (get_local $7)
+                                (get_local $9)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $7)
+                                (get_local $9)
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $0
+                                (set_local $3
                                   (i32.add
                                     (i32.const 216)
                                     (i32.shl
                                       (i32.shl
-                                        (get_local $1)
+                                        (get_local $0)
                                         (i32.const 1)
                                       )
                                       (i32.const 2)
@@ -10310,25 +10289,25 @@
                                 )
                                 (if
                                   (i32.and
-                                    (tee_local $2
+                                    (tee_local $1
                                       (i32.load
                                         (i32.const 176)
                                       )
                                     )
-                                    (tee_local $1
+                                    (tee_local $0
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $1)
+                                        (get_local $0)
                                       )
                                     )
                                   )
                                   (if
                                     (i32.lt_u
-                                      (tee_local $1
+                                      (tee_local $0
                                         (i32.load
-                                          (tee_local $2
+                                          (tee_local $1
                                             (i32.add
-                                              (get_local $0)
+                                              (get_local $3)
                                               (i32.const 8)
                                             )
                                           )
@@ -10341,10 +10320,10 @@
                                     (call $_abort)
                                     (block
                                       (set_local $20
-                                        (get_local $2)
-                                      )
-                                      (set_local $16
                                         (get_local $1)
+                                      )
+                                      (set_local $10
+                                        (get_local $0)
                                       )
                                     )
                                   )
@@ -10352,62 +10331,62 @@
                                     (i32.store
                                       (i32.const 176)
                                       (i32.or
-                                        (get_local $2)
                                         (get_local $1)
+                                        (get_local $0)
                                       )
                                     )
                                     (set_local $20
                                       (i32.add
-                                        (get_local $0)
+                                        (get_local $3)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $16
-                                      (get_local $0)
+                                    (set_local $10
+                                      (get_local $3)
                                     )
                                   )
                                 )
                                 (i32.store
                                   (get_local $20)
-                                  (get_local $4)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=12
-                                  (get_local $16)
-                                  (get_local $4)
+                                  (get_local $10)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=8
-                                  (get_local $4)
-                                  (get_local $16)
+                                  (get_local $5)
+                                  (get_local $10)
                                 )
                                 (i32.store offset=12
-                                  (get_local $4)
-                                  (get_local $0)
+                                  (get_local $5)
+                                  (get_local $3)
                                 )
                                 (br $do-once25)
                               )
                             )
-                            (set_local $1
+                            (set_local $2
                               (i32.add
                                 (i32.const 480)
                                 (i32.shl
-                                  (tee_local $2
+                                  (tee_local $3
                                     (if i32
                                       (tee_local $0
                                         (i32.shr_u
-                                          (get_local $7)
+                                          (get_local $9)
                                           (i32.const 8)
                                         )
                                       )
                                       (if i32
                                         (i32.gt_u
-                                          (get_local $7)
+                                          (get_local $9)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $7)
+                                              (get_local $9)
                                               (i32.add
                                                 (tee_local $0
                                                   (i32.add
@@ -10415,14 +10394,14 @@
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (tee_local $1
+                                                          (tee_local $0
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (tee_local $0
+                                                                  (tee_local $1
                                                                     (i32.shl
                                                                       (get_local $0)
-                                                                      (tee_local $2
+                                                                      (tee_local $3
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
@@ -10443,16 +10422,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $2)
+                                                          (get_local $3)
                                                         )
-                                                        (tee_local $1
+                                                        (tee_local $0
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $0
+                                                                (tee_local $1
                                                                   (i32.shl
-                                                                    (get_local $0)
                                                                     (get_local $1)
+                                                                    (get_local $0)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -10466,8 +10445,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $0)
                                                         (get_local $1)
+                                                        (get_local $0)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -10492,13 +10471,13 @@
                               )
                             )
                             (i32.store offset=28
-                              (get_local $4)
-                              (get_local $2)
+                              (get_local $5)
+                              (get_local $3)
                             )
                             (i32.store offset=4
                               (tee_local $0
                                 (i32.add
-                                  (get_local $4)
+                                  (get_local $5)
                                   (i32.const 16)
                                 )
                               )
@@ -10511,7 +10490,7 @@
                             (if
                               (i32.eqz
                                 (i32.and
-                                  (tee_local $3
+                                  (tee_local $1
                                     (i32.load
                                       (i32.const 180)
                                     )
@@ -10519,7 +10498,7 @@
                                   (tee_local $0
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $2)
+                                      (get_local $3)
                                     )
                                   )
                                 )
@@ -10528,43 +10507,43 @@
                                 (i32.store
                                   (i32.const 180)
                                   (i32.or
-                                    (get_local $3)
+                                    (get_local $1)
                                     (get_local $0)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $1)
-                                  (get_local $4)
+                                  (get_local $2)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=24
-                                  (get_local $4)
-                                  (get_local $1)
+                                  (get_local $5)
+                                  (get_local $2)
                                 )
                                 (i32.store offset=12
-                                  (get_local $4)
-                                  (get_local $4)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=8
-                                  (get_local $4)
-                                  (get_local $4)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                                 (br $do-once25)
                               )
                             )
-                            (set_local $2
+                            (set_local $3
                               (i32.shl
-                                (get_local $7)
+                                (get_local $9)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $2)
+                                      (get_local $3)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $2)
+                                    (get_local $3)
                                     (i32.const 31)
                                   )
                                 )
@@ -10572,7 +10551,7 @@
                             )
                             (set_local $0
                               (i32.load
-                                (get_local $1)
+                                (get_local $2)
                               )
                             )
                             (block $jumpthreading$outer$1
@@ -10587,59 +10566,52 @@
                                           )
                                           (i32.const -8)
                                         )
-                                        (get_local $7)
+                                        (get_local $9)
                                       )
                                     )
-                                    (set_local $1
+                                    (set_local $2
                                       (i32.shl
-                                        (get_local $2)
+                                        (get_local $3)
                                         (i32.const 1)
                                       )
                                     )
-                                    (if
-                                      (tee_local $3
-                                        (i32.load
-                                          (tee_local $2
-                                            (i32.add
+                                    (br_if $jumpthreading$inner$0
+                                      (i32.eqz
+                                        (tee_local $1
+                                          (i32.load
+                                            (tee_local $3
                                               (i32.add
-                                                (get_local $0)
-                                                (i32.const 16)
-                                              )
-                                              (i32.shl
-                                                (i32.shr_u
-                                                  (get_local $2)
-                                                  (i32.const 31)
+                                                (i32.add
+                                                  (get_local $0)
+                                                  (i32.const 16)
                                                 )
-                                                (i32.const 2)
+                                                (i32.shl
+                                                  (i32.shr_u
+                                                    (get_local $3)
+                                                    (i32.const 31)
+                                                  )
+                                                  (i32.const 2)
+                                                )
                                               )
                                             )
                                           )
                                         )
                                       )
-                                      (block
-                                        (set_local $2
-                                          (get_local $1)
-                                        )
-                                        (set_local $0
-                                          (get_local $3)
-                                        )
-                                        (br $while-in28)
+                                    )
+                                    (block
+                                      (set_local $3
+                                        (get_local $2)
                                       )
-                                      (block
-                                        (set_local $1
-                                          (get_local $0)
-                                        )
-                                        (set_local $0
-                                          (get_local $2)
-                                        )
-                                        (br $jumpthreading$inner$0)
+                                      (set_local $0
+                                        (get_local $1)
                                       )
+                                      (br $while-in28)
                                     )
                                   )
                                 )
                                 (if
                                   (i32.lt_u
-                                    (get_local $0)
+                                    (get_local $3)
                                     (i32.load
                                       (i32.const 192)
                                     )
@@ -10647,20 +10619,20 @@
                                   (call $_abort)
                                   (block
                                     (i32.store
-                                      (get_local $0)
-                                      (get_local $4)
+                                      (get_local $3)
+                                      (get_local $5)
                                     )
                                     (i32.store offset=24
-                                      (get_local $4)
-                                      (get_local $1)
+                                      (get_local $5)
+                                      (get_local $0)
                                     )
                                     (i32.store offset=12
-                                      (get_local $4)
-                                      (get_local $4)
+                                      (get_local $5)
+                                      (get_local $5)
                                     )
                                     (i32.store offset=8
-                                      (get_local $4)
-                                      (get_local $4)
+                                      (get_local $5)
+                                      (get_local $5)
                                     )
                                     (br $do-once25)
                                   )
@@ -10670,9 +10642,9 @@
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (tee_local $3
+                                    (tee_local $2
                                       (i32.load
-                                        (tee_local $1
+                                        (tee_local $3
                                           (i32.add
                                             (get_local $0)
                                             (i32.const 8)
@@ -10680,7 +10652,7 @@
                                         )
                                       )
                                     )
-                                    (tee_local $2
+                                    (tee_local $1
                                       (i32.load
                                         (i32.const 192)
                                       )
@@ -10688,28 +10660,28 @@
                                   )
                                   (i32.ge_u
                                     (get_local $0)
-                                    (get_local $2)
+                                    (get_local $1)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $3)
-                                    (get_local $4)
+                                    (get_local $2)
+                                    (get_local $5)
                                   )
                                   (i32.store
-                                    (get_local $1)
-                                    (get_local $4)
+                                    (get_local $3)
+                                    (get_local $5)
                                   )
                                   (i32.store offset=8
-                                    (get_local $4)
-                                    (get_local $3)
+                                    (get_local $5)
+                                    (get_local $2)
                                   )
                                   (i32.store offset=12
-                                    (get_local $4)
+                                    (get_local $5)
                                     (get_local $0)
                                   )
                                   (i32.store offset=24
-                                    (get_local $4)
+                                    (get_local $5)
                                     (i32.const 0)
                                   )
                                 )
@@ -10721,22 +10693,22 @@
                       )
                       (return
                         (i32.add
-                          (get_local $6)
+                          (get_local $13)
                           (i32.const 8)
                         )
                       )
                     )
                     (set_local $0
-                      (get_local $9)
+                      (get_local $6)
                     )
                   )
                   (set_local $0
-                    (get_local $9)
+                    (get_local $6)
                   )
                 )
               )
               (set_local $0
-                (get_local $9)
+                (get_local $6)
               )
             )
           )
@@ -10745,7 +10717,7 @@
     )
     (if
       (i32.ge_u
-        (tee_local $2
+        (tee_local $1
           (i32.load
             (i32.const 184)
           )
@@ -10753,16 +10725,16 @@
         (get_local $0)
       )
       (block
-        (set_local $3
+        (set_local $2
           (i32.load
             (i32.const 196)
           )
         )
         (if
           (i32.gt_u
-            (tee_local $1
+            (tee_local $3
               (i32.sub
-                (get_local $2)
+                (get_local $1)
                 (get_local $0)
               )
             )
@@ -10771,33 +10743,33 @@
           (block
             (i32.store
               (i32.const 196)
-              (tee_local $2
+              (tee_local $1
                 (i32.add
-                  (get_local $3)
+                  (get_local $2)
                   (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 184)
-              (get_local $1)
+              (get_local $3)
             )
             (i32.store offset=4
-              (get_local $2)
+              (get_local $1)
               (i32.or
-                (get_local $1)
+                (get_local $3)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $2)
                 (get_local $1)
+                (get_local $3)
               )
-              (get_local $1)
+              (get_local $3)
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
                 (get_local $0)
                 (i32.const 3)
@@ -10814,9 +10786,9 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
-                (get_local $2)
+                (get_local $1)
                 (i32.const 3)
               )
             )
@@ -10824,8 +10796,8 @@
               (tee_local $0
                 (i32.add
                   (i32.add
-                    (get_local $3)
                     (get_local $2)
+                    (get_local $1)
                   )
                   (i32.const 4)
                 )
@@ -10841,7 +10813,7 @@
         )
         (return
           (i32.add
-            (get_local $3)
+            (get_local $2)
             (i32.const 8)
           )
         )
@@ -10859,7 +10831,7 @@
       (block
         (i32.store
           (i32.const 188)
-          (tee_local $1
+          (tee_local $3
             (i32.sub
               (get_local $1)
               (get_local $0)
@@ -10868,9 +10840,9 @@
         )
         (i32.store
           (i32.const 200)
-          (tee_local $2
+          (tee_local $1
             (i32.add
-              (tee_local $3
+              (tee_local $2
                 (i32.load
                   (i32.const 200)
                 )
@@ -10880,14 +10852,14 @@
           )
         )
         (i32.store offset=4
-          (get_local $2)
+          (get_local $1)
           (i32.or
-            (get_local $1)
+            (get_local $3)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $3)
+          (get_local $2)
           (i32.or
             (get_local $0)
             (i32.const 3)
@@ -10895,7 +10867,7 @@
         )
         (return
           (i32.add
-            (get_local $3)
+            (get_local $2)
             (i32.const 8)
           )
         )
@@ -10960,7 +10932,7 @@
         )
       )
     )
-    (set_local $8
+    (set_local $10
       (i32.add
         (get_local $0)
         (i32.const 48)
@@ -10968,7 +10940,7 @@
     )
     (if
       (i32.le_u
-        (tee_local $9
+        (tee_local $8
           (i32.and
             (tee_local $6
               (i32.add
@@ -10985,7 +10957,7 @@
                 )
               )
             )
-            (tee_local $2
+            (tee_local $7
               (i32.sub
                 (i32.const 0)
                 (get_local $1)
@@ -11000,7 +10972,7 @@
       )
     )
     (if
-      (tee_local $4
+      (tee_local $2
         (i32.load
           (i32.const 616)
         )
@@ -11015,14 +10987,14 @@
                     (i32.const 608)
                   )
                 )
-                (get_local $9)
+                (get_local $8)
               )
             )
             (get_local $3)
           )
           (i32.gt_u
             (get_local $1)
-            (get_local $4)
+            (get_local $2)
           )
         )
         (return
@@ -11073,7 +11045,7 @@
                             (i32.add
                               (get_local $3)
                               (i32.load
-                                (tee_local $3
+                                (tee_local $2
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 4)
@@ -11111,14 +11083,14 @@
                               (i32.const 188)
                             )
                           )
-                          (get_local $2)
+                          (get_local $7)
                         )
                       )
                       (i32.const 2147483647)
                     )
                     (if
                       (i32.eq
-                        (tee_local $2
+                        (tee_local $3
                           (call $_sbrk
                             (get_local $1)
                           )
@@ -11128,13 +11100,13 @@
                             (get_local $4)
                           )
                           (i32.load
-                            (get_local $3)
+                            (get_local $2)
                           )
                         )
                       )
                       (br_if $jumpthreading$inner$12
                         (i32.ne
-                          (get_local $2)
+                          (get_local $3)
                           (i32.const -1)
                         )
                       )
@@ -11145,7 +11117,7 @@
                 )
                 (if
                   (i32.ne
-                    (tee_local $2
+                    (tee_local $3
                       (call $_sbrk
                         (i32.const 0)
                       )
@@ -11153,9 +11125,9 @@
                     (i32.const -1)
                   )
                   (block
-                    (set_local $3
+                    (set_local $4
                       (i32.add
-                        (tee_local $6
+                        (tee_local $7
                           (i32.load
                             (i32.const 608)
                           )
@@ -11163,7 +11135,7 @@
                         (tee_local $1
                           (if i32
                             (i32.and
-                              (tee_local $3
+                              (tee_local $2
                                 (i32.add
                                   (tee_local $4
                                     (i32.load
@@ -11174,17 +11146,17 @@
                                 )
                               )
                               (tee_local $1
-                                (get_local $2)
+                                (get_local $3)
                               )
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $9)
+                                (get_local $8)
                                 (get_local $1)
                               )
                               (i32.and
                                 (i32.add
-                                  (get_local $3)
+                                  (get_local $2)
                                   (get_local $1)
                                 )
                                 (i32.sub
@@ -11193,7 +11165,7 @@
                                 )
                               )
                             )
-                            (get_local $9)
+                            (get_local $8)
                           )
                         )
                       )
@@ -11211,7 +11183,7 @@
                       )
                       (block
                         (if
-                          (tee_local $4
+                          (tee_local $2
                             (i32.load
                               (i32.const 616)
                             )
@@ -11219,29 +11191,29 @@
                           (br_if $label$break$L279
                             (i32.or
                               (i32.le_u
-                                (get_local $3)
-                                (get_local $6)
+                                (get_local $4)
+                                (get_local $7)
                               )
                               (i32.gt_u
-                                (get_local $3)
                                 (get_local $4)
+                                (get_local $2)
                               )
                             )
                           )
                         )
                         (br_if $jumpthreading$inner$12
                           (i32.eq
-                            (tee_local $3
+                            (tee_local $2
                               (call $_sbrk
                                 (get_local $1)
                               )
                             )
-                            (get_local $2)
+                            (get_local $3)
                           )
                         )
                         (block
-                          (set_local $2
-                            (get_local $3)
+                          (set_local $3
+                            (get_local $2)
                           )
                           (br $jumpthreading$inner$4)
                         )
@@ -11251,7 +11223,7 @@
                 )
                 (br $label$break$L279)
               )
-              (set_local $3
+              (set_local $4
                 (i32.sub
                   (i32.const 0)
                   (get_local $1)
@@ -11260,7 +11232,7 @@
               (if
                 (i32.and
                   (i32.gt_u
-                    (get_local $8)
+                    (get_local $10)
                     (get_local $1)
                   )
                   (i32.and
@@ -11269,21 +11241,21 @@
                       (i32.const 2147483647)
                     )
                     (i32.ne
-                      (get_local $2)
+                      (get_local $3)
                       (i32.const -1)
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (tee_local $4
+                    (tee_local $2
                       (i32.and
                         (i32.add
                           (i32.sub
                             (get_local $5)
                             (get_local $1)
                           )
-                          (tee_local $4
+                          (tee_local $2
                             (i32.load
                               (i32.const 656)
                             )
@@ -11291,7 +11263,7 @@
                         )
                         (i32.sub
                           (i32.const 0)
-                          (get_local $4)
+                          (get_local $2)
                         )
                       )
                     )
@@ -11300,21 +11272,21 @@
                   (if
                     (i32.eq
                       (call $_sbrk
-                        (get_local $4)
+                        (get_local $2)
                       )
                       (i32.const -1)
                     )
                     (block
                       (drop
                         (call $_sbrk
-                          (get_local $3)
+                          (get_local $4)
                         )
                       )
                       (br $label$break$L279)
                     )
                     (set_local $1
                       (i32.add
-                        (get_local $4)
+                        (get_local $2)
                         (get_local $1)
                       )
                     )
@@ -11323,7 +11295,7 @@
               )
               (br_if $jumpthreading$inner$12
                 (i32.ne
-                  (get_local $2)
+                  (get_local $3)
                   (i32.const -1)
                 )
               )
@@ -11341,15 +11313,15 @@
         )
         (if
           (i32.lt_u
-            (get_local $9)
+            (get_local $8)
             (i32.const 2147483647)
           )
           (if
             (i32.and
               (i32.lt_u
-                (tee_local $2
+                (tee_local $3
                   (call $_sbrk
-                    (get_local $9)
+                    (get_local $8)
                   )
                 )
                 (tee_local $1
@@ -11360,7 +11332,7 @@
               )
               (i32.and
                 (i32.ne
-                  (get_local $2)
+                  (get_local $3)
                   (i32.const -1)
                 )
                 (i32.ne
@@ -11374,7 +11346,7 @@
                 (tee_local $1
                   (i32.sub
                     (get_local $1)
-                    (get_local $2)
+                    (get_local $3)
                   )
                 )
                 (i32.add
@@ -11389,7 +11361,7 @@
       )
       (i32.store
         (i32.const 608)
-        (tee_local $3
+        (tee_local $2
           (i32.add
             (i32.load
               (i32.const 608)
@@ -11400,25 +11372,25 @@
       )
       (if
         (i32.gt_u
-          (get_local $3)
+          (get_local $2)
           (i32.load
             (i32.const 612)
           )
         )
         (i32.store
           (i32.const 612)
-          (get_local $3)
+          (get_local $2)
         )
       )
       (block $do-once40
         (if
-          (tee_local $7
+          (tee_local $9
             (i32.load
               (i32.const 200)
             )
           )
           (block
-            (set_local $3
+            (set_local $2
               (i32.const 624)
             )
             (block $jumpthreading$outer$9
@@ -11426,18 +11398,18 @@
                 (loop $while-in45
                   (br_if $jumpthreading$inner$9
                     (i32.eq
-                      (get_local $2)
+                      (get_local $3)
                       (i32.add
-                        (tee_local $9
+                        (tee_local $6
                           (i32.load
-                            (get_local $3)
+                            (get_local $2)
                           )
                         )
-                        (tee_local $5
+                        (tee_local $7
                           (i32.load
                             (tee_local $4
                               (i32.add
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 4)
                               )
                             )
@@ -11447,9 +11419,9 @@
                     )
                   )
                   (br_if $while-in45
-                    (tee_local $3
+                    (tee_local $2
                       (i32.load offset=8
-                        (get_local $3)
+                        (get_local $2)
                       )
                     )
                   )
@@ -11460,7 +11432,7 @@
                 (i32.eqz
                   (i32.and
                     (i32.load offset=12
-                      (get_local $3)
+                      (get_local $2)
                     )
                     (i32.const 8)
                   )
@@ -11468,33 +11440,33 @@
                 (if
                   (i32.and
                     (i32.lt_u
-                      (get_local $7)
-                      (get_local $2)
+                      (get_local $9)
+                      (get_local $3)
                     )
                     (i32.ge_u
-                      (get_local $7)
                       (get_local $9)
+                      (get_local $6)
                     )
                   )
                   (block
                     (i32.store
                       (get_local $4)
                       (i32.add
-                        (get_local $5)
+                        (get_local $7)
                         (get_local $1)
                       )
                     )
-                    (set_local $3
+                    (set_local $2
                       (i32.add
-                        (get_local $7)
-                        (tee_local $2
+                        (get_local $9)
+                        (tee_local $3
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (tee_local $2
+                                (tee_local $3
                                   (i32.add
-                                    (get_local $7)
+                                    (get_local $9)
                                     (i32.const 8)
                                   )
                                 )
@@ -11503,7 +11475,7 @@
                             )
                             (i32.const 0)
                             (i32.and
-                              (get_local $2)
+                              (get_local $3)
                               (i32.const 7)
                             )
                           )
@@ -11514,7 +11486,7 @@
                       (i32.add
                         (i32.sub
                           (get_local $1)
-                          (get_local $2)
+                          (get_local $3)
                         )
                         (i32.load
                           (i32.const 188)
@@ -11523,14 +11495,14 @@
                     )
                     (i32.store
                       (i32.const 200)
-                      (get_local $3)
+                      (get_local $2)
                     )
                     (i32.store
                       (i32.const 188)
                       (get_local $1)
                     )
                     (i32.store offset=4
-                      (get_local $3)
+                      (get_local $2)
                       (i32.or
                         (get_local $1)
                         (i32.const 1)
@@ -11538,7 +11510,7 @@
                     )
                     (i32.store offset=4
                       (i32.add
-                        (get_local $3)
+                        (get_local $2)
                         (get_local $1)
                       )
                       (i32.const 40)
@@ -11554,11 +11526,11 @@
                 )
               )
             )
-            (set_local $10
+            (set_local $5
               (if i32
                 (i32.lt_u
-                  (get_local $2)
-                  (tee_local $3
+                  (get_local $3)
+                  (tee_local $2
                     (i32.load
                       (i32.const 192)
                     )
@@ -11567,20 +11539,20 @@
                 (block i32
                   (i32.store
                     (i32.const 192)
-                    (get_local $2)
+                    (get_local $3)
                   )
-                  (get_local $2)
+                  (get_local $3)
                 )
-                (get_local $3)
+                (get_local $2)
               )
             )
-            (set_local $5
+            (set_local $7
               (i32.add
-                (get_local $2)
+                (get_local $3)
                 (get_local $1)
               )
             )
-            (set_local $3
+            (set_local $2
               (i32.const 624)
             )
             (block $jumpthreading$outer$10
@@ -11589,21 +11561,21 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $3)
+                        (get_local $2)
                       )
-                      (get_local $5)
+                      (get_local $7)
                     )
                     (block
                       (set_local $4
-                        (get_local $3)
+                        (get_local $2)
                       )
                       (br $jumpthreading$inner$10)
                     )
                   )
                   (br_if $while-in47
-                    (tee_local $3
+                    (tee_local $2
                       (i32.load offset=8
-                        (get_local $3)
+                        (get_local $2)
                       )
                     )
                   )
@@ -11616,7 +11588,7 @@
               (if
                 (i32.and
                   (i32.load offset=12
-                    (get_local $3)
+                    (get_local $2)
                   )
                   (i32.const 8)
                 )
@@ -11626,34 +11598,34 @@
                 (block
                   (i32.store
                     (get_local $4)
-                    (get_local $2)
+                    (get_local $3)
                   )
                   (i32.store
-                    (tee_local $3
+                    (tee_local $2
                       (i32.add
-                        (get_local $3)
+                        (get_local $2)
                         (i32.const 4)
                       )
                     )
                     (i32.add
                       (i32.load
-                        (get_local $3)
+                        (get_local $2)
                       )
                       (get_local $1)
                     )
                   )
-                  (set_local $6
+                  (set_local $8
                     (i32.add
-                      (tee_local $9
+                      (tee_local $6
                         (i32.add
-                          (get_local $2)
+                          (get_local $3)
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
                                 (tee_local $1
                                   (i32.add
-                                    (get_local $2)
+                                    (get_local $3)
                                     (i32.const 8)
                                   )
                                 )
@@ -11671,19 +11643,19 @@
                       (get_local $0)
                     )
                   )
-                  (set_local $2
+                  (set_local $4
                     (i32.sub
                       (i32.sub
-                        (tee_local $8
+                        (tee_local $10
                           (i32.add
-                            (get_local $5)
+                            (get_local $7)
                             (select
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
                                   (tee_local $1
                                     (i32.add
-                                      (get_local $5)
+                                      (get_local $7)
                                       (i32.const 8)
                                     )
                                   )
@@ -11698,13 +11670,13 @@
                             )
                           )
                         )
-                        (get_local $9)
+                        (get_local $6)
                       )
                       (get_local $0)
                     )
                   )
                   (i32.store offset=4
-                    (get_local $9)
+                    (get_local $6)
                     (i32.or
                       (get_local $0)
                       (i32.const 3)
@@ -11713,8 +11685,8 @@
                   (block $do-once48
                     (if
                       (i32.eq
-                        (get_local $8)
-                        (get_local $7)
+                        (get_local $10)
+                        (get_local $9)
                       )
                       (block
                         (i32.store
@@ -11724,16 +11696,16 @@
                               (i32.load
                                 (i32.const 188)
                               )
-                              (get_local $2)
+                              (get_local $4)
                             )
                           )
                         )
                         (i32.store
                           (i32.const 200)
-                          (get_local $6)
+                          (get_local $8)
                         )
                         (i32.store offset=4
-                          (get_local $6)
+                          (get_local $8)
                           (i32.or
                             (get_local $0)
                             (i32.const 1)
@@ -11743,7 +11715,7 @@
                       (block
                         (if
                           (i32.eq
-                            (get_local $8)
+                            (get_local $10)
                             (i32.load
                               (i32.const 196)
                             )
@@ -11756,16 +11728,16 @@
                                   (i32.load
                                     (i32.const 184)
                                   )
-                                  (get_local $2)
+                                  (get_local $4)
                                 )
                               )
                             )
                             (i32.store
                               (i32.const 196)
-                              (get_local $6)
+                              (get_local $8)
                             )
                             (i32.store offset=4
-                              (get_local $6)
+                              (get_local $8)
                               (i32.or
                                 (get_local $0)
                                 (i32.const 1)
@@ -11773,7 +11745,7 @@
                             )
                             (i32.store
                               (i32.add
-                                (get_local $6)
+                                (get_local $8)
                                 (get_local $0)
                               )
                               (get_local $0)
@@ -11787,9 +11759,9 @@
                               (if i32
                                 (i32.eq
                                   (i32.and
-                                    (tee_local $1
+                                    (tee_local $0
                                       (i32.load offset=4
-                                        (get_local $8)
+                                        (get_local $10)
                                       )
                                     )
                                     (i32.const 3)
@@ -11797,44 +11769,44 @@
                                   (i32.const 1)
                                 )
                                 (block i32
-                                  (set_local $5
+                                  (set_local $7
                                     (i32.and
-                                      (get_local $1)
+                                      (get_local $0)
                                       (i32.const -8)
                                     )
                                   )
-                                  (set_local $0
+                                  (set_local $1
                                     (i32.shr_u
-                                      (get_local $1)
+                                      (get_local $0)
                                       (i32.const 3)
                                     )
                                   )
                                   (block $label$break$L331
                                     (if
                                       (i32.lt_u
-                                        (get_local $1)
+                                        (get_local $0)
                                         (i32.const 256)
                                       )
                                       (block
-                                        (set_local $3
+                                        (set_local $2
                                           (i32.load offset=12
-                                            (get_local $8)
+                                            (get_local $10)
                                           )
                                         )
                                         (block $do-once51
                                           (if
                                             (i32.ne
-                                              (tee_local $4
+                                              (tee_local $3
                                                 (i32.load offset=8
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                 )
                                               )
-                                              (tee_local $1
+                                              (tee_local $0
                                                 (i32.add
                                                   (i32.const 216)
                                                   (i32.shl
                                                     (i32.shl
-                                                      (get_local $0)
+                                                      (get_local $1)
                                                       (i32.const 1)
                                                     )
                                                     (i32.const 2)
@@ -11845,17 +11817,17 @@
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $4)
-                                                  (get_local $10)
+                                                  (get_local $3)
+                                                  (get_local $5)
                                                 )
                                                 (call $_abort)
                                               )
                                               (br_if $do-once51
                                                 (i32.eq
                                                   (i32.load offset=12
-                                                    (get_local $4)
+                                                    (get_local $3)
                                                   )
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                 )
                                               )
                                               (call $_abort)
@@ -11864,8 +11836,8 @@
                                         )
                                         (if
                                           (i32.eq
+                                            (get_local $2)
                                             (get_local $3)
-                                            (get_local $4)
                                           )
                                           (block
                                             (i32.store
@@ -11877,7 +11849,7 @@
                                                 (i32.xor
                                                   (i32.shl
                                                     (i32.const 1)
-                                                    (get_local $0)
+                                                    (get_local $1)
                                                   )
                                                   (i32.const -1)
                                                 )
@@ -11889,20 +11861,20 @@
                                         (block $do-once53
                                           (if
                                             (i32.eq
-                                              (get_local $3)
-                                              (get_local $1)
+                                              (get_local $2)
+                                              (get_local $0)
                                             )
                                             (set_local $21
                                               (i32.add
-                                                (get_local $3)
+                                                (get_local $2)
                                                 (i32.const 8)
                                               )
                                             )
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $3)
-                                                  (get_local $10)
+                                                  (get_local $2)
+                                                  (get_local $5)
                                                 )
                                                 (call $_abort)
                                               )
@@ -11911,12 +11883,12 @@
                                                   (i32.load
                                                     (tee_local $0
                                                       (i32.add
-                                                        (get_local $3)
+                                                        (get_local $2)
                                                         (i32.const 8)
                                                       )
                                                     )
                                                   )
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                 )
                                                 (block
                                                   (set_local $21
@@ -11930,18 +11902,18 @@
                                           )
                                         )
                                         (i32.store offset=12
-                                          (get_local $4)
                                           (get_local $3)
+                                          (get_local $2)
                                         )
                                         (i32.store
                                           (get_local $21)
-                                          (get_local $4)
+                                          (get_local $3)
                                         )
                                       )
                                       (block
-                                        (set_local $7
+                                        (set_local $12
                                           (i32.load offset=24
-                                            (get_local $8)
+                                            (get_local $10)
                                           )
                                         )
                                         (block $do-once55
@@ -11949,41 +11921,41 @@
                                             (i32.eq
                                               (tee_local $0
                                                 (i32.load offset=12
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                 )
                                               )
-                                              (get_local $8)
+                                              (get_local $10)
                                             )
                                             (block
                                               (if
-                                                (tee_local $1
-                                                  (i32.load
-                                                    (tee_local $3
-                                                      (i32.add
-                                                        (tee_local $0
-                                                          (i32.add
-                                                            (get_local $8)
-                                                            (i32.const 16)
+                                                (i32.eqz
+                                                  (tee_local $1
+                                                    (i32.load
+                                                      (tee_local $0
+                                                        (i32.add
+                                                          (tee_local $3
+                                                            (i32.add
+                                                              (get_local $10)
+                                                              (i32.const 16)
+                                                            )
                                                           )
+                                                          (i32.const 4)
                                                         )
-                                                        (i32.const 4)
                                                       )
                                                     )
                                                   )
-                                                )
-                                                (set_local $0
-                                                  (get_local $3)
                                                 )
                                                 (if
-                                                  (i32.eqz
-                                                    (tee_local $1
-                                                      (i32.load
-                                                        (get_local $0)
-                                                      )
+                                                  (tee_local $1
+                                                    (i32.load
+                                                      (get_local $3)
                                                     )
                                                   )
+                                                  (set_local $0
+                                                    (get_local $3)
+                                                  )
                                                   (block
-                                                    (set_local $11
+                                                    (set_local $14
                                                       (i32.const 0)
                                                     )
                                                     (br $do-once55)
@@ -11992,9 +11964,9 @@
                                               )
                                               (loop $while-in58
                                                 (if
-                                                  (tee_local $4
+                                                  (tee_local $3
                                                     (i32.load
-                                                      (tee_local $3
+                                                      (tee_local $2
                                                         (i32.add
                                                           (get_local $1)
                                                           (i32.const 20)
@@ -12004,18 +11976,18 @@
                                                   )
                                                   (block
                                                     (set_local $1
-                                                      (get_local $4)
+                                                      (get_local $3)
                                                     )
                                                     (set_local $0
-                                                      (get_local $3)
+                                                      (get_local $2)
                                                     )
                                                     (br $while-in58)
                                                   )
                                                 )
                                                 (if
-                                                  (tee_local $4
+                                                  (tee_local $3
                                                     (i32.load
-                                                      (tee_local $3
+                                                      (tee_local $2
                                                         (i32.add
                                                           (get_local $1)
                                                           (i32.const 16)
@@ -12025,10 +11997,10 @@
                                                   )
                                                   (block
                                                     (set_local $1
-                                                      (get_local $4)
+                                                      (get_local $3)
                                                     )
                                                     (set_local $0
-                                                      (get_local $3)
+                                                      (get_local $2)
                                                     )
                                                     (br $while-in58)
                                                   )
@@ -12037,7 +12009,7 @@
                                               (if
                                                 (i32.lt_u
                                                   (get_local $0)
-                                                  (get_local $10)
+                                                  (get_local $5)
                                                 )
                                                 (call $_abort)
                                                 (block
@@ -12045,7 +12017,7 @@
                                                     (get_local $0)
                                                     (i32.const 0)
                                                   )
-                                                  (set_local $11
+                                                  (set_local $14
                                                     (get_local $1)
                                                   )
                                                 )
@@ -12054,12 +12026,12 @@
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (tee_local $4
+                                                  (tee_local $2
                                                     (i32.load offset=8
-                                                      (get_local $8)
+                                                      (get_local $10)
                                                     )
                                                   )
-                                                  (get_local $10)
+                                                  (get_local $5)
                                                 )
                                                 (call $_abort)
                                               )
@@ -12068,12 +12040,12 @@
                                                   (i32.load
                                                     (tee_local $3
                                                       (i32.add
-                                                        (get_local $4)
+                                                        (get_local $2)
                                                         (i32.const 12)
                                                       )
                                                     )
                                                   )
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                 )
                                                 (call $_abort)
                                               )
@@ -12087,7 +12059,7 @@
                                                       )
                                                     )
                                                   )
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                 )
                                                 (block
                                                   (i32.store
@@ -12096,9 +12068,9 @@
                                                   )
                                                   (i32.store
                                                     (get_local $1)
-                                                    (get_local $4)
+                                                    (get_local $2)
                                                   )
-                                                  (set_local $11
+                                                  (set_local $14
                                                     (get_local $0)
                                                   )
                                                 )
@@ -12109,13 +12081,13 @@
                                         )
                                         (br_if $label$break$L331
                                           (i32.eqz
-                                            (get_local $7)
+                                            (get_local $12)
                                           )
                                         )
                                         (block $do-once59
                                           (if
                                             (i32.eq
-                                              (get_local $8)
+                                              (get_local $10)
                                               (i32.load
                                                 (tee_local $0
                                                   (i32.add
@@ -12123,7 +12095,7 @@
                                                     (i32.shl
                                                       (tee_local $1
                                                         (i32.load offset=28
-                                                          (get_local $8)
+                                                          (get_local $10)
                                                         )
                                                       )
                                                       (i32.const 2)
@@ -12135,10 +12107,10 @@
                                             (block
                                               (i32.store
                                                 (get_local $0)
-                                                (get_local $11)
+                                                (get_local $14)
                                               )
                                               (br_if $do-once59
-                                                (get_local $11)
+                                                (get_local $14)
                                               )
                                               (i32.store
                                                 (i32.const 180)
@@ -12160,7 +12132,7 @@
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $7)
+                                                  (get_local $12)
                                                   (i32.load
                                                     (i32.const 192)
                                                   )
@@ -12172,25 +12144,25 @@
                                                   (i32.load
                                                     (tee_local $0
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $12)
                                                         (i32.const 16)
                                                       )
                                                     )
                                                   )
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                 )
                                                 (i32.store
                                                   (get_local $0)
-                                                  (get_local $11)
+                                                  (get_local $14)
                                                 )
                                                 (i32.store offset=20
-                                                  (get_local $7)
-                                                  (get_local $11)
+                                                  (get_local $12)
+                                                  (get_local $14)
                                                 )
                                               )
                                               (br_if $label$break$L331
                                                 (i32.eqz
-                                                  (get_local $11)
+                                                  (get_local $14)
                                                 )
                                               )
                                             )
@@ -12198,8 +12170,8 @@
                                         )
                                         (if
                                           (i32.lt_u
-                                            (get_local $11)
-                                            (tee_local $3
+                                            (get_local $14)
+                                            (tee_local $1
                                               (i32.load
                                                 (i32.const 192)
                                               )
@@ -12208,15 +12180,15 @@
                                           (call $_abort)
                                         )
                                         (i32.store offset=24
-                                          (get_local $11)
-                                          (get_local $7)
+                                          (get_local $14)
+                                          (get_local $12)
                                         )
                                         (if
-                                          (tee_local $1
+                                          (tee_local $3
                                             (i32.load
                                               (tee_local $0
                                                 (i32.add
-                                                  (get_local $8)
+                                                  (get_local $10)
                                                   (i32.const 16)
                                                 )
                                               )
@@ -12224,18 +12196,18 @@
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $1)
                                               (get_local $3)
+                                              (get_local $1)
                                             )
                                             (call $_abort)
                                             (block
                                               (i32.store offset=16
-                                                (get_local $11)
-                                                (get_local $1)
+                                                (get_local $14)
+                                                (get_local $3)
                                               )
                                               (i32.store offset=24
-                                                (get_local $1)
-                                                (get_local $11)
+                                                (get_local $3)
+                                                (get_local $14)
                                               )
                                             )
                                           )
@@ -12259,30 +12231,30 @@
                                           (call $_abort)
                                           (block
                                             (i32.store offset=20
-                                              (get_local $11)
+                                              (get_local $14)
                                               (get_local $0)
                                             )
                                             (i32.store offset=24
                                               (get_local $0)
-                                              (get_local $11)
+                                              (get_local $14)
                                             )
                                           )
                                         )
                                       )
                                     )
                                   )
-                                  (set_local $2
+                                  (set_local $4
                                     (i32.add
-                                      (get_local $5)
-                                      (get_local $2)
+                                      (get_local $7)
+                                      (get_local $4)
                                     )
                                   )
                                   (i32.add
-                                    (get_local $8)
-                                    (get_local $5)
+                                    (get_local $10)
+                                    (get_local $7)
                                   )
                                 )
-                                (get_local $8)
+                                (get_local $10)
                               )
                               (i32.const 4)
                             )
@@ -12295,37 +12267,37 @@
                           )
                         )
                         (i32.store offset=4
-                          (get_local $6)
+                          (get_local $8)
                           (i32.or
-                            (get_local $2)
+                            (get_local $4)
                             (i32.const 1)
                           )
                         )
                         (i32.store
                           (i32.add
-                            (get_local $6)
-                            (get_local $2)
+                            (get_local $8)
+                            (get_local $4)
                           )
-                          (get_local $2)
+                          (get_local $4)
                         )
-                        (set_local $1
+                        (set_local $0
                           (i32.shr_u
-                            (get_local $2)
+                            (get_local $4)
                             (i32.const 3)
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $2)
+                            (get_local $4)
                             (i32.const 256)
                           )
                           (block
-                            (set_local $0
+                            (set_local $3
                               (i32.add
                                 (i32.const 216)
                                 (i32.shl
                                   (i32.shl
-                                    (get_local $1)
+                                    (get_local $0)
                                     (i32.const 1)
                                   )
                                   (i32.const 2)
@@ -12335,26 +12307,26 @@
                             (block $do-once63
                               (if
                                 (i32.and
-                                  (tee_local $2
+                                  (tee_local $1
                                     (i32.load
                                       (i32.const 176)
                                     )
                                   )
-                                  (tee_local $1
+                                  (tee_local $0
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $1)
+                                      (get_local $0)
                                     )
                                   )
                                 )
                                 (block
                                   (if
                                     (i32.ge_u
-                                      (tee_local $1
+                                      (tee_local $0
                                         (i32.load
-                                          (tee_local $2
+                                          (tee_local $1
                                             (i32.add
-                                              (get_local $0)
+                                              (get_local $3)
                                               (i32.const 8)
                                             )
                                           )
@@ -12366,10 +12338,10 @@
                                     )
                                     (block
                                       (set_local $22
-                                        (get_local $2)
-                                      )
-                                      (set_local $17
                                         (get_local $1)
+                                      )
+                                      (set_local $11
+                                        (get_local $0)
                                       )
                                       (br $do-once63)
                                     )
@@ -12380,42 +12352,42 @@
                                   (i32.store
                                     (i32.const 176)
                                     (i32.or
-                                      (get_local $2)
                                       (get_local $1)
+                                      (get_local $0)
                                     )
                                   )
                                   (set_local $22
                                     (i32.add
-                                      (get_local $0)
+                                      (get_local $3)
                                       (i32.const 8)
                                     )
                                   )
-                                  (set_local $17
-                                    (get_local $0)
+                                  (set_local $11
+                                    (get_local $3)
                                   )
                                 )
                               )
                             )
                             (i32.store
                               (get_local $22)
-                              (get_local $6)
+                              (get_local $8)
                             )
                             (i32.store offset=12
-                              (get_local $17)
-                              (get_local $6)
+                              (get_local $11)
+                              (get_local $8)
                             )
                             (i32.store offset=8
-                              (get_local $6)
-                              (get_local $17)
+                              (get_local $8)
+                              (get_local $11)
                             )
                             (i32.store offset=12
-                              (get_local $6)
-                              (get_local $0)
+                              (get_local $8)
+                              (get_local $3)
                             )
                             (br $do-once48)
                           )
                         )
-                        (set_local $1
+                        (set_local $2
                           (i32.add
                             (i32.const 480)
                             (i32.shl
@@ -12424,7 +12396,7 @@
                                   (if i32
                                     (tee_local $0
                                       (i32.shr_u
-                                        (get_local $2)
+                                        (get_local $4)
                                         (i32.const 8)
                                       )
                                     )
@@ -12433,7 +12405,7 @@
                                         (br_if $do-once65
                                           (i32.const 31)
                                           (i32.gt_u
-                                            (get_local $2)
+                                            (get_local $4)
                                             (i32.const 16777215)
                                           )
                                         )
@@ -12441,7 +12413,7 @@
                                       (i32.or
                                         (i32.and
                                           (i32.shr_u
-                                            (get_local $2)
+                                            (get_local $4)
                                             (i32.add
                                               (tee_local $0
                                                 (i32.add
@@ -12449,11 +12421,11 @@
                                                     (i32.const 14)
                                                     (i32.or
                                                       (i32.or
-                                                        (tee_local $1
+                                                        (tee_local $0
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $0
+                                                                (tee_local $1
                                                                   (i32.shl
                                                                     (get_local $0)
                                                                     (tee_local $3
@@ -12479,14 +12451,14 @@
                                                         )
                                                         (get_local $3)
                                                       )
-                                                      (tee_local $1
+                                                      (tee_local $0
                                                         (i32.and
                                                           (i32.shr_u
                                                             (i32.add
-                                                              (tee_local $0
+                                                              (tee_local $1
                                                                 (i32.shl
-                                                                  (get_local $0)
                                                                   (get_local $1)
+                                                                  (get_local $0)
                                                                 )
                                                               )
                                                               (i32.const 245760)
@@ -12500,8 +12472,8 @@
                                                   )
                                                   (i32.shr_u
                                                     (i32.shl
-                                                      (get_local $0)
                                                       (get_local $1)
+                                                      (get_local $0)
                                                     )
                                                     (i32.const 15)
                                                   )
@@ -12527,13 +12499,13 @@
                           )
                         )
                         (i32.store offset=28
-                          (get_local $6)
+                          (get_local $8)
                           (get_local $3)
                         )
                         (i32.store offset=4
                           (tee_local $0
                             (i32.add
-                              (get_local $6)
+                              (get_local $8)
                               (i32.const 16)
                             )
                           )
@@ -12546,7 +12518,7 @@
                         (if
                           (i32.eqz
                             (i32.and
-                              (tee_local $4
+                              (tee_local $1
                                 (i32.load
                                   (i32.const 180)
                                 )
@@ -12563,32 +12535,32 @@
                             (i32.store
                               (i32.const 180)
                               (i32.or
-                                (get_local $4)
+                                (get_local $1)
                                 (get_local $0)
                               )
                             )
                             (i32.store
-                              (get_local $1)
-                              (get_local $6)
+                              (get_local $2)
+                              (get_local $8)
                             )
                             (i32.store offset=24
-                              (get_local $6)
-                              (get_local $1)
+                              (get_local $8)
+                              (get_local $2)
                             )
                             (i32.store offset=12
-                              (get_local $6)
-                              (get_local $6)
+                              (get_local $8)
+                              (get_local $8)
                             )
                             (i32.store offset=8
-                              (get_local $6)
-                              (get_local $6)
+                              (get_local $8)
+                              (get_local $8)
                             )
                             (br $do-once48)
                           )
                         )
                         (set_local $3
                           (i32.shl
-                            (get_local $2)
+                            (get_local $4)
                             (select
                               (i32.const 0)
                               (i32.sub
@@ -12607,7 +12579,7 @@
                         )
                         (set_local $0
                           (i32.load
-                            (get_local $1)
+                            (get_local $2)
                           )
                         )
                         (block $jumpthreading$outer$6
@@ -12622,59 +12594,52 @@
                                       )
                                       (i32.const -8)
                                     )
-                                    (get_local $2)
+                                    (get_local $4)
                                   )
                                 )
-                                (set_local $1
+                                (set_local $2
                                   (i32.shl
                                     (get_local $3)
                                     (i32.const 1)
                                   )
                                 )
-                                (if
-                                  (tee_local $4
-                                    (i32.load
-                                      (tee_local $3
-                                        (i32.add
+                                (br_if $jumpthreading$inner$5
+                                  (i32.eqz
+                                    (tee_local $1
+                                      (i32.load
+                                        (tee_local $3
                                           (i32.add
-                                            (get_local $0)
-                                            (i32.const 16)
-                                          )
-                                          (i32.shl
-                                            (i32.shr_u
-                                              (get_local $3)
-                                              (i32.const 31)
+                                            (i32.add
+                                              (get_local $0)
+                                              (i32.const 16)
                                             )
-                                            (i32.const 2)
+                                            (i32.shl
+                                              (i32.shr_u
+                                                (get_local $3)
+                                                (i32.const 31)
+                                              )
+                                              (i32.const 2)
+                                            )
                                           )
                                         )
                                       )
                                     )
                                   )
-                                  (block
-                                    (set_local $3
-                                      (get_local $1)
-                                    )
-                                    (set_local $0
-                                      (get_local $4)
-                                    )
-                                    (br $while-in68)
+                                )
+                                (block
+                                  (set_local $3
+                                    (get_local $2)
                                   )
-                                  (block
-                                    (set_local $1
-                                      (get_local $0)
-                                    )
-                                    (set_local $0
-                                      (get_local $3)
-                                    )
-                                    (br $jumpthreading$inner$5)
+                                  (set_local $0
+                                    (get_local $1)
                                   )
+                                  (br $while-in68)
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $0)
+                                (get_local $3)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -12682,20 +12647,20 @@
                               (call $_abort)
                               (block
                                 (i32.store
-                                  (get_local $0)
-                                  (get_local $6)
+                                  (get_local $3)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=24
-                                  (get_local $6)
-                                  (get_local $1)
+                                  (get_local $8)
+                                  (get_local $0)
                                 )
                                 (i32.store offset=12
-                                  (get_local $6)
-                                  (get_local $6)
+                                  (get_local $8)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=8
-                                  (get_local $6)
-                                  (get_local $6)
+                                  (get_local $8)
+                                  (get_local $8)
                                 )
                                 (br $do-once48)
                               )
@@ -12705,9 +12670,9 @@
                           (if
                             (i32.and
                               (i32.ge_u
-                                (tee_local $3
+                                (tee_local $2
                                   (i32.load
-                                    (tee_local $1
+                                    (tee_local $3
                                       (i32.add
                                         (get_local $0)
                                         (i32.const 8)
@@ -12715,7 +12680,7 @@
                                     )
                                   )
                                 )
-                                (tee_local $2
+                                (tee_local $1
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -12723,28 +12688,28 @@
                               )
                               (i32.ge_u
                                 (get_local $0)
-                                (get_local $2)
+                                (get_local $1)
                               )
                             )
                             (block
                               (i32.store offset=12
-                                (get_local $3)
-                                (get_local $6)
+                                (get_local $2)
+                                (get_local $8)
                               )
                               (i32.store
-                                (get_local $1)
-                                (get_local $6)
+                                (get_local $3)
+                                (get_local $8)
                               )
                               (i32.store offset=8
-                                (get_local $6)
-                                (get_local $3)
+                                (get_local $8)
+                                (get_local $2)
                               )
                               (i32.store offset=12
-                                (get_local $6)
+                                (get_local $8)
                                 (get_local $0)
                               )
                               (i32.store offset=24
-                                (get_local $6)
+                                (get_local $8)
                                 (i32.const 0)
                               )
                             )
@@ -12756,7 +12721,7 @@
                   )
                   (return
                     (i32.add
-                      (get_local $9)
+                      (get_local $6)
                       (i32.const 8)
                     )
                   )
@@ -12767,24 +12732,24 @@
               (block $while-out69
                 (if
                   (i32.le_u
-                    (tee_local $3
+                    (tee_local $2
                       (i32.load
                         (get_local $4)
                       )
                     )
-                    (get_local $7)
+                    (get_local $9)
                   )
                   (br_if $while-out69
                     (i32.gt_u
-                      (tee_local $3
+                      (tee_local $2
                         (i32.add
-                          (get_local $3)
+                          (get_local $2)
                           (i32.load offset=4
                             (get_local $4)
                           )
                         )
                       )
-                      (get_local $7)
+                      (get_local $9)
                     )
                   )
                 )
@@ -12796,22 +12761,22 @@
                 (br $while-in70)
               )
             )
-            (set_local $5
+            (set_local $7
               (i32.add
                 (tee_local $4
                   (i32.add
-                    (get_local $3)
+                    (get_local $2)
                     (i32.const -47)
                   )
                 )
                 (i32.const 8)
               )
             )
-            (set_local $8
+            (set_local $5
               (i32.add
-                (tee_local $9
+                (tee_local $11
                   (select
-                    (get_local $7)
+                    (get_local $9)
                     (tee_local $4
                       (i32.add
                         (get_local $4)
@@ -12819,13 +12784,13 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (get_local $5)
+                              (get_local $7)
                             )
                             (i32.const 7)
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $5)
+                            (get_local $7)
                             (i32.const 7)
                           )
                         )
@@ -12833,9 +12798,9 @@
                     )
                     (i32.lt_u
                       (get_local $4)
-                      (tee_local $6
+                      (tee_local $7
                         (i32.add
-                          (get_local $7)
+                          (get_local $9)
                           (i32.const 16)
                         )
                       )
@@ -12847,9 +12812,9 @@
             )
             (i32.store
               (i32.const 200)
-              (tee_local $5
+              (tee_local $6
                 (i32.add
-                  (get_local $2)
+                  (get_local $3)
                   (tee_local $4
                     (select
                       (i32.and
@@ -12857,7 +12822,7 @@
                           (i32.const 0)
                           (tee_local $4
                             (i32.add
-                              (get_local $2)
+                              (get_local $3)
                               (i32.const 8)
                             )
                           )
@@ -12887,7 +12852,7 @@
               )
             )
             (i32.store offset=4
-              (get_local $5)
+              (get_local $6)
               (i32.or
                 (get_local $4)
                 (i32.const 1)
@@ -12895,7 +12860,7 @@
             )
             (i32.store offset=4
               (i32.add
-                (get_local $5)
+                (get_local $6)
                 (get_local $4)
               )
               (i32.const 40)
@@ -12909,39 +12874,39 @@
             (i32.store
               (tee_local $4
                 (i32.add
-                  (get_local $9)
+                  (get_local $11)
                   (i32.const 4)
                 )
               )
               (i32.const 27)
             )
             (i32.store
-              (get_local $8)
+              (get_local $5)
               (i32.load
                 (i32.const 624)
               )
             )
             (i32.store offset=4
-              (get_local $8)
+              (get_local $5)
               (i32.load
                 (i32.const 628)
               )
             )
             (i32.store offset=8
-              (get_local $8)
+              (get_local $5)
               (i32.load
                 (i32.const 632)
               )
             )
             (i32.store offset=12
-              (get_local $8)
+              (get_local $5)
               (i32.load
                 (i32.const 636)
               )
             )
             (i32.store
               (i32.const 624)
-              (get_local $2)
+              (get_local $3)
             )
             (i32.store
               (i32.const 628)
@@ -12953,11 +12918,11 @@
             )
             (i32.store
               (i32.const 632)
-              (get_local $8)
+              (get_local $5)
             )
             (set_local $1
               (i32.add
-                (get_local $9)
+                (get_local $11)
                 (i32.const 24)
               )
             )
@@ -12977,14 +12942,14 @@
                     (get_local $1)
                     (i32.const 4)
                   )
-                  (get_local $3)
+                  (get_local $2)
                 )
               )
             )
             (if
               (i32.ne
+                (get_local $11)
                 (get_local $9)
-                (get_local $7)
               )
               (block
                 (i32.store
@@ -12997,39 +12962,39 @@
                   )
                 )
                 (i32.store offset=4
-                  (get_local $7)
+                  (get_local $9)
                   (i32.or
-                    (tee_local $5
+                    (tee_local $6
                       (i32.sub
+                        (get_local $11)
                         (get_local $9)
-                        (get_local $7)
                       )
                     )
                     (i32.const 1)
                   )
                 )
                 (i32.store
-                  (get_local $9)
-                  (get_local $5)
+                  (get_local $11)
+                  (get_local $6)
                 )
-                (set_local $2
+                (set_local $1
                   (i32.shr_u
-                    (get_local $5)
+                    (get_local $6)
                     (i32.const 3)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $5)
+                    (get_local $6)
                     (i32.const 256)
                   )
                   (block
-                    (set_local $1
+                    (set_local $2
                       (i32.add
                         (i32.const 216)
                         (i32.shl
                           (i32.shl
-                            (get_local $2)
+                            (get_local $1)
                             (i32.const 1)
                           )
                           (i32.const 2)
@@ -13043,20 +13008,20 @@
                             (i32.const 176)
                           )
                         )
-                        (tee_local $2
+                        (tee_local $1
                           (i32.shl
                             (i32.const 1)
-                            (get_local $2)
+                            (get_local $1)
                           )
                         )
                       )
                       (if
                         (i32.lt_u
-                          (tee_local $2
+                          (tee_local $1
                             (i32.load
                               (tee_local $3
                                 (i32.add
-                                  (get_local $1)
+                                  (get_local $2)
                                   (i32.const 8)
                                 )
                               )
@@ -13071,8 +13036,8 @@
                           (set_local $23
                             (get_local $3)
                           )
-                          (set_local $18
-                            (get_local $2)
+                          (set_local $12
+                            (get_local $1)
                           )
                         )
                       )
@@ -13081,61 +13046,61 @@
                           (i32.const 176)
                           (i32.or
                             (get_local $3)
-                            (get_local $2)
+                            (get_local $1)
                           )
                         )
                         (set_local $23
                           (i32.add
-                            (get_local $1)
+                            (get_local $2)
                             (i32.const 8)
                           )
                         )
-                        (set_local $18
-                          (get_local $1)
+                        (set_local $12
+                          (get_local $2)
                         )
                       )
                     )
                     (i32.store
                       (get_local $23)
-                      (get_local $7)
+                      (get_local $9)
                     )
                     (i32.store offset=12
-                      (get_local $18)
-                      (get_local $7)
+                      (get_local $12)
+                      (get_local $9)
                     )
                     (i32.store offset=8
-                      (get_local $7)
-                      (get_local $18)
+                      (get_local $9)
+                      (get_local $12)
                     )
                     (i32.store offset=12
-                      (get_local $7)
-                      (get_local $1)
+                      (get_local $9)
+                      (get_local $2)
                     )
                     (br $do-once40)
                   )
                 )
-                (set_local $2
+                (set_local $4
                   (i32.add
                     (i32.const 480)
                     (i32.shl
-                      (tee_local $3
+                      (tee_local $2
                         (if i32
                           (tee_local $1
                             (i32.shr_u
-                              (get_local $5)
+                              (get_local $6)
                               (i32.const 8)
                             )
                           )
                           (if i32
                             (i32.gt_u
-                              (get_local $5)
+                              (get_local $6)
                               (i32.const 16777215)
                             )
                             (i32.const 31)
                             (i32.or
                               (i32.and
                                 (i32.shr_u
-                                  (get_local $5)
+                                  (get_local $6)
                                   (i32.add
                                     (tee_local $1
                                       (i32.add
@@ -13143,14 +13108,14 @@
                                           (i32.const 14)
                                           (i32.or
                                             (i32.or
-                                              (tee_local $2
+                                              (tee_local $1
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (tee_local $1
+                                                      (tee_local $3
                                                         (i32.shl
                                                           (get_local $1)
-                                                          (tee_local $3
+                                                          (tee_local $2
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
@@ -13171,16 +13136,16 @@
                                                   (i32.const 4)
                                                 )
                                               )
-                                              (get_local $3)
+                                              (get_local $2)
                                             )
-                                            (tee_local $2
+                                            (tee_local $1
                                               (i32.and
                                                 (i32.shr_u
                                                   (i32.add
-                                                    (tee_local $1
+                                                    (tee_local $3
                                                       (i32.shl
+                                                        (get_local $3)
                                                         (get_local $1)
-                                                        (get_local $2)
                                                       )
                                                     )
                                                     (i32.const 245760)
@@ -13194,8 +13159,8 @@
                                         )
                                         (i32.shr_u
                                           (i32.shl
+                                            (get_local $3)
                                             (get_local $1)
-                                            (get_local $2)
                                           )
                                           (i32.const 15)
                                         )
@@ -13220,21 +13185,21 @@
                   )
                 )
                 (i32.store offset=28
-                  (get_local $7)
-                  (get_local $3)
+                  (get_local $9)
+                  (get_local $2)
                 )
                 (i32.store offset=20
-                  (get_local $7)
+                  (get_local $9)
                   (i32.const 0)
                 )
                 (i32.store
-                  (get_local $6)
+                  (get_local $7)
                   (i32.const 0)
                 )
                 (if
                   (i32.eqz
                     (i32.and
-                      (tee_local $4
+                      (tee_local $3
                         (i32.load
                           (i32.const 180)
                         )
@@ -13242,7 +13207,7 @@
                       (tee_local $1
                         (i32.shl
                           (i32.const 1)
-                          (get_local $3)
+                          (get_local $2)
                         )
                       )
                     )
@@ -13251,43 +13216,43 @@
                     (i32.store
                       (i32.const 180)
                       (i32.or
-                        (get_local $4)
+                        (get_local $3)
                         (get_local $1)
                       )
                     )
                     (i32.store
-                      (get_local $2)
-                      (get_local $7)
+                      (get_local $4)
+                      (get_local $9)
                     )
                     (i32.store offset=24
-                      (get_local $7)
-                      (get_local $2)
+                      (get_local $9)
+                      (get_local $4)
                     )
                     (i32.store offset=12
-                      (get_local $7)
-                      (get_local $7)
+                      (get_local $9)
+                      (get_local $9)
                     )
                     (i32.store offset=8
-                      (get_local $7)
-                      (get_local $7)
+                      (get_local $9)
+                      (get_local $9)
                     )
                     (br $do-once40)
                   )
                 )
-                (set_local $3
+                (set_local $2
                   (i32.shl
-                    (get_local $5)
+                    (get_local $6)
                     (select
                       (i32.const 0)
                       (i32.sub
                         (i32.const 25)
                         (i32.shr_u
-                          (get_local $3)
+                          (get_local $2)
                           (i32.const 1)
                         )
                       )
                       (i32.eq
-                        (get_local $3)
+                        (get_local $2)
                         (i32.const 31)
                       )
                     )
@@ -13295,7 +13260,7 @@
                 )
                 (set_local $1
                   (i32.load
-                    (get_local $2)
+                    (get_local $4)
                   )
                 )
                 (block $jumpthreading$outer$8
@@ -13310,59 +13275,52 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $5)
+                            (get_local $6)
                           )
                         )
-                        (set_local $2
+                        (set_local $4
                           (i32.shl
-                            (get_local $3)
+                            (get_local $2)
                             (i32.const 1)
                           )
                         )
-                        (if
-                          (tee_local $4
-                            (i32.load
-                              (tee_local $3
-                                (i32.add
+                        (br_if $jumpthreading$inner$7
+                          (i32.eqz
+                            (tee_local $3
+                              (i32.load
+                                (tee_local $2
                                   (i32.add
-                                    (get_local $1)
-                                    (i32.const 16)
-                                  )
-                                  (i32.shl
-                                    (i32.shr_u
-                                      (get_local $3)
-                                      (i32.const 31)
+                                    (i32.add
+                                      (get_local $1)
+                                      (i32.const 16)
                                     )
-                                    (i32.const 2)
+                                    (i32.shl
+                                      (i32.shr_u
+                                        (get_local $2)
+                                        (i32.const 31)
+                                      )
+                                      (i32.const 2)
+                                    )
                                   )
                                 )
                               )
                             )
                           )
-                          (block
-                            (set_local $3
-                              (get_local $2)
-                            )
-                            (set_local $1
-                              (get_local $4)
-                            )
-                            (br $while-in74)
+                        )
+                        (block
+                          (set_local $2
+                            (get_local $4)
                           )
-                          (block
-                            (set_local $2
-                              (get_local $1)
-                            )
-                            (set_local $1
-                              (get_local $3)
-                            )
-                            (br $jumpthreading$inner$7)
+                          (set_local $1
+                            (get_local $3)
                           )
+                          (br $while-in74)
                         )
                       )
                     )
                     (if
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $2)
                         (i32.load
                           (i32.const 192)
                         )
@@ -13370,20 +13328,20 @@
                       (call $_abort)
                       (block
                         (i32.store
-                          (get_local $1)
-                          (get_local $7)
+                          (get_local $2)
+                          (get_local $9)
                         )
                         (i32.store offset=24
-                          (get_local $7)
-                          (get_local $2)
+                          (get_local $9)
+                          (get_local $1)
                         )
                         (i32.store offset=12
-                          (get_local $7)
-                          (get_local $7)
+                          (get_local $9)
+                          (get_local $9)
                         )
                         (i32.store offset=8
-                          (get_local $7)
-                          (get_local $7)
+                          (get_local $9)
+                          (get_local $9)
                         )
                         (br $do-once40)
                       )
@@ -13417,22 +13375,22 @@
                     (block
                       (i32.store offset=12
                         (get_local $4)
-                        (get_local $7)
+                        (get_local $9)
                       )
                       (i32.store
                         (get_local $2)
-                        (get_local $7)
+                        (get_local $9)
                       )
                       (i32.store offset=8
-                        (get_local $7)
+                        (get_local $9)
                         (get_local $4)
                       )
                       (i32.store offset=12
-                        (get_local $7)
+                        (get_local $9)
                         (get_local $1)
                       )
                       (i32.store offset=24
-                        (get_local $7)
+                        (get_local $9)
                         (i32.const 0)
                       )
                     )
@@ -13446,25 +13404,25 @@
             (if
               (i32.or
                 (i32.eqz
-                  (tee_local $3
+                  (tee_local $2
                     (i32.load
                       (i32.const 192)
                     )
                   )
                 )
                 (i32.lt_u
-                  (get_local $2)
                   (get_local $3)
+                  (get_local $2)
                 )
               )
               (i32.store
                 (i32.const 192)
-                (get_local $2)
+                (get_local $3)
               )
             )
             (i32.store
               (i32.const 624)
-              (get_local $2)
+              (get_local $3)
             )
             (i32.store
               (i32.const 628)
@@ -13484,7 +13442,7 @@
               (i32.const 208)
               (i32.const -1)
             )
-            (set_local $3
+            (set_local $2
               (i32.const 0)
             )
             (loop $while-in43
@@ -13494,7 +13452,7 @@
                     (i32.const 216)
                     (i32.shl
                       (i32.shl
-                        (get_local $3)
+                        (get_local $2)
                         (i32.const 1)
                       )
                       (i32.const 2)
@@ -13509,9 +13467,9 @@
               )
               (br_if $while-in43
                 (i32.ne
-                  (tee_local $3
+                  (tee_local $2
                     (i32.add
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const 1)
                     )
                   )
@@ -13521,17 +13479,17 @@
             )
             (i32.store
               (i32.const 200)
-              (tee_local $3
+              (tee_local $2
                 (i32.add
-                  (get_local $2)
-                  (tee_local $2
+                  (get_local $3)
+                  (tee_local $3
                     (select
                       (i32.and
                         (i32.sub
                           (i32.const 0)
-                          (tee_local $2
+                          (tee_local $3
                             (i32.add
-                              (get_local $2)
+                              (get_local $3)
                               (i32.const 8)
                             )
                           )
@@ -13540,7 +13498,7 @@
                       )
                       (i32.const 0)
                       (i32.and
-                        (get_local $2)
+                        (get_local $3)
                         (i32.const 7)
                       )
                     )
@@ -13556,12 +13514,12 @@
                     (get_local $1)
                     (i32.const -40)
                   )
-                  (get_local $2)
+                  (get_local $3)
                 )
               )
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
                 (get_local $1)
                 (i32.const 1)
@@ -13569,7 +13527,7 @@
             )
             (i32.store offset=4
               (i32.add
-                (get_local $3)
+                (get_local $2)
                 (get_local $1)
               )
               (i32.const 40)
@@ -13595,7 +13553,7 @@
         (block
           (i32.store
             (i32.const 188)
-            (tee_local $1
+            (tee_local $3
               (i32.sub
                 (get_local $1)
                 (get_local $0)
@@ -13604,9 +13562,9 @@
           )
           (i32.store
             (i32.const 200)
-            (tee_local $2
+            (tee_local $1
               (i32.add
-                (tee_local $3
+                (tee_local $2
                   (i32.load
                     (i32.const 200)
                   )
@@ -13616,14 +13574,14 @@
             )
           )
           (i32.store offset=4
-            (get_local $2)
+            (get_local $1)
             (i32.or
-              (get_local $1)
+              (get_local $3)
               (i32.const 1)
             )
           )
           (i32.store offset=4
-            (get_local $3)
+            (get_local $2)
             (i32.or
               (get_local $0)
               (i32.const 3)
@@ -13631,7 +13589,7 @@
           )
           (return
             (i32.add
-              (get_local $3)
+              (get_local $2)
               (i32.const 8)
             )
           )
@@ -13668,7 +13626,7 @@
     )
     (if
       (i32.lt_u
-        (tee_local $2
+        (tee_local $1
           (i32.add
             (get_local $0)
             (i32.const -8)
@@ -13684,9 +13642,9 @@
     )
     (if
       (i32.eq
-        (tee_local $10
+        (tee_local $5
           (i32.and
-            (tee_local $3
+            (tee_local $7
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -13701,12 +13659,12 @@
       )
       (call $_abort)
     )
-    (set_local $6
+    (set_local $8
       (i32.add
-        (get_local $2)
+        (get_local $1)
         (tee_local $0
           (i32.and
-            (get_local $3)
+            (get_local $7)
             (i32.const -8)
           )
         )
@@ -13715,43 +13673,43 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $3)
+          (get_local $7)
           (i32.const 1)
         )
         (block
-          (set_local $4
-            (get_local $2)
+          (set_local $3
+            (get_local $1)
           )
-          (set_local $1
+          (set_local $4
             (get_local $0)
           )
         )
         (block
-          (set_local $8
+          (set_local $7
             (i32.load
-              (get_local $2)
+              (get_local $1)
             )
           )
           (if
             (i32.eqz
-              (get_local $10)
+              (get_local $5)
             )
             (return)
           )
-          (set_local $3
+          (set_local $0
             (i32.add
-              (get_local $8)
+              (get_local $7)
               (get_local $0)
             )
           )
           (if
             (i32.lt_u
-              (tee_local $0
+              (tee_local $1
                 (i32.add
-                  (get_local $2)
+                  (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $8)
+                    (get_local $7)
                   )
                 )
               )
@@ -13761,7 +13719,7 @@
           )
           (if
             (i32.eq
-              (get_local $0)
+              (get_local $1)
               (i32.load
                 (i32.const 196)
               )
@@ -13770,11 +13728,11 @@
               (if
                 (i32.ne
                   (i32.and
-                    (tee_local $1
+                    (tee_local $4
                       (i32.load
-                        (tee_local $4
+                        (tee_local $3
                           (i32.add
-                            (get_local $6)
+                            (get_local $8)
                             (i32.const 4)
                           )
                         )
@@ -13785,73 +13743,73 @@
                   (i32.const 3)
                 )
                 (block
+                  (set_local $3
+                    (get_local $1)
+                  )
                   (set_local $4
                     (get_local $0)
-                  )
-                  (set_local $1
-                    (get_local $3)
                   )
                   (br $do-once)
                 )
               )
               (i32.store
                 (i32.const 184)
-                (get_local $3)
+                (get_local $0)
               )
               (i32.store
-                (get_local $4)
+                (get_local $3)
                 (i32.and
-                  (get_local $1)
+                  (get_local $4)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $0)
+                (get_local $1)
                 (i32.or
-                  (get_local $3)
+                  (get_local $0)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
+                  (get_local $1)
                   (get_local $0)
-                  (get_local $3)
                 )
-                (get_local $3)
+                (get_local $0)
               )
               (return)
             )
           )
-          (set_local $10
+          (set_local $5
             (i32.shr_u
-              (get_local $8)
+              (get_local $7)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $8)
+              (get_local $7)
               (i32.const 256)
             )
             (block
-              (set_local $2
+              (set_local $6
                 (i32.load offset=12
-                  (get_local $0)
+                  (get_local $1)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $4
+                  (tee_local $3
                     (i32.load offset=8
-                      (get_local $0)
+                      (get_local $1)
                     )
                   )
-                  (tee_local $1
+                  (tee_local $4
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $10)
+                          (get_local $5)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -13862,7 +13820,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $4)
+                      (get_local $3)
                       (get_local $11)
                     )
                     (call $_abort)
@@ -13870,9 +13828,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $4)
+                        (get_local $3)
                       )
-                      (get_local $0)
+                      (get_local $1)
                     )
                     (call $_abort)
                   )
@@ -13880,8 +13838,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $2)
-                  (get_local $4)
+                  (get_local $6)
+                  (get_local $3)
                 )
                 (block
                   (i32.store
@@ -13893,36 +13851,36 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $10)
+                          (get_local $5)
                         )
                         (i32.const -1)
                       )
                     )
                   )
+                  (set_local $3
+                    (get_local $1)
+                  )
                   (set_local $4
                     (get_local $0)
-                  )
-                  (set_local $1
-                    (get_local $3)
                   )
                   (br $do-once)
                 )
               )
               (if
                 (i32.eq
-                  (get_local $2)
-                  (get_local $1)
+                  (get_local $6)
+                  (get_local $4)
                 )
-                (set_local $5
+                (set_local $2
                   (i32.add
-                    (get_local $2)
+                    (get_local $6)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $2)
+                      (get_local $6)
                       (get_local $11)
                     )
                     (call $_abort)
@@ -13930,42 +13888,42 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $1
+                        (tee_local $4
                           (i32.add
-                            (get_local $2)
+                            (get_local $6)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $0)
-                    )
-                    (set_local $5
                       (get_local $1)
+                    )
+                    (set_local $2
+                      (get_local $4)
                     )
                     (call $_abort)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $4)
-                (get_local $2)
+                (get_local $3)
+                (get_local $6)
               )
               (i32.store
-                (get_local $5)
-                (get_local $4)
+                (get_local $2)
+                (get_local $3)
+              )
+              (set_local $3
+                (get_local $1)
               )
               (set_local $4
                 (get_local $0)
-              )
-              (set_local $1
-                (get_local $3)
               )
               (br $do-once)
             )
           )
           (set_local $12
             (i32.load offset=24
-              (get_local $0)
+              (get_local $1)
             )
           )
           (block $do-once0
@@ -13973,21 +13931,21 @@
               (i32.eq
                 (tee_local $2
                   (i32.load offset=12
-                    (get_local $0)
+                    (get_local $1)
                   )
                 )
-                (get_local $0)
+                (get_local $1)
               )
               (block
                 (if
                   (i32.eqz
-                    (tee_local $2
+                    (tee_local $5
                       (i32.load
-                        (tee_local $5
+                        (tee_local $2
                           (i32.add
-                            (tee_local $8
+                            (tee_local $7
                               (i32.add
-                                (get_local $0)
+                                (get_local $1)
                                 (i32.const 16)
                               )
                             )
@@ -13998,16 +13956,16 @@
                     )
                   )
                   (if
-                    (tee_local $2
+                    (tee_local $5
                       (i32.load
-                        (get_local $8)
+                        (get_local $7)
                       )
                     )
-                    (set_local $5
-                      (get_local $8)
+                    (set_local $2
+                      (get_local $7)
                     )
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.const 0)
                       )
                       (br $do-once0)
@@ -14016,42 +13974,42 @@
                 )
                 (loop $while-in
                   (if
-                    (tee_local $8
+                    (tee_local $7
                       (i32.load
                         (tee_local $10
                           (i32.add
-                            (get_local $2)
+                            (get_local $5)
                             (i32.const 20)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $2
-                        (get_local $8)
-                      )
                       (set_local $5
+                        (get_local $7)
+                      )
+                      (set_local $2
                         (get_local $10)
                       )
                       (br $while-in)
                     )
                   )
                   (if
-                    (tee_local $8
+                    (tee_local $7
                       (i32.load
                         (tee_local $10
                           (i32.add
-                            (get_local $2)
+                            (get_local $5)
                             (i32.const 16)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $2
-                        (get_local $8)
-                      )
                       (set_local $5
+                        (get_local $7)
+                      )
+                      (set_local $2
                         (get_local $10)
                       )
                       (br $while-in)
@@ -14060,17 +14018,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $5)
+                    (get_local $2)
                     (get_local $11)
                   )
                   (call $_abort)
                   (block
                     (i32.store
-                      (get_local $5)
+                      (get_local $2)
                       (i32.const 0)
                     )
-                    (set_local $7
-                      (get_local $2)
+                    (set_local $6
+                      (get_local $5)
                     )
                   )
                 )
@@ -14078,9 +14036,9 @@
               (block
                 (if
                   (i32.lt_u
-                    (tee_local $5
+                    (tee_local $10
                       (i32.load offset=8
-                        (get_local $0)
+                        (get_local $1)
                       )
                     )
                     (get_local $11)
@@ -14090,39 +14048,39 @@
                 (if
                   (i32.ne
                     (i32.load
-                      (tee_local $8
+                      (tee_local $7
                         (i32.add
-                          (get_local $5)
+                          (get_local $10)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $1)
                   )
                   (call $_abort)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $10
+                      (tee_local $5
                         (i32.add
                           (get_local $2)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $1)
                   )
                   (block
                     (i32.store
-                      (get_local $8)
+                      (get_local $7)
                       (get_local $2)
                     )
                     (i32.store
-                      (get_local $10)
                       (get_local $5)
+                      (get_local $10)
                     )
-                    (set_local $7
+                    (set_local $6
                       (get_local $2)
                     )
                   )
@@ -14136,15 +14094,15 @@
             (block
               (if
                 (i32.eq
-                  (get_local $0)
+                  (get_local $1)
                   (i32.load
-                    (tee_local $5
+                    (tee_local $2
                       (i32.add
                         (i32.const 480)
                         (i32.shl
-                          (tee_local $2
+                          (tee_local $5
                             (i32.load offset=28
-                              (get_local $0)
+                              (get_local $1)
                             )
                           )
                           (i32.const 2)
@@ -14155,12 +14113,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $5)
-                    (get_local $7)
+                    (get_local $2)
+                    (get_local $6)
                   )
                   (if
                     (i32.eqz
-                      (get_local $7)
+                      (get_local $6)
                     )
                     (block
                       (i32.store
@@ -14172,17 +14130,17 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $2)
+                              (get_local $5)
                             )
                             (i32.const -1)
                           )
                         )
                       )
+                      (set_local $3
+                        (get_local $1)
+                      )
                       (set_local $4
                         (get_local $0)
-                      )
-                      (set_local $1
-                        (get_local $3)
                       )
                       (br $do-once)
                     )
@@ -14208,27 +14166,27 @@
                           )
                         )
                       )
-                      (get_local $0)
+                      (get_local $1)
                     )
                     (i32.store
                       (get_local $2)
-                      (get_local $7)
+                      (get_local $6)
                     )
                     (i32.store offset=20
                       (get_local $12)
-                      (get_local $7)
+                      (get_local $6)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $7)
+                      (get_local $6)
                     )
                     (block
+                      (set_local $3
+                        (get_local $1)
+                      )
                       (set_local $4
                         (get_local $0)
-                      )
-                      (set_local $1
-                        (get_local $3)
                       )
                       (br $do-once)
                     )
@@ -14237,8 +14195,8 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $7)
-                  (tee_local $2
+                  (get_local $6)
+                  (tee_local $5
                     (i32.load
                       (i32.const 192)
                     )
@@ -14247,15 +14205,15 @@
                 (call $_abort)
               )
               (i32.store offset=24
-                (get_local $7)
+                (get_local $6)
                 (get_local $12)
               )
               (if
-                (tee_local $5
+                (tee_local $7
                   (i32.load
-                    (tee_local $8
+                    (tee_local $2
                       (i32.add
-                        (get_local $0)
+                        (get_local $1)
                         (i32.const 16)
                       )
                     )
@@ -14263,18 +14221,18 @@
                 )
                 (if
                   (i32.lt_u
+                    (get_local $7)
                     (get_local $5)
-                    (get_local $2)
                   )
                   (call $_abort)
                   (block
                     (i32.store offset=16
+                      (get_local $6)
                       (get_local $7)
-                      (get_local $5)
                     )
                     (i32.store offset=24
-                      (get_local $5)
                       (get_local $7)
+                      (get_local $6)
                     )
                   )
                 )
@@ -14282,7 +14240,7 @@
               (if
                 (tee_local $2
                   (i32.load offset=4
-                    (get_local $8)
+                    (get_local $2)
                   )
                 )
                 (if
@@ -14295,37 +14253,37 @@
                   (call $_abort)
                   (block
                     (i32.store offset=20
-                      (get_local $7)
+                      (get_local $6)
                       (get_local $2)
                     )
                     (i32.store offset=24
                       (get_local $2)
-                      (get_local $7)
+                      (get_local $6)
+                    )
+                    (set_local $3
+                      (get_local $1)
                     )
                     (set_local $4
                       (get_local $0)
                     )
-                    (set_local $1
-                      (get_local $3)
-                    )
                   )
                 )
                 (block
+                  (set_local $3
+                    (get_local $1)
+                  )
                   (set_local $4
                     (get_local $0)
-                  )
-                  (set_local $1
-                    (get_local $3)
                   )
                 )
               )
             )
             (block
+              (set_local $3
+                (get_local $1)
+              )
               (set_local $4
                 (get_local $0)
-              )
-              (set_local $1
-                (get_local $3)
               )
             )
           )
@@ -14334,19 +14292,19 @@
     )
     (if
       (i32.ge_u
-        (get_local $4)
-        (get_local $6)
+        (get_local $3)
+        (get_local $8)
       )
       (call $_abort)
     )
     (if
       (i32.eqz
         (i32.and
-          (tee_local $0
+          (tee_local $1
             (i32.load
-              (tee_local $3
+              (tee_local $0
                 (i32.add
-                  (get_local $6)
+                  (get_local $8)
                   (i32.const 4)
                 )
               )
@@ -14359,36 +14317,36 @@
     )
     (if
       (i32.and
-        (get_local $0)
+        (get_local $1)
         (i32.const 2)
       )
       (block
         (i32.store
-          (get_local $3)
+          (get_local $0)
           (i32.and
-            (get_local $0)
+            (get_local $1)
             (i32.const -2)
           )
         )
         (i32.store offset=4
-          (get_local $4)
+          (get_local $3)
           (i32.or
-            (get_local $1)
+            (get_local $4)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
+            (get_local $3)
             (get_local $4)
-            (get_local $1)
           )
-          (get_local $1)
+          (get_local $4)
         )
       )
       (block
         (if
           (i32.eq
-            (get_local $6)
+            (get_local $8)
             (i32.load
               (i32.const 200)
             )
@@ -14401,16 +14359,16 @@
                   (i32.load
                     (i32.const 188)
                   )
-                  (get_local $1)
+                  (get_local $4)
                 )
               )
             )
             (i32.store
               (i32.const 200)
-              (get_local $4)
+              (get_local $3)
             )
             (i32.store offset=4
-              (get_local $4)
+              (get_local $3)
               (i32.or
                 (get_local $0)
                 (i32.const 1)
@@ -14418,7 +14376,7 @@
             )
             (if
               (i32.ne
-                (get_local $4)
+                (get_local $3)
                 (i32.load
                   (i32.const 196)
                 )
@@ -14438,7 +14396,7 @@
         )
         (if
           (i32.eq
-            (get_local $6)
+            (get_local $8)
             (i32.load
               (i32.const 196)
             )
@@ -14451,16 +14409,16 @@
                   (i32.load
                     (i32.const 184)
                   )
-                  (get_local $1)
+                  (get_local $4)
                 )
               )
             )
             (i32.store
               (i32.const 196)
-              (get_local $4)
+              (get_local $3)
             )
             (i32.store offset=4
-              (get_local $4)
+              (get_local $3)
               (i32.or
                 (get_local $0)
                 (i32.const 1)
@@ -14468,7 +14426,7 @@
             )
             (i32.store
               (i32.add
-                (get_local $4)
+                (get_local $3)
                 (get_local $0)
               )
               (get_local $0)
@@ -14476,38 +14434,38 @@
             (return)
           )
         )
-        (set_local $2
+        (set_local $5
           (i32.add
             (i32.and
-              (get_local $0)
+              (get_local $1)
               (i32.const -8)
             )
-            (get_local $1)
+            (get_local $4)
           )
         )
-        (set_local $5
+        (set_local $4
           (i32.shr_u
-            (get_local $0)
+            (get_local $1)
             (i32.const 3)
           )
         )
         (block $do-once4
           (if
             (i32.lt_u
-              (get_local $0)
+              (get_local $1)
               (i32.const 256)
             )
             (block
-              (set_local $3
+              (set_local $2
                 (i32.load offset=12
-                  (get_local $6)
+                  (get_local $8)
                 )
               )
               (if
                 (i32.ne
                   (tee_local $1
                     (i32.load offset=8
-                      (get_local $6)
+                      (get_local $8)
                     )
                   )
                   (tee_local $0
@@ -14515,7 +14473,7 @@
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $5)
+                          (get_local $4)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -14538,7 +14496,7 @@
                       (i32.load offset=12
                         (get_local $1)
                       )
-                      (get_local $6)
+                      (get_local $8)
                     )
                     (call $_abort)
                   )
@@ -14546,7 +14504,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $3)
+                  (get_local $2)
                   (get_local $1)
                 )
                 (block
@@ -14559,7 +14517,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $5)
+                          (get_local $4)
                         )
                         (i32.const -1)
                       )
@@ -14570,19 +14528,19 @@
               )
               (if
                 (i32.eq
-                  (get_local $3)
+                  (get_local $2)
                   (get_local $0)
                 )
                 (set_local $14
                   (i32.add
-                    (get_local $3)
+                    (get_local $2)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $3)
+                      (get_local $2)
                       (i32.load
                         (i32.const 192)
                       )
@@ -14594,12 +14552,12 @@
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $3)
+                            (get_local $2)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $6)
+                      (get_local $8)
                     )
                     (set_local $14
                       (get_local $0)
@@ -14610,7 +14568,7 @@
               )
               (i32.store offset=12
                 (get_local $1)
-                (get_local $3)
+                (get_local $2)
               )
               (i32.store
                 (get_local $14)
@@ -14618,9 +14576,9 @@
               )
             )
             (block
-              (set_local $7
+              (set_local $6
                 (i32.load offset=24
-                  (get_local $6)
+                  (get_local $8)
                 )
               )
               (block $do-once6
@@ -14628,21 +14586,21 @@
                   (i32.eq
                     (tee_local $0
                       (i32.load offset=12
-                        (get_local $6)
+                        (get_local $8)
                       )
                     )
-                    (get_local $6)
+                    (get_local $8)
                   )
                   (block
                     (if
                       (i32.eqz
-                        (tee_local $0
+                        (tee_local $4
                           (i32.load
-                            (tee_local $1
+                            (tee_local $0
                               (i32.add
-                                (tee_local $3
+                                (tee_local $1
                                   (i32.add
-                                    (get_local $6)
+                                    (get_local $8)
                                     (i32.const 16)
                                   )
                                 )
@@ -14653,13 +14611,13 @@
                         )
                       )
                       (if
-                        (tee_local $0
+                        (tee_local $4
                           (i32.load
-                            (get_local $3)
+                            (get_local $1)
                           )
                         )
-                        (set_local $1
-                          (get_local $3)
+                        (set_local $0
+                          (get_local $1)
                         )
                         (block
                           (set_local $9
@@ -14671,43 +14629,43 @@
                     )
                     (loop $while-in9
                       (if
-                        (tee_local $3
+                        (tee_local $1
                           (i32.load
-                            (tee_local $5
+                            (tee_local $2
                               (i32.add
-                                (get_local $0)
+                                (get_local $4)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $0
-                            (get_local $3)
+                          (set_local $4
+                            (get_local $1)
                           )
-                          (set_local $1
-                            (get_local $5)
+                          (set_local $0
+                            (get_local $2)
                           )
                           (br $while-in9)
                         )
                       )
                       (if
-                        (tee_local $3
+                        (tee_local $1
                           (i32.load
-                            (tee_local $5
+                            (tee_local $2
                               (i32.add
-                                (get_local $0)
+                                (get_local $4)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $0
-                            (get_local $3)
+                          (set_local $4
+                            (get_local $1)
                           )
-                          (set_local $1
-                            (get_local $5)
+                          (set_local $0
+                            (get_local $2)
                           )
                           (br $while-in9)
                         )
@@ -14715,7 +14673,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $0)
                         (i32.load
                           (i32.const 192)
                         )
@@ -14723,11 +14681,11 @@
                       (call $_abort)
                       (block
                         (i32.store
-                          (get_local $1)
+                          (get_local $0)
                           (i32.const 0)
                         )
                         (set_local $9
-                          (get_local $0)
+                          (get_local $4)
                         )
                       )
                     )
@@ -14735,9 +14693,9 @@
                   (block
                     (if
                       (i32.lt_u
-                        (tee_local $1
+                        (tee_local $2
                           (i32.load offset=8
-                            (get_local $6)
+                            (get_local $8)
                           )
                         )
                         (i32.load
@@ -14749,37 +14707,37 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (tee_local $3
+                          (tee_local $1
                             (i32.add
-                              (get_local $1)
+                              (get_local $2)
                               (i32.const 12)
                             )
                           )
                         )
-                        (get_local $6)
+                        (get_local $8)
                       )
                       (call $_abort)
                     )
                     (if
                       (i32.eq
                         (i32.load
-                          (tee_local $5
+                          (tee_local $4
                             (i32.add
                               (get_local $0)
                               (i32.const 8)
                             )
                           )
                         )
-                        (get_local $6)
+                        (get_local $8)
                       )
                       (block
                         (i32.store
-                          (get_local $3)
+                          (get_local $1)
                           (get_local $0)
                         )
                         (i32.store
-                          (get_local $5)
-                          (get_local $1)
+                          (get_local $4)
+                          (get_local $2)
                         )
                         (set_local $9
                           (get_local $0)
@@ -14791,19 +14749,19 @@
                 )
               )
               (if
-                (get_local $7)
+                (get_local $6)
                 (block
                   (if
                     (i32.eq
-                      (get_local $6)
+                      (get_local $8)
                       (i32.load
-                        (tee_local $1
+                        (tee_local $0
                           (i32.add
                             (i32.const 480)
                             (i32.shl
-                              (tee_local $0
+                              (tee_local $4
                                 (i32.load offset=28
-                                  (get_local $6)
+                                  (get_local $8)
                                 )
                               )
                               (i32.const 2)
@@ -14814,7 +14772,7 @@
                     )
                     (block
                       (i32.store
-                        (get_local $1)
+                        (get_local $0)
                         (get_local $9)
                       )
                       (if
@@ -14831,7 +14789,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $0)
+                                  (get_local $4)
                                 )
                                 (i32.const -1)
                               )
@@ -14844,7 +14802,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $7)
+                          (get_local $6)
                           (i32.load
                             (i32.const 192)
                           )
@@ -14856,19 +14814,19 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $7)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                             )
                           )
-                          (get_local $6)
+                          (get_local $8)
                         )
                         (i32.store
                           (get_local $0)
                           (get_local $9)
                         )
                         (i32.store offset=20
-                          (get_local $7)
+                          (get_local $6)
                           (get_local $9)
                         )
                       )
@@ -14882,7 +14840,7 @@
                   (if
                     (i32.lt_u
                       (get_local $9)
-                      (tee_local $0
+                      (tee_local $4
                         (i32.load
                           (i32.const 192)
                         )
@@ -14892,14 +14850,14 @@
                   )
                   (i32.store offset=24
                     (get_local $9)
-                    (get_local $7)
+                    (get_local $6)
                   )
                   (if
                     (tee_local $1
                       (i32.load
-                        (tee_local $3
+                        (tee_local $0
                           (i32.add
-                            (get_local $6)
+                            (get_local $8)
                             (i32.const 16)
                           )
                         )
@@ -14908,7 +14866,7 @@
                     (if
                       (i32.lt_u
                         (get_local $1)
-                        (get_local $0)
+                        (get_local $4)
                       )
                       (call $_abort)
                       (block
@@ -14926,7 +14884,7 @@
                   (if
                     (tee_local $0
                       (i32.load offset=4
-                        (get_local $3)
+                        (get_local $0)
                       )
                     )
                     (if
@@ -14955,22 +14913,22 @@
           )
         )
         (i32.store offset=4
-          (get_local $4)
+          (get_local $3)
           (i32.or
-            (get_local $2)
+            (get_local $5)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
-            (get_local $4)
-            (get_local $2)
+            (get_local $3)
+            (get_local $5)
           )
-          (get_local $2)
+          (get_local $5)
         )
         (if
           (i32.eq
-            (get_local $4)
+            (get_local $3)
             (i32.load
               (i32.const 196)
             )
@@ -14978,34 +14936,34 @@
           (block
             (i32.store
               (i32.const 184)
-              (get_local $2)
+              (get_local $5)
             )
             (return)
           )
-          (set_local $1
-            (get_local $2)
+          (set_local $4
+            (get_local $5)
           )
         )
       )
     )
-    (set_local $2
+    (set_local $0
       (i32.shr_u
-        (get_local $1)
+        (get_local $4)
         (i32.const 3)
       )
     )
     (if
       (i32.lt_u
-        (get_local $1)
+        (get_local $4)
         (i32.const 256)
       )
       (block
-        (set_local $3
+        (set_local $1
           (i32.add
             (i32.const 216)
             (i32.shl
               (i32.shl
-                (get_local $2)
+                (get_local $0)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -15014,25 +14972,25 @@
         )
         (if
           (i32.and
-            (tee_local $0
+            (tee_local $4
               (i32.load
                 (i32.const 176)
               )
             )
-            (tee_local $1
+            (tee_local $0
               (i32.shl
                 (i32.const 1)
-                (get_local $2)
+                (get_local $0)
               )
             )
           )
           (if
             (i32.lt_u
-              (tee_local $1
+              (tee_local $0
                 (i32.load
-                  (tee_local $0
+                  (tee_local $4
                     (i32.add
-                      (get_local $3)
+                      (get_local $1)
                       (i32.const 8)
                     )
                   )
@@ -15045,10 +15003,10 @@
             (call $_abort)
             (block
               (set_local $15
-                (get_local $0)
+                (get_local $4)
               )
               (set_local $13
-                (get_local $1)
+                (get_local $0)
               )
             )
           )
@@ -15056,36 +15014,36 @@
             (i32.store
               (i32.const 176)
               (i32.or
+                (get_local $4)
                 (get_local $0)
-                (get_local $1)
               )
             )
             (set_local $15
               (i32.add
-                (get_local $3)
+                (get_local $1)
                 (i32.const 8)
               )
             )
             (set_local $13
-              (get_local $3)
+              (get_local $1)
             )
           )
         )
         (i32.store
           (get_local $15)
-          (get_local $4)
+          (get_local $3)
         )
         (i32.store offset=12
           (get_local $13)
-          (get_local $4)
+          (get_local $3)
         )
         (i32.store offset=8
-          (get_local $4)
+          (get_local $3)
           (get_local $13)
         )
         (i32.store offset=12
-          (get_local $4)
           (get_local $3)
+          (get_local $1)
         )
         (return)
       )
@@ -15094,24 +15052,24 @@
       (i32.add
         (i32.const 480)
         (i32.shl
-          (tee_local $3
+          (tee_local $2
             (if i32
               (tee_local $0
                 (i32.shr_u
-                  (get_local $1)
+                  (get_local $4)
                   (i32.const 8)
                 )
               )
               (if i32
                 (i32.gt_u
-                  (get_local $1)
+                  (get_local $4)
                   (i32.const 16777215)
                 )
                 (i32.const 31)
                 (i32.or
                   (i32.and
                     (i32.shr_u
-                      (get_local $1)
+                      (get_local $4)
                       (i32.add
                         (tee_local $0
                           (i32.add
@@ -15119,14 +15077,14 @@
                               (i32.const 14)
                               (i32.or
                                 (i32.or
-                                  (tee_local $3
+                                  (tee_local $0
                                     (i32.and
                                       (i32.shr_u
                                         (i32.add
-                                          (tee_local $2
+                                          (tee_local $1
                                             (i32.shl
                                               (get_local $0)
-                                              (tee_local $0
+                                              (tee_local $2
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
@@ -15147,16 +15105,16 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $0)
+                                  (get_local $2)
                                 )
                                 (tee_local $0
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (tee_local $3
+                                        (tee_local $1
                                           (i32.shl
-                                            (get_local $2)
-                                            (get_local $3)
+                                            (get_local $1)
+                                            (get_local $0)
                                           )
                                         )
                                         (i32.const 245760)
@@ -15170,7 +15128,7 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $3)
+                                (get_local $1)
                                 (get_local $0)
                               )
                               (i32.const 15)
@@ -15196,47 +15154,47 @@
       )
     )
     (i32.store offset=28
-      (get_local $4)
       (get_local $3)
+      (get_local $2)
     )
     (i32.store offset=20
-      (get_local $4)
+      (get_local $3)
       (i32.const 0)
     )
     (i32.store offset=16
-      (get_local $4)
+      (get_local $3)
       (i32.const 0)
     )
     (block $do-once12
       (if
         (i32.and
-          (tee_local $0
+          (tee_local $1
             (i32.load
               (i32.const 180)
             )
           )
-          (tee_local $2
+          (tee_local $0
             (i32.shl
               (i32.const 1)
-              (get_local $3)
+              (get_local $2)
             )
           )
         )
         (block
           (set_local $2
             (i32.shl
-              (get_local $1)
+              (get_local $4)
               (select
                 (i32.const 0)
                 (i32.sub
                   (i32.const 25)
                   (i32.shr_u
-                    (get_local $3)
+                    (get_local $2)
                     (i32.const 1)
                   )
                 )
                 (i32.eq
-                  (get_local $3)
+                  (get_local $2)
                   (i32.const 31)
                 )
               )
@@ -15259,7 +15217,7 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $1)
+                      (get_local $4)
                     )
                   )
                   (set_local $5
@@ -15270,7 +15228,7 @@
                   )
                   (br_if $jumpthreading$inner$0
                     (i32.eqz
-                      (tee_local $3
+                      (tee_local $1
                         (i32.load
                           (tee_local $2
                             (i32.add
@@ -15296,7 +15254,7 @@
                       (get_local $5)
                     )
                     (set_local $0
-                      (get_local $3)
+                      (get_local $1)
                     )
                     (br $while-in15)
                   )
@@ -15313,19 +15271,19 @@
                 (block
                   (i32.store
                     (get_local $2)
-                    (get_local $4)
+                    (get_local $3)
                   )
                   (i32.store offset=24
-                    (get_local $4)
+                    (get_local $3)
                     (get_local $0)
                   )
                   (i32.store offset=12
-                    (get_local $4)
-                    (get_local $4)
+                    (get_local $3)
+                    (get_local $3)
                   )
                   (i32.store offset=8
-                    (get_local $4)
-                    (get_local $4)
+                    (get_local $3)
+                    (get_local $3)
                   )
                   (br $do-once12)
                 )
@@ -15335,9 +15293,9 @@
             (if
               (i32.and
                 (i32.ge_u
-                  (tee_local $1
+                  (tee_local $2
                     (i32.load
-                      (tee_local $2
+                      (tee_local $1
                         (i32.add
                           (get_local $0)
                           (i32.const 8)
@@ -15345,7 +15303,7 @@
                       )
                     )
                   )
-                  (tee_local $3
+                  (tee_local $4
                     (i32.load
                       (i32.const 192)
                     )
@@ -15353,28 +15311,28 @@
                 )
                 (i32.ge_u
                   (get_local $0)
-                  (get_local $3)
+                  (get_local $4)
                 )
               )
               (block
                 (i32.store offset=12
-                  (get_local $1)
-                  (get_local $4)
+                  (get_local $2)
+                  (get_local $3)
                 )
                 (i32.store
-                  (get_local $2)
-                  (get_local $4)
+                  (get_local $1)
+                  (get_local $3)
                 )
                 (i32.store offset=8
-                  (get_local $4)
-                  (get_local $1)
+                  (get_local $3)
+                  (get_local $2)
                 )
                 (i32.store offset=12
-                  (get_local $4)
+                  (get_local $3)
                   (get_local $0)
                 )
                 (i32.store offset=24
-                  (get_local $4)
+                  (get_local $3)
                   (i32.const 0)
                 )
               )
@@ -15386,25 +15344,25 @@
           (i32.store
             (i32.const 180)
             (i32.or
+              (get_local $1)
               (get_local $0)
-              (get_local $2)
             )
           )
           (i32.store
             (get_local $5)
-            (get_local $4)
+            (get_local $3)
           )
           (i32.store offset=24
-            (get_local $4)
+            (get_local $3)
             (get_local $5)
           )
           (i32.store offset=12
-            (get_local $4)
-            (get_local $4)
+            (get_local $3)
+            (get_local $3)
           )
           (i32.store offset=8
-            (get_local $4)
-            (get_local $4)
+            (get_local $3)
+            (get_local $3)
           )
         )
       )
@@ -15430,7 +15388,7 @@
     (loop $while-in17
       (set_local $0
         (i32.add
-          (tee_local $1
+          (tee_local $4
             (i32.load
               (get_local $0)
             )
@@ -15439,7 +15397,7 @@
         )
       )
       (br_if $while-in17
-        (get_local $1)
+        (get_local $4)
       )
     )
     (i32.store
@@ -15469,6 +15427,7 @@
     )
   )
   (func $_i64Add (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+    (local $4 i32)
     (set_global $tempRet0
       (i32.add
         (i32.add
@@ -15476,7 +15435,7 @@
           (get_local $3)
         )
         (i32.lt_u
-          (tee_local $1
+          (tee_local $4
             (i32.add
               (get_local $0)
               (get_local $2)
@@ -15486,7 +15445,7 @@
         )
       )
     )
-    (get_local $1)
+    (get_local $4)
   )
   (func $_memset (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (local $3 i32)

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -157,9 +157,9 @@
         (block
           (if
             (i32.and
-              (tee_local $5
+              (tee_local $1
                 (i32.shr_u
-                  (tee_local $6
+                  (tee_local $5
                     (i32.load
                       (i32.const 1208)
                     )
@@ -190,24 +190,24 @@
               (i32.const 3)
             )
             (block
-              (set_local $7
+              (set_local $0
                 (i32.load
-                  (tee_local $5
+                  (tee_local $1
                     (i32.add
                       (tee_local $2
                         (i32.load
-                          (tee_local $4
+                          (tee_local $11
                             (i32.add
-                              (tee_local $8
+                              (tee_local $7
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
                                     (i32.shl
-                                      (tee_local $0
+                                      (tee_local $6
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $5)
+                                              (get_local $1)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
@@ -233,17 +233,17 @@
               )
               (if
                 (i32.eq
-                  (get_local $8)
                   (get_local $7)
+                  (get_local $0)
                 )
                 (i32.store
                   (i32.const 1208)
                   (i32.and
-                    (get_local $6)
+                    (get_local $5)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $0)
+                        (get_local $6)
                       )
                       (i32.const -1)
                     )
@@ -252,7 +252,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $0)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -264,7 +264,7 @@
                       (i32.load
                         (tee_local $17
                           (i32.add
-                            (get_local $7)
+                            (get_local $0)
                             (i32.const 12)
                           )
                         )
@@ -274,11 +274,11 @@
                     (block
                       (i32.store
                         (get_local $17)
-                        (get_local $8)
+                        (get_local $7)
                       )
                       (i32.store
-                        (get_local $4)
-                        (get_local $7)
+                        (get_local $11)
+                        (get_local $0)
                       )
                     )
                     (call $qa)
@@ -288,9 +288,9 @@
               (i32.store offset=4
                 (get_local $2)
                 (i32.or
-                  (tee_local $7
+                  (tee_local $0
                     (i32.shl
-                      (get_local $0)
+                      (get_local $6)
                       (i32.const 3)
                     )
                   )
@@ -298,18 +298,18 @@
                 )
               )
               (i32.store
-                (tee_local $4
+                (tee_local $11
                   (i32.add
                     (i32.add
                       (get_local $2)
-                      (get_local $7)
+                      (get_local $0)
                     )
                     (i32.const 4)
                   )
                 )
                 (i32.or
                   (i32.load
-                    (get_local $4)
+                    (get_local $11)
                   )
                   (i32.const 1)
                 )
@@ -318,14 +318,14 @@
                 (get_local $25)
               )
               (return
-                (get_local $5)
+                (get_local $1)
               )
             )
           )
           (if
             (i32.gt_u
               (get_local $2)
-              (tee_local $4
+              (tee_local $11
                 (i32.load
                   (i32.const 1216)
                 )
@@ -333,22 +333,22 @@
             )
             (block
               (if
-                (get_local $5)
+                (get_local $1)
                 (block
-                  (set_local $8
+                  (set_local $7
                     (i32.and
                       (i32.shr_u
-                        (tee_local $7
+                        (tee_local $0
                           (i32.add
                             (i32.and
-                              (tee_local $8
+                              (tee_local $7
                                 (i32.and
                                   (i32.shl
-                                    (get_local $5)
+                                    (get_local $1)
                                     (get_local $0)
                                   )
                                   (i32.or
-                                    (tee_local $7
+                                    (tee_local $0
                                       (i32.shl
                                         (i32.const 2)
                                         (get_local $0)
@@ -356,14 +356,14 @@
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $7)
+                                      (get_local $0)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $8)
+                                (get_local $7)
                               )
                             )
                             (i32.const -1)
@@ -374,32 +374,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $8
+                  (set_local $7
                     (i32.load
                       (tee_local $17
                         (i32.add
-                          (tee_local $10
+                          (tee_local $9
                             (i32.load
                               (tee_local $15
                                 (i32.add
-                                  (tee_local $3
+                                  (tee_local $4
                                     (i32.add
                                       (i32.const 1248)
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $9
+                                          (tee_local $8
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $7
+                                                      (tee_local $0
                                                         (i32.and
                                                           (i32.shr_u
                                                             (tee_local $17
                                                               (i32.shr_u
+                                                                (get_local $0)
                                                                 (get_local $7)
-                                                                (get_local $8)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -407,15 +407,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $8)
+                                                      (get_local $7)
                                                     )
                                                     (tee_local $17
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (tee_local $10
+                                                          (tee_local $9
                                                             (i32.shr_u
                                                               (get_local $17)
-                                                              (get_local $7)
+                                                              (get_local $0)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -424,12 +424,12 @@
                                                       )
                                                     )
                                                   )
-                                                  (tee_local $10
+                                                  (tee_local $9
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (tee_local $3
+                                                        (tee_local $4
                                                           (i32.shr_u
-                                                            (get_local $10)
+                                                            (get_local $9)
                                                             (get_local $17)
                                                           )
                                                         )
@@ -439,13 +439,13 @@
                                                     )
                                                   )
                                                 )
-                                                (tee_local $3
+                                                (tee_local $4
                                                   (i32.and
                                                     (i32.shr_u
                                                       (tee_local $15
                                                         (i32.shr_u
-                                                          (get_local $3)
-                                                          (get_local $10)
+                                                          (get_local $4)
+                                                          (get_local $9)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -456,7 +456,7 @@
                                               )
                                               (i32.shr_u
                                                 (get_local $15)
-                                                (get_local $3)
+                                                (get_local $4)
                                               )
                                             )
                                           )
@@ -478,31 +478,31 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $3)
-                      (get_local $8)
+                      (get_local $4)
+                      (get_local $7)
                     )
                     (block
                       (i32.store
                         (i32.const 1208)
                         (i32.and
-                          (get_local $6)
+                          (get_local $5)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $9)
+                              (get_local $8)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $34
-                        (get_local $4)
+                      (set_local $33
+                        (get_local $11)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $8)
+                          (get_local $7)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -512,25 +512,25 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $7
+                            (tee_local $0
                               (i32.add
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $10)
+                          (get_local $9)
                         )
                         (block
                           (i32.store
-                            (get_local $7)
-                            (get_local $3)
+                            (get_local $0)
+                            (get_local $4)
                           )
                           (i32.store
                             (get_local $15)
-                            (get_local $8)
+                            (get_local $7)
                           )
-                          (set_local $34
+                          (set_local $33
                             (i32.load
                               (i32.const 1216)
                             )
@@ -541,7 +541,7 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $10)
+                    (get_local $9)
                     (i32.or
                       (get_local $2)
                       (i32.const 3)
@@ -550,15 +550,15 @@
                   (i32.store offset=4
                     (tee_local $15
                       (i32.add
-                        (get_local $10)
+                        (get_local $9)
                         (get_local $2)
                       )
                     )
                     (i32.or
-                      (tee_local $8
+                      (tee_local $7
                         (i32.sub
                           (i32.shl
-                            (get_local $9)
+                            (get_local $8)
                             (i32.const 3)
                           )
                           (get_local $2)
@@ -570,26 +570,26 @@
                   (i32.store
                     (i32.add
                       (get_local $15)
-                      (get_local $8)
+                      (get_local $7)
                     )
-                    (get_local $8)
+                    (get_local $7)
                   )
                   (if
-                    (get_local $34)
+                    (get_local $33)
                     (block
-                      (set_local $3
+                      (set_local $4
                         (i32.load
                           (i32.const 1228)
                         )
                       )
-                      (set_local $6
+                      (set_local $5
                         (i32.add
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (tee_local $4
+                              (tee_local $11
                                 (i32.shr_u
-                                  (get_local $34)
+                                  (get_local $33)
                                   (i32.const 3)
                                 )
                               )
@@ -606,10 +606,10 @@
                               (i32.const 1208)
                             )
                           )
-                          (tee_local $5
+                          (tee_local $1
                             (i32.shl
                               (i32.const 1)
-                              (get_local $4)
+                              (get_local $11)
                             )
                           )
                         )
@@ -617,9 +617,9 @@
                           (i32.lt_u
                             (tee_local $0
                               (i32.load
-                                (tee_local $5
+                                (tee_local $1
                                   (i32.add
-                                    (get_local $6)
+                                    (get_local $5)
                                     (i32.const 8)
                                   )
                                 )
@@ -632,9 +632,9 @@
                           (call $qa)
                           (block
                             (set_local $41
-                              (get_local $5)
+                              (get_local $1)
                             )
-                            (set_local $27
+                            (set_local $34
                               (get_local $0)
                             )
                           )
@@ -644,41 +644,41 @@
                             (i32.const 1208)
                             (i32.or
                               (get_local $0)
-                              (get_local $5)
+                              (get_local $1)
                             )
                           )
                           (set_local $41
                             (i32.add
-                              (get_local $6)
+                              (get_local $5)
                               (i32.const 8)
                             )
                           )
-                          (set_local $27
-                            (get_local $6)
+                          (set_local $34
+                            (get_local $5)
                           )
                         )
                       )
                       (i32.store
                         (get_local $41)
-                        (get_local $3)
+                        (get_local $4)
                       )
                       (i32.store offset=12
-                        (get_local $27)
-                        (get_local $3)
+                        (get_local $34)
+                        (get_local $4)
                       )
                       (i32.store offset=8
-                        (get_local $3)
-                        (get_local $27)
+                        (get_local $4)
+                        (get_local $34)
                       )
                       (i32.store offset=12
-                        (get_local $3)
-                        (get_local $6)
+                        (get_local $4)
+                        (get_local $5)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 1216)
-                    (get_local $8)
+                    (get_local $7)
                   )
                   (i32.store
                     (i32.const 1228)
@@ -702,7 +702,7 @@
                   (set_local $15
                     (i32.and
                       (i32.shr_u
-                        (tee_local $8
+                        (tee_local $7
                           (i32.add
                             (i32.and
                               (get_local $15)
@@ -723,7 +723,7 @@
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (tee_local $4
+                          (tee_local $11
                             (i32.load
                               (i32.add
                                 (i32.shl
@@ -732,12 +732,12 @@
                                       (i32.or
                                         (i32.or
                                           (i32.or
-                                            (tee_local $8
+                                            (tee_local $7
                                               (i32.and
                                                 (i32.shr_u
-                                                  (tee_local $6
+                                                  (tee_local $5
                                                     (i32.shr_u
-                                                      (get_local $8)
+                                                      (get_local $7)
                                                       (get_local $15)
                                                     )
                                                   )
@@ -748,13 +748,13 @@
                                             )
                                             (get_local $15)
                                           )
-                                          (tee_local $6
+                                          (tee_local $5
                                             (i32.and
                                               (i32.shr_u
-                                                (tee_local $3
+                                                (tee_local $4
                                                   (i32.shr_u
-                                                    (get_local $6)
-                                                    (get_local $8)
+                                                    (get_local $5)
+                                                    (get_local $7)
                                                   )
                                                 )
                                                 (i32.const 2)
@@ -763,13 +763,13 @@
                                             )
                                           )
                                         )
-                                        (tee_local $3
+                                        (tee_local $4
                                           (i32.and
                                             (i32.shr_u
                                               (tee_local $0
                                                 (i32.shr_u
-                                                  (get_local $3)
-                                                  (get_local $6)
+                                                  (get_local $4)
+                                                  (get_local $5)
                                                 )
                                               )
                                               (i32.const 1)
@@ -781,10 +781,10 @@
                                       (tee_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $5
+                                            (tee_local $1
                                               (i32.shr_u
                                                 (get_local $0)
-                                                (get_local $3)
+                                                (get_local $4)
                                               )
                                             )
                                             (i32.const 1)
@@ -794,7 +794,7 @@
                                       )
                                     )
                                     (i32.shr_u
-                                      (get_local $5)
+                                      (get_local $1)
                                       (get_local $0)
                                     )
                                   )
@@ -810,50 +810,50 @@
                       (get_local $2)
                     )
                   )
-                  (set_local $5
-                    (get_local $4)
+                  (set_local $1
+                    (get_local $11)
                   )
-                  (set_local $3
-                    (get_local $4)
+                  (set_local $4
+                    (get_local $11)
                   )
                   (loop $while-in
                     (block $while-out
                       (if
-                        (tee_local $4
+                        (tee_local $11
                           (i32.load offset=16
-                            (get_local $5)
+                            (get_local $1)
                           )
                         )
-                        (set_local $7
-                          (get_local $4)
+                        (set_local $6
+                          (get_local $11)
                         )
                         (if
-                          (tee_local $6
+                          (tee_local $5
                             (i32.load offset=20
-                              (get_local $5)
+                              (get_local $1)
                             )
                           )
-                          (set_local $7
-                            (get_local $6)
+                          (set_local $6
+                            (get_local $5)
                           )
                           (block
-                            (set_local $7
+                            (set_local $3
                               (get_local $0)
                             )
-                            (set_local $1
-                              (get_local $3)
+                            (set_local $6
+                              (get_local $4)
                             )
                             (br $while-out)
                           )
                         )
                       )
-                      (set_local $6
+                      (set_local $5
                         (i32.lt_u
-                          (tee_local $4
+                          (tee_local $11
                             (i32.sub
                               (i32.and
                                 (i32.load offset=4
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                                 (i32.const -8)
                               )
@@ -865,19 +865,19 @@
                       )
                       (set_local $0
                         (select
-                          (get_local $4)
+                          (get_local $11)
                           (get_local $0)
-                          (get_local $6)
+                          (get_local $5)
                         )
                       )
-                      (set_local $5
-                        (get_local $7)
+                      (set_local $1
+                        (get_local $6)
                       )
-                      (set_local $3
+                      (set_local $4
                         (select
-                          (get_local $7)
-                          (get_local $3)
                           (get_local $6)
+                          (get_local $4)
+                          (get_local $5)
                         )
                       )
                       (br $while-in)
@@ -885,8 +885,8 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $1)
-                      (tee_local $3
+                      (get_local $6)
+                      (tee_local $4
                         (i32.load
                           (i32.const 1224)
                         )
@@ -896,10 +896,10 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $1)
-                      (tee_local $5
+                      (get_local $6)
+                      (tee_local $1
                         (i32.add
-                          (get_local $1)
+                          (get_local $6)
                           (get_local $2)
                         )
                       )
@@ -908,7 +908,7 @@
                   )
                   (set_local $0
                     (i32.load offset=24
-                      (get_local $1)
+                      (get_local $6)
                     )
                   )
                   (block $do-once4
@@ -916,38 +916,38 @@
                       (i32.eq
                         (tee_local $17
                           (i32.load offset=12
-                            (get_local $1)
+                            (get_local $6)
                           )
                         )
-                        (get_local $1)
+                        (get_local $6)
                       )
                       (block
                         (if
-                          (tee_local $9
+                          (tee_local $8
                             (i32.load
-                              (tee_local $10
+                              (tee_local $9
                                 (i32.add
-                                  (get_local $1)
+                                  (get_local $6)
                                   (i32.const 20)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $4
-                              (get_local $9)
+                            (set_local $11
+                              (get_local $8)
                             )
-                            (set_local $6
-                              (get_local $10)
+                            (set_local $5
+                              (get_local $9)
                             )
                           )
                           (if
                             (i32.eqz
-                              (tee_local $4
+                              (tee_local $11
                                 (i32.load
-                                  (tee_local $6
+                                  (tee_local $5
                                     (i32.add
-                                      (get_local $1)
+                                      (get_local $6)
                                       (i32.const 16)
                                     )
                                   )
@@ -955,7 +955,7 @@
                               )
                             )
                             (block
-                              (set_local $23
+                              (set_local $21
                                 (i32.const 0)
                               )
                               (br $do-once4)
@@ -964,43 +964,43 @@
                         )
                         (loop $while-in7
                           (if
-                            (tee_local $9
+                            (tee_local $8
                               (i32.load
-                                (tee_local $10
+                                (tee_local $9
                                   (i32.add
-                                    (get_local $4)
+                                    (get_local $11)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $4
-                                (get_local $9)
+                              (set_local $11
+                                (get_local $8)
                               )
-                              (set_local $6
-                                (get_local $10)
+                              (set_local $5
+                                (get_local $9)
                               )
                               (br $while-in7)
                             )
                           )
                           (if
-                            (tee_local $9
+                            (tee_local $8
                               (i32.load
-                                (tee_local $10
+                                (tee_local $9
                                   (i32.add
-                                    (get_local $4)
+                                    (get_local $11)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $4
-                                (get_local $9)
+                              (set_local $11
+                                (get_local $8)
                               )
-                              (set_local $6
-                                (get_local $10)
+                              (set_local $5
+                                (get_local $9)
                               )
                               (br $while-in7)
                             )
@@ -1008,17 +1008,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $6)
-                            (get_local $3)
+                            (get_local $5)
+                            (get_local $4)
                           )
                           (call $qa)
                           (block
                             (i32.store
-                              (get_local $6)
+                              (get_local $5)
                               (i32.const 0)
                             )
-                            (set_local $23
-                              (get_local $4)
+                            (set_local $21
+                              (get_local $11)
                             )
                           )
                         )
@@ -1026,51 +1026,51 @@
                       (block
                         (if
                           (i32.lt_u
-                            (tee_local $10
+                            (tee_local $9
                               (i32.load offset=8
-                                (get_local $1)
+                                (get_local $6)
                               )
                             )
-                            (get_local $3)
+                            (get_local $4)
                           )
                           (call $qa)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (tee_local $9
+                              (tee_local $8
                                 (i32.add
-                                  (get_local $10)
+                                  (get_local $9)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $1)
+                            (get_local $6)
                           )
                           (call $qa)
                         )
                         (if
                           (i32.eq
                             (i32.load
-                              (tee_local $6
+                              (tee_local $5
                                 (i32.add
                                   (get_local $17)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $1)
+                            (get_local $6)
                           )
                           (block
                             (i32.store
-                              (get_local $9)
+                              (get_local $8)
                               (get_local $17)
                             )
                             (i32.store
-                              (get_local $6)
-                              (get_local $10)
+                              (get_local $5)
+                              (get_local $9)
                             )
-                            (set_local $23
+                            (set_local $21
                               (get_local $17)
                             )
                           )
@@ -1085,15 +1085,15 @@
                       (block
                         (if
                           (i32.eq
-                            (get_local $1)
+                            (get_local $6)
                             (i32.load
-                              (tee_local $3
+                              (tee_local $4
                                 (i32.add
                                   (i32.const 1512)
                                   (i32.shl
                                     (tee_local $17
                                       (i32.load offset=28
-                                        (get_local $1)
+                                        (get_local $6)
                                       )
                                     )
                                     (i32.const 2)
@@ -1104,12 +1104,12 @@
                           )
                           (block
                             (i32.store
-                              (get_local $3)
-                              (get_local $23)
+                              (get_local $4)
+                              (get_local $21)
                             )
                             (if
                               (i32.eqz
-                                (get_local $23)
+                                (get_local $21)
                               )
                               (block
                                 (i32.store
@@ -1151,27 +1151,27 @@
                                     )
                                   )
                                 )
-                                (get_local $1)
+                                (get_local $6)
                               )
                               (i32.store
                                 (get_local $17)
-                                (get_local $23)
+                                (get_local $21)
                               )
                               (i32.store offset=20
                                 (get_local $0)
-                                (get_local $23)
+                                (get_local $21)
                               )
                             )
                             (br_if $do-once8
                               (i32.eqz
-                                (get_local $23)
+                                (get_local $21)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $23)
+                            (get_local $21)
                             (tee_local $17
                               (i32.load
                                 (i32.const 1224)
@@ -1181,42 +1181,42 @@
                           (call $qa)
                         )
                         (i32.store offset=24
-                          (get_local $23)
+                          (get_local $21)
                           (get_local $0)
                         )
                         (if
-                          (tee_local $3
+                          (tee_local $4
                             (i32.load offset=16
-                              (get_local $1)
+                              (get_local $6)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $3)
+                              (get_local $4)
                               (get_local $17)
                             )
                             (call $qa)
                             (block
                               (i32.store offset=16
-                                (get_local $23)
-                                (get_local $3)
+                                (get_local $21)
+                                (get_local $4)
                               )
                               (i32.store offset=24
-                                (get_local $3)
-                                (get_local $23)
+                                (get_local $4)
+                                (get_local $21)
                               )
                             )
                           )
                         )
                         (if
-                          (tee_local $3
+                          (tee_local $4
                             (i32.load offset=20
-                              (get_local $1)
+                              (get_local $6)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $3)
+                              (get_local $4)
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1224,12 +1224,12 @@
                             (call $qa)
                             (block
                               (i32.store offset=20
-                                (get_local $23)
-                                (get_local $3)
+                                (get_local $21)
+                                (get_local $4)
                               )
                               (i32.store offset=24
-                                (get_local $3)
-                                (get_local $23)
+                                (get_local $4)
+                                (get_local $21)
                               )
                             )
                           )
@@ -1239,16 +1239,16 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $3)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $6)
                         (i32.or
                           (tee_local $0
                             (i32.add
-                              (get_local $7)
+                              (get_local $3)
                               (get_local $2)
                             )
                           )
@@ -1256,10 +1256,10 @@
                         )
                       )
                       (i32.store
-                        (tee_local $3
+                        (tee_local $4
                           (i32.add
                             (i32.add
-                              (get_local $1)
+                              (get_local $6)
                               (get_local $0)
                             )
                             (i32.const 4)
@@ -1267,7 +1267,7 @@
                         )
                         (i32.or
                           (i32.load
-                            (get_local $3)
+                            (get_local $4)
                           )
                           (i32.const 1)
                         )
@@ -1275,28 +1275,28 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $6)
                         (i32.or
                           (get_local $2)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $5)
+                        (get_local $1)
                         (i32.or
-                          (get_local $7)
+                          (get_local $3)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $5)
-                          (get_local $7)
+                          (get_local $1)
+                          (get_local $3)
                         )
-                        (get_local $7)
+                        (get_local $3)
                       )
                       (if
-                        (tee_local $3
+                        (tee_local $4
                           (i32.load
                             (i32.const 1216)
                           )
@@ -1307,14 +1307,14 @@
                               (i32.const 1228)
                             )
                           )
-                          (set_local $3
+                          (set_local $4
                             (i32.add
                               (i32.const 1248)
                               (i32.shl
                                 (i32.shl
                                   (tee_local $17
                                     (i32.shr_u
-                                      (get_local $3)
+                                      (get_local $4)
                                       (i32.const 3)
                                     )
                                   )
@@ -1326,12 +1326,12 @@
                           )
                           (if
                             (i32.and
-                              (tee_local $10
+                              (tee_local $9
                                 (i32.load
                                   (i32.const 1208)
                                 )
                               )
-                              (tee_local $6
+                              (tee_local $5
                                 (i32.shl
                                   (i32.const 1)
                                   (get_local $17)
@@ -1340,11 +1340,11 @@
                             )
                             (if
                               (i32.lt_u
-                                (tee_local $10
+                                (tee_local $9
                                   (i32.load
-                                    (tee_local $6
+                                    (tee_local $5
                                       (i32.add
-                                        (get_local $3)
+                                        (get_local $4)
                                         (i32.const 8)
                                       )
                                     )
@@ -1357,10 +1357,10 @@
                               (call $qa)
                               (block
                                 (set_local $42
-                                  (get_local $6)
+                                  (get_local $5)
                                 )
                                 (set_local $35
-                                  (get_local $10)
+                                  (get_local $9)
                                 )
                               )
                             )
@@ -1368,18 +1368,18 @@
                               (i32.store
                                 (i32.const 1208)
                                 (i32.or
-                                  (get_local $10)
-                                  (get_local $6)
+                                  (get_local $9)
+                                  (get_local $5)
                                 )
                               )
                               (set_local $42
                                 (i32.add
-                                  (get_local $3)
+                                  (get_local $4)
                                   (i32.const 8)
                                 )
                               )
                               (set_local $35
-                                (get_local $3)
+                                (get_local $4)
                               )
                             )
                           )
@@ -1397,17 +1397,17 @@
                           )
                           (i32.store offset=12
                             (get_local $0)
-                            (get_local $3)
+                            (get_local $4)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 1216)
-                        (get_local $7)
+                        (get_local $3)
                       )
                       (i32.store
                         (i32.const 1228)
-                        (get_local $5)
+                        (get_local $1)
                       )
                     )
                   )
@@ -1416,17 +1416,17 @@
                   )
                   (return
                     (i32.add
-                      (get_local $1)
+                      (get_local $6)
                       (i32.const 8)
                     )
                   )
                 )
-                (set_local $6
+                (set_local $4
                   (get_local $2)
                 )
               )
             )
-            (set_local $6
+            (set_local $4
               (get_local $2)
             )
           )
@@ -1436,13 +1436,13 @@
             (get_local $0)
             (i32.const -65)
           )
-          (set_local $6
+          (set_local $4
             (i32.const -1)
           )
           (block
             (set_local $0
               (i32.and
-                (tee_local $3
+                (tee_local $4
                   (i32.add
                     (get_local $0)
                     (i32.const 11)
@@ -1452,13 +1452,13 @@
               )
             )
             (if
-              (tee_local $10
+              (tee_local $9
                 (i32.load
                   (i32.const 1212)
                 )
               )
               (block
-                (set_local $6
+                (set_local $5
                   (i32.sub
                     (i32.const 0)
                     (get_local $0)
@@ -1470,11 +1470,11 @@
                       (i32.load
                         (i32.add
                           (i32.shl
-                            (tee_local $27
+                            (tee_local $21
                               (if i32
                                 (tee_local $17
                                   (i32.shr_u
-                                    (get_local $3)
+                                    (get_local $4)
                                     (i32.const 8)
                                   )
                                 )
@@ -1499,10 +1499,10 @@
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (tee_local $9
+                                                            (tee_local $8
                                                               (i32.shl
                                                                 (get_local $17)
-                                                                (tee_local $3
+                                                                (tee_local $4
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
@@ -1523,15 +1523,15 @@
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $3)
+                                                    (get_local $4)
                                                   )
-                                                  (tee_local $9
+                                                  (tee_local $8
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $4
+                                                          (tee_local $11
                                                             (i32.shl
-                                                              (get_local $9)
+                                                              (get_local $8)
                                                               (get_local $17)
                                                             )
                                                           )
@@ -1546,8 +1546,8 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $4)
-                                                  (get_local $9)
+                                                  (get_local $11)
+                                                  (get_local $8)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -1574,13 +1574,13 @@
                       )
                     )
                     (block
-                      (set_local $9
-                        (get_local $6)
+                      (set_local $8
+                        (get_local $5)
                       )
-                      (set_local $4
+                      (set_local $11
                         (i32.const 0)
                       )
-                      (set_local $3
+                      (set_local $4
                         (i32.shl
                           (get_local $0)
                           (select
@@ -1588,12 +1588,12 @@
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $27)
+                                (get_local $21)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $27)
+                              (get_local $21)
                               (i32.const 31)
                             )
                           )
@@ -1602,7 +1602,7 @@
                       (set_local $17
                         (get_local $15)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 0)
                       )
                       (loop $while-in14
@@ -1610,7 +1610,7 @@
                           (i32.lt_u
                             (tee_local $2
                               (i32.sub
-                                (tee_local $5
+                                (tee_local $1
                                   (i32.and
                                     (i32.load offset=4
                                       (get_local $17)
@@ -1621,41 +1621,41 @@
                                 (get_local $0)
                               )
                             )
-                            (get_local $9)
+                            (get_local $8)
                           )
                           (if
                             (i32.eq
-                              (get_local $5)
+                              (get_local $1)
                               (get_local $0)
                             )
                             (block
-                              (set_local $29
+                              (set_local $28
                                 (get_local $2)
                               )
-                              (set_local $28
+                              (set_local $27
                                 (get_local $17)
                               )
-                              (set_local $32
+                              (set_local $31
                                 (get_local $17)
                               )
-                              (set_local $9
+                              (set_local $8
                                 (i32.const 90)
                               )
                               (br $label$break$a)
                             )
                             (block
-                              (set_local $9
+                              (set_local $8
                                 (get_local $2)
                               )
-                              (set_local $8
+                              (set_local $7
                                 (get_local $17)
                               )
                             )
                           )
                         )
-                        (set_local $5
+                        (set_local $1
                           (select
-                            (get_local $4)
+                            (get_local $11)
                             (tee_local $2
                               (i32.load offset=20
                                 (get_local $17)
@@ -1676,7 +1676,7 @@
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $3)
+                                          (get_local $4)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -1696,25 +1696,25 @@
                           )
                           (block
                             (set_local $36
-                              (get_local $9)
-                            )
-                            (set_local $37
-                              (get_local $5)
-                            )
-                            (set_local $33
                               (get_local $8)
                             )
-                            (set_local $9
+                            (set_local $37
+                              (get_local $1)
+                            )
+                            (set_local $32
+                              (get_local $7)
+                            )
+                            (set_local $8
                               (i32.const 86)
                             )
                           )
                           (block
-                            (set_local $4
-                              (get_local $5)
+                            (set_local $11
+                              (get_local $1)
                             )
-                            (set_local $3
+                            (set_local $4
                               (i32.shl
-                                (get_local $3)
+                                (get_local $4)
                                 (i32.xor
                                   (i32.and
                                     (get_local $2)
@@ -1731,15 +1731,15 @@
                     )
                     (block
                       (set_local $36
-                        (get_local $6)
+                        (get_local $5)
                       )
                       (set_local $37
                         (i32.const 0)
                       )
-                      (set_local $33
+                      (set_local $32
                         (i32.const 0)
                       )
-                      (set_local $9
+                      (set_local $8
                         (i32.const 86)
                       )
                     )
@@ -1747,7 +1747,7 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $9)
+                    (get_local $8)
                     (i32.const 86)
                   )
                   (if
@@ -1758,20 +1758,20 @@
                             (get_local $37)
                           )
                           (i32.eqz
-                            (get_local $33)
+                            (get_local $32)
                           )
                         )
                         (block i32
                           (if
                             (i32.eqz
-                              (tee_local $6
+                              (tee_local $5
                                 (i32.and
-                                  (get_local $10)
+                                  (get_local $9)
                                   (i32.or
                                     (tee_local $15
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $27)
+                                        (get_local $21)
                                       )
                                     )
                                     (i32.sub
@@ -1783,22 +1783,22 @@
                               )
                             )
                             (block
-                              (set_local $6
+                              (set_local $4
                                 (get_local $0)
                               )
                               (br $do-once)
                             )
                           )
-                          (set_local $6
+                          (set_local $5
                             (i32.and
                               (i32.shr_u
                                 (tee_local $15
                                   (i32.add
                                     (i32.and
-                                      (get_local $6)
+                                      (get_local $5)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $6)
+                                        (get_local $5)
                                       )
                                     )
                                     (i32.const -1)
@@ -1823,7 +1823,7 @@
                                                 (tee_local $2
                                                   (i32.shr_u
                                                     (get_local $15)
-                                                    (get_local $6)
+                                                    (get_local $5)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -1831,12 +1831,12 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $6)
+                                          (get_local $5)
                                         )
                                         (tee_local $2
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $5
+                                              (tee_local $1
                                                 (i32.shr_u
                                                   (get_local $2)
                                                   (get_local $15)
@@ -1848,12 +1848,12 @@
                                           )
                                         )
                                       )
-                                      (tee_local $5
+                                      (tee_local $1
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $8
+                                            (tee_local $7
                                               (i32.shr_u
-                                                (get_local $5)
+                                                (get_local $1)
                                                 (get_local $2)
                                               )
                                             )
@@ -1863,13 +1863,13 @@
                                         )
                                       )
                                     )
-                                    (tee_local $8
+                                    (tee_local $7
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $3
+                                          (tee_local $4
                                             (i32.shr_u
-                                              (get_local $8)
-                                              (get_local $5)
+                                              (get_local $7)
+                                              (get_local $1)
                                             )
                                           )
                                           (i32.const 1)
@@ -1879,8 +1879,8 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $3)
-                                    (get_local $8)
+                                    (get_local $4)
+                                    (get_local $7)
                                   )
                                 )
                                 (i32.const 2)
@@ -1893,16 +1893,16 @@
                       )
                     )
                     (block
-                      (set_local $29
+                      (set_local $28
                         (get_local $36)
                       )
-                      (set_local $28
+                      (set_local $27
                         (get_local $2)
                       )
-                      (set_local $32
-                        (get_local $33)
+                      (set_local $31
+                        (get_local $32)
                       )
-                      (set_local $9
+                      (set_local $8
                         (i32.const 90)
                       )
                     )
@@ -1910,98 +1910,98 @@
                       (set_local $16
                         (get_local $36)
                       )
-                      (set_local $11
-                        (get_local $33)
+                      (set_local $10
+                        (get_local $32)
                       )
                     )
                   )
                 )
                 (if
                   (i32.eq
-                    (get_local $9)
+                    (get_local $8)
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $9
+                    (set_local $8
                       (i32.const 0)
                     )
-                    (set_local $3
+                    (set_local $4
                       (i32.lt_u
-                        (tee_local $8
+                        (tee_local $7
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $28)
+                                (get_local $27)
                               )
                               (i32.const -8)
                             )
                             (get_local $0)
                           )
                         )
-                        (get_local $29)
-                      )
-                    )
-                    (set_local $5
-                      (select
-                        (get_local $8)
-                        (get_local $29)
-                        (get_local $3)
-                      )
-                    )
-                    (set_local $8
-                      (select
                         (get_local $28)
-                        (get_local $32)
-                        (get_local $3)
+                      )
+                    )
+                    (set_local $1
+                      (select
+                        (get_local $7)
+                        (get_local $28)
+                        (get_local $4)
+                      )
+                    )
+                    (set_local $7
+                      (select
+                        (get_local $27)
+                        (get_local $31)
+                        (get_local $4)
                       )
                     )
                     (if
-                      (tee_local $3
+                      (tee_local $4
                         (i32.load offset=16
-                          (get_local $28)
+                          (get_local $27)
                         )
                       )
                       (block
-                        (set_local $29
-                          (get_local $5)
-                        )
                         (set_local $28
-                          (get_local $3)
+                          (get_local $1)
                         )
-                        (set_local $32
-                          (get_local $8)
+                        (set_local $27
+                          (get_local $4)
+                        )
+                        (set_local $31
+                          (get_local $7)
                         )
                         (br $while-in16)
                       )
                     )
                     (if
-                      (tee_local $28
+                      (tee_local $27
                         (i32.load offset=20
-                          (get_local $28)
+                          (get_local $27)
                         )
                       )
                       (block
-                        (set_local $29
-                          (get_local $5)
+                        (set_local $28
+                          (get_local $1)
                         )
-                        (set_local $32
-                          (get_local $8)
+                        (set_local $31
+                          (get_local $7)
                         )
                         (br $while-in16)
                       )
                       (block
                         (set_local $16
-                          (get_local $5)
+                          (get_local $1)
                         )
-                        (set_local $11
-                          (get_local $8)
+                        (set_local $10
+                          (get_local $7)
                         )
                       )
                     )
                   )
                 )
                 (if
-                  (get_local $11)
+                  (get_local $10)
                   (if
                     (i32.lt_u
                       (get_local $16)
@@ -2015,8 +2015,8 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $11)
-                          (tee_local $10
+                          (get_local $10)
+                          (tee_local $9
                             (i32.load
                               (i32.const 1224)
                             )
@@ -2026,57 +2026,57 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $11)
-                          (tee_local $8
+                          (get_local $10)
+                          (tee_local $7
                             (i32.add
-                              (get_local $11)
+                              (get_local $10)
                               (get_local $0)
                             )
                           )
                         )
                         (call $qa)
                       )
-                      (set_local $5
+                      (set_local $1
                         (i32.load offset=24
-                          (get_local $11)
+                          (get_local $10)
                         )
                       )
                       (block $do-once17
                         (if
                           (i32.eq
-                            (tee_local $3
+                            (tee_local $4
                               (i32.load offset=12
-                                (get_local $11)
+                                (get_local $10)
                               )
                             )
-                            (get_local $11)
+                            (get_local $10)
                           )
                           (block
                             (if
-                              (tee_local $6
+                              (tee_local $5
                                 (i32.load
                                   (tee_local $2
                                     (i32.add
-                                      (get_local $11)
+                                      (get_local $10)
                                       (i32.const 20)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $4
-                                  (get_local $6)
+                                (set_local $11
+                                  (get_local $5)
                                 )
                                 (set_local $3
                                   (get_local $2)
                                 )
                               )
                               (if
-                                (tee_local $4
+                                (tee_local $11
                                   (i32.load
                                     (tee_local $15
                                       (i32.add
-                                        (get_local $11)
+                                        (get_local $10)
                                         (i32.const 16)
                                       )
                                     )
@@ -2086,7 +2086,7 @@
                                   (get_local $15)
                                 )
                                 (block
-                                  (set_local $22
+                                  (set_local $23
                                     (i32.const 0)
                                   )
                                   (br $do-once17)
@@ -2095,19 +2095,19 @@
                             )
                             (loop $while-in20
                               (if
-                                (tee_local $6
+                                (tee_local $5
                                   (i32.load
                                     (tee_local $2
                                       (i32.add
-                                        (get_local $4)
+                                        (get_local $11)
                                         (i32.const 20)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $4
-                                    (get_local $6)
+                                  (set_local $11
+                                    (get_local $5)
                                   )
                                   (set_local $3
                                     (get_local $2)
@@ -2116,19 +2116,19 @@
                                 )
                               )
                               (if
-                                (tee_local $6
+                                (tee_local $5
                                   (i32.load
                                     (tee_local $2
                                       (i32.add
-                                        (get_local $4)
+                                        (get_local $11)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $4
-                                    (get_local $6)
+                                  (set_local $11
+                                    (get_local $5)
                                   )
                                   (set_local $3
                                     (get_local $2)
@@ -2140,7 +2140,7 @@
                             (if
                               (i32.lt_u
                                 (get_local $3)
-                                (get_local $10)
+                                (get_local $9)
                               )
                               (call $qa)
                               (block
@@ -2148,8 +2148,8 @@
                                   (get_local $3)
                                   (i32.const 0)
                                 )
-                                (set_local $22
-                                  (get_local $4)
+                                (set_local $23
+                                  (get_local $11)
                                 )
                               )
                             )
@@ -2159,24 +2159,24 @@
                               (i32.lt_u
                                 (tee_local $2
                                   (i32.load offset=8
-                                    (get_local $11)
+                                    (get_local $10)
                                   )
                                 )
-                                (get_local $10)
+                                (get_local $9)
                               )
                               (call $qa)
                             )
                             (if
                               (i32.ne
                                 (i32.load
-                                  (tee_local $6
+                                  (tee_local $5
                                     (i32.add
                                       (get_local $2)
                                       (i32.const 12)
                                     )
                                   )
                                 )
-                                (get_local $11)
+                                (get_local $10)
                               )
                               (call $qa)
                             )
@@ -2185,24 +2185,24 @@
                                 (i32.load
                                   (tee_local $15
                                     (i32.add
-                                      (get_local $3)
+                                      (get_local $4)
                                       (i32.const 8)
                                     )
                                   )
                                 )
-                                (get_local $11)
+                                (get_local $10)
                               )
                               (block
                                 (i32.store
-                                  (get_local $6)
-                                  (get_local $3)
+                                  (get_local $5)
+                                  (get_local $4)
                                 )
                                 (i32.store
                                   (get_local $15)
                                   (get_local $2)
                                 )
-                                (set_local $22
-                                  (get_local $3)
+                                (set_local $23
+                                  (get_local $4)
                                 )
                               )
                               (call $qa)
@@ -2212,19 +2212,19 @@
                       )
                       (block $do-once21
                         (if
-                          (get_local $5)
+                          (get_local $1)
                           (block
                             (if
                               (i32.eq
-                                (get_local $11)
+                                (get_local $10)
                                 (i32.load
-                                  (tee_local $10
+                                  (tee_local $9
                                     (i32.add
                                       (i32.const 1512)
                                       (i32.shl
-                                        (tee_local $3
+                                        (tee_local $4
                                           (i32.load offset=28
-                                            (get_local $11)
+                                            (get_local $10)
                                           )
                                         )
                                         (i32.const 2)
@@ -2235,12 +2235,12 @@
                               )
                               (block
                                 (i32.store
-                                  (get_local $10)
-                                  (get_local $22)
+                                  (get_local $9)
+                                  (get_local $23)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $22)
+                                    (get_local $23)
                                   )
                                   (block
                                     (i32.store
@@ -2252,7 +2252,7 @@
                                         (i32.xor
                                           (i32.shl
                                             (i32.const 1)
-                                            (get_local $3)
+                                            (get_local $4)
                                           )
                                           (i32.const -1)
                                         )
@@ -2265,7 +2265,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $5)
+                                    (get_local $1)
                                     (i32.load
                                       (i32.const 1224)
                                     )
@@ -2275,35 +2275,35 @@
                                 (if
                                   (i32.eq
                                     (i32.load
-                                      (tee_local $3
+                                      (tee_local $4
                                         (i32.add
-                                          (get_local $5)
+                                          (get_local $1)
                                           (i32.const 16)
                                         )
                                       )
                                     )
-                                    (get_local $11)
+                                    (get_local $10)
                                   )
                                   (i32.store
-                                    (get_local $3)
-                                    (get_local $22)
+                                    (get_local $4)
+                                    (get_local $23)
                                   )
                                   (i32.store offset=20
-                                    (get_local $5)
-                                    (get_local $22)
+                                    (get_local $1)
+                                    (get_local $23)
                                   )
                                 )
                                 (br_if $do-once21
                                   (i32.eqz
-                                    (get_local $22)
+                                    (get_local $23)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $22)
-                                (tee_local $3
+                                (get_local $23)
+                                (tee_local $4
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2312,42 +2312,42 @@
                               (call $qa)
                             )
                             (i32.store offset=24
-                              (get_local $22)
-                              (get_local $5)
+                              (get_local $23)
+                              (get_local $1)
                             )
                             (if
-                              (tee_local $10
+                              (tee_local $9
                                 (i32.load offset=16
-                                  (get_local $11)
+                                  (get_local $10)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $10)
-                                  (get_local $3)
+                                  (get_local $9)
+                                  (get_local $4)
                                 )
                                 (call $qa)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $22)
-                                    (get_local $10)
+                                    (get_local $23)
+                                    (get_local $9)
                                   )
                                   (i32.store offset=24
-                                    (get_local $10)
-                                    (get_local $22)
+                                    (get_local $9)
+                                    (get_local $23)
                                   )
                                 )
                               )
                             )
                             (if
-                              (tee_local $10
+                              (tee_local $9
                                 (i32.load offset=20
-                                  (get_local $11)
+                                  (get_local $10)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $10)
+                                  (get_local $9)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2355,12 +2355,12 @@
                                 (call $qa)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $22)
-                                    (get_local $10)
+                                    (get_local $23)
+                                    (get_local $9)
                                   )
                                   (i32.store offset=24
-                                    (get_local $10)
-                                    (get_local $22)
+                                    (get_local $9)
+                                    (get_local $23)
                                   )
                                 )
                               )
@@ -2376,9 +2376,9 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $11)
+                              (get_local $10)
                               (i32.or
-                                (tee_local $5
+                                (tee_local $1
                                   (i32.add
                                     (get_local $16)
                                     (get_local $0)
@@ -2388,18 +2388,18 @@
                               )
                             )
                             (i32.store
-                              (tee_local $10
+                              (tee_local $9
                                 (i32.add
                                   (i32.add
-                                    (get_local $11)
-                                    (get_local $5)
+                                    (get_local $10)
+                                    (get_local $1)
                                   )
                                   (i32.const 4)
                                 )
                               )
                               (i32.or
                                 (i32.load
-                                  (get_local $10)
+                                  (get_local $9)
                                 )
                                 (i32.const 1)
                               )
@@ -2407,14 +2407,14 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $11)
+                              (get_local $10)
                               (i32.or
                                 (get_local $0)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
-                              (get_local $8)
+                              (get_local $7)
                               (i32.or
                                 (get_local $16)
                                 (i32.const 1)
@@ -2422,12 +2422,12 @@
                             )
                             (i32.store
                               (i32.add
-                                (get_local $8)
+                                (get_local $7)
                                 (get_local $16)
                               )
                               (get_local $16)
                             )
-                            (set_local $10
+                            (set_local $9
                               (i32.shr_u
                                 (get_local $16)
                                 (i32.const 3)
@@ -2439,12 +2439,12 @@
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $5
+                                (set_local $1
                                   (i32.add
                                     (i32.const 1248)
                                     (i32.shl
                                       (i32.shl
-                                        (get_local $10)
+                                        (get_local $9)
                                         (i32.const 1)
                                       )
                                       (i32.const 2)
@@ -2453,7 +2453,7 @@
                                 )
                                 (if
                                   (i32.and
-                                    (tee_local $3
+                                    (tee_local $4
                                       (i32.load
                                         (i32.const 1208)
                                       )
@@ -2461,17 +2461,17 @@
                                     (tee_local $2
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $10)
+                                        (get_local $9)
                                       )
                                     )
                                   )
                                   (if
                                     (i32.lt_u
-                                      (tee_local $3
+                                      (tee_local $4
                                         (i32.load
                                           (tee_local $2
                                             (i32.add
-                                              (get_local $5)
+                                              (get_local $1)
                                               (i32.const 8)
                                             )
                                           )
@@ -2486,8 +2486,8 @@
                                       (set_local $19
                                         (get_local $2)
                                       )
-                                      (set_local $7
-                                        (get_local $3)
+                                      (set_local $6
+                                        (get_local $4)
                                       )
                                     )
                                   )
@@ -2495,36 +2495,36 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $3)
+                                        (get_local $4)
                                         (get_local $2)
                                       )
                                     )
                                     (set_local $19
                                       (i32.add
-                                        (get_local $5)
+                                        (get_local $1)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $7
-                                      (get_local $5)
+                                    (set_local $6
+                                      (get_local $1)
                                     )
                                   )
                                 )
                                 (i32.store
                                   (get_local $19)
-                                  (get_local $8)
+                                  (get_local $7)
                                 )
                                 (i32.store offset=12
+                                  (get_local $6)
                                   (get_local $7)
-                                  (get_local $8)
                                 )
                                 (i32.store offset=8
-                                  (get_local $8)
                                   (get_local $7)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=12
-                                  (get_local $8)
-                                  (get_local $5)
+                                  (get_local $7)
+                                  (get_local $1)
                                 )
                                 (br $do-once25)
                               )
@@ -2533,9 +2533,9 @@
                               (i32.add
                                 (i32.const 1512)
                                 (i32.shl
-                                  (tee_local $3
+                                  (tee_local $11
                                     (if i32
-                                      (tee_local $5
+                                      (tee_local $1
                                         (i32.shr_u
                                           (get_local $16)
                                           (i32.const 8)
@@ -2558,18 +2558,18 @@
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (tee_local $5
+                                                          (tee_local $1
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
                                                                   (tee_local $2
                                                                     (i32.shl
-                                                                      (get_local $5)
-                                                                      (tee_local $3
+                                                                      (get_local $1)
+                                                                      (tee_local $4
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $5)
+                                                                              (get_local $1)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -2586,16 +2586,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $3)
+                                                          (get_local $4)
                                                         )
                                                         (tee_local $2
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $10
+                                                                (tee_local $9
                                                                   (i32.shl
                                                                     (get_local $2)
-                                                                    (get_local $5)
+                                                                    (get_local $1)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -2609,7 +2609,7 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $10)
+                                                        (get_local $9)
                                                         (get_local $2)
                                                       )
                                                       (i32.const 15)
@@ -2635,13 +2635,13 @@
                               )
                             )
                             (i32.store offset=28
-                              (get_local $8)
-                              (get_local $3)
+                              (get_local $7)
+                              (get_local $11)
                             )
                             (i32.store offset=4
                               (tee_local $2
                                 (i32.add
-                                  (get_local $8)
+                                  (get_local $7)
                                   (i32.const 16)
                                 )
                               )
@@ -2659,10 +2659,10 @@
                                       (i32.const 1212)
                                     )
                                   )
-                                  (tee_local $10
+                                  (tee_local $9
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $3)
+                                      (get_local $11)
                                     )
                                   )
                                 )
@@ -2672,29 +2672,29 @@
                                   (i32.const 1212)
                                   (i32.or
                                     (get_local $2)
-                                    (get_local $10)
+                                    (get_local $9)
                                   )
                                 )
                                 (i32.store
                                   (get_local $15)
-                                  (get_local $8)
+                                  (get_local $7)
                                 )
                                 (i32.store offset=24
-                                  (get_local $8)
+                                  (get_local $7)
                                   (get_local $15)
                                 )
                                 (i32.store offset=12
-                                  (get_local $8)
-                                  (get_local $8)
+                                  (get_local $7)
+                                  (get_local $7)
                                 )
                                 (i32.store offset=8
-                                  (get_local $8)
-                                  (get_local $8)
+                                  (get_local $7)
+                                  (get_local $7)
                                 )
                                 (br $do-once25)
                               )
                             )
-                            (set_local $10
+                            (set_local $9
                               (i32.shl
                                 (get_local $16)
                                 (select
@@ -2702,12 +2702,12 @@
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $3)
+                                      (get_local $11)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $3)
+                                    (get_local $11)
                                     (i32.const 31)
                                   )
                                 )
@@ -2734,14 +2734,14 @@
                                     (set_local $18
                                       (get_local $2)
                                     )
-                                    (set_local $9
+                                    (set_local $8
                                       (i32.const 148)
                                     )
                                     (br $while-out27)
                                   )
                                 )
                                 (if
-                                  (tee_local $3
+                                  (tee_local $4
                                     (i32.load
                                       (tee_local $15
                                         (i32.add
@@ -2751,7 +2751,7 @@
                                           )
                                           (i32.shl
                                             (i32.shr_u
-                                              (get_local $10)
+                                              (get_local $9)
                                               (i32.const 31)
                                             )
                                             (i32.const 2)
@@ -2761,25 +2761,25 @@
                                     )
                                   )
                                   (block
-                                    (set_local $10
+                                    (set_local $9
                                       (i32.shl
-                                        (get_local $10)
+                                        (get_local $9)
                                         (i32.const 1)
                                       )
                                     )
                                     (set_local $2
-                                      (get_local $3)
+                                      (get_local $4)
                                     )
                                     (br $while-in28)
                                   )
                                   (block
-                                    (set_local $21
+                                    (set_local $22
                                       (get_local $15)
                                     )
                                     (set_local $14
                                       (get_local $2)
                                     )
-                                    (set_local $9
+                                    (set_local $8
                                       (i32.const 145)
                                     )
                                   )
@@ -2788,12 +2788,12 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $9)
+                                (get_local $8)
                                 (i32.const 145)
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $21)
+                                  (get_local $22)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2801,32 +2801,32 @@
                                 (call $qa)
                                 (block
                                   (i32.store
-                                    (get_local $21)
-                                    (get_local $8)
+                                    (get_local $22)
+                                    (get_local $7)
                                   )
                                   (i32.store offset=24
-                                    (get_local $8)
+                                    (get_local $7)
                                     (get_local $14)
                                   )
                                   (i32.store offset=12
-                                    (get_local $8)
-                                    (get_local $8)
+                                    (get_local $7)
+                                    (get_local $7)
                                   )
                                   (i32.store offset=8
-                                    (get_local $8)
-                                    (get_local $8)
+                                    (get_local $7)
+                                    (get_local $7)
                                   )
                                 )
                               )
                               (if
                                 (i32.eq
-                                  (get_local $9)
+                                  (get_local $8)
                                   (i32.const 148)
                                 )
                                 (if
                                   (i32.and
                                     (i32.ge_u
-                                      (tee_local $10
+                                      (tee_local $9
                                         (i32.load
                                           (tee_local $2
                                             (i32.add
@@ -2836,7 +2836,7 @@
                                           )
                                         )
                                       )
-                                      (tee_local $3
+                                      (tee_local $4
                                         (i32.load
                                           (i32.const 1224)
                                         )
@@ -2844,28 +2844,28 @@
                                     )
                                     (i32.ge_u
                                       (get_local $18)
-                                      (get_local $3)
+                                      (get_local $4)
                                     )
                                   )
                                   (block
                                     (i32.store offset=12
-                                      (get_local $10)
-                                      (get_local $8)
+                                      (get_local $9)
+                                      (get_local $7)
                                     )
                                     (i32.store
                                       (get_local $2)
-                                      (get_local $8)
+                                      (get_local $7)
                                     )
                                     (i32.store offset=8
-                                      (get_local $8)
-                                      (get_local $10)
+                                      (get_local $7)
+                                      (get_local $9)
                                     )
                                     (i32.store offset=12
-                                      (get_local $8)
+                                      (get_local $7)
                                       (get_local $18)
                                     )
                                     (i32.store offset=24
-                                      (get_local $8)
+                                      (get_local $7)
                                       (i32.const 0)
                                     )
                                   )
@@ -2881,21 +2881,21 @@
                       )
                       (return
                         (i32.add
-                          (get_local $11)
+                          (get_local $10)
                           (i32.const 8)
                         )
                       )
                     )
-                    (set_local $6
+                    (set_local $4
                       (get_local $0)
                     )
                   )
-                  (set_local $6
+                  (set_local $4
                     (get_local $0)
                   )
                 )
               )
-              (set_local $6
+              (set_local $4
                 (get_local $0)
               )
             )
@@ -2905,12 +2905,12 @@
     )
     (if
       (i32.ge_u
-        (tee_local $11
+        (tee_local $10
           (i32.load
             (i32.const 1216)
           )
         )
-        (get_local $6)
+        (get_local $4)
       )
       (block
         (set_local $14
@@ -2922,8 +2922,8 @@
           (i32.gt_u
             (tee_local $18
               (i32.sub
-                (get_local $11)
-                (get_local $6)
+                (get_local $10)
+                (get_local $4)
               )
             )
             (i32.const 15)
@@ -2931,10 +2931,10 @@
           (block
             (i32.store
               (i32.const 1228)
-              (tee_local $21
+              (tee_local $22
                 (i32.add
                   (get_local $14)
-                  (get_local $6)
+                  (get_local $4)
                 )
               )
             )
@@ -2943,7 +2943,7 @@
               (get_local $18)
             )
             (i32.store offset=4
-              (get_local $21)
+              (get_local $22)
               (i32.or
                 (get_local $18)
                 (i32.const 1)
@@ -2951,7 +2951,7 @@
             )
             (i32.store
               (i32.add
-                (get_local $21)
+                (get_local $22)
                 (get_local $18)
               )
               (get_local $18)
@@ -2959,7 +2959,7 @@
             (i32.store offset=4
               (get_local $14)
               (i32.or
-                (get_local $6)
+                (get_local $4)
                 (i32.const 3)
               )
             )
@@ -2976,7 +2976,7 @@
             (i32.store offset=4
               (get_local $14)
               (i32.or
-                (get_local $11)
+                (get_local $10)
                 (i32.const 3)
               )
             )
@@ -2985,7 +2985,7 @@
                 (i32.add
                   (i32.add
                     (get_local $14)
-                    (get_local $11)
+                    (get_local $10)
                   )
                   (i32.const 4)
                 )
@@ -3017,7 +3017,7 @@
             (i32.const 1220)
           )
         )
-        (get_local $6)
+        (get_local $4)
       )
       (block
         (i32.store
@@ -3025,25 +3025,25 @@
           (tee_local $18
             (i32.sub
               (get_local $14)
-              (get_local $6)
+              (get_local $4)
             )
           )
         )
         (i32.store
           (i32.const 1232)
-          (tee_local $11
+          (tee_local $10
             (i32.add
               (tee_local $14
                 (i32.load
                   (i32.const 1232)
                 )
               )
-              (get_local $6)
+              (get_local $4)
             )
           )
         )
         (i32.store offset=4
-          (get_local $11)
+          (get_local $10)
           (i32.or
             (get_local $18)
             (i32.const 1)
@@ -3052,7 +3052,7 @@
         (i32.store offset=4
           (get_local $14)
           (i32.or
-            (get_local $6)
+            (get_local $4)
             (i32.const 3)
           )
         )
@@ -3118,7 +3118,7 @@
     )
     (set_local $14
       (i32.add
-        (get_local $6)
+        (get_local $4)
         (i32.const 48)
       )
     )
@@ -3126,7 +3126,7 @@
       (i32.le_u
         (tee_local $13
           (i32.and
-            (tee_local $11
+            (tee_local $10
               (i32.add
                 (tee_local $13
                   (i32.load
@@ -3135,13 +3135,13 @@
                 )
                 (tee_local $18
                   (i32.add
-                    (get_local $6)
+                    (get_local $4)
                     (i32.const 47)
                   )
                 )
               )
             )
-            (tee_local $21
+            (tee_local $22
               (i32.sub
                 (i32.const 0)
                 (get_local $13)
@@ -3149,7 +3149,7 @@
             )
           )
         )
-        (get_local $6)
+        (get_local $4)
       )
       (block
         (set_global $r
@@ -3169,9 +3169,9 @@
       (if
         (i32.or
           (i32.le_u
-            (tee_local $7
+            (tee_local $6
               (i32.add
-                (tee_local $3
+                (tee_local $11
                   (i32.load
                     (i32.const 1640)
                   )
@@ -3179,10 +3179,10 @@
                 (get_local $13)
               )
             )
-            (get_local $3)
+            (get_local $11)
           )
           (i32.gt_u
-            (get_local $7)
+            (get_local $6)
             (get_local $16)
           )
         )
@@ -3198,7 +3198,7 @@
     )
     (if
       (i32.eq
-        (tee_local $9
+        (tee_local $8
           (block $label$break$b i32
             (if i32
               (i32.and
@@ -3217,16 +3217,16 @@
                       )
                     )
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.const 1656)
                       )
                       (loop $while-in32
                         (block $while-out31
                           (if
                             (i32.le_u
-                              (tee_local $3
+                              (tee_local $11
                                 (i32.load
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                               )
                               (get_local $16)
@@ -3234,11 +3234,11 @@
                             (if
                               (i32.gt_u
                                 (i32.add
-                                  (get_local $3)
+                                  (get_local $11)
                                   (i32.load
                                     (tee_local $19
                                       (i32.add
-                                        (get_local $7)
+                                        (get_local $6)
                                         (i32.const 4)
                                       )
                                     )
@@ -3248,7 +3248,7 @@
                               )
                               (block
                                 (set_local $0
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                                 (set_local $5
                                   (get_local $19)
@@ -3258,13 +3258,13 @@
                             )
                           )
                           (br_if $while-in32
-                            (tee_local $7
+                            (tee_local $6
                               (i32.load offset=8
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                           )
-                          (set_local $9
+                          (set_local $8
                             (i32.const 171)
                           )
                           (br $label$break$c)
@@ -3272,15 +3272,15 @@
                       )
                       (if
                         (i32.lt_u
-                          (tee_local $7
+                          (tee_local $6
                             (i32.and
                               (i32.sub
-                                (get_local $11)
+                                (get_local $10)
                                 (i32.load
                                   (i32.const 1220)
                                 )
                               )
-                              (get_local $21)
+                              (get_local $22)
                             )
                           )
                           (i32.const 2147483647)
@@ -3289,7 +3289,7 @@
                           (i32.eq
                             (tee_local $19
                               (call $ta
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                             (i32.add
@@ -3311,7 +3311,7 @@
                                 (get_local $19)
                               )
                               (set_local $26
-                                (get_local $7)
+                                (get_local $6)
                               )
                               (br $label$break$b
                                 (i32.const 191)
@@ -3322,17 +3322,17 @@
                             (set_local $12
                               (get_local $19)
                             )
-                            (set_local $1
-                              (get_local $7)
+                            (set_local $3
+                              (get_local $6)
                             )
-                            (set_local $9
+                            (set_local $8
                               (i32.const 181)
                             )
                           )
                         )
                       )
                     )
-                    (set_local $9
+                    (set_local $8
                       (i32.const 171)
                     )
                   )
@@ -3340,7 +3340,7 @@
                 (block $do-once33
                   (if
                     (i32.eq
-                      (get_local $9)
+                      (get_local $8)
                       (i32.const 171)
                     )
                     (if
@@ -3358,7 +3358,7 @@
                             (i32.and
                               (tee_local $19
                                 (i32.add
-                                  (tee_local $7
+                                  (tee_local $6
                                     (i32.load
                                       (i32.const 1684)
                                     )
@@ -3382,7 +3382,7 @@
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                               )
                             )
@@ -3391,7 +3391,7 @@
                         )
                         (set_local $0
                           (i32.add
-                            (tee_local $7
+                            (tee_local $6
                               (i32.load
                                 (i32.const 1640)
                               )
@@ -3403,7 +3403,7 @@
                           (i32.and
                             (i32.gt_u
                               (get_local $2)
-                              (get_local $6)
+                              (get_local $4)
                             )
                             (i32.lt_u
                               (get_local $2)
@@ -3421,7 +3421,7 @@
                                 (i32.or
                                   (i32.le_u
                                     (get_local $0)
-                                    (get_local $7)
+                                    (get_local $6)
                                   )
                                   (i32.gt_u
                                     (get_local $0)
@@ -3454,10 +3454,10 @@
                                 (set_local $12
                                   (get_local $19)
                                 )
-                                (set_local $1
+                                (set_local $3
                                   (get_local $2)
                                 )
-                                (set_local $9
+                                (set_local $8
                                   (i32.const 181)
                                 )
                               )
@@ -3471,25 +3471,25 @@
                 (block $label$break$d
                   (if
                     (i32.eq
-                      (get_local $9)
+                      (get_local $8)
                       (i32.const 181)
                     )
                     (block
                       (set_local $19
                         (i32.sub
                           (i32.const 0)
-                          (get_local $1)
+                          (get_local $3)
                         )
                       )
                       (if
                         (i32.and
                           (i32.gt_u
                             (get_local $14)
-                            (get_local $1)
+                            (get_local $3)
                           )
                           (i32.and
                             (i32.lt_u
-                              (get_local $1)
+                              (get_local $3)
                               (i32.const 2147483647)
                             )
                             (i32.ne
@@ -3505,7 +3505,7 @@
                                 (i32.add
                                   (i32.sub
                                     (get_local $18)
-                                    (get_local $1)
+                                    (get_local $3)
                                   )
                                   (tee_local $16
                                     (i32.load
@@ -3536,19 +3536,19 @@
                               )
                               (br $label$break$d)
                             )
-                            (set_local $4
+                            (set_local $1
                               (i32.add
                                 (get_local $0)
-                                (get_local $1)
+                                (get_local $3)
                               )
                             )
                           )
-                          (set_local $4
-                            (get_local $1)
+                          (set_local $1
+                            (get_local $3)
                           )
                         )
-                        (set_local $4
-                          (get_local $1)
+                        (set_local $1
+                          (get_local $3)
                         )
                       )
                       (if
@@ -3561,7 +3561,7 @@
                             (get_local $12)
                           )
                           (set_local $26
-                            (get_local $4)
+                            (get_local $1)
                           )
                           (br $label$break$b
                             (i32.const 191)
@@ -3595,7 +3595,7 @@
         (if
           (i32.and
             (i32.lt_u
-              (tee_local $4
+              (tee_local $1
                 (call $ta
                   (get_local $13)
                 )
@@ -3608,7 +3608,7 @@
             )
             (i32.and
               (i32.ne
-                (get_local $4)
+                (get_local $1)
                 (i32.const -1)
               )
               (i32.ne
@@ -3622,22 +3622,22 @@
               (tee_local $12
                 (i32.sub
                   (get_local $13)
-                  (get_local $4)
+                  (get_local $1)
                 )
               )
               (i32.add
-                (get_local $6)
+                (get_local $4)
                 (i32.const 40)
               )
             )
             (block
               (set_local $20
-                (get_local $4)
+                (get_local $1)
               )
               (set_local $26
                 (get_local $12)
               )
-              (set_local $9
+              (set_local $8
                 (i32.const 191)
               )
             )
@@ -3647,7 +3647,7 @@
     )
     (if
       (i32.eq
-        (get_local $9)
+        (get_local $8)
         (i32.const 191)
       )
       (block
@@ -3682,7 +3682,7 @@
               )
             )
             (block
-              (set_local $1
+              (set_local $3
                 (i32.const 1656)
               )
               (loop $do-in41
@@ -3691,16 +3691,16 @@
                     (i32.eq
                       (get_local $20)
                       (i32.add
-                        (tee_local $4
+                        (tee_local $1
                           (i32.load
-                            (get_local $1)
+                            (get_local $3)
                           )
                         )
                         (tee_local $18
                           (i32.load
                             (tee_local $13
                               (i32.add
-                                (get_local $1)
+                                (get_local $3)
                                 (i32.const 4)
                               )
                             )
@@ -3710,7 +3710,7 @@
                     )
                     (block
                       (set_local $49
-                        (get_local $4)
+                        (get_local $1)
                       )
                       (set_local $50
                         (get_local $13)
@@ -3719,9 +3719,9 @@
                         (get_local $18)
                       )
                       (set_local $52
-                        (get_local $1)
+                        (get_local $3)
                       )
-                      (set_local $9
+                      (set_local $8
                         (i32.const 201)
                       )
                       (br $do-out40)
@@ -3729,9 +3729,9 @@
                   )
                   (br_if $do-in41
                     (i32.ne
-                      (tee_local $1
+                      (tee_local $3
                         (i32.load offset=8
-                          (get_local $1)
+                          (get_local $3)
                         )
                       )
                       (i32.const 0)
@@ -3741,7 +3741,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $9)
+                  (get_local $8)
                   (i32.const 201)
                 )
                 (if
@@ -3772,7 +3772,7 @@
                           (get_local $26)
                         )
                       )
-                      (set_local $1
+                      (set_local $3
                         (i32.add
                           (get_local $12)
                           (tee_local $18
@@ -3780,7 +3780,7 @@
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (tee_local $1
+                                  (tee_local $3
                                     (i32.add
                                       (get_local $12)
                                       (i32.const 8)
@@ -3791,7 +3791,7 @@
                               )
                               (i32.const 0)
                               (i32.and
-                                (get_local $1)
+                                (get_local $3)
                                 (i32.const 7)
                               )
                             )
@@ -3811,14 +3811,14 @@
                       )
                       (i32.store
                         (i32.const 1232)
-                        (get_local $1)
+                        (get_local $3)
                       )
                       (i32.store
                         (i32.const 1220)
                         (get_local $13)
                       )
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $3)
                         (i32.or
                           (get_local $13)
                           (i32.const 1)
@@ -3826,7 +3826,7 @@
                       )
                       (i32.store offset=4
                         (i32.add
-                          (get_local $1)
+                          (get_local $3)
                           (get_local $13)
                         )
                         (i32.const 40)
@@ -3842,7 +3842,7 @@
                   )
                 )
               )
-              (set_local $8
+              (set_local $7
                 (if i32
                   (i32.lt_u
                     (get_local $20)
@@ -3868,7 +3868,7 @@
                   (get_local $26)
                 )
               )
-              (set_local $1
+              (set_local $3
                 (i32.const 1656)
               )
               (loop $while-in43
@@ -3876,38 +3876,38 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $1)
+                        (get_local $3)
                       )
                       (get_local $13)
                     )
                     (block
                       (set_local $53
-                        (get_local $1)
+                        (get_local $3)
                       )
                       (set_local $43
-                        (get_local $1)
+                        (get_local $3)
                       )
-                      (set_local $9
+                      (set_local $8
                         (i32.const 209)
                       )
                       (br $while-out42)
                     )
                   )
                   (br_if $while-in43
-                    (tee_local $1
+                    (tee_local $3
                       (i32.load offset=8
-                        (get_local $1)
+                        (get_local $3)
                       )
                     )
                   )
-                  (set_local $30
+                  (set_local $29
                     (i32.const 1656)
                   )
                 )
               )
               (if
                 (i32.eq
-                  (get_local $9)
+                  (get_local $8)
                   (i32.const 209)
                 )
                 (if
@@ -3917,7 +3917,7 @@
                     )
                     (i32.const 8)
                   )
-                  (set_local $30
+                  (set_local $29
                     (i32.const 1656)
                   )
                   (block
@@ -3926,7 +3926,7 @@
                       (get_local $20)
                     )
                     (i32.store
-                      (tee_local $1
+                      (tee_local $3
                         (i32.add
                           (get_local $43)
                           (i32.const 4)
@@ -3934,7 +3934,7 @@
                       )
                       (i32.add
                         (i32.load
-                          (get_local $1)
+                          (get_local $3)
                         )
                         (get_local $26)
                       )
@@ -3946,7 +3946,7 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $1
+                              (tee_local $3
                                 (i32.add
                                   (get_local $20)
                                   (i32.const 8)
@@ -3957,20 +3957,20 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $1)
+                            (get_local $3)
                             (i32.const 7)
                           )
                         )
                       )
                     )
-                    (set_local $4
+                    (set_local $1
                       (i32.add
                         (get_local $13)
                         (select
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $1
+                              (tee_local $3
                                 (i32.add
                                   (get_local $13)
                                   (i32.const 8)
@@ -3981,38 +3981,38 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $1)
+                            (get_local $3)
                             (i32.const 7)
                           )
                         )
                       )
                     )
-                    (set_local $1
+                    (set_local $3
                       (i32.add
                         (get_local $18)
-                        (get_local $6)
+                        (get_local $4)
                       )
                     )
                     (set_local $14
                       (i32.sub
                         (i32.sub
-                          (get_local $4)
+                          (get_local $1)
                           (get_local $18)
                         )
-                        (get_local $6)
+                        (get_local $4)
                       )
                     )
                     (i32.store offset=4
                       (get_local $18)
                       (i32.or
-                        (get_local $6)
+                        (get_local $4)
                         (i32.const 3)
                       )
                     )
                     (block $do-once44
                       (if
                         (i32.eq
-                          (get_local $4)
+                          (get_local $1)
                           (get_local $12)
                         )
                         (block
@@ -4029,10 +4029,10 @@
                           )
                           (i32.store
                             (i32.const 1232)
-                            (get_local $1)
+                            (get_local $3)
                           )
                           (i32.store offset=4
-                            (get_local $1)
+                            (get_local $3)
                             (i32.or
                               (get_local $2)
                               (i32.const 1)
@@ -4042,7 +4042,7 @@
                         (block
                           (if
                             (i32.eq
-                              (get_local $4)
+                              (get_local $1)
                               (i32.load
                                 (i32.const 1228)
                               )
@@ -4061,10 +4061,10 @@
                               )
                               (i32.store
                                 (i32.const 1228)
-                                (get_local $1)
+                                (get_local $3)
                               )
                               (i32.store offset=4
-                                (get_local $1)
+                                (get_local $3)
                                 (i32.or
                                   (get_local $2)
                                   (i32.const 1)
@@ -4072,7 +4072,7 @@
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $1)
+                                  (get_local $3)
                                   (get_local $2)
                                 )
                                 (get_local $2)
@@ -4088,7 +4088,7 @@
                                     (i32.and
                                       (tee_local $2
                                         (i32.load offset=4
-                                          (get_local $4)
+                                          (get_local $1)
                                         )
                                       )
                                       (i32.const 3)
@@ -4115,17 +4115,17 @@
                                           (i32.const 256)
                                         )
                                         (block
-                                          (set_local $11
+                                          (set_local $10
                                             (i32.load offset=12
-                                              (get_local $4)
+                                              (get_local $1)
                                             )
                                           )
                                           (block $do-once47
                                             (if
                                               (i32.ne
-                                                (tee_local $21
+                                                (tee_local $22
                                                   (i32.load offset=8
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
                                                 )
                                                 (tee_local $19
@@ -4144,17 +4144,17 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $21)
-                                                    (get_local $8)
+                                                    (get_local $22)
+                                                    (get_local $7)
                                                   )
                                                   (call $qa)
                                                 )
                                                 (br_if $do-once47
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $21)
+                                                      (get_local $22)
                                                     )
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
                                                 )
                                                 (call $qa)
@@ -4163,8 +4163,8 @@
                                           )
                                           (if
                                             (i32.eq
-                                              (get_local $11)
-                                              (get_local $21)
+                                              (get_local $10)
+                                              (get_local $22)
                                             )
                                             (block
                                               (i32.store
@@ -4188,20 +4188,20 @@
                                           (block $do-once49
                                             (if
                                               (i32.eq
-                                                (get_local $11)
+                                                (get_local $10)
                                                 (get_local $19)
                                               )
                                               (set_local $44
                                                 (i32.add
-                                                  (get_local $11)
+                                                  (get_local $10)
                                                   (i32.const 8)
                                                 )
                                               )
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $11)
-                                                    (get_local $8)
+                                                    (get_local $10)
+                                                    (get_local $7)
                                                   )
                                                   (call $qa)
                                                 )
@@ -4210,12 +4210,12 @@
                                                     (i32.load
                                                       (tee_local $0
                                                         (i32.add
-                                                          (get_local $11)
+                                                          (get_local $10)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
                                                   (block
                                                     (set_local $44
@@ -4229,18 +4229,18 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $21)
-                                            (get_local $11)
+                                            (get_local $22)
+                                            (get_local $10)
                                           )
                                           (i32.store
                                             (get_local $44)
-                                            (get_local $21)
+                                            (get_local $22)
                                           )
                                         )
                                         (block
                                           (set_local $19
                                             (i32.load offset=24
-                                              (get_local $4)
+                                              (get_local $1)
                                             )
                                           )
                                           (block $do-once51
@@ -4248,20 +4248,20 @@
                                               (i32.eq
                                                 (tee_local $0
                                                   (i32.load offset=12
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
                                                 )
-                                                (get_local $4)
+                                                (get_local $1)
                                               )
                                               (block
                                                 (if
-                                                  (tee_local $3
+                                                  (tee_local $11
                                                     (i32.load
-                                                      (tee_local $7
+                                                      (tee_local $6
                                                         (i32.add
                                                           (tee_local $16
                                                             (i32.add
-                                                              (get_local $4)
+                                                              (get_local $1)
                                                               (i32.const 16)
                                                             )
                                                           )
@@ -4272,20 +4272,20 @@
                                                   )
                                                   (block
                                                     (set_local $0
-                                                      (get_local $3)
+                                                      (get_local $11)
                                                     )
                                                     (set_local $16
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $22
+                                                    (tee_local $23
                                                       (i32.load
                                                         (get_local $16)
                                                       )
                                                     )
                                                     (set_local $0
-                                                      (get_local $22)
+                                                      (get_local $23)
                                                     )
                                                     (block
                                                       (set_local $24
@@ -4297,9 +4297,9 @@
                                                 )
                                                 (loop $while-in54
                                                   (if
-                                                    (tee_local $3
+                                                    (tee_local $11
                                                       (i32.load
-                                                        (tee_local $7
+                                                        (tee_local $6
                                                           (i32.add
                                                             (get_local $0)
                                                             (i32.const 20)
@@ -4309,18 +4309,18 @@
                                                     )
                                                     (block
                                                       (set_local $0
-                                                        (get_local $3)
+                                                        (get_local $11)
                                                       )
                                                       (set_local $16
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                       )
                                                       (br $while-in54)
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $3
+                                                    (tee_local $11
                                                       (i32.load
-                                                        (tee_local $7
+                                                        (tee_local $6
                                                           (i32.add
                                                             (get_local $0)
                                                             (i32.const 16)
@@ -4330,10 +4330,10 @@
                                                     )
                                                     (block
                                                       (set_local $0
-                                                        (get_local $3)
+                                                        (get_local $11)
                                                       )
                                                       (set_local $16
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                       )
                                                       (br $while-in54)
                                                     )
@@ -4342,7 +4342,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $16)
-                                                    (get_local $8)
+                                                    (get_local $7)
                                                   )
                                                   (call $qa)
                                                   (block
@@ -4359,26 +4359,26 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.load offset=8
-                                                        (get_local $4)
+                                                        (get_local $1)
                                                       )
                                                     )
-                                                    (get_local $8)
+                                                    (get_local $7)
                                                   )
                                                   (call $qa)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (tee_local $3
+                                                      (tee_local $11
                                                         (i32.add
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                           (i32.const 12)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
                                                   (call $qa)
                                                 )
@@ -4392,16 +4392,16 @@
                                                         )
                                                       )
                                                     )
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $3)
+                                                      (get_local $11)
                                                       (get_local $0)
                                                     )
                                                     (i32.store
                                                       (get_local $16)
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                     )
                                                     (set_local $24
                                                       (get_local $0)
@@ -4420,15 +4420,15 @@
                                           (block $do-once55
                                             (if
                                               (i32.eq
-                                                (get_local $4)
+                                                (get_local $1)
                                                 (i32.load
-                                                  (tee_local $21
+                                                  (tee_local $22
                                                     (i32.add
                                                       (i32.const 1512)
                                                       (i32.shl
                                                         (tee_local $0
                                                           (i32.load offset=28
-                                                            (get_local $4)
+                                                            (get_local $1)
                                                           )
                                                         )
                                                         (i32.const 2)
@@ -4439,7 +4439,7 @@
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $21)
+                                                  (get_local $22)
                                                   (get_local $24)
                                                 )
                                                 (br_if $do-once55
@@ -4475,17 +4475,17 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $11
+                                                      (tee_local $10
                                                         (i32.add
                                                           (get_local $19)
                                                           (i32.const 16)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
                                                   (i32.store
-                                                    (get_local $11)
+                                                    (get_local $10)
                                                     (get_local $24)
                                                   )
                                                   (i32.store offset=20
@@ -4517,11 +4517,11 @@
                                             (get_local $19)
                                           )
                                           (if
-                                            (tee_local $11
+                                            (tee_local $10
                                               (i32.load
-                                                (tee_local $21
+                                                (tee_local $22
                                                   (i32.add
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                     (i32.const 16)
                                                   )
                                                 )
@@ -4529,17 +4529,17 @@
                                             )
                                             (if
                                               (i32.lt_u
-                                                (get_local $11)
+                                                (get_local $10)
                                                 (get_local $0)
                                               )
                                               (call $qa)
                                               (block
                                                 (i32.store offset=16
                                                   (get_local $24)
-                                                  (get_local $11)
+                                                  (get_local $10)
                                                 )
                                                 (i32.store offset=24
-                                                  (get_local $11)
+                                                  (get_local $10)
                                                   (get_local $24)
                                                 )
                                               )
@@ -4547,16 +4547,16 @@
                                           )
                                           (br_if $label$break$e
                                             (i32.eqz
-                                              (tee_local $11
+                                              (tee_local $10
                                                 (i32.load offset=4
-                                                  (get_local $21)
+                                                  (get_local $22)
                                                 )
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $11)
+                                              (get_local $10)
                                               (i32.load
                                                 (i32.const 1224)
                                               )
@@ -4565,10 +4565,10 @@
                                             (block
                                               (i32.store offset=20
                                                 (get_local $24)
-                                                (get_local $11)
+                                                (get_local $10)
                                               )
                                               (i32.store offset=24
-                                                (get_local $11)
+                                                (get_local $10)
                                                 (get_local $24)
                                               )
                                             )
@@ -4583,11 +4583,11 @@
                                       )
                                     )
                                     (i32.add
-                                      (get_local $4)
+                                      (get_local $1)
                                       (get_local $5)
                                     )
                                   )
-                                  (get_local $4)
+                                  (get_local $1)
                                 )
                                 (i32.const 4)
                               )
@@ -4600,7 +4600,7 @@
                             )
                           )
                           (i32.store offset=4
-                            (get_local $1)
+                            (get_local $3)
                             (i32.or
                               (get_local $14)
                               (i32.const 1)
@@ -4608,7 +4608,7 @@
                           )
                           (i32.store
                             (i32.add
-                              (get_local $1)
+                              (get_local $3)
                               (get_local $14)
                             )
                             (get_local $14)
@@ -4640,7 +4640,7 @@
                               (block $do-once59
                                 (if
                                   (i32.and
-                                    (tee_local $11
+                                    (tee_local $10
                                       (i32.load
                                         (i32.const 1208)
                                       )
@@ -4685,7 +4685,7 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $11)
+                                        (get_local $10)
                                         (get_local $0)
                                       )
                                     )
@@ -4703,18 +4703,18 @@
                               )
                               (i32.store
                                 (get_local $45)
-                                (get_local $1)
+                                (get_local $3)
                               )
                               (i32.store offset=12
                                 (get_local $38)
-                                (get_local $1)
+                                (get_local $3)
                               )
                               (i32.store offset=8
-                                (get_local $1)
+                                (get_local $3)
                                 (get_local $38)
                               )
                               (i32.store offset=12
-                                (get_local $1)
+                                (get_local $3)
                                 (get_local $2)
                               )
                               (br $do-once44)
@@ -4724,7 +4724,7 @@
                             (i32.add
                               (i32.const 1512)
                               (i32.shl
-                                (tee_local $6
+                                (tee_local $5
                                   (block $do-once61 i32
                                     (if i32
                                       (tee_local $0
@@ -4748,7 +4748,7 @@
                                             (i32.shr_u
                                               (get_local $14)
                                               (i32.add
-                                                (tee_local $7
+                                                (tee_local $6
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
@@ -4761,7 +4761,7 @@
                                                                   (tee_local $5
                                                                     (i32.shl
                                                                       (get_local $0)
-                                                                      (tee_local $11
+                                                                      (tee_local $10
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
@@ -4782,7 +4782,7 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $11)
+                                                          (get_local $10)
                                                         )
                                                         (tee_local $5
                                                           (i32.and
@@ -4818,7 +4818,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $7)
+                                            (get_local $6)
                                             (i32.const 1)
                                           )
                                         )
@@ -4832,13 +4832,13 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $1)
-                            (get_local $6)
+                            (get_local $3)
+                            (get_local $5)
                           )
                           (i32.store offset=4
                             (tee_local $2
                               (i32.add
-                                (get_local $1)
+                                (get_local $3)
                                 (i32.const 16)
                               )
                             )
@@ -4856,10 +4856,10 @@
                                     (i32.const 1212)
                                   )
                                 )
-                                (tee_local $7
+                                (tee_local $6
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $6)
+                                    (get_local $5)
                                   )
                                 )
                               )
@@ -4869,29 +4869,29 @@
                                 (i32.const 1212)
                                 (i32.or
                                   (get_local $2)
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                               )
                               (i32.store
                                 (get_local $0)
-                                (get_local $1)
+                                (get_local $3)
                               )
                               (i32.store offset=24
-                                (get_local $1)
+                                (get_local $3)
                                 (get_local $0)
                               )
                               (i32.store offset=12
-                                (get_local $1)
-                                (get_local $1)
+                                (get_local $3)
+                                (get_local $3)
                               )
                               (i32.store offset=8
-                                (get_local $1)
-                                (get_local $1)
+                                (get_local $3)
+                                (get_local $3)
                               )
                               (br $do-once44)
                             )
                           )
-                          (set_local $7
+                          (set_local $6
                             (i32.shl
                               (get_local $14)
                               (select
@@ -4899,12 +4899,12 @@
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $6)
+                                    (get_local $5)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $6)
+                                  (get_local $5)
                                   (i32.const 31)
                                 )
                               )
@@ -4931,7 +4931,7 @@
                                   (set_local $39
                                     (get_local $2)
                                   )
-                                  (set_local $9
+                                  (set_local $8
                                     (i32.const 279)
                                   )
                                   (br $while-out63)
@@ -4948,7 +4948,7 @@
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $7)
+                                            (get_local $6)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -4958,9 +4958,9 @@
                                   )
                                 )
                                 (block
-                                  (set_local $7
+                                  (set_local $6
                                     (i32.shl
-                                      (get_local $7)
+                                      (get_local $6)
                                       (i32.const 1)
                                     )
                                   )
@@ -4976,7 +4976,7 @@
                                   (set_local $54
                                     (get_local $2)
                                   )
-                                  (set_local $9
+                                  (set_local $8
                                     (i32.const 276)
                                   )
                                 )
@@ -4985,7 +4985,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $9)
+                              (get_local $8)
                               (i32.const 276)
                             )
                             (if
@@ -4999,31 +4999,31 @@
                               (block
                                 (i32.store
                                   (get_local $46)
-                                  (get_local $1)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=24
-                                  (get_local $1)
+                                  (get_local $3)
                                   (get_local $54)
                                 )
                                 (i32.store offset=12
-                                  (get_local $1)
-                                  (get_local $1)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=8
-                                  (get_local $1)
-                                  (get_local $1)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $9)
+                                (get_local $8)
                                 (i32.const 279)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (tee_local $7
+                                    (tee_local $6
                                       (i32.load
                                         (tee_local $2
                                           (i32.add
@@ -5046,23 +5046,23 @@
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $7)
-                                    (get_local $1)
+                                    (get_local $6)
+                                    (get_local $3)
                                   )
                                   (i32.store
                                     (get_local $2)
-                                    (get_local $1)
+                                    (get_local $3)
                                   )
                                   (i32.store offset=8
-                                    (get_local $1)
-                                    (get_local $7)
+                                    (get_local $3)
+                                    (get_local $6)
                                   )
                                   (i32.store offset=12
-                                    (get_local $1)
+                                    (get_local $3)
                                     (get_local $39)
                                   )
                                   (i32.store offset=24
-                                    (get_local $1)
+                                    (get_local $3)
                                     (i32.const 0)
                                   )
                                 )
@@ -5089,9 +5089,9 @@
                 (block $while-out65
                   (if
                     (i32.le_u
-                      (tee_local $1
+                      (tee_local $3
                         (i32.load
-                          (get_local $30)
+                          (get_local $29)
                         )
                       )
                       (get_local $12)
@@ -5100,9 +5100,9 @@
                       (i32.gt_u
                         (tee_local $14
                           (i32.add
-                            (get_local $1)
+                            (get_local $3)
                             (i32.load offset=4
-                              (get_local $30)
+                              (get_local $29)
                             )
                           )
                         )
@@ -5116,9 +5116,9 @@
                       )
                     )
                   )
-                  (set_local $30
+                  (set_local $29
                     (i32.load offset=8
-                      (get_local $30)
+                      (get_local $29)
                     )
                   )
                   (br $while-in66)
@@ -5135,12 +5135,12 @@
                   (i32.const 8)
                 )
               )
-              (set_local $1
+              (set_local $3
                 (i32.add
                   (tee_local $18
                     (select
                       (get_local $12)
-                      (tee_local $1
+                      (tee_local $3
                         (i32.add
                           (get_local $18)
                           (select
@@ -5160,7 +5160,7 @@
                         )
                       )
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $3)
                         (tee_local $14
                           (i32.add
                             (get_local $12)
@@ -5175,7 +5175,7 @@
               )
               (i32.store
                 (i32.const 1232)
-                (tee_local $4
+                (tee_local $1
                   (i32.add
                     (get_local $20)
                     (tee_local $13
@@ -5183,7 +5183,7 @@
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (tee_local $4
+                            (tee_local $1
                               (i32.add
                                 (get_local $20)
                                 (i32.const 8)
@@ -5194,7 +5194,7 @@
                         )
                         (i32.const 0)
                         (i32.and
-                          (get_local $4)
+                          (get_local $1)
                           (i32.const 7)
                         )
                       )
@@ -5204,7 +5204,7 @@
               )
               (i32.store
                 (i32.const 1220)
-                (tee_local $7
+                (tee_local $6
                   (i32.sub
                     (i32.add
                       (get_local $26)
@@ -5215,16 +5215,16 @@
                 )
               )
               (i32.store offset=4
-                (get_local $4)
+                (get_local $1)
                 (i32.or
-                  (get_local $7)
+                  (get_local $6)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $4)
-                  (get_local $7)
+                  (get_local $1)
+                  (get_local $6)
                 )
                 (i32.const 40)
               )
@@ -5235,7 +5235,7 @@
                 )
               )
               (i32.store
-                (tee_local $7
+                (tee_local $6
                   (i32.add
                     (get_local $18)
                     (i32.const 4)
@@ -5244,25 +5244,25 @@
                 (i32.const 27)
               )
               (i32.store
-                (get_local $1)
+                (get_local $3)
                 (i32.load
                   (i32.const 1656)
                 )
               )
               (i32.store offset=4
-                (get_local $1)
+                (get_local $3)
                 (i32.load
                   (i32.const 1660)
                 )
               )
               (i32.store offset=8
-                (get_local $1)
+                (get_local $3)
                 (i32.load
                   (i32.const 1664)
                 )
               )
               (i32.store offset=12
-                (get_local $1)
+                (get_local $3)
                 (i32.load
                   (i32.const 1668)
                 )
@@ -5281,9 +5281,9 @@
               )
               (i32.store
                 (i32.const 1664)
-                (get_local $1)
+                (get_local $3)
               )
-              (set_local $1
+              (set_local $3
                 (i32.add
                   (get_local $18)
                   (i32.const 24)
@@ -5291,9 +5291,9 @@
               )
               (loop $do-in68
                 (i32.store
-                  (tee_local $1
+                  (tee_local $3
                     (i32.add
-                      (get_local $1)
+                      (get_local $3)
                       (i32.const 4)
                     )
                   )
@@ -5302,7 +5302,7 @@
                 (br_if $do-in68
                   (i32.lt_u
                     (i32.add
-                      (get_local $1)
+                      (get_local $3)
                       (i32.const 4)
                     )
                     (get_local $0)
@@ -5316,10 +5316,10 @@
                 )
                 (block
                   (i32.store
-                    (get_local $7)
+                    (get_local $6)
                     (i32.and
                       (i32.load
-                        (get_local $7)
+                        (get_local $6)
                       )
                       (i32.const -2)
                     )
@@ -5327,7 +5327,7 @@
                   (i32.store offset=4
                     (get_local $12)
                     (i32.or
-                      (tee_local $1
+                      (tee_local $3
                         (i32.sub
                           (get_local $18)
                           (get_local $12)
@@ -5338,17 +5338,17 @@
                   )
                   (i32.store
                     (get_local $18)
-                    (get_local $1)
+                    (get_local $3)
                   )
-                  (set_local $4
+                  (set_local $1
                     (i32.shr_u
-                      (get_local $1)
+                      (get_local $3)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $3)
                       (i32.const 256)
                     )
                     (block
@@ -5357,7 +5357,7 @@
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (get_local $4)
+                              (get_local $1)
                               (i32.const 1)
                             )
                             (i32.const 2)
@@ -5374,7 +5374,7 @@
                           (tee_local $5
                             (i32.shl
                               (i32.const 1)
-                              (get_local $4)
+                              (get_local $1)
                             )
                           )
                         )
@@ -5450,20 +5450,20 @@
                           (if i32
                             (tee_local $13
                               (i32.shr_u
-                                (get_local $1)
+                                (get_local $3)
                                 (i32.const 8)
                               )
                             )
                             (if i32
                               (i32.gt_u
-                                (get_local $1)
+                                (get_local $3)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $1)
+                                    (get_local $3)
                                     (i32.add
                                       (tee_local $0
                                         (i32.add
@@ -5505,7 +5505,7 @@
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (tee_local $4
+                                                      (tee_local $1
                                                         (i32.shl
                                                           (get_local $5)
                                                           (get_local $13)
@@ -5522,7 +5522,7 @@
                                           )
                                           (i32.shr_u
                                             (i32.shl
-                                              (get_local $4)
+                                              (get_local $1)
                                               (get_local $5)
                                             )
                                             (i32.const 15)
@@ -5567,7 +5567,7 @@
                             (i32.const 1212)
                           )
                         )
-                        (tee_local $4
+                        (tee_local $1
                           (i32.shl
                             (i32.const 1)
                             (get_local $2)
@@ -5580,7 +5580,7 @@
                         (i32.const 1212)
                         (i32.or
                           (get_local $5)
-                          (get_local $4)
+                          (get_local $1)
                         )
                       )
                       (i32.store
@@ -5602,9 +5602,9 @@
                       (br $do-once38)
                     )
                   )
-                  (set_local $4
+                  (set_local $1
                     (i32.shl
-                      (get_local $1)
+                      (get_local $3)
                       (select
                         (i32.const 0)
                         (i32.sub
@@ -5636,13 +5636,13 @@
                             )
                             (i32.const -8)
                           )
-                          (get_local $1)
+                          (get_local $3)
                         )
                         (block
-                          (set_local $31
+                          (set_local $30
                             (get_local $5)
                           )
-                          (set_local $9
+                          (set_local $8
                             (i32.const 305)
                           )
                           (br $while-out69)
@@ -5659,7 +5659,7 @@
                                 )
                                 (i32.shl
                                   (i32.shr_u
-                                    (get_local $4)
+                                    (get_local $1)
                                     (i32.const 31)
                                   )
                                   (i32.const 2)
@@ -5669,9 +5669,9 @@
                           )
                         )
                         (block
-                          (set_local $4
+                          (set_local $1
                             (i32.shl
-                              (get_local $4)
+                              (get_local $1)
                               (i32.const 1)
                             )
                           )
@@ -5687,7 +5687,7 @@
                           (set_local $55
                             (get_local $5)
                           )
-                          (set_local $9
+                          (set_local $8
                             (i32.const 302)
                           )
                         )
@@ -5696,7 +5696,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $9)
+                      (get_local $8)
                       (i32.const 302)
                     )
                     (if
@@ -5728,36 +5728,36 @@
                     )
                     (if
                       (i32.eq
-                        (get_local $9)
+                        (get_local $8)
                         (i32.const 305)
                       )
                       (if
                         (i32.and
                           (i32.ge_u
-                            (tee_local $4
+                            (tee_local $1
                               (i32.load
                                 (tee_local $5
                                   (i32.add
-                                    (get_local $31)
+                                    (get_local $30)
                                     (i32.const 8)
                                   )
                                 )
                               )
                             )
-                            (tee_local $1
+                            (tee_local $3
                               (i32.load
                                 (i32.const 1224)
                               )
                             )
                           )
                           (i32.ge_u
-                            (get_local $31)
-                            (get_local $1)
+                            (get_local $30)
+                            (get_local $3)
                           )
                         )
                         (block
                           (i32.store offset=12
-                            (get_local $4)
+                            (get_local $1)
                             (get_local $12)
                           )
                           (i32.store
@@ -5766,11 +5766,11 @@
                           )
                           (i32.store offset=8
                             (get_local $12)
-                            (get_local $4)
+                            (get_local $1)
                           )
                           (i32.store offset=12
                             (get_local $12)
-                            (get_local $31)
+                            (get_local $30)
                           )
                           (i32.store offset=24
                             (get_local $12)
@@ -5788,7 +5788,7 @@
               (if
                 (i32.or
                   (i32.eqz
-                    (tee_local $4
+                    (tee_local $1
                       (i32.load
                         (i32.const 1224)
                       )
@@ -5796,7 +5796,7 @@
                   )
                   (i32.lt_u
                     (get_local $20)
-                    (get_local $4)
+                    (get_local $1)
                   )
                 )
                 (i32.store
@@ -5826,7 +5826,7 @@
                 (i32.const 1240)
                 (i32.const -1)
               )
-              (set_local $4
+              (set_local $1
                 (i32.const 0)
               )
               (loop $do-in
@@ -5836,7 +5836,7 @@
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $4)
+                          (get_local $1)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -5851,9 +5851,9 @@
                 )
                 (br_if $do-in
                   (i32.ne
-                    (tee_local $4
+                    (tee_local $1
                       (i32.add
-                        (get_local $4)
+                        (get_local $1)
                         (i32.const 1)
                       )
                     )
@@ -5863,7 +5863,7 @@
               )
               (i32.store
                 (i32.const 1232)
-                (tee_local $4
+                (tee_local $1
                   (i32.add
                     (get_local $20)
                     (tee_local $13
@@ -5871,7 +5871,7 @@
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (tee_local $4
+                            (tee_local $1
                               (i32.add
                                 (get_local $20)
                                 (i32.const 8)
@@ -5882,7 +5882,7 @@
                         )
                         (i32.const 0)
                         (i32.and
-                          (get_local $4)
+                          (get_local $1)
                           (i32.const 7)
                         )
                       )
@@ -5892,7 +5892,7 @@
               )
               (i32.store
                 (i32.const 1220)
-                (tee_local $1
+                (tee_local $3
                   (i32.sub
                     (i32.add
                       (get_local $26)
@@ -5903,16 +5903,16 @@
                 )
               )
               (i32.store offset=4
-                (get_local $4)
+                (get_local $1)
                 (i32.or
-                  (get_local $1)
+                  (get_local $3)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $4)
                   (get_local $1)
+                  (get_local $3)
                 )
                 (i32.const 40)
               )
@@ -5932,42 +5932,42 @@
                 (i32.const 1220)
               )
             )
-            (get_local $6)
+            (get_local $4)
           )
           (block
             (i32.store
               (i32.const 1220)
-              (tee_local $31
+              (tee_local $30
                 (i32.sub
                   (get_local $12)
-                  (get_local $6)
+                  (get_local $4)
                 )
               )
             )
             (i32.store
               (i32.const 1232)
-              (tee_local $9
+              (tee_local $8
                 (i32.add
                   (tee_local $12
                     (i32.load
                       (i32.const 1232)
                     )
                   )
-                  (get_local $6)
+                  (get_local $4)
                 )
               )
             )
             (i32.store offset=4
-              (get_local $9)
+              (get_local $8)
               (i32.or
-                (get_local $31)
+                (get_local $30)
                 (i32.const 1)
               )
             )
             (i32.store offset=4
               (get_local $12)
               (i32.or
-                (get_local $6)
+                (get_local $4)
                 (i32.const 3)
               )
             )
@@ -6039,7 +6039,7 @@
       (i32.eq
         (tee_local $0
           (i32.and
-            (tee_local $3
+            (tee_local $4
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -6057,9 +6057,9 @@
     (set_local $8
       (i32.add
         (get_local $1)
-        (tee_local $5
+        (tee_local $6
           (i32.and
-            (get_local $3)
+            (get_local $4)
             (i32.const -8)
           )
         )
@@ -6068,7 +6068,7 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $3)
+          (get_local $4)
           (i32.const 1)
         )
         (block
@@ -6076,11 +6076,11 @@
             (get_local $1)
           )
           (set_local $7
-            (get_local $5)
+            (get_local $6)
           )
         )
         (block
-          (set_local $11
+          (set_local $10
             (i32.load
               (get_local $1)
             )
@@ -6091,10 +6091,10 @@
             )
             (return)
           )
-          (set_local $5
+          (set_local $6
             (i32.add
-              (get_local $11)
-              (get_local $5)
+              (get_local $10)
+              (get_local $6)
             )
           )
           (if
@@ -6104,7 +6104,7 @@
                   (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $11)
+                    (get_local $10)
                   )
                 )
               )
@@ -6123,7 +6123,7 @@
               (if
                 (i32.ne
                   (i32.and
-                    (tee_local $6
+                    (tee_local $3
                       (i32.load
                         (tee_local $1
                           (i32.add
@@ -6142,48 +6142,48 @@
                     (get_local $0)
                   )
                   (set_local $7
-                    (get_local $5)
+                    (get_local $6)
                   )
                   (br $do-once)
                 )
               )
               (i32.store
                 (i32.const 1216)
-                (get_local $5)
+                (get_local $6)
               )
               (i32.store
                 (get_local $1)
                 (i32.and
-                  (get_local $6)
+                  (get_local $3)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
                 (get_local $0)
                 (i32.or
-                  (get_local $5)
+                  (get_local $6)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
                   (get_local $0)
-                  (get_local $5)
+                  (get_local $6)
                 )
-                (get_local $5)
+                (get_local $6)
               )
               (return)
             )
           )
-          (set_local $6
+          (set_local $3
             (i32.shr_u
-              (get_local $11)
+              (get_local $10)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $11)
+              (get_local $10)
               (i32.const 256)
             )
             (block
@@ -6194,17 +6194,17 @@
               )
               (if
                 (i32.ne
-                  (tee_local $11
+                  (tee_local $10
                     (i32.load offset=8
                       (get_local $0)
                     )
                   )
-                  (tee_local $3
+                  (tee_local $4
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $6)
+                          (get_local $3)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6215,7 +6215,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $11)
+                      (get_local $10)
                       (get_local $14)
                     )
                     (call $qa)
@@ -6223,7 +6223,7 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $11)
+                        (get_local $10)
                       )
                       (get_local $0)
                     )
@@ -6234,7 +6234,7 @@
               (if
                 (i32.eq
                   (get_local $1)
-                  (get_local $11)
+                  (get_local $10)
                 )
                 (block
                   (i32.store
@@ -6246,7 +6246,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $6)
+                          (get_local $3)
                         )
                         (i32.const -1)
                       )
@@ -6256,7 +6256,7 @@
                     (get_local $0)
                   )
                   (set_local $7
-                    (get_local $5)
+                    (get_local $6)
                   )
                   (br $do-once)
                 )
@@ -6264,9 +6264,9 @@
               (if
                 (i32.eq
                   (get_local $1)
-                  (get_local $3)
+                  (get_local $4)
                 )
-                (set_local $10
+                (set_local $9
                   (i32.add
                     (get_local $1)
                     (i32.const 8)
@@ -6283,7 +6283,7 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $3
+                        (tee_local $4
                           (i32.add
                             (get_local $1)
                             (i32.const 8)
@@ -6292,31 +6292,31 @@
                       )
                       (get_local $0)
                     )
-                    (set_local $10
-                      (get_local $3)
+                    (set_local $9
+                      (get_local $4)
                     )
                     (call $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $11)
+                (get_local $10)
                 (get_local $1)
               )
               (i32.store
+                (get_local $9)
                 (get_local $10)
-                (get_local $11)
               )
               (set_local $2
                 (get_local $0)
               )
               (set_local $7
-                (get_local $5)
+                (get_local $6)
               )
               (br $do-once)
             )
           )
-          (set_local $11
+          (set_local $10
             (i32.load offset=24
               (get_local $0)
             )
@@ -6333,11 +6333,11 @@
               )
               (block
                 (if
-                  (tee_local $10
+                  (tee_local $9
                     (i32.load
-                      (tee_local $6
+                      (tee_local $3
                         (i32.add
-                          (tee_local $3
+                          (tee_local $4
                             (i32.add
                               (get_local $0)
                               (i32.const 16)
@@ -6350,22 +6350,22 @@
                   )
                   (block
                     (set_local $1
-                      (get_local $10)
+                      (get_local $9)
                     )
-                    (set_local $3
-                      (get_local $6)
+                    (set_local $4
+                      (get_local $3)
                     )
                   )
                   (if
                     (i32.eqz
                       (tee_local $1
                         (i32.load
-                          (get_local $3)
+                          (get_local $4)
                         )
                       )
                     )
                     (block
-                      (set_local $4
+                      (set_local $5
                         (i32.const 0)
                       )
                       (br $do-once0)
@@ -6374,9 +6374,9 @@
                 )
                 (loop $while-in
                   (if
-                    (tee_local $10
+                    (tee_local $9
                       (i32.load
-                        (tee_local $6
+                        (tee_local $3
                           (i32.add
                             (get_local $1)
                             (i32.const 20)
@@ -6386,18 +6386,18 @@
                     )
                     (block
                       (set_local $1
-                        (get_local $10)
+                        (get_local $9)
                       )
-                      (set_local $3
-                        (get_local $6)
+                      (set_local $4
+                        (get_local $3)
                       )
                       (br $while-in)
                     )
                   )
                   (if
-                    (tee_local $10
+                    (tee_local $9
                       (i32.load
-                        (tee_local $6
+                        (tee_local $3
                           (i32.add
                             (get_local $1)
                             (i32.const 16)
@@ -6407,36 +6407,36 @@
                     )
                     (block
                       (set_local $1
-                        (get_local $10)
+                        (get_local $9)
                       )
-                      (set_local $3
-                        (get_local $6)
+                      (set_local $4
+                        (get_local $3)
                       )
                       (br $while-in)
                     )
                     (block
-                      (set_local $6
+                      (set_local $12
                         (get_local $1)
                       )
-                      (set_local $9
-                        (get_local $3)
+                      (set_local $3
+                        (get_local $4)
                       )
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $9)
+                    (get_local $3)
                     (get_local $14)
                   )
                   (call $qa)
                   (block
                     (i32.store
-                      (get_local $9)
+                      (get_local $3)
                       (i32.const 0)
                     )
-                    (set_local $4
-                      (get_local $6)
+                    (set_local $5
+                      (get_local $12)
                     )
                   )
                 )
@@ -6444,7 +6444,7 @@
               (block
                 (if
                   (i32.lt_u
-                    (tee_local $6
+                    (tee_local $3
                       (i32.load offset=8
                         (get_local $0)
                       )
@@ -6456,9 +6456,9 @@
                 (if
                   (i32.ne
                     (i32.load
-                      (tee_local $10
+                      (tee_local $9
                         (i32.add
-                          (get_local $6)
+                          (get_local $3)
                           (i32.const 12)
                         )
                       )
@@ -6470,7 +6470,7 @@
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $3
+                      (tee_local $4
                         (i32.add
                           (get_local $1)
                           (i32.const 8)
@@ -6481,14 +6481,14 @@
                   )
                   (block
                     (i32.store
-                      (get_local $10)
+                      (get_local $9)
                       (get_local $1)
                     )
                     (i32.store
+                      (get_local $4)
                       (get_local $3)
-                      (get_local $6)
                     )
-                    (set_local $4
+                    (set_local $5
                       (get_local $1)
                     )
                   )
@@ -6498,13 +6498,13 @@
             )
           )
           (if
-            (get_local $11)
+            (get_local $10)
             (block
               (if
                 (i32.eq
                   (get_local $0)
                   (i32.load
-                    (tee_local $6
+                    (tee_local $3
                       (i32.add
                         (i32.const 1512)
                         (i32.shl
@@ -6521,12 +6521,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $6)
-                    (get_local $4)
+                    (get_local $3)
+                    (get_local $5)
                   )
                   (if
                     (i32.eqz
-                      (get_local $4)
+                      (get_local $5)
                     )
                     (block
                       (i32.store
@@ -6548,7 +6548,7 @@
                         (get_local $0)
                       )
                       (set_local $7
-                        (get_local $5)
+                        (get_local $6)
                       )
                       (br $do-once)
                     )
@@ -6557,7 +6557,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $11)
+                      (get_local $10)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6569,7 +6569,7 @@
                       (i32.load
                         (tee_local $1
                           (i32.add
-                            (get_local $11)
+                            (get_local $10)
                             (i32.const 16)
                           )
                         )
@@ -6578,23 +6578,23 @@
                     )
                     (i32.store
                       (get_local $1)
-                      (get_local $4)
+                      (get_local $5)
                     )
                     (i32.store offset=20
-                      (get_local $11)
-                      (get_local $4)
+                      (get_local $10)
+                      (get_local $5)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $4)
+                      (get_local $5)
                     )
                     (block
                       (set_local $2
                         (get_local $0)
                       )
                       (set_local $7
-                        (get_local $5)
+                        (get_local $6)
                       )
                       (br $do-once)
                     )
@@ -6603,7 +6603,7 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $4)
+                  (get_local $5)
                   (tee_local $1
                     (i32.load
                       (i32.const 1224)
@@ -6613,13 +6613,13 @@
                 (call $qa)
               )
               (i32.store offset=24
-                (get_local $4)
-                (get_local $11)
+                (get_local $5)
+                (get_local $10)
               )
               (if
-                (tee_local $3
+                (tee_local $4
                   (i32.load
-                    (tee_local $6
+                    (tee_local $3
                       (i32.add
                         (get_local $0)
                         (i32.const 16)
@@ -6629,31 +6629,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $3)
+                    (get_local $4)
                     (get_local $1)
                   )
                   (call $qa)
                   (block
                     (i32.store offset=16
+                      (get_local $5)
                       (get_local $4)
-                      (get_local $3)
                     )
                     (i32.store offset=24
-                      (get_local $3)
                       (get_local $4)
+                      (get_local $5)
                     )
                   )
                 )
               )
               (if
-                (tee_local $3
+                (tee_local $4
                   (i32.load offset=4
-                    (get_local $6)
+                    (get_local $3)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $3)
+                    (get_local $4)
                     (i32.load
                       (i32.const 1224)
                     )
@@ -6661,18 +6661,18 @@
                   (call $qa)
                   (block
                     (i32.store offset=20
+                      (get_local $5)
                       (get_local $4)
-                      (get_local $3)
                     )
                     (i32.store offset=24
-                      (get_local $3)
                       (get_local $4)
+                      (get_local $5)
                     )
                     (set_local $2
                       (get_local $0)
                     )
                     (set_local $7
-                      (get_local $5)
+                      (get_local $6)
                     )
                   )
                 )
@@ -6681,7 +6681,7 @@
                     (get_local $0)
                   )
                   (set_local $7
-                    (get_local $5)
+                    (get_local $6)
                   )
                 )
               )
@@ -6691,7 +6691,7 @@
                 (get_local $0)
               )
               (set_local $7
-                (get_local $5)
+                (get_local $6)
               )
             )
           )
@@ -6710,7 +6710,7 @@
         (i32.and
           (tee_local $1
             (i32.load
-              (tee_local $5
+              (tee_local $6
                 (i32.add
                   (get_local $8)
                   (i32.const 4)
@@ -6730,7 +6730,7 @@
       )
       (block
         (i32.store
-          (get_local $5)
+          (get_local $6)
           (i32.and
             (get_local $1)
             (i32.const -2)
@@ -6765,7 +6765,7 @@
           (block
             (i32.store
               (i32.const 1220)
-              (tee_local $4
+              (tee_local $5
                 (i32.add
                   (i32.load
                     (i32.const 1220)
@@ -6781,7 +6781,7 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $4)
+                (get_local $5)
                 (i32.const 1)
               )
             )
@@ -6815,7 +6815,7 @@
           (block
             (i32.store
               (i32.const 1216)
-              (tee_local $4
+              (tee_local $5
                 (i32.add
                   (i32.load
                     (i32.const 1216)
@@ -6831,21 +6831,21 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $4)
+                (get_local $5)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $2)
-                (get_local $4)
+                (get_local $5)
               )
-              (get_local $4)
+              (get_local $5)
             )
             (return)
           )
         )
-        (set_local $4
+        (set_local $5
           (i32.add
             (i32.and
               (get_local $1)
@@ -6867,19 +6867,19 @@
               (i32.const 256)
             )
             (block
-              (set_local $9
+              (set_local $3
                 (i32.load offset=12
                   (get_local $8)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $6
+                  (tee_local $12
                     (i32.load offset=8
                       (get_local $8)
                     )
                   )
-                  (tee_local $3
+                  (tee_local $4
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
@@ -6895,7 +6895,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $6)
+                      (get_local $12)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6905,7 +6905,7 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $6)
+                        (get_local $12)
                       )
                       (get_local $8)
                     )
@@ -6915,8 +6915,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $9)
-                  (get_local $6)
+                  (get_local $3)
+                  (get_local $12)
                 )
                 (block
                   (i32.store
@@ -6939,19 +6939,19 @@
               )
               (if
                 (i32.eq
-                  (get_local $9)
                   (get_local $3)
+                  (get_local $4)
                 )
                 (set_local $17
                   (i32.add
-                    (get_local $9)
+                    (get_local $3)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $9)
+                      (get_local $3)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6961,9 +6961,9 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $3
+                        (tee_local $4
                           (i32.add
-                            (get_local $9)
+                            (get_local $3)
                             (i32.const 8)
                           )
                         )
@@ -6971,23 +6971,23 @@
                       (get_local $8)
                     )
                     (set_local $17
-                      (get_local $3)
+                      (get_local $4)
                     )
                     (call $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $6)
-                (get_local $9)
+                (get_local $12)
+                (get_local $3)
               )
               (i32.store
                 (get_local $17)
-                (get_local $6)
+                (get_local $12)
               )
             )
             (block
-              (set_local $6
+              (set_local $12
                 (i32.load offset=24
                   (get_local $8)
                 )
@@ -6995,7 +6995,7 @@
               (block $do-once6
                 (if
                   (i32.eq
-                    (tee_local $9
+                    (tee_local $3
                       (i32.load offset=12
                         (get_local $8)
                       )
@@ -7004,11 +7004,11 @@
                   )
                   (block
                     (if
-                      (tee_local $10
+                      (tee_local $9
                         (i32.load
                           (tee_local $1
                             (i32.add
-                              (tee_local $3
+                              (tee_local $4
                                 (i32.add
                                   (get_local $8)
                                   (i32.const 16)
@@ -7021,9 +7021,9 @@
                       )
                       (block
                         (set_local $0
-                          (get_local $10)
+                          (get_local $9)
                         )
-                        (set_local $3
+                        (set_local $4
                           (get_local $1)
                         )
                       )
@@ -7031,12 +7031,12 @@
                         (i32.eqz
                           (tee_local $0
                             (i32.load
-                              (get_local $3)
+                              (get_local $4)
                             )
                           )
                         )
                         (block
-                          (set_local $12
+                          (set_local $11
                             (i32.const 0)
                           )
                           (br $do-once6)
@@ -7045,7 +7045,7 @@
                     )
                     (loop $while-in9
                       (if
-                        (tee_local $10
+                        (tee_local $9
                           (i32.load
                             (tee_local $1
                               (i32.add
@@ -7057,16 +7057,16 @@
                         )
                         (block
                           (set_local $0
-                            (get_local $10)
+                            (get_local $9)
                           )
-                          (set_local $3
+                          (set_local $4
                             (get_local $1)
                           )
                           (br $while-in9)
                         )
                       )
                       (if
-                        (tee_local $10
+                        (tee_local $9
                           (i32.load
                             (tee_local $1
                               (i32.add
@@ -7078,9 +7078,9 @@
                         )
                         (block
                           (set_local $0
-                            (get_local $10)
+                            (get_local $9)
                           )
-                          (set_local $3
+                          (set_local $4
                             (get_local $1)
                           )
                           (br $while-in9)
@@ -7089,7 +7089,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $3)
+                        (get_local $4)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7097,10 +7097,10 @@
                       (call $qa)
                       (block
                         (i32.store
-                          (get_local $3)
+                          (get_local $4)
                           (i32.const 0)
                         )
-                        (set_local $12
+                        (set_local $11
                           (get_local $0)
                         )
                       )
@@ -7123,7 +7123,7 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (tee_local $10
+                          (tee_local $9
                             (i32.add
                               (get_local $1)
                               (i32.const 12)
@@ -7137,9 +7137,9 @@
                     (if
                       (i32.eq
                         (i32.load
-                          (tee_local $3
+                          (tee_local $4
                             (i32.add
-                              (get_local $9)
+                              (get_local $3)
                               (i32.const 8)
                             )
                           )
@@ -7148,15 +7148,15 @@
                       )
                       (block
                         (i32.store
-                          (get_local $10)
                           (get_local $9)
+                          (get_local $3)
                         )
                         (i32.store
-                          (get_local $3)
+                          (get_local $4)
                           (get_local $1)
                         )
-                        (set_local $12
-                          (get_local $9)
+                        (set_local $11
+                          (get_local $3)
                         )
                       )
                       (call $qa)
@@ -7165,17 +7165,17 @@
                 )
               )
               (if
-                (get_local $6)
+                (get_local $12)
                 (block
                   (if
                     (i32.eq
                       (get_local $8)
                       (i32.load
-                        (tee_local $5
+                        (tee_local $6
                           (i32.add
                             (i32.const 1512)
                             (i32.shl
-                              (tee_local $9
+                              (tee_local $3
                                 (i32.load offset=28
                                   (get_local $8)
                                 )
@@ -7188,12 +7188,12 @@
                     )
                     (block
                       (i32.store
-                        (get_local $5)
-                        (get_local $12)
+                        (get_local $6)
+                        (get_local $11)
                       )
                       (if
                         (i32.eqz
-                          (get_local $12)
+                          (get_local $11)
                         )
                         (block
                           (i32.store
@@ -7205,7 +7205,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $9)
+                                  (get_local $3)
                                 )
                                 (i32.const -1)
                               )
@@ -7218,7 +7218,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $6)
+                          (get_local $12)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -7228,9 +7228,9 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $9
+                            (tee_local $3
                               (i32.add
-                                (get_local $6)
+                                (get_local $12)
                                 (i32.const 16)
                               )
                             )
@@ -7238,25 +7238,25 @@
                           (get_local $8)
                         )
                         (i32.store
-                          (get_local $9)
-                          (get_local $12)
+                          (get_local $3)
+                          (get_local $11)
                         )
                         (i32.store offset=20
-                          (get_local $6)
                           (get_local $12)
+                          (get_local $11)
                         )
                       )
                       (br_if $do-once4
                         (i32.eqz
-                          (get_local $12)
+                          (get_local $11)
                         )
                       )
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $12)
-                      (tee_local $9
+                      (get_local $11)
+                      (tee_local $3
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7265,13 +7265,13 @@
                     (call $qa)
                   )
                   (i32.store offset=24
+                    (get_local $11)
                     (get_local $12)
-                    (get_local $6)
                   )
                   (if
                     (tee_local $0
                       (i32.load
-                        (tee_local $5
+                        (tee_local $6
                           (i32.add
                             (get_local $8)
                             (i32.const 16)
@@ -7282,17 +7282,17 @@
                     (if
                       (i32.lt_u
                         (get_local $0)
-                        (get_local $9)
+                        (get_local $3)
                       )
                       (call $qa)
                       (block
                         (i32.store offset=16
-                          (get_local $12)
+                          (get_local $11)
                           (get_local $0)
                         )
                         (i32.store offset=24
                           (get_local $0)
-                          (get_local $12)
+                          (get_local $11)
                         )
                       )
                     )
@@ -7300,7 +7300,7 @@
                   (if
                     (tee_local $0
                       (i32.load offset=4
-                        (get_local $5)
+                        (get_local $6)
                       )
                     )
                     (if
@@ -7313,12 +7313,12 @@
                       (call $qa)
                       (block
                         (i32.store offset=20
-                          (get_local $12)
+                          (get_local $11)
                           (get_local $0)
                         )
                         (i32.store offset=24
                           (get_local $0)
-                          (get_local $12)
+                          (get_local $11)
                         )
                       )
                     )
@@ -7331,16 +7331,16 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $4)
+            (get_local $5)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $4)
+            (get_local $5)
           )
-          (get_local $4)
+          (get_local $5)
         )
         (if
           (i32.eq
@@ -7352,12 +7352,12 @@
           (block
             (i32.store
               (i32.const 1216)
-              (get_local $4)
+              (get_local $5)
             )
             (return)
           )
           (set_local $0
-            (get_local $4)
+            (get_local $5)
           )
         )
       )
@@ -7388,12 +7388,12 @@
         )
         (if
           (i32.and
-            (tee_local $5
+            (tee_local $6
               (i32.load
                 (i32.const 1208)
               )
             )
-            (tee_local $4
+            (tee_local $5
               (i32.shl
                 (i32.const 1)
                 (get_local $7)
@@ -7402,9 +7402,9 @@
           )
           (if
             (i32.lt_u
-              (tee_local $5
+              (tee_local $6
                 (i32.load
-                  (tee_local $4
+                  (tee_local $5
                     (i32.add
                       (get_local $1)
                       (i32.const 8)
@@ -7419,10 +7419,10 @@
             (call $qa)
             (block
               (set_local $15
-                (get_local $4)
+                (get_local $5)
               )
               (set_local $13
-                (get_local $5)
+                (get_local $6)
               )
             )
           )
@@ -7430,8 +7430,8 @@
             (i32.store
               (i32.const 1208)
               (i32.or
+                (get_local $6)
                 (get_local $5)
-                (get_local $4)
               )
             )
             (set_local $15
@@ -7464,7 +7464,7 @@
         (return)
       )
     )
-    (set_local $4
+    (set_local $5
       (i32.add
         (i32.const 1512)
         (i32.shl
@@ -7487,7 +7487,7 @@
                     (i32.shr_u
                       (get_local $0)
                       (i32.add
-                        (tee_local $4
+                        (tee_local $5
                           (i32.add
                             (i32.sub
                               (i32.const 14)
@@ -7527,7 +7527,7 @@
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (tee_local $5
+                                        (tee_local $6
                                           (i32.shl
                                             (get_local $15)
                                             (get_local $1)
@@ -7544,7 +7544,7 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $5)
+                                (get_local $6)
                                 (get_local $15)
                               )
                               (i32.const 15)
@@ -7557,7 +7557,7 @@
                     (i32.const 1)
                   )
                   (i32.shl
-                    (get_local $4)
+                    (get_local $5)
                     (i32.const 1)
                   )
                 )
@@ -7588,7 +7588,7 @@
             (i32.const 1212)
           )
         )
-        (tee_local $5
+        (tee_local $6
           (i32.shl
             (i32.const 1)
             (get_local $7)
@@ -7617,7 +7617,7 @@
         )
         (set_local $1
           (i32.load
-            (get_local $4)
+            (get_local $5)
           )
         )
         (loop $while-in15
@@ -7643,7 +7643,7 @@
               )
             )
             (if
-              (tee_local $12
+              (tee_local $11
                 (i32.load
                   (tee_local $7
                     (i32.add
@@ -7670,7 +7670,7 @@
                   )
                 )
                 (set_local $1
-                  (get_local $12)
+                  (get_local $11)
                 )
                 (br $while-in15)
               )
@@ -7738,7 +7738,7 @@
                       )
                     )
                   )
-                  (tee_local $5
+                  (tee_local $6
                     (i32.load
                       (i32.const 1224)
                     )
@@ -7746,7 +7746,7 @@
                 )
                 (i32.ge_u
                   (get_local $16)
-                  (get_local $5)
+                  (get_local $6)
                 )
               )
               (block
@@ -7781,16 +7781,16 @@
           (i32.const 1212)
           (i32.or
             (get_local $15)
-            (get_local $5)
+            (get_local $6)
           )
         )
         (i32.store
-          (get_local $4)
+          (get_local $5)
           (get_local $2)
         )
         (i32.store offset=24
           (get_local $2)
-          (get_local $4)
+          (get_local $5)
         )
         (i32.store offset=12
           (get_local $2)
@@ -8720,16 +8720,16 @@
                     )
                   )
                 )
+                (set_local $0
+                  (get_local $2)
+                )
               )
-            )
-            (set_local $2
-              (get_local $0)
             )
           )
           (call $xa
             (i32.const 1188)
           )
-          (get_local $2)
+          (get_local $0)
         )
       )
     )
@@ -9312,7 +9312,7 @@
     (local $1 i32)
     (local $2 i32)
     (local $3 i32)
-    (set_local $3
+    (set_local $2
       (if i32
         (i32.gt_s
           (i32.load offset=76
@@ -9351,9 +9351,9 @@
               )
               (if
                 (i32.lt_u
-                  (tee_local $2
+                  (tee_local $0
                     (i32.load
-                      (tee_local $0
+                      (tee_local $3
                         (i32.add
                           (get_local $1)
                           (i32.const 20)
@@ -9367,14 +9367,14 @@
                 )
                 (block
                   (i32.store
-                    (get_local $0)
+                    (get_local $3)
                     (i32.add
-                      (get_local $2)
+                      (get_local $0)
                       (i32.const 1)
                     )
                   )
                   (i32.store8
-                    (get_local $2)
+                    (get_local $0)
                     (i32.const 10)
                   )
                   (br $do-once
@@ -9395,7 +9395,7 @@
       )
     )
     (if
-      (get_local $3)
+      (get_local $2)
       (call $Ta
         (get_local $1)
       )

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -155,9 +155,9 @@
         (block
           (if
             (i32.and
-              (tee_local $5
+              (tee_local $1
                 (i32.shr_u
-                  (tee_local $6
+                  (tee_local $5
                     (i32.load
                       (i32.const 1208)
                     )
@@ -188,24 +188,24 @@
               (i32.const 3)
             )
             (block
-              (set_local $7
+              (set_local $0
                 (i32.load
-                  (tee_local $5
+                  (tee_local $1
                     (i32.add
                       (tee_local $2
                         (i32.load
-                          (tee_local $4
+                          (tee_local $11
                             (i32.add
-                              (tee_local $8
+                              (tee_local $7
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
                                     (i32.shl
-                                      (tee_local $0
+                                      (tee_local $6
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $5)
+                                              (get_local $1)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
@@ -231,17 +231,17 @@
               )
               (if
                 (i32.eq
-                  (get_local $8)
                   (get_local $7)
+                  (get_local $0)
                 )
                 (i32.store
                   (i32.const 1208)
                   (i32.and
-                    (get_local $6)
+                    (get_local $5)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $0)
+                        (get_local $6)
                       )
                       (i32.const -1)
                     )
@@ -250,7 +250,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $0)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -262,7 +262,7 @@
                       (i32.load
                         (tee_local $17
                           (i32.add
-                            (get_local $7)
+                            (get_local $0)
                             (i32.const 12)
                           )
                         )
@@ -272,11 +272,11 @@
                     (block
                       (i32.store
                         (get_local $17)
-                        (get_local $8)
+                        (get_local $7)
                       )
                       (i32.store
-                        (get_local $4)
-                        (get_local $7)
+                        (get_local $11)
+                        (get_local $0)
                       )
                     )
                     (call $qa)
@@ -286,9 +286,9 @@
               (i32.store offset=4
                 (get_local $2)
                 (i32.or
-                  (tee_local $7
+                  (tee_local $0
                     (i32.shl
-                      (get_local $0)
+                      (get_local $6)
                       (i32.const 3)
                     )
                   )
@@ -296,18 +296,18 @@
                 )
               )
               (i32.store
-                (tee_local $4
+                (tee_local $11
                   (i32.add
                     (i32.add
                       (get_local $2)
-                      (get_local $7)
+                      (get_local $0)
                     )
                     (i32.const 4)
                   )
                 )
                 (i32.or
                   (i32.load
-                    (get_local $4)
+                    (get_local $11)
                   )
                   (i32.const 1)
                 )
@@ -316,14 +316,14 @@
                 (get_local $25)
               )
               (return
-                (get_local $5)
+                (get_local $1)
               )
             )
           )
           (if
             (i32.gt_u
               (get_local $2)
-              (tee_local $4
+              (tee_local $11
                 (i32.load
                   (i32.const 1216)
                 )
@@ -331,22 +331,22 @@
             )
             (block
               (if
-                (get_local $5)
+                (get_local $1)
                 (block
-                  (set_local $8
+                  (set_local $7
                     (i32.and
                       (i32.shr_u
-                        (tee_local $7
+                        (tee_local $0
                           (i32.add
                             (i32.and
-                              (tee_local $8
+                              (tee_local $7
                                 (i32.and
                                   (i32.shl
-                                    (get_local $5)
+                                    (get_local $1)
                                     (get_local $0)
                                   )
                                   (i32.or
-                                    (tee_local $7
+                                    (tee_local $0
                                       (i32.shl
                                         (i32.const 2)
                                         (get_local $0)
@@ -354,14 +354,14 @@
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $7)
+                                      (get_local $0)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $8)
+                                (get_local $7)
                               )
                             )
                             (i32.const -1)
@@ -372,32 +372,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $8
+                  (set_local $7
                     (i32.load
                       (tee_local $17
                         (i32.add
-                          (tee_local $10
+                          (tee_local $9
                             (i32.load
                               (tee_local $15
                                 (i32.add
-                                  (tee_local $3
+                                  (tee_local $4
                                     (i32.add
                                       (i32.const 1248)
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $9
+                                          (tee_local $8
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $7
+                                                      (tee_local $0
                                                         (i32.and
                                                           (i32.shr_u
                                                             (tee_local $17
                                                               (i32.shr_u
+                                                                (get_local $0)
                                                                 (get_local $7)
-                                                                (get_local $8)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -405,15 +405,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $8)
+                                                      (get_local $7)
                                                     )
                                                     (tee_local $17
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (tee_local $10
+                                                          (tee_local $9
                                                             (i32.shr_u
                                                               (get_local $17)
-                                                              (get_local $7)
+                                                              (get_local $0)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -422,12 +422,12 @@
                                                       )
                                                     )
                                                   )
-                                                  (tee_local $10
+                                                  (tee_local $9
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (tee_local $3
+                                                        (tee_local $4
                                                           (i32.shr_u
-                                                            (get_local $10)
+                                                            (get_local $9)
                                                             (get_local $17)
                                                           )
                                                         )
@@ -437,13 +437,13 @@
                                                     )
                                                   )
                                                 )
-                                                (tee_local $3
+                                                (tee_local $4
                                                   (i32.and
                                                     (i32.shr_u
                                                       (tee_local $15
                                                         (i32.shr_u
-                                                          (get_local $3)
-                                                          (get_local $10)
+                                                          (get_local $4)
+                                                          (get_local $9)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -454,7 +454,7 @@
                                               )
                                               (i32.shr_u
                                                 (get_local $15)
-                                                (get_local $3)
+                                                (get_local $4)
                                               )
                                             )
                                           )
@@ -476,31 +476,31 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $3)
-                      (get_local $8)
+                      (get_local $4)
+                      (get_local $7)
                     )
                     (block
                       (i32.store
                         (i32.const 1208)
                         (i32.and
-                          (get_local $6)
+                          (get_local $5)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $9)
+                              (get_local $8)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $34
-                        (get_local $4)
+                      (set_local $33
+                        (get_local $11)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $8)
+                          (get_local $7)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -510,25 +510,25 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $7
+                            (tee_local $0
                               (i32.add
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $10)
+                          (get_local $9)
                         )
                         (block
                           (i32.store
-                            (get_local $7)
-                            (get_local $3)
+                            (get_local $0)
+                            (get_local $4)
                           )
                           (i32.store
                             (get_local $15)
-                            (get_local $8)
+                            (get_local $7)
                           )
-                          (set_local $34
+                          (set_local $33
                             (i32.load
                               (i32.const 1216)
                             )
@@ -539,7 +539,7 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $10)
+                    (get_local $9)
                     (i32.or
                       (get_local $2)
                       (i32.const 3)
@@ -548,15 +548,15 @@
                   (i32.store offset=4
                     (tee_local $15
                       (i32.add
-                        (get_local $10)
+                        (get_local $9)
                         (get_local $2)
                       )
                     )
                     (i32.or
-                      (tee_local $8
+                      (tee_local $7
                         (i32.sub
                           (i32.shl
-                            (get_local $9)
+                            (get_local $8)
                             (i32.const 3)
                           )
                           (get_local $2)
@@ -568,26 +568,26 @@
                   (i32.store
                     (i32.add
                       (get_local $15)
-                      (get_local $8)
+                      (get_local $7)
                     )
-                    (get_local $8)
+                    (get_local $7)
                   )
                   (if
-                    (get_local $34)
+                    (get_local $33)
                     (block
-                      (set_local $3
+                      (set_local $4
                         (i32.load
                           (i32.const 1228)
                         )
                       )
-                      (set_local $6
+                      (set_local $5
                         (i32.add
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (tee_local $4
+                              (tee_local $11
                                 (i32.shr_u
-                                  (get_local $34)
+                                  (get_local $33)
                                   (i32.const 3)
                                 )
                               )
@@ -604,10 +604,10 @@
                               (i32.const 1208)
                             )
                           )
-                          (tee_local $5
+                          (tee_local $1
                             (i32.shl
                               (i32.const 1)
-                              (get_local $4)
+                              (get_local $11)
                             )
                           )
                         )
@@ -615,9 +615,9 @@
                           (i32.lt_u
                             (tee_local $0
                               (i32.load
-                                (tee_local $5
+                                (tee_local $1
                                   (i32.add
-                                    (get_local $6)
+                                    (get_local $5)
                                     (i32.const 8)
                                   )
                                 )
@@ -630,9 +630,9 @@
                           (call $qa)
                           (block
                             (set_local $41
-                              (get_local $5)
+                              (get_local $1)
                             )
-                            (set_local $27
+                            (set_local $34
                               (get_local $0)
                             )
                           )
@@ -642,41 +642,41 @@
                             (i32.const 1208)
                             (i32.or
                               (get_local $0)
-                              (get_local $5)
+                              (get_local $1)
                             )
                           )
                           (set_local $41
                             (i32.add
-                              (get_local $6)
+                              (get_local $5)
                               (i32.const 8)
                             )
                           )
-                          (set_local $27
-                            (get_local $6)
+                          (set_local $34
+                            (get_local $5)
                           )
                         )
                       )
                       (i32.store
                         (get_local $41)
-                        (get_local $3)
+                        (get_local $4)
                       )
                       (i32.store offset=12
-                        (get_local $27)
-                        (get_local $3)
+                        (get_local $34)
+                        (get_local $4)
                       )
                       (i32.store offset=8
-                        (get_local $3)
-                        (get_local $27)
+                        (get_local $4)
+                        (get_local $34)
                       )
                       (i32.store offset=12
-                        (get_local $3)
-                        (get_local $6)
+                        (get_local $4)
+                        (get_local $5)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 1216)
-                    (get_local $8)
+                    (get_local $7)
                   )
                   (i32.store
                     (i32.const 1228)
@@ -700,7 +700,7 @@
                   (set_local $15
                     (i32.and
                       (i32.shr_u
-                        (tee_local $8
+                        (tee_local $7
                           (i32.add
                             (i32.and
                               (get_local $15)
@@ -721,7 +721,7 @@
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (tee_local $4
+                          (tee_local $11
                             (i32.load
                               (i32.add
                                 (i32.shl
@@ -730,12 +730,12 @@
                                       (i32.or
                                         (i32.or
                                           (i32.or
-                                            (tee_local $8
+                                            (tee_local $7
                                               (i32.and
                                                 (i32.shr_u
-                                                  (tee_local $6
+                                                  (tee_local $5
                                                     (i32.shr_u
-                                                      (get_local $8)
+                                                      (get_local $7)
                                                       (get_local $15)
                                                     )
                                                   )
@@ -746,13 +746,13 @@
                                             )
                                             (get_local $15)
                                           )
-                                          (tee_local $6
+                                          (tee_local $5
                                             (i32.and
                                               (i32.shr_u
-                                                (tee_local $3
+                                                (tee_local $4
                                                   (i32.shr_u
-                                                    (get_local $6)
-                                                    (get_local $8)
+                                                    (get_local $5)
+                                                    (get_local $7)
                                                   )
                                                 )
                                                 (i32.const 2)
@@ -761,13 +761,13 @@
                                             )
                                           )
                                         )
-                                        (tee_local $3
+                                        (tee_local $4
                                           (i32.and
                                             (i32.shr_u
                                               (tee_local $0
                                                 (i32.shr_u
-                                                  (get_local $3)
-                                                  (get_local $6)
+                                                  (get_local $4)
+                                                  (get_local $5)
                                                 )
                                               )
                                               (i32.const 1)
@@ -779,10 +779,10 @@
                                       (tee_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $5
+                                            (tee_local $1
                                               (i32.shr_u
                                                 (get_local $0)
-                                                (get_local $3)
+                                                (get_local $4)
                                               )
                                             )
                                             (i32.const 1)
@@ -792,7 +792,7 @@
                                       )
                                     )
                                     (i32.shr_u
-                                      (get_local $5)
+                                      (get_local $1)
                                       (get_local $0)
                                     )
                                   )
@@ -808,50 +808,50 @@
                       (get_local $2)
                     )
                   )
-                  (set_local $5
-                    (get_local $4)
+                  (set_local $1
+                    (get_local $11)
                   )
-                  (set_local $3
-                    (get_local $4)
+                  (set_local $4
+                    (get_local $11)
                   )
                   (loop $while-in
                     (block $while-out
                       (if
-                        (tee_local $4
+                        (tee_local $11
                           (i32.load offset=16
-                            (get_local $5)
+                            (get_local $1)
                           )
                         )
-                        (set_local $7
-                          (get_local $4)
+                        (set_local $6
+                          (get_local $11)
                         )
                         (if
-                          (tee_local $6
+                          (tee_local $5
                             (i32.load offset=20
-                              (get_local $5)
+                              (get_local $1)
                             )
                           )
-                          (set_local $7
-                            (get_local $6)
+                          (set_local $6
+                            (get_local $5)
                           )
                           (block
-                            (set_local $7
+                            (set_local $3
                               (get_local $0)
                             )
-                            (set_local $1
-                              (get_local $3)
+                            (set_local $6
+                              (get_local $4)
                             )
                             (br $while-out)
                           )
                         )
                       )
-                      (set_local $6
+                      (set_local $5
                         (i32.lt_u
-                          (tee_local $4
+                          (tee_local $11
                             (i32.sub
                               (i32.and
                                 (i32.load offset=4
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                                 (i32.const -8)
                               )
@@ -863,19 +863,19 @@
                       )
                       (set_local $0
                         (select
-                          (get_local $4)
+                          (get_local $11)
                           (get_local $0)
-                          (get_local $6)
+                          (get_local $5)
                         )
                       )
-                      (set_local $5
-                        (get_local $7)
+                      (set_local $1
+                        (get_local $6)
                       )
-                      (set_local $3
+                      (set_local $4
                         (select
-                          (get_local $7)
-                          (get_local $3)
                           (get_local $6)
+                          (get_local $4)
+                          (get_local $5)
                         )
                       )
                       (br $while-in)
@@ -883,8 +883,8 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $1)
-                      (tee_local $3
+                      (get_local $6)
+                      (tee_local $4
                         (i32.load
                           (i32.const 1224)
                         )
@@ -894,10 +894,10 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $1)
-                      (tee_local $5
+                      (get_local $6)
+                      (tee_local $1
                         (i32.add
-                          (get_local $1)
+                          (get_local $6)
                           (get_local $2)
                         )
                       )
@@ -906,7 +906,7 @@
                   )
                   (set_local $0
                     (i32.load offset=24
-                      (get_local $1)
+                      (get_local $6)
                     )
                   )
                   (block $do-once4
@@ -914,38 +914,38 @@
                       (i32.eq
                         (tee_local $17
                           (i32.load offset=12
-                            (get_local $1)
+                            (get_local $6)
                           )
                         )
-                        (get_local $1)
+                        (get_local $6)
                       )
                       (block
                         (if
-                          (tee_local $9
+                          (tee_local $8
                             (i32.load
-                              (tee_local $10
+                              (tee_local $9
                                 (i32.add
-                                  (get_local $1)
+                                  (get_local $6)
                                   (i32.const 20)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $4
-                              (get_local $9)
+                            (set_local $11
+                              (get_local $8)
                             )
-                            (set_local $6
-                              (get_local $10)
+                            (set_local $5
+                              (get_local $9)
                             )
                           )
                           (if
                             (i32.eqz
-                              (tee_local $4
+                              (tee_local $11
                                 (i32.load
-                                  (tee_local $6
+                                  (tee_local $5
                                     (i32.add
-                                      (get_local $1)
+                                      (get_local $6)
                                       (i32.const 16)
                                     )
                                   )
@@ -953,7 +953,7 @@
                               )
                             )
                             (block
-                              (set_local $23
+                              (set_local $21
                                 (i32.const 0)
                               )
                               (br $do-once4)
@@ -962,43 +962,43 @@
                         )
                         (loop $while-in7
                           (if
-                            (tee_local $9
+                            (tee_local $8
                               (i32.load
-                                (tee_local $10
+                                (tee_local $9
                                   (i32.add
-                                    (get_local $4)
+                                    (get_local $11)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $4
-                                (get_local $9)
+                              (set_local $11
+                                (get_local $8)
                               )
-                              (set_local $6
-                                (get_local $10)
+                              (set_local $5
+                                (get_local $9)
                               )
                               (br $while-in7)
                             )
                           )
                           (if
-                            (tee_local $9
+                            (tee_local $8
                               (i32.load
-                                (tee_local $10
+                                (tee_local $9
                                   (i32.add
-                                    (get_local $4)
+                                    (get_local $11)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $4
-                                (get_local $9)
+                              (set_local $11
+                                (get_local $8)
                               )
-                              (set_local $6
-                                (get_local $10)
+                              (set_local $5
+                                (get_local $9)
                               )
                               (br $while-in7)
                             )
@@ -1006,17 +1006,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $6)
-                            (get_local $3)
+                            (get_local $5)
+                            (get_local $4)
                           )
                           (call $qa)
                           (block
                             (i32.store
-                              (get_local $6)
+                              (get_local $5)
                               (i32.const 0)
                             )
-                            (set_local $23
-                              (get_local $4)
+                            (set_local $21
+                              (get_local $11)
                             )
                           )
                         )
@@ -1024,51 +1024,51 @@
                       (block
                         (if
                           (i32.lt_u
-                            (tee_local $10
+                            (tee_local $9
                               (i32.load offset=8
-                                (get_local $1)
+                                (get_local $6)
                               )
                             )
-                            (get_local $3)
+                            (get_local $4)
                           )
                           (call $qa)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (tee_local $9
+                              (tee_local $8
                                 (i32.add
-                                  (get_local $10)
+                                  (get_local $9)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $1)
+                            (get_local $6)
                           )
                           (call $qa)
                         )
                         (if
                           (i32.eq
                             (i32.load
-                              (tee_local $6
+                              (tee_local $5
                                 (i32.add
                                   (get_local $17)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $1)
+                            (get_local $6)
                           )
                           (block
                             (i32.store
-                              (get_local $9)
+                              (get_local $8)
                               (get_local $17)
                             )
                             (i32.store
-                              (get_local $6)
-                              (get_local $10)
+                              (get_local $5)
+                              (get_local $9)
                             )
-                            (set_local $23
+                            (set_local $21
                               (get_local $17)
                             )
                           )
@@ -1083,15 +1083,15 @@
                       (block
                         (if
                           (i32.eq
-                            (get_local $1)
+                            (get_local $6)
                             (i32.load
-                              (tee_local $3
+                              (tee_local $4
                                 (i32.add
                                   (i32.const 1512)
                                   (i32.shl
                                     (tee_local $17
                                       (i32.load offset=28
-                                        (get_local $1)
+                                        (get_local $6)
                                       )
                                     )
                                     (i32.const 2)
@@ -1102,12 +1102,12 @@
                           )
                           (block
                             (i32.store
-                              (get_local $3)
-                              (get_local $23)
+                              (get_local $4)
+                              (get_local $21)
                             )
                             (if
                               (i32.eqz
-                                (get_local $23)
+                                (get_local $21)
                               )
                               (block
                                 (i32.store
@@ -1149,27 +1149,27 @@
                                     )
                                   )
                                 )
-                                (get_local $1)
+                                (get_local $6)
                               )
                               (i32.store
                                 (get_local $17)
-                                (get_local $23)
+                                (get_local $21)
                               )
                               (i32.store offset=20
                                 (get_local $0)
-                                (get_local $23)
+                                (get_local $21)
                               )
                             )
                             (br_if $do-once8
                               (i32.eqz
-                                (get_local $23)
+                                (get_local $21)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $23)
+                            (get_local $21)
                             (tee_local $17
                               (i32.load
                                 (i32.const 1224)
@@ -1179,42 +1179,42 @@
                           (call $qa)
                         )
                         (i32.store offset=24
-                          (get_local $23)
+                          (get_local $21)
                           (get_local $0)
                         )
                         (if
-                          (tee_local $3
+                          (tee_local $4
                             (i32.load offset=16
-                              (get_local $1)
+                              (get_local $6)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $3)
+                              (get_local $4)
                               (get_local $17)
                             )
                             (call $qa)
                             (block
                               (i32.store offset=16
-                                (get_local $23)
-                                (get_local $3)
+                                (get_local $21)
+                                (get_local $4)
                               )
                               (i32.store offset=24
-                                (get_local $3)
-                                (get_local $23)
+                                (get_local $4)
+                                (get_local $21)
                               )
                             )
                           )
                         )
                         (if
-                          (tee_local $3
+                          (tee_local $4
                             (i32.load offset=20
-                              (get_local $1)
+                              (get_local $6)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $3)
+                              (get_local $4)
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1222,12 +1222,12 @@
                             (call $qa)
                             (block
                               (i32.store offset=20
-                                (get_local $23)
-                                (get_local $3)
+                                (get_local $21)
+                                (get_local $4)
                               )
                               (i32.store offset=24
-                                (get_local $3)
-                                (get_local $23)
+                                (get_local $4)
+                                (get_local $21)
                               )
                             )
                           )
@@ -1237,16 +1237,16 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $3)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $6)
                         (i32.or
                           (tee_local $0
                             (i32.add
-                              (get_local $7)
+                              (get_local $3)
                               (get_local $2)
                             )
                           )
@@ -1254,10 +1254,10 @@
                         )
                       )
                       (i32.store
-                        (tee_local $3
+                        (tee_local $4
                           (i32.add
                             (i32.add
-                              (get_local $1)
+                              (get_local $6)
                               (get_local $0)
                             )
                             (i32.const 4)
@@ -1265,7 +1265,7 @@
                         )
                         (i32.or
                           (i32.load
-                            (get_local $3)
+                            (get_local $4)
                           )
                           (i32.const 1)
                         )
@@ -1273,28 +1273,28 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $6)
                         (i32.or
                           (get_local $2)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $5)
+                        (get_local $1)
                         (i32.or
-                          (get_local $7)
+                          (get_local $3)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $5)
-                          (get_local $7)
+                          (get_local $1)
+                          (get_local $3)
                         )
-                        (get_local $7)
+                        (get_local $3)
                       )
                       (if
-                        (tee_local $3
+                        (tee_local $4
                           (i32.load
                             (i32.const 1216)
                           )
@@ -1305,14 +1305,14 @@
                               (i32.const 1228)
                             )
                           )
-                          (set_local $3
+                          (set_local $4
                             (i32.add
                               (i32.const 1248)
                               (i32.shl
                                 (i32.shl
                                   (tee_local $17
                                     (i32.shr_u
-                                      (get_local $3)
+                                      (get_local $4)
                                       (i32.const 3)
                                     )
                                   )
@@ -1324,12 +1324,12 @@
                           )
                           (if
                             (i32.and
-                              (tee_local $10
+                              (tee_local $9
                                 (i32.load
                                   (i32.const 1208)
                                 )
                               )
-                              (tee_local $6
+                              (tee_local $5
                                 (i32.shl
                                   (i32.const 1)
                                   (get_local $17)
@@ -1338,11 +1338,11 @@
                             )
                             (if
                               (i32.lt_u
-                                (tee_local $10
+                                (tee_local $9
                                   (i32.load
-                                    (tee_local $6
+                                    (tee_local $5
                                       (i32.add
-                                        (get_local $3)
+                                        (get_local $4)
                                         (i32.const 8)
                                       )
                                     )
@@ -1355,10 +1355,10 @@
                               (call $qa)
                               (block
                                 (set_local $42
-                                  (get_local $6)
+                                  (get_local $5)
                                 )
                                 (set_local $35
-                                  (get_local $10)
+                                  (get_local $9)
                                 )
                               )
                             )
@@ -1366,18 +1366,18 @@
                               (i32.store
                                 (i32.const 1208)
                                 (i32.or
-                                  (get_local $10)
-                                  (get_local $6)
+                                  (get_local $9)
+                                  (get_local $5)
                                 )
                               )
                               (set_local $42
                                 (i32.add
-                                  (get_local $3)
+                                  (get_local $4)
                                   (i32.const 8)
                                 )
                               )
                               (set_local $35
-                                (get_local $3)
+                                (get_local $4)
                               )
                             )
                           )
@@ -1395,17 +1395,17 @@
                           )
                           (i32.store offset=12
                             (get_local $0)
-                            (get_local $3)
+                            (get_local $4)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 1216)
-                        (get_local $7)
+                        (get_local $3)
                       )
                       (i32.store
                         (i32.const 1228)
-                        (get_local $5)
+                        (get_local $1)
                       )
                     )
                   )
@@ -1414,17 +1414,17 @@
                   )
                   (return
                     (i32.add
-                      (get_local $1)
+                      (get_local $6)
                       (i32.const 8)
                     )
                   )
                 )
-                (set_local $6
+                (set_local $4
                   (get_local $2)
                 )
               )
             )
-            (set_local $6
+            (set_local $4
               (get_local $2)
             )
           )
@@ -1434,13 +1434,13 @@
             (get_local $0)
             (i32.const -65)
           )
-          (set_local $6
+          (set_local $4
             (i32.const -1)
           )
           (block
             (set_local $0
               (i32.and
-                (tee_local $3
+                (tee_local $4
                   (i32.add
                     (get_local $0)
                     (i32.const 11)
@@ -1450,13 +1450,13 @@
               )
             )
             (if
-              (tee_local $10
+              (tee_local $9
                 (i32.load
                   (i32.const 1212)
                 )
               )
               (block
-                (set_local $6
+                (set_local $5
                   (i32.sub
                     (i32.const 0)
                     (get_local $0)
@@ -1468,11 +1468,11 @@
                       (i32.load
                         (i32.add
                           (i32.shl
-                            (tee_local $27
+                            (tee_local $21
                               (if i32
                                 (tee_local $17
                                   (i32.shr_u
-                                    (get_local $3)
+                                    (get_local $4)
                                     (i32.const 8)
                                   )
                                 )
@@ -1497,10 +1497,10 @@
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (tee_local $9
+                                                            (tee_local $8
                                                               (i32.shl
                                                                 (get_local $17)
-                                                                (tee_local $3
+                                                                (tee_local $4
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
@@ -1521,15 +1521,15 @@
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $3)
+                                                    (get_local $4)
                                                   )
-                                                  (tee_local $9
+                                                  (tee_local $8
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $4
+                                                          (tee_local $11
                                                             (i32.shl
-                                                              (get_local $9)
+                                                              (get_local $8)
                                                               (get_local $17)
                                                             )
                                                           )
@@ -1544,8 +1544,8 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $4)
-                                                  (get_local $9)
+                                                  (get_local $11)
+                                                  (get_local $8)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -1572,13 +1572,13 @@
                       )
                     )
                     (block
-                      (set_local $9
-                        (get_local $6)
+                      (set_local $8
+                        (get_local $5)
                       )
-                      (set_local $4
+                      (set_local $11
                         (i32.const 0)
                       )
-                      (set_local $3
+                      (set_local $4
                         (i32.shl
                           (get_local $0)
                           (select
@@ -1586,12 +1586,12 @@
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $27)
+                                (get_local $21)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $27)
+                              (get_local $21)
                               (i32.const 31)
                             )
                           )
@@ -1600,7 +1600,7 @@
                       (set_local $17
                         (get_local $15)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 0)
                       )
                       (loop $while-in14
@@ -1608,7 +1608,7 @@
                           (i32.lt_u
                             (tee_local $2
                               (i32.sub
-                                (tee_local $5
+                                (tee_local $1
                                   (i32.and
                                     (i32.load offset=4
                                       (get_local $17)
@@ -1619,41 +1619,41 @@
                                 (get_local $0)
                               )
                             )
-                            (get_local $9)
+                            (get_local $8)
                           )
                           (if
                             (i32.eq
-                              (get_local $5)
+                              (get_local $1)
                               (get_local $0)
                             )
                             (block
-                              (set_local $29
+                              (set_local $28
                                 (get_local $2)
                               )
-                              (set_local $28
+                              (set_local $27
                                 (get_local $17)
                               )
-                              (set_local $32
+                              (set_local $31
                                 (get_local $17)
                               )
-                              (set_local $9
+                              (set_local $8
                                 (i32.const 90)
                               )
                               (br $label$break$a)
                             )
                             (block
-                              (set_local $9
+                              (set_local $8
                                 (get_local $2)
                               )
-                              (set_local $8
+                              (set_local $7
                                 (get_local $17)
                               )
                             )
                           )
                         )
-                        (set_local $5
+                        (set_local $1
                           (select
-                            (get_local $4)
+                            (get_local $11)
                             (tee_local $2
                               (i32.load offset=20
                                 (get_local $17)
@@ -1674,7 +1674,7 @@
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $3)
+                                          (get_local $4)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -1694,25 +1694,25 @@
                           )
                           (block
                             (set_local $36
-                              (get_local $9)
-                            )
-                            (set_local $37
-                              (get_local $5)
-                            )
-                            (set_local $33
                               (get_local $8)
                             )
-                            (set_local $9
+                            (set_local $37
+                              (get_local $1)
+                            )
+                            (set_local $32
+                              (get_local $7)
+                            )
+                            (set_local $8
                               (i32.const 86)
                             )
                           )
                           (block
-                            (set_local $4
-                              (get_local $5)
+                            (set_local $11
+                              (get_local $1)
                             )
-                            (set_local $3
+                            (set_local $4
                               (i32.shl
-                                (get_local $3)
+                                (get_local $4)
                                 (i32.xor
                                   (i32.and
                                     (get_local $2)
@@ -1729,15 +1729,15 @@
                     )
                     (block
                       (set_local $36
-                        (get_local $6)
+                        (get_local $5)
                       )
                       (set_local $37
                         (i32.const 0)
                       )
-                      (set_local $33
+                      (set_local $32
                         (i32.const 0)
                       )
-                      (set_local $9
+                      (set_local $8
                         (i32.const 86)
                       )
                     )
@@ -1745,7 +1745,7 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $9)
+                    (get_local $8)
                     (i32.const 86)
                   )
                   (if
@@ -1756,20 +1756,20 @@
                             (get_local $37)
                           )
                           (i32.eqz
-                            (get_local $33)
+                            (get_local $32)
                           )
                         )
                         (block i32
                           (if
                             (i32.eqz
-                              (tee_local $6
+                              (tee_local $5
                                 (i32.and
-                                  (get_local $10)
+                                  (get_local $9)
                                   (i32.or
                                     (tee_local $15
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $27)
+                                        (get_local $21)
                                       )
                                     )
                                     (i32.sub
@@ -1781,22 +1781,22 @@
                               )
                             )
                             (block
-                              (set_local $6
+                              (set_local $4
                                 (get_local $0)
                               )
                               (br $do-once)
                             )
                           )
-                          (set_local $6
+                          (set_local $5
                             (i32.and
                               (i32.shr_u
                                 (tee_local $15
                                   (i32.add
                                     (i32.and
-                                      (get_local $6)
+                                      (get_local $5)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $6)
+                                        (get_local $5)
                                       )
                                     )
                                     (i32.const -1)
@@ -1821,7 +1821,7 @@
                                                 (tee_local $2
                                                   (i32.shr_u
                                                     (get_local $15)
-                                                    (get_local $6)
+                                                    (get_local $5)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -1829,12 +1829,12 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $6)
+                                          (get_local $5)
                                         )
                                         (tee_local $2
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $5
+                                              (tee_local $1
                                                 (i32.shr_u
                                                   (get_local $2)
                                                   (get_local $15)
@@ -1846,12 +1846,12 @@
                                           )
                                         )
                                       )
-                                      (tee_local $5
+                                      (tee_local $1
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $8
+                                            (tee_local $7
                                               (i32.shr_u
-                                                (get_local $5)
+                                                (get_local $1)
                                                 (get_local $2)
                                               )
                                             )
@@ -1861,13 +1861,13 @@
                                         )
                                       )
                                     )
-                                    (tee_local $8
+                                    (tee_local $7
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $3
+                                          (tee_local $4
                                             (i32.shr_u
-                                              (get_local $8)
-                                              (get_local $5)
+                                              (get_local $7)
+                                              (get_local $1)
                                             )
                                           )
                                           (i32.const 1)
@@ -1877,8 +1877,8 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $3)
-                                    (get_local $8)
+                                    (get_local $4)
+                                    (get_local $7)
                                   )
                                 )
                                 (i32.const 2)
@@ -1891,16 +1891,16 @@
                       )
                     )
                     (block
-                      (set_local $29
+                      (set_local $28
                         (get_local $36)
                       )
-                      (set_local $28
+                      (set_local $27
                         (get_local $2)
                       )
-                      (set_local $32
-                        (get_local $33)
+                      (set_local $31
+                        (get_local $32)
                       )
-                      (set_local $9
+                      (set_local $8
                         (i32.const 90)
                       )
                     )
@@ -1908,98 +1908,98 @@
                       (set_local $16
                         (get_local $36)
                       )
-                      (set_local $11
-                        (get_local $33)
+                      (set_local $10
+                        (get_local $32)
                       )
                     )
                   )
                 )
                 (if
                   (i32.eq
-                    (get_local $9)
+                    (get_local $8)
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $9
+                    (set_local $8
                       (i32.const 0)
                     )
-                    (set_local $3
+                    (set_local $4
                       (i32.lt_u
-                        (tee_local $8
+                        (tee_local $7
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $28)
+                                (get_local $27)
                               )
                               (i32.const -8)
                             )
                             (get_local $0)
                           )
                         )
-                        (get_local $29)
-                      )
-                    )
-                    (set_local $5
-                      (select
-                        (get_local $8)
-                        (get_local $29)
-                        (get_local $3)
-                      )
-                    )
-                    (set_local $8
-                      (select
                         (get_local $28)
-                        (get_local $32)
-                        (get_local $3)
+                      )
+                    )
+                    (set_local $1
+                      (select
+                        (get_local $7)
+                        (get_local $28)
+                        (get_local $4)
+                      )
+                    )
+                    (set_local $7
+                      (select
+                        (get_local $27)
+                        (get_local $31)
+                        (get_local $4)
                       )
                     )
                     (if
-                      (tee_local $3
+                      (tee_local $4
                         (i32.load offset=16
-                          (get_local $28)
+                          (get_local $27)
                         )
                       )
                       (block
-                        (set_local $29
-                          (get_local $5)
-                        )
                         (set_local $28
-                          (get_local $3)
+                          (get_local $1)
                         )
-                        (set_local $32
-                          (get_local $8)
+                        (set_local $27
+                          (get_local $4)
+                        )
+                        (set_local $31
+                          (get_local $7)
                         )
                         (br $while-in16)
                       )
                     )
                     (if
-                      (tee_local $28
+                      (tee_local $27
                         (i32.load offset=20
-                          (get_local $28)
+                          (get_local $27)
                         )
                       )
                       (block
-                        (set_local $29
-                          (get_local $5)
+                        (set_local $28
+                          (get_local $1)
                         )
-                        (set_local $32
-                          (get_local $8)
+                        (set_local $31
+                          (get_local $7)
                         )
                         (br $while-in16)
                       )
                       (block
                         (set_local $16
-                          (get_local $5)
+                          (get_local $1)
                         )
-                        (set_local $11
-                          (get_local $8)
+                        (set_local $10
+                          (get_local $7)
                         )
                       )
                     )
                   )
                 )
                 (if
-                  (get_local $11)
+                  (get_local $10)
                   (if
                     (i32.lt_u
                       (get_local $16)
@@ -2013,8 +2013,8 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $11)
-                          (tee_local $10
+                          (get_local $10)
+                          (tee_local $9
                             (i32.load
                               (i32.const 1224)
                             )
@@ -2024,57 +2024,57 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $11)
-                          (tee_local $8
+                          (get_local $10)
+                          (tee_local $7
                             (i32.add
-                              (get_local $11)
+                              (get_local $10)
                               (get_local $0)
                             )
                           )
                         )
                         (call $qa)
                       )
-                      (set_local $5
+                      (set_local $1
                         (i32.load offset=24
-                          (get_local $11)
+                          (get_local $10)
                         )
                       )
                       (block $do-once17
                         (if
                           (i32.eq
-                            (tee_local $3
+                            (tee_local $4
                               (i32.load offset=12
-                                (get_local $11)
+                                (get_local $10)
                               )
                             )
-                            (get_local $11)
+                            (get_local $10)
                           )
                           (block
                             (if
-                              (tee_local $6
+                              (tee_local $5
                                 (i32.load
                                   (tee_local $2
                                     (i32.add
-                                      (get_local $11)
+                                      (get_local $10)
                                       (i32.const 20)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $4
-                                  (get_local $6)
+                                (set_local $11
+                                  (get_local $5)
                                 )
                                 (set_local $3
                                   (get_local $2)
                                 )
                               )
                               (if
-                                (tee_local $4
+                                (tee_local $11
                                   (i32.load
                                     (tee_local $15
                                       (i32.add
-                                        (get_local $11)
+                                        (get_local $10)
                                         (i32.const 16)
                                       )
                                     )
@@ -2084,7 +2084,7 @@
                                   (get_local $15)
                                 )
                                 (block
-                                  (set_local $22
+                                  (set_local $23
                                     (i32.const 0)
                                   )
                                   (br $do-once17)
@@ -2093,19 +2093,19 @@
                             )
                             (loop $while-in20
                               (if
-                                (tee_local $6
+                                (tee_local $5
                                   (i32.load
                                     (tee_local $2
                                       (i32.add
-                                        (get_local $4)
+                                        (get_local $11)
                                         (i32.const 20)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $4
-                                    (get_local $6)
+                                  (set_local $11
+                                    (get_local $5)
                                   )
                                   (set_local $3
                                     (get_local $2)
@@ -2114,19 +2114,19 @@
                                 )
                               )
                               (if
-                                (tee_local $6
+                                (tee_local $5
                                   (i32.load
                                     (tee_local $2
                                       (i32.add
-                                        (get_local $4)
+                                        (get_local $11)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $4
-                                    (get_local $6)
+                                  (set_local $11
+                                    (get_local $5)
                                   )
                                   (set_local $3
                                     (get_local $2)
@@ -2138,7 +2138,7 @@
                             (if
                               (i32.lt_u
                                 (get_local $3)
-                                (get_local $10)
+                                (get_local $9)
                               )
                               (call $qa)
                               (block
@@ -2146,8 +2146,8 @@
                                   (get_local $3)
                                   (i32.const 0)
                                 )
-                                (set_local $22
-                                  (get_local $4)
+                                (set_local $23
+                                  (get_local $11)
                                 )
                               )
                             )
@@ -2157,24 +2157,24 @@
                               (i32.lt_u
                                 (tee_local $2
                                   (i32.load offset=8
-                                    (get_local $11)
+                                    (get_local $10)
                                   )
                                 )
-                                (get_local $10)
+                                (get_local $9)
                               )
                               (call $qa)
                             )
                             (if
                               (i32.ne
                                 (i32.load
-                                  (tee_local $6
+                                  (tee_local $5
                                     (i32.add
                                       (get_local $2)
                                       (i32.const 12)
                                     )
                                   )
                                 )
-                                (get_local $11)
+                                (get_local $10)
                               )
                               (call $qa)
                             )
@@ -2183,24 +2183,24 @@
                                 (i32.load
                                   (tee_local $15
                                     (i32.add
-                                      (get_local $3)
+                                      (get_local $4)
                                       (i32.const 8)
                                     )
                                   )
                                 )
-                                (get_local $11)
+                                (get_local $10)
                               )
                               (block
                                 (i32.store
-                                  (get_local $6)
-                                  (get_local $3)
+                                  (get_local $5)
+                                  (get_local $4)
                                 )
                                 (i32.store
                                   (get_local $15)
                                   (get_local $2)
                                 )
-                                (set_local $22
-                                  (get_local $3)
+                                (set_local $23
+                                  (get_local $4)
                                 )
                               )
                               (call $qa)
@@ -2210,19 +2210,19 @@
                       )
                       (block $do-once21
                         (if
-                          (get_local $5)
+                          (get_local $1)
                           (block
                             (if
                               (i32.eq
-                                (get_local $11)
+                                (get_local $10)
                                 (i32.load
-                                  (tee_local $10
+                                  (tee_local $9
                                     (i32.add
                                       (i32.const 1512)
                                       (i32.shl
-                                        (tee_local $3
+                                        (tee_local $4
                                           (i32.load offset=28
-                                            (get_local $11)
+                                            (get_local $10)
                                           )
                                         )
                                         (i32.const 2)
@@ -2233,12 +2233,12 @@
                               )
                               (block
                                 (i32.store
-                                  (get_local $10)
-                                  (get_local $22)
+                                  (get_local $9)
+                                  (get_local $23)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $22)
+                                    (get_local $23)
                                   )
                                   (block
                                     (i32.store
@@ -2250,7 +2250,7 @@
                                         (i32.xor
                                           (i32.shl
                                             (i32.const 1)
-                                            (get_local $3)
+                                            (get_local $4)
                                           )
                                           (i32.const -1)
                                         )
@@ -2263,7 +2263,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $5)
+                                    (get_local $1)
                                     (i32.load
                                       (i32.const 1224)
                                     )
@@ -2273,35 +2273,35 @@
                                 (if
                                   (i32.eq
                                     (i32.load
-                                      (tee_local $3
+                                      (tee_local $4
                                         (i32.add
-                                          (get_local $5)
+                                          (get_local $1)
                                           (i32.const 16)
                                         )
                                       )
                                     )
-                                    (get_local $11)
+                                    (get_local $10)
                                   )
                                   (i32.store
-                                    (get_local $3)
-                                    (get_local $22)
+                                    (get_local $4)
+                                    (get_local $23)
                                   )
                                   (i32.store offset=20
-                                    (get_local $5)
-                                    (get_local $22)
+                                    (get_local $1)
+                                    (get_local $23)
                                   )
                                 )
                                 (br_if $do-once21
                                   (i32.eqz
-                                    (get_local $22)
+                                    (get_local $23)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $22)
-                                (tee_local $3
+                                (get_local $23)
+                                (tee_local $4
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2310,42 +2310,42 @@
                               (call $qa)
                             )
                             (i32.store offset=24
-                              (get_local $22)
-                              (get_local $5)
+                              (get_local $23)
+                              (get_local $1)
                             )
                             (if
-                              (tee_local $10
+                              (tee_local $9
                                 (i32.load offset=16
-                                  (get_local $11)
+                                  (get_local $10)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $10)
-                                  (get_local $3)
+                                  (get_local $9)
+                                  (get_local $4)
                                 )
                                 (call $qa)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $22)
-                                    (get_local $10)
+                                    (get_local $23)
+                                    (get_local $9)
                                   )
                                   (i32.store offset=24
-                                    (get_local $10)
-                                    (get_local $22)
+                                    (get_local $9)
+                                    (get_local $23)
                                   )
                                 )
                               )
                             )
                             (if
-                              (tee_local $10
+                              (tee_local $9
                                 (i32.load offset=20
-                                  (get_local $11)
+                                  (get_local $10)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $10)
+                                  (get_local $9)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2353,12 +2353,12 @@
                                 (call $qa)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $22)
-                                    (get_local $10)
+                                    (get_local $23)
+                                    (get_local $9)
                                   )
                                   (i32.store offset=24
-                                    (get_local $10)
-                                    (get_local $22)
+                                    (get_local $9)
+                                    (get_local $23)
                                   )
                                 )
                               )
@@ -2374,9 +2374,9 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $11)
+                              (get_local $10)
                               (i32.or
-                                (tee_local $5
+                                (tee_local $1
                                   (i32.add
                                     (get_local $16)
                                     (get_local $0)
@@ -2386,18 +2386,18 @@
                               )
                             )
                             (i32.store
-                              (tee_local $10
+                              (tee_local $9
                                 (i32.add
                                   (i32.add
-                                    (get_local $11)
-                                    (get_local $5)
+                                    (get_local $10)
+                                    (get_local $1)
                                   )
                                   (i32.const 4)
                                 )
                               )
                               (i32.or
                                 (i32.load
-                                  (get_local $10)
+                                  (get_local $9)
                                 )
                                 (i32.const 1)
                               )
@@ -2405,14 +2405,14 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $11)
+                              (get_local $10)
                               (i32.or
                                 (get_local $0)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
-                              (get_local $8)
+                              (get_local $7)
                               (i32.or
                                 (get_local $16)
                                 (i32.const 1)
@@ -2420,12 +2420,12 @@
                             )
                             (i32.store
                               (i32.add
-                                (get_local $8)
+                                (get_local $7)
                                 (get_local $16)
                               )
                               (get_local $16)
                             )
-                            (set_local $10
+                            (set_local $9
                               (i32.shr_u
                                 (get_local $16)
                                 (i32.const 3)
@@ -2437,12 +2437,12 @@
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $5
+                                (set_local $1
                                   (i32.add
                                     (i32.const 1248)
                                     (i32.shl
                                       (i32.shl
-                                        (get_local $10)
+                                        (get_local $9)
                                         (i32.const 1)
                                       )
                                       (i32.const 2)
@@ -2451,7 +2451,7 @@
                                 )
                                 (if
                                   (i32.and
-                                    (tee_local $3
+                                    (tee_local $4
                                       (i32.load
                                         (i32.const 1208)
                                       )
@@ -2459,17 +2459,17 @@
                                     (tee_local $2
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $10)
+                                        (get_local $9)
                                       )
                                     )
                                   )
                                   (if
                                     (i32.lt_u
-                                      (tee_local $3
+                                      (tee_local $4
                                         (i32.load
                                           (tee_local $2
                                             (i32.add
-                                              (get_local $5)
+                                              (get_local $1)
                                               (i32.const 8)
                                             )
                                           )
@@ -2484,8 +2484,8 @@
                                       (set_local $19
                                         (get_local $2)
                                       )
-                                      (set_local $7
-                                        (get_local $3)
+                                      (set_local $6
+                                        (get_local $4)
                                       )
                                     )
                                   )
@@ -2493,36 +2493,36 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $3)
+                                        (get_local $4)
                                         (get_local $2)
                                       )
                                     )
                                     (set_local $19
                                       (i32.add
-                                        (get_local $5)
+                                        (get_local $1)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $7
-                                      (get_local $5)
+                                    (set_local $6
+                                      (get_local $1)
                                     )
                                   )
                                 )
                                 (i32.store
                                   (get_local $19)
-                                  (get_local $8)
+                                  (get_local $7)
                                 )
                                 (i32.store offset=12
+                                  (get_local $6)
                                   (get_local $7)
-                                  (get_local $8)
                                 )
                                 (i32.store offset=8
-                                  (get_local $8)
                                   (get_local $7)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=12
-                                  (get_local $8)
-                                  (get_local $5)
+                                  (get_local $7)
+                                  (get_local $1)
                                 )
                                 (br $do-once25)
                               )
@@ -2531,9 +2531,9 @@
                               (i32.add
                                 (i32.const 1512)
                                 (i32.shl
-                                  (tee_local $3
+                                  (tee_local $11
                                     (if i32
-                                      (tee_local $5
+                                      (tee_local $1
                                         (i32.shr_u
                                           (get_local $16)
                                           (i32.const 8)
@@ -2556,18 +2556,18 @@
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (tee_local $5
+                                                          (tee_local $1
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
                                                                   (tee_local $2
                                                                     (i32.shl
-                                                                      (get_local $5)
-                                                                      (tee_local $3
+                                                                      (get_local $1)
+                                                                      (tee_local $4
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $5)
+                                                                              (get_local $1)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -2584,16 +2584,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $3)
+                                                          (get_local $4)
                                                         )
                                                         (tee_local $2
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $10
+                                                                (tee_local $9
                                                                   (i32.shl
                                                                     (get_local $2)
-                                                                    (get_local $5)
+                                                                    (get_local $1)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -2607,7 +2607,7 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $10)
+                                                        (get_local $9)
                                                         (get_local $2)
                                                       )
                                                       (i32.const 15)
@@ -2633,13 +2633,13 @@
                               )
                             )
                             (i32.store offset=28
-                              (get_local $8)
-                              (get_local $3)
+                              (get_local $7)
+                              (get_local $11)
                             )
                             (i32.store offset=4
                               (tee_local $2
                                 (i32.add
-                                  (get_local $8)
+                                  (get_local $7)
                                   (i32.const 16)
                                 )
                               )
@@ -2657,10 +2657,10 @@
                                       (i32.const 1212)
                                     )
                                   )
-                                  (tee_local $10
+                                  (tee_local $9
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $3)
+                                      (get_local $11)
                                     )
                                   )
                                 )
@@ -2670,29 +2670,29 @@
                                   (i32.const 1212)
                                   (i32.or
                                     (get_local $2)
-                                    (get_local $10)
+                                    (get_local $9)
                                   )
                                 )
                                 (i32.store
                                   (get_local $15)
-                                  (get_local $8)
+                                  (get_local $7)
                                 )
                                 (i32.store offset=24
-                                  (get_local $8)
+                                  (get_local $7)
                                   (get_local $15)
                                 )
                                 (i32.store offset=12
-                                  (get_local $8)
-                                  (get_local $8)
+                                  (get_local $7)
+                                  (get_local $7)
                                 )
                                 (i32.store offset=8
-                                  (get_local $8)
-                                  (get_local $8)
+                                  (get_local $7)
+                                  (get_local $7)
                                 )
                                 (br $do-once25)
                               )
                             )
-                            (set_local $10
+                            (set_local $9
                               (i32.shl
                                 (get_local $16)
                                 (select
@@ -2700,12 +2700,12 @@
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $3)
+                                      (get_local $11)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $3)
+                                    (get_local $11)
                                     (i32.const 31)
                                   )
                                 )
@@ -2732,14 +2732,14 @@
                                     (set_local $18
                                       (get_local $2)
                                     )
-                                    (set_local $9
+                                    (set_local $8
                                       (i32.const 148)
                                     )
                                     (br $while-out27)
                                   )
                                 )
                                 (if
-                                  (tee_local $3
+                                  (tee_local $4
                                     (i32.load
                                       (tee_local $15
                                         (i32.add
@@ -2749,7 +2749,7 @@
                                           )
                                           (i32.shl
                                             (i32.shr_u
-                                              (get_local $10)
+                                              (get_local $9)
                                               (i32.const 31)
                                             )
                                             (i32.const 2)
@@ -2759,25 +2759,25 @@
                                     )
                                   )
                                   (block
-                                    (set_local $10
+                                    (set_local $9
                                       (i32.shl
-                                        (get_local $10)
+                                        (get_local $9)
                                         (i32.const 1)
                                       )
                                     )
                                     (set_local $2
-                                      (get_local $3)
+                                      (get_local $4)
                                     )
                                     (br $while-in28)
                                   )
                                   (block
-                                    (set_local $21
+                                    (set_local $22
                                       (get_local $15)
                                     )
                                     (set_local $14
                                       (get_local $2)
                                     )
-                                    (set_local $9
+                                    (set_local $8
                                       (i32.const 145)
                                     )
                                   )
@@ -2786,12 +2786,12 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $9)
+                                (get_local $8)
                                 (i32.const 145)
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $21)
+                                  (get_local $22)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2799,32 +2799,32 @@
                                 (call $qa)
                                 (block
                                   (i32.store
-                                    (get_local $21)
-                                    (get_local $8)
+                                    (get_local $22)
+                                    (get_local $7)
                                   )
                                   (i32.store offset=24
-                                    (get_local $8)
+                                    (get_local $7)
                                     (get_local $14)
                                   )
                                   (i32.store offset=12
-                                    (get_local $8)
-                                    (get_local $8)
+                                    (get_local $7)
+                                    (get_local $7)
                                   )
                                   (i32.store offset=8
-                                    (get_local $8)
-                                    (get_local $8)
+                                    (get_local $7)
+                                    (get_local $7)
                                   )
                                 )
                               )
                               (if
                                 (i32.eq
-                                  (get_local $9)
+                                  (get_local $8)
                                   (i32.const 148)
                                 )
                                 (if
                                   (i32.and
                                     (i32.ge_u
-                                      (tee_local $10
+                                      (tee_local $9
                                         (i32.load
                                           (tee_local $2
                                             (i32.add
@@ -2834,7 +2834,7 @@
                                           )
                                         )
                                       )
-                                      (tee_local $3
+                                      (tee_local $4
                                         (i32.load
                                           (i32.const 1224)
                                         )
@@ -2842,28 +2842,28 @@
                                     )
                                     (i32.ge_u
                                       (get_local $18)
-                                      (get_local $3)
+                                      (get_local $4)
                                     )
                                   )
                                   (block
                                     (i32.store offset=12
-                                      (get_local $10)
-                                      (get_local $8)
+                                      (get_local $9)
+                                      (get_local $7)
                                     )
                                     (i32.store
                                       (get_local $2)
-                                      (get_local $8)
+                                      (get_local $7)
                                     )
                                     (i32.store offset=8
-                                      (get_local $8)
-                                      (get_local $10)
+                                      (get_local $7)
+                                      (get_local $9)
                                     )
                                     (i32.store offset=12
-                                      (get_local $8)
+                                      (get_local $7)
                                       (get_local $18)
                                     )
                                     (i32.store offset=24
-                                      (get_local $8)
+                                      (get_local $7)
                                       (i32.const 0)
                                     )
                                   )
@@ -2879,21 +2879,21 @@
                       )
                       (return
                         (i32.add
-                          (get_local $11)
+                          (get_local $10)
                           (i32.const 8)
                         )
                       )
                     )
-                    (set_local $6
+                    (set_local $4
                       (get_local $0)
                     )
                   )
-                  (set_local $6
+                  (set_local $4
                     (get_local $0)
                   )
                 )
               )
-              (set_local $6
+              (set_local $4
                 (get_local $0)
               )
             )
@@ -2903,12 +2903,12 @@
     )
     (if
       (i32.ge_u
-        (tee_local $11
+        (tee_local $10
           (i32.load
             (i32.const 1216)
           )
         )
-        (get_local $6)
+        (get_local $4)
       )
       (block
         (set_local $14
@@ -2920,8 +2920,8 @@
           (i32.gt_u
             (tee_local $18
               (i32.sub
-                (get_local $11)
-                (get_local $6)
+                (get_local $10)
+                (get_local $4)
               )
             )
             (i32.const 15)
@@ -2929,10 +2929,10 @@
           (block
             (i32.store
               (i32.const 1228)
-              (tee_local $21
+              (tee_local $22
                 (i32.add
                   (get_local $14)
-                  (get_local $6)
+                  (get_local $4)
                 )
               )
             )
@@ -2941,7 +2941,7 @@
               (get_local $18)
             )
             (i32.store offset=4
-              (get_local $21)
+              (get_local $22)
               (i32.or
                 (get_local $18)
                 (i32.const 1)
@@ -2949,7 +2949,7 @@
             )
             (i32.store
               (i32.add
-                (get_local $21)
+                (get_local $22)
                 (get_local $18)
               )
               (get_local $18)
@@ -2957,7 +2957,7 @@
             (i32.store offset=4
               (get_local $14)
               (i32.or
-                (get_local $6)
+                (get_local $4)
                 (i32.const 3)
               )
             )
@@ -2974,7 +2974,7 @@
             (i32.store offset=4
               (get_local $14)
               (i32.or
-                (get_local $11)
+                (get_local $10)
                 (i32.const 3)
               )
             )
@@ -2983,7 +2983,7 @@
                 (i32.add
                   (i32.add
                     (get_local $14)
-                    (get_local $11)
+                    (get_local $10)
                   )
                   (i32.const 4)
                 )
@@ -3015,7 +3015,7 @@
             (i32.const 1220)
           )
         )
-        (get_local $6)
+        (get_local $4)
       )
       (block
         (i32.store
@@ -3023,25 +3023,25 @@
           (tee_local $18
             (i32.sub
               (get_local $14)
-              (get_local $6)
+              (get_local $4)
             )
           )
         )
         (i32.store
           (i32.const 1232)
-          (tee_local $11
+          (tee_local $10
             (i32.add
               (tee_local $14
                 (i32.load
                   (i32.const 1232)
                 )
               )
-              (get_local $6)
+              (get_local $4)
             )
           )
         )
         (i32.store offset=4
-          (get_local $11)
+          (get_local $10)
           (i32.or
             (get_local $18)
             (i32.const 1)
@@ -3050,7 +3050,7 @@
         (i32.store offset=4
           (get_local $14)
           (i32.or
-            (get_local $6)
+            (get_local $4)
             (i32.const 3)
           )
         )
@@ -3116,7 +3116,7 @@
     )
     (set_local $14
       (i32.add
-        (get_local $6)
+        (get_local $4)
         (i32.const 48)
       )
     )
@@ -3124,7 +3124,7 @@
       (i32.le_u
         (tee_local $13
           (i32.and
-            (tee_local $11
+            (tee_local $10
               (i32.add
                 (tee_local $13
                   (i32.load
@@ -3133,13 +3133,13 @@
                 )
                 (tee_local $18
                   (i32.add
-                    (get_local $6)
+                    (get_local $4)
                     (i32.const 47)
                   )
                 )
               )
             )
-            (tee_local $21
+            (tee_local $22
               (i32.sub
                 (i32.const 0)
                 (get_local $13)
@@ -3147,7 +3147,7 @@
             )
           )
         )
-        (get_local $6)
+        (get_local $4)
       )
       (block
         (set_global $r
@@ -3167,9 +3167,9 @@
       (if
         (i32.or
           (i32.le_u
-            (tee_local $7
+            (tee_local $6
               (i32.add
-                (tee_local $3
+                (tee_local $11
                   (i32.load
                     (i32.const 1640)
                   )
@@ -3177,10 +3177,10 @@
                 (get_local $13)
               )
             )
-            (get_local $3)
+            (get_local $11)
           )
           (i32.gt_u
-            (get_local $7)
+            (get_local $6)
             (get_local $16)
           )
         )
@@ -3196,7 +3196,7 @@
     )
     (if
       (i32.eq
-        (tee_local $9
+        (tee_local $8
           (block $label$break$b i32
             (if i32
               (i32.and
@@ -3215,16 +3215,16 @@
                       )
                     )
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.const 1656)
                       )
                       (loop $while-in32
                         (block $while-out31
                           (if
                             (i32.le_u
-                              (tee_local $3
+                              (tee_local $11
                                 (i32.load
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                               )
                               (get_local $16)
@@ -3232,11 +3232,11 @@
                             (if
                               (i32.gt_u
                                 (i32.add
-                                  (get_local $3)
+                                  (get_local $11)
                                   (i32.load
                                     (tee_local $19
                                       (i32.add
-                                        (get_local $7)
+                                        (get_local $6)
                                         (i32.const 4)
                                       )
                                     )
@@ -3246,7 +3246,7 @@
                               )
                               (block
                                 (set_local $0
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                                 (set_local $5
                                   (get_local $19)
@@ -3256,13 +3256,13 @@
                             )
                           )
                           (br_if $while-in32
-                            (tee_local $7
+                            (tee_local $6
                               (i32.load offset=8
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                           )
-                          (set_local $9
+                          (set_local $8
                             (i32.const 171)
                           )
                           (br $label$break$c)
@@ -3270,15 +3270,15 @@
                       )
                       (if
                         (i32.lt_u
-                          (tee_local $7
+                          (tee_local $6
                             (i32.and
                               (i32.sub
-                                (get_local $11)
+                                (get_local $10)
                                 (i32.load
                                   (i32.const 1220)
                                 )
                               )
-                              (get_local $21)
+                              (get_local $22)
                             )
                           )
                           (i32.const 2147483647)
@@ -3287,7 +3287,7 @@
                           (i32.eq
                             (tee_local $19
                               (call $ta
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                             (i32.add
@@ -3309,7 +3309,7 @@
                                 (get_local $19)
                               )
                               (set_local $26
-                                (get_local $7)
+                                (get_local $6)
                               )
                               (br $label$break$b
                                 (i32.const 191)
@@ -3320,17 +3320,17 @@
                             (set_local $12
                               (get_local $19)
                             )
-                            (set_local $1
-                              (get_local $7)
+                            (set_local $3
+                              (get_local $6)
                             )
-                            (set_local $9
+                            (set_local $8
                               (i32.const 181)
                             )
                           )
                         )
                       )
                     )
-                    (set_local $9
+                    (set_local $8
                       (i32.const 171)
                     )
                   )
@@ -3338,7 +3338,7 @@
                 (block $do-once33
                   (if
                     (i32.eq
-                      (get_local $9)
+                      (get_local $8)
                       (i32.const 171)
                     )
                     (if
@@ -3356,7 +3356,7 @@
                             (i32.and
                               (tee_local $19
                                 (i32.add
-                                  (tee_local $7
+                                  (tee_local $6
                                     (i32.load
                                       (i32.const 1684)
                                     )
@@ -3380,7 +3380,7 @@
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                               )
                             )
@@ -3389,7 +3389,7 @@
                         )
                         (set_local $0
                           (i32.add
-                            (tee_local $7
+                            (tee_local $6
                               (i32.load
                                 (i32.const 1640)
                               )
@@ -3401,7 +3401,7 @@
                           (i32.and
                             (i32.gt_u
                               (get_local $2)
-                              (get_local $6)
+                              (get_local $4)
                             )
                             (i32.lt_u
                               (get_local $2)
@@ -3419,7 +3419,7 @@
                                 (i32.or
                                   (i32.le_u
                                     (get_local $0)
-                                    (get_local $7)
+                                    (get_local $6)
                                   )
                                   (i32.gt_u
                                     (get_local $0)
@@ -3452,10 +3452,10 @@
                                 (set_local $12
                                   (get_local $19)
                                 )
-                                (set_local $1
+                                (set_local $3
                                   (get_local $2)
                                 )
-                                (set_local $9
+                                (set_local $8
                                   (i32.const 181)
                                 )
                               )
@@ -3469,25 +3469,25 @@
                 (block $label$break$d
                   (if
                     (i32.eq
-                      (get_local $9)
+                      (get_local $8)
                       (i32.const 181)
                     )
                     (block
                       (set_local $19
                         (i32.sub
                           (i32.const 0)
-                          (get_local $1)
+                          (get_local $3)
                         )
                       )
                       (if
                         (i32.and
                           (i32.gt_u
                             (get_local $14)
-                            (get_local $1)
+                            (get_local $3)
                           )
                           (i32.and
                             (i32.lt_u
-                              (get_local $1)
+                              (get_local $3)
                               (i32.const 2147483647)
                             )
                             (i32.ne
@@ -3503,7 +3503,7 @@
                                 (i32.add
                                   (i32.sub
                                     (get_local $18)
-                                    (get_local $1)
+                                    (get_local $3)
                                   )
                                   (tee_local $16
                                     (i32.load
@@ -3534,19 +3534,19 @@
                               )
                               (br $label$break$d)
                             )
-                            (set_local $4
+                            (set_local $1
                               (i32.add
                                 (get_local $0)
-                                (get_local $1)
+                                (get_local $3)
                               )
                             )
                           )
-                          (set_local $4
-                            (get_local $1)
+                          (set_local $1
+                            (get_local $3)
                           )
                         )
-                        (set_local $4
-                          (get_local $1)
+                        (set_local $1
+                          (get_local $3)
                         )
                       )
                       (if
@@ -3559,7 +3559,7 @@
                             (get_local $12)
                           )
                           (set_local $26
-                            (get_local $4)
+                            (get_local $1)
                           )
                           (br $label$break$b
                             (i32.const 191)
@@ -3593,7 +3593,7 @@
         (if
           (i32.and
             (i32.lt_u
-              (tee_local $4
+              (tee_local $1
                 (call $ta
                   (get_local $13)
                 )
@@ -3606,7 +3606,7 @@
             )
             (i32.and
               (i32.ne
-                (get_local $4)
+                (get_local $1)
                 (i32.const -1)
               )
               (i32.ne
@@ -3620,22 +3620,22 @@
               (tee_local $12
                 (i32.sub
                   (get_local $13)
-                  (get_local $4)
+                  (get_local $1)
                 )
               )
               (i32.add
-                (get_local $6)
+                (get_local $4)
                 (i32.const 40)
               )
             )
             (block
               (set_local $20
-                (get_local $4)
+                (get_local $1)
               )
               (set_local $26
                 (get_local $12)
               )
-              (set_local $9
+              (set_local $8
                 (i32.const 191)
               )
             )
@@ -3645,7 +3645,7 @@
     )
     (if
       (i32.eq
-        (get_local $9)
+        (get_local $8)
         (i32.const 191)
       )
       (block
@@ -3680,7 +3680,7 @@
               )
             )
             (block
-              (set_local $1
+              (set_local $3
                 (i32.const 1656)
               )
               (loop $do-in41
@@ -3689,16 +3689,16 @@
                     (i32.eq
                       (get_local $20)
                       (i32.add
-                        (tee_local $4
+                        (tee_local $1
                           (i32.load
-                            (get_local $1)
+                            (get_local $3)
                           )
                         )
                         (tee_local $18
                           (i32.load
                             (tee_local $13
                               (i32.add
-                                (get_local $1)
+                                (get_local $3)
                                 (i32.const 4)
                               )
                             )
@@ -3708,7 +3708,7 @@
                     )
                     (block
                       (set_local $49
-                        (get_local $4)
+                        (get_local $1)
                       )
                       (set_local $50
                         (get_local $13)
@@ -3717,9 +3717,9 @@
                         (get_local $18)
                       )
                       (set_local $52
-                        (get_local $1)
+                        (get_local $3)
                       )
-                      (set_local $9
+                      (set_local $8
                         (i32.const 201)
                       )
                       (br $do-out40)
@@ -3727,9 +3727,9 @@
                   )
                   (br_if $do-in41
                     (i32.ne
-                      (tee_local $1
+                      (tee_local $3
                         (i32.load offset=8
-                          (get_local $1)
+                          (get_local $3)
                         )
                       )
                       (i32.const 0)
@@ -3739,7 +3739,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $9)
+                  (get_local $8)
                   (i32.const 201)
                 )
                 (if
@@ -3770,7 +3770,7 @@
                           (get_local $26)
                         )
                       )
-                      (set_local $1
+                      (set_local $3
                         (i32.add
                           (get_local $12)
                           (tee_local $18
@@ -3778,7 +3778,7 @@
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (tee_local $1
+                                  (tee_local $3
                                     (i32.add
                                       (get_local $12)
                                       (i32.const 8)
@@ -3789,7 +3789,7 @@
                               )
                               (i32.const 0)
                               (i32.and
-                                (get_local $1)
+                                (get_local $3)
                                 (i32.const 7)
                               )
                             )
@@ -3809,14 +3809,14 @@
                       )
                       (i32.store
                         (i32.const 1232)
-                        (get_local $1)
+                        (get_local $3)
                       )
                       (i32.store
                         (i32.const 1220)
                         (get_local $13)
                       )
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $3)
                         (i32.or
                           (get_local $13)
                           (i32.const 1)
@@ -3824,7 +3824,7 @@
                       )
                       (i32.store offset=4
                         (i32.add
-                          (get_local $1)
+                          (get_local $3)
                           (get_local $13)
                         )
                         (i32.const 40)
@@ -3840,7 +3840,7 @@
                   )
                 )
               )
-              (set_local $8
+              (set_local $7
                 (if i32
                   (i32.lt_u
                     (get_local $20)
@@ -3866,7 +3866,7 @@
                   (get_local $26)
                 )
               )
-              (set_local $1
+              (set_local $3
                 (i32.const 1656)
               )
               (loop $while-in43
@@ -3874,38 +3874,38 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $1)
+                        (get_local $3)
                       )
                       (get_local $13)
                     )
                     (block
                       (set_local $53
-                        (get_local $1)
+                        (get_local $3)
                       )
                       (set_local $43
-                        (get_local $1)
+                        (get_local $3)
                       )
-                      (set_local $9
+                      (set_local $8
                         (i32.const 209)
                       )
                       (br $while-out42)
                     )
                   )
                   (br_if $while-in43
-                    (tee_local $1
+                    (tee_local $3
                       (i32.load offset=8
-                        (get_local $1)
+                        (get_local $3)
                       )
                     )
                   )
-                  (set_local $30
+                  (set_local $29
                     (i32.const 1656)
                   )
                 )
               )
               (if
                 (i32.eq
-                  (get_local $9)
+                  (get_local $8)
                   (i32.const 209)
                 )
                 (if
@@ -3915,7 +3915,7 @@
                     )
                     (i32.const 8)
                   )
-                  (set_local $30
+                  (set_local $29
                     (i32.const 1656)
                   )
                   (block
@@ -3924,7 +3924,7 @@
                       (get_local $20)
                     )
                     (i32.store
-                      (tee_local $1
+                      (tee_local $3
                         (i32.add
                           (get_local $43)
                           (i32.const 4)
@@ -3932,7 +3932,7 @@
                       )
                       (i32.add
                         (i32.load
-                          (get_local $1)
+                          (get_local $3)
                         )
                         (get_local $26)
                       )
@@ -3944,7 +3944,7 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $1
+                              (tee_local $3
                                 (i32.add
                                   (get_local $20)
                                   (i32.const 8)
@@ -3955,20 +3955,20 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $1)
+                            (get_local $3)
                             (i32.const 7)
                           )
                         )
                       )
                     )
-                    (set_local $4
+                    (set_local $1
                       (i32.add
                         (get_local $13)
                         (select
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $1
+                              (tee_local $3
                                 (i32.add
                                   (get_local $13)
                                   (i32.const 8)
@@ -3979,38 +3979,38 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $1)
+                            (get_local $3)
                             (i32.const 7)
                           )
                         )
                       )
                     )
-                    (set_local $1
+                    (set_local $3
                       (i32.add
                         (get_local $18)
-                        (get_local $6)
+                        (get_local $4)
                       )
                     )
                     (set_local $14
                       (i32.sub
                         (i32.sub
-                          (get_local $4)
+                          (get_local $1)
                           (get_local $18)
                         )
-                        (get_local $6)
+                        (get_local $4)
                       )
                     )
                     (i32.store offset=4
                       (get_local $18)
                       (i32.or
-                        (get_local $6)
+                        (get_local $4)
                         (i32.const 3)
                       )
                     )
                     (block $do-once44
                       (if
                         (i32.eq
-                          (get_local $4)
+                          (get_local $1)
                           (get_local $12)
                         )
                         (block
@@ -4027,10 +4027,10 @@
                           )
                           (i32.store
                             (i32.const 1232)
-                            (get_local $1)
+                            (get_local $3)
                           )
                           (i32.store offset=4
-                            (get_local $1)
+                            (get_local $3)
                             (i32.or
                               (get_local $2)
                               (i32.const 1)
@@ -4040,7 +4040,7 @@
                         (block
                           (if
                             (i32.eq
-                              (get_local $4)
+                              (get_local $1)
                               (i32.load
                                 (i32.const 1228)
                               )
@@ -4059,10 +4059,10 @@
                               )
                               (i32.store
                                 (i32.const 1228)
-                                (get_local $1)
+                                (get_local $3)
                               )
                               (i32.store offset=4
-                                (get_local $1)
+                                (get_local $3)
                                 (i32.or
                                   (get_local $2)
                                   (i32.const 1)
@@ -4070,7 +4070,7 @@
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $1)
+                                  (get_local $3)
                                   (get_local $2)
                                 )
                                 (get_local $2)
@@ -4086,7 +4086,7 @@
                                     (i32.and
                                       (tee_local $2
                                         (i32.load offset=4
-                                          (get_local $4)
+                                          (get_local $1)
                                         )
                                       )
                                       (i32.const 3)
@@ -4113,17 +4113,17 @@
                                           (i32.const 256)
                                         )
                                         (block
-                                          (set_local $11
+                                          (set_local $10
                                             (i32.load offset=12
-                                              (get_local $4)
+                                              (get_local $1)
                                             )
                                           )
                                           (block $do-once47
                                             (if
                                               (i32.ne
-                                                (tee_local $21
+                                                (tee_local $22
                                                   (i32.load offset=8
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
                                                 )
                                                 (tee_local $19
@@ -4142,17 +4142,17 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $21)
-                                                    (get_local $8)
+                                                    (get_local $22)
+                                                    (get_local $7)
                                                   )
                                                   (call $qa)
                                                 )
                                                 (br_if $do-once47
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $21)
+                                                      (get_local $22)
                                                     )
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
                                                 )
                                                 (call $qa)
@@ -4161,8 +4161,8 @@
                                           )
                                           (if
                                             (i32.eq
-                                              (get_local $11)
-                                              (get_local $21)
+                                              (get_local $10)
+                                              (get_local $22)
                                             )
                                             (block
                                               (i32.store
@@ -4186,20 +4186,20 @@
                                           (block $do-once49
                                             (if
                                               (i32.eq
-                                                (get_local $11)
+                                                (get_local $10)
                                                 (get_local $19)
                                               )
                                               (set_local $44
                                                 (i32.add
-                                                  (get_local $11)
+                                                  (get_local $10)
                                                   (i32.const 8)
                                                 )
                                               )
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $11)
-                                                    (get_local $8)
+                                                    (get_local $10)
+                                                    (get_local $7)
                                                   )
                                                   (call $qa)
                                                 )
@@ -4208,12 +4208,12 @@
                                                     (i32.load
                                                       (tee_local $0
                                                         (i32.add
-                                                          (get_local $11)
+                                                          (get_local $10)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
                                                   (block
                                                     (set_local $44
@@ -4227,18 +4227,18 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $21)
-                                            (get_local $11)
+                                            (get_local $22)
+                                            (get_local $10)
                                           )
                                           (i32.store
                                             (get_local $44)
-                                            (get_local $21)
+                                            (get_local $22)
                                           )
                                         )
                                         (block
                                           (set_local $19
                                             (i32.load offset=24
-                                              (get_local $4)
+                                              (get_local $1)
                                             )
                                           )
                                           (block $do-once51
@@ -4246,20 +4246,20 @@
                                               (i32.eq
                                                 (tee_local $0
                                                   (i32.load offset=12
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
                                                 )
-                                                (get_local $4)
+                                                (get_local $1)
                                               )
                                               (block
                                                 (if
-                                                  (tee_local $3
+                                                  (tee_local $11
                                                     (i32.load
-                                                      (tee_local $7
+                                                      (tee_local $6
                                                         (i32.add
                                                           (tee_local $16
                                                             (i32.add
-                                                              (get_local $4)
+                                                              (get_local $1)
                                                               (i32.const 16)
                                                             )
                                                           )
@@ -4270,20 +4270,20 @@
                                                   )
                                                   (block
                                                     (set_local $0
-                                                      (get_local $3)
+                                                      (get_local $11)
                                                     )
                                                     (set_local $16
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $22
+                                                    (tee_local $23
                                                       (i32.load
                                                         (get_local $16)
                                                       )
                                                     )
                                                     (set_local $0
-                                                      (get_local $22)
+                                                      (get_local $23)
                                                     )
                                                     (block
                                                       (set_local $24
@@ -4295,9 +4295,9 @@
                                                 )
                                                 (loop $while-in54
                                                   (if
-                                                    (tee_local $3
+                                                    (tee_local $11
                                                       (i32.load
-                                                        (tee_local $7
+                                                        (tee_local $6
                                                           (i32.add
                                                             (get_local $0)
                                                             (i32.const 20)
@@ -4307,18 +4307,18 @@
                                                     )
                                                     (block
                                                       (set_local $0
-                                                        (get_local $3)
+                                                        (get_local $11)
                                                       )
                                                       (set_local $16
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                       )
                                                       (br $while-in54)
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $3
+                                                    (tee_local $11
                                                       (i32.load
-                                                        (tee_local $7
+                                                        (tee_local $6
                                                           (i32.add
                                                             (get_local $0)
                                                             (i32.const 16)
@@ -4328,10 +4328,10 @@
                                                     )
                                                     (block
                                                       (set_local $0
-                                                        (get_local $3)
+                                                        (get_local $11)
                                                       )
                                                       (set_local $16
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                       )
                                                       (br $while-in54)
                                                     )
@@ -4340,7 +4340,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $16)
-                                                    (get_local $8)
+                                                    (get_local $7)
                                                   )
                                                   (call $qa)
                                                   (block
@@ -4357,26 +4357,26 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.load offset=8
-                                                        (get_local $4)
+                                                        (get_local $1)
                                                       )
                                                     )
-                                                    (get_local $8)
+                                                    (get_local $7)
                                                   )
                                                   (call $qa)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (tee_local $3
+                                                      (tee_local $11
                                                         (i32.add
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                           (i32.const 12)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
                                                   (call $qa)
                                                 )
@@ -4390,16 +4390,16 @@
                                                         )
                                                       )
                                                     )
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $3)
+                                                      (get_local $11)
                                                       (get_local $0)
                                                     )
                                                     (i32.store
                                                       (get_local $16)
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                     )
                                                     (set_local $24
                                                       (get_local $0)
@@ -4418,15 +4418,15 @@
                                           (block $do-once55
                                             (if
                                               (i32.eq
-                                                (get_local $4)
+                                                (get_local $1)
                                                 (i32.load
-                                                  (tee_local $21
+                                                  (tee_local $22
                                                     (i32.add
                                                       (i32.const 1512)
                                                       (i32.shl
                                                         (tee_local $0
                                                           (i32.load offset=28
-                                                            (get_local $4)
+                                                            (get_local $1)
                                                           )
                                                         )
                                                         (i32.const 2)
@@ -4437,7 +4437,7 @@
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $21)
+                                                  (get_local $22)
                                                   (get_local $24)
                                                 )
                                                 (br_if $do-once55
@@ -4473,17 +4473,17 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $11
+                                                      (tee_local $10
                                                         (i32.add
                                                           (get_local $19)
                                                           (i32.const 16)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
                                                   (i32.store
-                                                    (get_local $11)
+                                                    (get_local $10)
                                                     (get_local $24)
                                                   )
                                                   (i32.store offset=20
@@ -4515,11 +4515,11 @@
                                             (get_local $19)
                                           )
                                           (if
-                                            (tee_local $11
+                                            (tee_local $10
                                               (i32.load
-                                                (tee_local $21
+                                                (tee_local $22
                                                   (i32.add
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                     (i32.const 16)
                                                   )
                                                 )
@@ -4527,17 +4527,17 @@
                                             )
                                             (if
                                               (i32.lt_u
-                                                (get_local $11)
+                                                (get_local $10)
                                                 (get_local $0)
                                               )
                                               (call $qa)
                                               (block
                                                 (i32.store offset=16
                                                   (get_local $24)
-                                                  (get_local $11)
+                                                  (get_local $10)
                                                 )
                                                 (i32.store offset=24
-                                                  (get_local $11)
+                                                  (get_local $10)
                                                   (get_local $24)
                                                 )
                                               )
@@ -4545,16 +4545,16 @@
                                           )
                                           (br_if $label$break$e
                                             (i32.eqz
-                                              (tee_local $11
+                                              (tee_local $10
                                                 (i32.load offset=4
-                                                  (get_local $21)
+                                                  (get_local $22)
                                                 )
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $11)
+                                              (get_local $10)
                                               (i32.load
                                                 (i32.const 1224)
                                               )
@@ -4563,10 +4563,10 @@
                                             (block
                                               (i32.store offset=20
                                                 (get_local $24)
-                                                (get_local $11)
+                                                (get_local $10)
                                               )
                                               (i32.store offset=24
-                                                (get_local $11)
+                                                (get_local $10)
                                                 (get_local $24)
                                               )
                                             )
@@ -4581,11 +4581,11 @@
                                       )
                                     )
                                     (i32.add
-                                      (get_local $4)
+                                      (get_local $1)
                                       (get_local $5)
                                     )
                                   )
-                                  (get_local $4)
+                                  (get_local $1)
                                 )
                                 (i32.const 4)
                               )
@@ -4598,7 +4598,7 @@
                             )
                           )
                           (i32.store offset=4
-                            (get_local $1)
+                            (get_local $3)
                             (i32.or
                               (get_local $14)
                               (i32.const 1)
@@ -4606,7 +4606,7 @@
                           )
                           (i32.store
                             (i32.add
-                              (get_local $1)
+                              (get_local $3)
                               (get_local $14)
                             )
                             (get_local $14)
@@ -4638,7 +4638,7 @@
                               (block $do-once59
                                 (if
                                   (i32.and
-                                    (tee_local $11
+                                    (tee_local $10
                                       (i32.load
                                         (i32.const 1208)
                                       )
@@ -4683,7 +4683,7 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $11)
+                                        (get_local $10)
                                         (get_local $0)
                                       )
                                     )
@@ -4701,18 +4701,18 @@
                               )
                               (i32.store
                                 (get_local $45)
-                                (get_local $1)
+                                (get_local $3)
                               )
                               (i32.store offset=12
                                 (get_local $38)
-                                (get_local $1)
+                                (get_local $3)
                               )
                               (i32.store offset=8
-                                (get_local $1)
+                                (get_local $3)
                                 (get_local $38)
                               )
                               (i32.store offset=12
-                                (get_local $1)
+                                (get_local $3)
                                 (get_local $2)
                               )
                               (br $do-once44)
@@ -4722,7 +4722,7 @@
                             (i32.add
                               (i32.const 1512)
                               (i32.shl
-                                (tee_local $6
+                                (tee_local $5
                                   (block $do-once61 i32
                                     (if i32
                                       (tee_local $0
@@ -4746,7 +4746,7 @@
                                             (i32.shr_u
                                               (get_local $14)
                                               (i32.add
-                                                (tee_local $7
+                                                (tee_local $6
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
@@ -4759,7 +4759,7 @@
                                                                   (tee_local $5
                                                                     (i32.shl
                                                                       (get_local $0)
-                                                                      (tee_local $11
+                                                                      (tee_local $10
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
@@ -4780,7 +4780,7 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $11)
+                                                          (get_local $10)
                                                         )
                                                         (tee_local $5
                                                           (i32.and
@@ -4816,7 +4816,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $7)
+                                            (get_local $6)
                                             (i32.const 1)
                                           )
                                         )
@@ -4830,13 +4830,13 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $1)
-                            (get_local $6)
+                            (get_local $3)
+                            (get_local $5)
                           )
                           (i32.store offset=4
                             (tee_local $2
                               (i32.add
-                                (get_local $1)
+                                (get_local $3)
                                 (i32.const 16)
                               )
                             )
@@ -4854,10 +4854,10 @@
                                     (i32.const 1212)
                                   )
                                 )
-                                (tee_local $7
+                                (tee_local $6
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $6)
+                                    (get_local $5)
                                   )
                                 )
                               )
@@ -4867,29 +4867,29 @@
                                 (i32.const 1212)
                                 (i32.or
                                   (get_local $2)
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                               )
                               (i32.store
                                 (get_local $0)
-                                (get_local $1)
+                                (get_local $3)
                               )
                               (i32.store offset=24
-                                (get_local $1)
+                                (get_local $3)
                                 (get_local $0)
                               )
                               (i32.store offset=12
-                                (get_local $1)
-                                (get_local $1)
+                                (get_local $3)
+                                (get_local $3)
                               )
                               (i32.store offset=8
-                                (get_local $1)
-                                (get_local $1)
+                                (get_local $3)
+                                (get_local $3)
                               )
                               (br $do-once44)
                             )
                           )
-                          (set_local $7
+                          (set_local $6
                             (i32.shl
                               (get_local $14)
                               (select
@@ -4897,12 +4897,12 @@
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $6)
+                                    (get_local $5)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $6)
+                                  (get_local $5)
                                   (i32.const 31)
                                 )
                               )
@@ -4929,7 +4929,7 @@
                                   (set_local $39
                                     (get_local $2)
                                   )
-                                  (set_local $9
+                                  (set_local $8
                                     (i32.const 279)
                                   )
                                   (br $while-out63)
@@ -4946,7 +4946,7 @@
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $7)
+                                            (get_local $6)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -4956,9 +4956,9 @@
                                   )
                                 )
                                 (block
-                                  (set_local $7
+                                  (set_local $6
                                     (i32.shl
-                                      (get_local $7)
+                                      (get_local $6)
                                       (i32.const 1)
                                     )
                                   )
@@ -4974,7 +4974,7 @@
                                   (set_local $54
                                     (get_local $2)
                                   )
-                                  (set_local $9
+                                  (set_local $8
                                     (i32.const 276)
                                   )
                                 )
@@ -4983,7 +4983,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $9)
+                              (get_local $8)
                               (i32.const 276)
                             )
                             (if
@@ -4997,31 +4997,31 @@
                               (block
                                 (i32.store
                                   (get_local $46)
-                                  (get_local $1)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=24
-                                  (get_local $1)
+                                  (get_local $3)
                                   (get_local $54)
                                 )
                                 (i32.store offset=12
-                                  (get_local $1)
-                                  (get_local $1)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=8
-                                  (get_local $1)
-                                  (get_local $1)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $9)
+                                (get_local $8)
                                 (i32.const 279)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (tee_local $7
+                                    (tee_local $6
                                       (i32.load
                                         (tee_local $2
                                           (i32.add
@@ -5044,23 +5044,23 @@
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $7)
-                                    (get_local $1)
+                                    (get_local $6)
+                                    (get_local $3)
                                   )
                                   (i32.store
                                     (get_local $2)
-                                    (get_local $1)
+                                    (get_local $3)
                                   )
                                   (i32.store offset=8
-                                    (get_local $1)
-                                    (get_local $7)
+                                    (get_local $3)
+                                    (get_local $6)
                                   )
                                   (i32.store offset=12
-                                    (get_local $1)
+                                    (get_local $3)
                                     (get_local $39)
                                   )
                                   (i32.store offset=24
-                                    (get_local $1)
+                                    (get_local $3)
                                     (i32.const 0)
                                   )
                                 )
@@ -5087,9 +5087,9 @@
                 (block $while-out65
                   (if
                     (i32.le_u
-                      (tee_local $1
+                      (tee_local $3
                         (i32.load
-                          (get_local $30)
+                          (get_local $29)
                         )
                       )
                       (get_local $12)
@@ -5098,9 +5098,9 @@
                       (i32.gt_u
                         (tee_local $14
                           (i32.add
-                            (get_local $1)
+                            (get_local $3)
                             (i32.load offset=4
-                              (get_local $30)
+                              (get_local $29)
                             )
                           )
                         )
@@ -5114,9 +5114,9 @@
                       )
                     )
                   )
-                  (set_local $30
+                  (set_local $29
                     (i32.load offset=8
-                      (get_local $30)
+                      (get_local $29)
                     )
                   )
                   (br $while-in66)
@@ -5133,12 +5133,12 @@
                   (i32.const 8)
                 )
               )
-              (set_local $1
+              (set_local $3
                 (i32.add
                   (tee_local $18
                     (select
                       (get_local $12)
-                      (tee_local $1
+                      (tee_local $3
                         (i32.add
                           (get_local $18)
                           (select
@@ -5158,7 +5158,7 @@
                         )
                       )
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $3)
                         (tee_local $14
                           (i32.add
                             (get_local $12)
@@ -5173,7 +5173,7 @@
               )
               (i32.store
                 (i32.const 1232)
-                (tee_local $4
+                (tee_local $1
                   (i32.add
                     (get_local $20)
                     (tee_local $13
@@ -5181,7 +5181,7 @@
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (tee_local $4
+                            (tee_local $1
                               (i32.add
                                 (get_local $20)
                                 (i32.const 8)
@@ -5192,7 +5192,7 @@
                         )
                         (i32.const 0)
                         (i32.and
-                          (get_local $4)
+                          (get_local $1)
                           (i32.const 7)
                         )
                       )
@@ -5202,7 +5202,7 @@
               )
               (i32.store
                 (i32.const 1220)
-                (tee_local $7
+                (tee_local $6
                   (i32.sub
                     (i32.add
                       (get_local $26)
@@ -5213,16 +5213,16 @@
                 )
               )
               (i32.store offset=4
-                (get_local $4)
+                (get_local $1)
                 (i32.or
-                  (get_local $7)
+                  (get_local $6)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $4)
-                  (get_local $7)
+                  (get_local $1)
+                  (get_local $6)
                 )
                 (i32.const 40)
               )
@@ -5233,7 +5233,7 @@
                 )
               )
               (i32.store
-                (tee_local $7
+                (tee_local $6
                   (i32.add
                     (get_local $18)
                     (i32.const 4)
@@ -5242,25 +5242,25 @@
                 (i32.const 27)
               )
               (i32.store
-                (get_local $1)
+                (get_local $3)
                 (i32.load
                   (i32.const 1656)
                 )
               )
               (i32.store offset=4
-                (get_local $1)
+                (get_local $3)
                 (i32.load
                   (i32.const 1660)
                 )
               )
               (i32.store offset=8
-                (get_local $1)
+                (get_local $3)
                 (i32.load
                   (i32.const 1664)
                 )
               )
               (i32.store offset=12
-                (get_local $1)
+                (get_local $3)
                 (i32.load
                   (i32.const 1668)
                 )
@@ -5279,9 +5279,9 @@
               )
               (i32.store
                 (i32.const 1664)
-                (get_local $1)
+                (get_local $3)
               )
-              (set_local $1
+              (set_local $3
                 (i32.add
                   (get_local $18)
                   (i32.const 24)
@@ -5289,9 +5289,9 @@
               )
               (loop $do-in68
                 (i32.store
-                  (tee_local $1
+                  (tee_local $3
                     (i32.add
-                      (get_local $1)
+                      (get_local $3)
                       (i32.const 4)
                     )
                   )
@@ -5300,7 +5300,7 @@
                 (br_if $do-in68
                   (i32.lt_u
                     (i32.add
-                      (get_local $1)
+                      (get_local $3)
                       (i32.const 4)
                     )
                     (get_local $0)
@@ -5314,10 +5314,10 @@
                 )
                 (block
                   (i32.store
-                    (get_local $7)
+                    (get_local $6)
                     (i32.and
                       (i32.load
-                        (get_local $7)
+                        (get_local $6)
                       )
                       (i32.const -2)
                     )
@@ -5325,7 +5325,7 @@
                   (i32.store offset=4
                     (get_local $12)
                     (i32.or
-                      (tee_local $1
+                      (tee_local $3
                         (i32.sub
                           (get_local $18)
                           (get_local $12)
@@ -5336,17 +5336,17 @@
                   )
                   (i32.store
                     (get_local $18)
-                    (get_local $1)
+                    (get_local $3)
                   )
-                  (set_local $4
+                  (set_local $1
                     (i32.shr_u
-                      (get_local $1)
+                      (get_local $3)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $3)
                       (i32.const 256)
                     )
                     (block
@@ -5355,7 +5355,7 @@
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (get_local $4)
+                              (get_local $1)
                               (i32.const 1)
                             )
                             (i32.const 2)
@@ -5372,7 +5372,7 @@
                           (tee_local $5
                             (i32.shl
                               (i32.const 1)
-                              (get_local $4)
+                              (get_local $1)
                             )
                           )
                         )
@@ -5448,20 +5448,20 @@
                           (if i32
                             (tee_local $13
                               (i32.shr_u
-                                (get_local $1)
+                                (get_local $3)
                                 (i32.const 8)
                               )
                             )
                             (if i32
                               (i32.gt_u
-                                (get_local $1)
+                                (get_local $3)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $1)
+                                    (get_local $3)
                                     (i32.add
                                       (tee_local $0
                                         (i32.add
@@ -5503,7 +5503,7 @@
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (tee_local $4
+                                                      (tee_local $1
                                                         (i32.shl
                                                           (get_local $5)
                                                           (get_local $13)
@@ -5520,7 +5520,7 @@
                                           )
                                           (i32.shr_u
                                             (i32.shl
-                                              (get_local $4)
+                                              (get_local $1)
                                               (get_local $5)
                                             )
                                             (i32.const 15)
@@ -5565,7 +5565,7 @@
                             (i32.const 1212)
                           )
                         )
-                        (tee_local $4
+                        (tee_local $1
                           (i32.shl
                             (i32.const 1)
                             (get_local $2)
@@ -5578,7 +5578,7 @@
                         (i32.const 1212)
                         (i32.or
                           (get_local $5)
-                          (get_local $4)
+                          (get_local $1)
                         )
                       )
                       (i32.store
@@ -5600,9 +5600,9 @@
                       (br $do-once38)
                     )
                   )
-                  (set_local $4
+                  (set_local $1
                     (i32.shl
-                      (get_local $1)
+                      (get_local $3)
                       (select
                         (i32.const 0)
                         (i32.sub
@@ -5634,13 +5634,13 @@
                             )
                             (i32.const -8)
                           )
-                          (get_local $1)
+                          (get_local $3)
                         )
                         (block
-                          (set_local $31
+                          (set_local $30
                             (get_local $5)
                           )
-                          (set_local $9
+                          (set_local $8
                             (i32.const 305)
                           )
                           (br $while-out69)
@@ -5657,7 +5657,7 @@
                                 )
                                 (i32.shl
                                   (i32.shr_u
-                                    (get_local $4)
+                                    (get_local $1)
                                     (i32.const 31)
                                   )
                                   (i32.const 2)
@@ -5667,9 +5667,9 @@
                           )
                         )
                         (block
-                          (set_local $4
+                          (set_local $1
                             (i32.shl
-                              (get_local $4)
+                              (get_local $1)
                               (i32.const 1)
                             )
                           )
@@ -5685,7 +5685,7 @@
                           (set_local $55
                             (get_local $5)
                           )
-                          (set_local $9
+                          (set_local $8
                             (i32.const 302)
                           )
                         )
@@ -5694,7 +5694,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $9)
+                      (get_local $8)
                       (i32.const 302)
                     )
                     (if
@@ -5726,36 +5726,36 @@
                     )
                     (if
                       (i32.eq
-                        (get_local $9)
+                        (get_local $8)
                         (i32.const 305)
                       )
                       (if
                         (i32.and
                           (i32.ge_u
-                            (tee_local $4
+                            (tee_local $1
                               (i32.load
                                 (tee_local $5
                                   (i32.add
-                                    (get_local $31)
+                                    (get_local $30)
                                     (i32.const 8)
                                   )
                                 )
                               )
                             )
-                            (tee_local $1
+                            (tee_local $3
                               (i32.load
                                 (i32.const 1224)
                               )
                             )
                           )
                           (i32.ge_u
-                            (get_local $31)
-                            (get_local $1)
+                            (get_local $30)
+                            (get_local $3)
                           )
                         )
                         (block
                           (i32.store offset=12
-                            (get_local $4)
+                            (get_local $1)
                             (get_local $12)
                           )
                           (i32.store
@@ -5764,11 +5764,11 @@
                           )
                           (i32.store offset=8
                             (get_local $12)
-                            (get_local $4)
+                            (get_local $1)
                           )
                           (i32.store offset=12
                             (get_local $12)
-                            (get_local $31)
+                            (get_local $30)
                           )
                           (i32.store offset=24
                             (get_local $12)
@@ -5786,7 +5786,7 @@
               (if
                 (i32.or
                   (i32.eqz
-                    (tee_local $4
+                    (tee_local $1
                       (i32.load
                         (i32.const 1224)
                       )
@@ -5794,7 +5794,7 @@
                   )
                   (i32.lt_u
                     (get_local $20)
-                    (get_local $4)
+                    (get_local $1)
                   )
                 )
                 (i32.store
@@ -5824,7 +5824,7 @@
                 (i32.const 1240)
                 (i32.const -1)
               )
-              (set_local $4
+              (set_local $1
                 (i32.const 0)
               )
               (loop $do-in
@@ -5834,7 +5834,7 @@
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $4)
+                          (get_local $1)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -5849,9 +5849,9 @@
                 )
                 (br_if $do-in
                   (i32.ne
-                    (tee_local $4
+                    (tee_local $1
                       (i32.add
-                        (get_local $4)
+                        (get_local $1)
                         (i32.const 1)
                       )
                     )
@@ -5861,7 +5861,7 @@
               )
               (i32.store
                 (i32.const 1232)
-                (tee_local $4
+                (tee_local $1
                   (i32.add
                     (get_local $20)
                     (tee_local $13
@@ -5869,7 +5869,7 @@
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (tee_local $4
+                            (tee_local $1
                               (i32.add
                                 (get_local $20)
                                 (i32.const 8)
@@ -5880,7 +5880,7 @@
                         )
                         (i32.const 0)
                         (i32.and
-                          (get_local $4)
+                          (get_local $1)
                           (i32.const 7)
                         )
                       )
@@ -5890,7 +5890,7 @@
               )
               (i32.store
                 (i32.const 1220)
-                (tee_local $1
+                (tee_local $3
                   (i32.sub
                     (i32.add
                       (get_local $26)
@@ -5901,16 +5901,16 @@
                 )
               )
               (i32.store offset=4
-                (get_local $4)
+                (get_local $1)
                 (i32.or
-                  (get_local $1)
+                  (get_local $3)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $4)
                   (get_local $1)
+                  (get_local $3)
                 )
                 (i32.const 40)
               )
@@ -5930,42 +5930,42 @@
                 (i32.const 1220)
               )
             )
-            (get_local $6)
+            (get_local $4)
           )
           (block
             (i32.store
               (i32.const 1220)
-              (tee_local $31
+              (tee_local $30
                 (i32.sub
                   (get_local $12)
-                  (get_local $6)
+                  (get_local $4)
                 )
               )
             )
             (i32.store
               (i32.const 1232)
-              (tee_local $9
+              (tee_local $8
                 (i32.add
                   (tee_local $12
                     (i32.load
                       (i32.const 1232)
                     )
                   )
-                  (get_local $6)
+                  (get_local $4)
                 )
               )
             )
             (i32.store offset=4
-              (get_local $9)
+              (get_local $8)
               (i32.or
-                (get_local $31)
+                (get_local $30)
                 (i32.const 1)
               )
             )
             (i32.store offset=4
               (get_local $12)
               (i32.or
-                (get_local $6)
+                (get_local $4)
                 (i32.const 3)
               )
             )
@@ -6037,7 +6037,7 @@
       (i32.eq
         (tee_local $0
           (i32.and
-            (tee_local $3
+            (tee_local $4
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -6055,9 +6055,9 @@
     (set_local $8
       (i32.add
         (get_local $1)
-        (tee_local $5
+        (tee_local $6
           (i32.and
-            (get_local $3)
+            (get_local $4)
             (i32.const -8)
           )
         )
@@ -6066,7 +6066,7 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $3)
+          (get_local $4)
           (i32.const 1)
         )
         (block
@@ -6074,11 +6074,11 @@
             (get_local $1)
           )
           (set_local $7
-            (get_local $5)
+            (get_local $6)
           )
         )
         (block
-          (set_local $11
+          (set_local $10
             (i32.load
               (get_local $1)
             )
@@ -6089,10 +6089,10 @@
             )
             (return)
           )
-          (set_local $5
+          (set_local $6
             (i32.add
-              (get_local $11)
-              (get_local $5)
+              (get_local $10)
+              (get_local $6)
             )
           )
           (if
@@ -6102,7 +6102,7 @@
                   (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $11)
+                    (get_local $10)
                   )
                 )
               )
@@ -6121,7 +6121,7 @@
               (if
                 (i32.ne
                   (i32.and
-                    (tee_local $6
+                    (tee_local $3
                       (i32.load
                         (tee_local $1
                           (i32.add
@@ -6140,48 +6140,48 @@
                     (get_local $0)
                   )
                   (set_local $7
-                    (get_local $5)
+                    (get_local $6)
                   )
                   (br $do-once)
                 )
               )
               (i32.store
                 (i32.const 1216)
-                (get_local $5)
+                (get_local $6)
               )
               (i32.store
                 (get_local $1)
                 (i32.and
-                  (get_local $6)
+                  (get_local $3)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
                 (get_local $0)
                 (i32.or
-                  (get_local $5)
+                  (get_local $6)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
                   (get_local $0)
-                  (get_local $5)
+                  (get_local $6)
                 )
-                (get_local $5)
+                (get_local $6)
               )
               (return)
             )
           )
-          (set_local $6
+          (set_local $3
             (i32.shr_u
-              (get_local $11)
+              (get_local $10)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $11)
+              (get_local $10)
               (i32.const 256)
             )
             (block
@@ -6192,17 +6192,17 @@
               )
               (if
                 (i32.ne
-                  (tee_local $11
+                  (tee_local $10
                     (i32.load offset=8
                       (get_local $0)
                     )
                   )
-                  (tee_local $3
+                  (tee_local $4
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $6)
+                          (get_local $3)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6213,7 +6213,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $11)
+                      (get_local $10)
                       (get_local $14)
                     )
                     (call $qa)
@@ -6221,7 +6221,7 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $11)
+                        (get_local $10)
                       )
                       (get_local $0)
                     )
@@ -6232,7 +6232,7 @@
               (if
                 (i32.eq
                   (get_local $1)
-                  (get_local $11)
+                  (get_local $10)
                 )
                 (block
                   (i32.store
@@ -6244,7 +6244,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $6)
+                          (get_local $3)
                         )
                         (i32.const -1)
                       )
@@ -6254,7 +6254,7 @@
                     (get_local $0)
                   )
                   (set_local $7
-                    (get_local $5)
+                    (get_local $6)
                   )
                   (br $do-once)
                 )
@@ -6262,9 +6262,9 @@
               (if
                 (i32.eq
                   (get_local $1)
-                  (get_local $3)
+                  (get_local $4)
                 )
-                (set_local $10
+                (set_local $9
                   (i32.add
                     (get_local $1)
                     (i32.const 8)
@@ -6281,7 +6281,7 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $3
+                        (tee_local $4
                           (i32.add
                             (get_local $1)
                             (i32.const 8)
@@ -6290,31 +6290,31 @@
                       )
                       (get_local $0)
                     )
-                    (set_local $10
-                      (get_local $3)
+                    (set_local $9
+                      (get_local $4)
                     )
                     (call $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $11)
+                (get_local $10)
                 (get_local $1)
               )
               (i32.store
+                (get_local $9)
                 (get_local $10)
-                (get_local $11)
               )
               (set_local $2
                 (get_local $0)
               )
               (set_local $7
-                (get_local $5)
+                (get_local $6)
               )
               (br $do-once)
             )
           )
-          (set_local $11
+          (set_local $10
             (i32.load offset=24
               (get_local $0)
             )
@@ -6331,11 +6331,11 @@
               )
               (block
                 (if
-                  (tee_local $10
+                  (tee_local $9
                     (i32.load
-                      (tee_local $6
+                      (tee_local $3
                         (i32.add
-                          (tee_local $3
+                          (tee_local $4
                             (i32.add
                               (get_local $0)
                               (i32.const 16)
@@ -6348,22 +6348,22 @@
                   )
                   (block
                     (set_local $1
-                      (get_local $10)
+                      (get_local $9)
                     )
-                    (set_local $3
-                      (get_local $6)
+                    (set_local $4
+                      (get_local $3)
                     )
                   )
                   (if
                     (i32.eqz
                       (tee_local $1
                         (i32.load
-                          (get_local $3)
+                          (get_local $4)
                         )
                       )
                     )
                     (block
-                      (set_local $4
+                      (set_local $5
                         (i32.const 0)
                       )
                       (br $do-once0)
@@ -6372,9 +6372,9 @@
                 )
                 (loop $while-in
                   (if
-                    (tee_local $10
+                    (tee_local $9
                       (i32.load
-                        (tee_local $6
+                        (tee_local $3
                           (i32.add
                             (get_local $1)
                             (i32.const 20)
@@ -6384,18 +6384,18 @@
                     )
                     (block
                       (set_local $1
-                        (get_local $10)
+                        (get_local $9)
                       )
-                      (set_local $3
-                        (get_local $6)
+                      (set_local $4
+                        (get_local $3)
                       )
                       (br $while-in)
                     )
                   )
                   (if
-                    (tee_local $10
+                    (tee_local $9
                       (i32.load
-                        (tee_local $6
+                        (tee_local $3
                           (i32.add
                             (get_local $1)
                             (i32.const 16)
@@ -6405,36 +6405,36 @@
                     )
                     (block
                       (set_local $1
-                        (get_local $10)
+                        (get_local $9)
                       )
-                      (set_local $3
-                        (get_local $6)
+                      (set_local $4
+                        (get_local $3)
                       )
                       (br $while-in)
                     )
                     (block
-                      (set_local $6
+                      (set_local $12
                         (get_local $1)
                       )
-                      (set_local $9
-                        (get_local $3)
+                      (set_local $3
+                        (get_local $4)
                       )
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $9)
+                    (get_local $3)
                     (get_local $14)
                   )
                   (call $qa)
                   (block
                     (i32.store
-                      (get_local $9)
+                      (get_local $3)
                       (i32.const 0)
                     )
-                    (set_local $4
-                      (get_local $6)
+                    (set_local $5
+                      (get_local $12)
                     )
                   )
                 )
@@ -6442,7 +6442,7 @@
               (block
                 (if
                   (i32.lt_u
-                    (tee_local $6
+                    (tee_local $3
                       (i32.load offset=8
                         (get_local $0)
                       )
@@ -6454,9 +6454,9 @@
                 (if
                   (i32.ne
                     (i32.load
-                      (tee_local $10
+                      (tee_local $9
                         (i32.add
-                          (get_local $6)
+                          (get_local $3)
                           (i32.const 12)
                         )
                       )
@@ -6468,7 +6468,7 @@
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $3
+                      (tee_local $4
                         (i32.add
                           (get_local $1)
                           (i32.const 8)
@@ -6479,14 +6479,14 @@
                   )
                   (block
                     (i32.store
-                      (get_local $10)
+                      (get_local $9)
                       (get_local $1)
                     )
                     (i32.store
+                      (get_local $4)
                       (get_local $3)
-                      (get_local $6)
                     )
-                    (set_local $4
+                    (set_local $5
                       (get_local $1)
                     )
                   )
@@ -6496,13 +6496,13 @@
             )
           )
           (if
-            (get_local $11)
+            (get_local $10)
             (block
               (if
                 (i32.eq
                   (get_local $0)
                   (i32.load
-                    (tee_local $6
+                    (tee_local $3
                       (i32.add
                         (i32.const 1512)
                         (i32.shl
@@ -6519,12 +6519,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $6)
-                    (get_local $4)
+                    (get_local $3)
+                    (get_local $5)
                   )
                   (if
                     (i32.eqz
-                      (get_local $4)
+                      (get_local $5)
                     )
                     (block
                       (i32.store
@@ -6546,7 +6546,7 @@
                         (get_local $0)
                       )
                       (set_local $7
-                        (get_local $5)
+                        (get_local $6)
                       )
                       (br $do-once)
                     )
@@ -6555,7 +6555,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $11)
+                      (get_local $10)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6567,7 +6567,7 @@
                       (i32.load
                         (tee_local $1
                           (i32.add
-                            (get_local $11)
+                            (get_local $10)
                             (i32.const 16)
                           )
                         )
@@ -6576,23 +6576,23 @@
                     )
                     (i32.store
                       (get_local $1)
-                      (get_local $4)
+                      (get_local $5)
                     )
                     (i32.store offset=20
-                      (get_local $11)
-                      (get_local $4)
+                      (get_local $10)
+                      (get_local $5)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $4)
+                      (get_local $5)
                     )
                     (block
                       (set_local $2
                         (get_local $0)
                       )
                       (set_local $7
-                        (get_local $5)
+                        (get_local $6)
                       )
                       (br $do-once)
                     )
@@ -6601,7 +6601,7 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $4)
+                  (get_local $5)
                   (tee_local $1
                     (i32.load
                       (i32.const 1224)
@@ -6611,13 +6611,13 @@
                 (call $qa)
               )
               (i32.store offset=24
-                (get_local $4)
-                (get_local $11)
+                (get_local $5)
+                (get_local $10)
               )
               (if
-                (tee_local $3
+                (tee_local $4
                   (i32.load
-                    (tee_local $6
+                    (tee_local $3
                       (i32.add
                         (get_local $0)
                         (i32.const 16)
@@ -6627,31 +6627,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $3)
+                    (get_local $4)
                     (get_local $1)
                   )
                   (call $qa)
                   (block
                     (i32.store offset=16
+                      (get_local $5)
                       (get_local $4)
-                      (get_local $3)
                     )
                     (i32.store offset=24
-                      (get_local $3)
                       (get_local $4)
+                      (get_local $5)
                     )
                   )
                 )
               )
               (if
-                (tee_local $3
+                (tee_local $4
                   (i32.load offset=4
-                    (get_local $6)
+                    (get_local $3)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $3)
+                    (get_local $4)
                     (i32.load
                       (i32.const 1224)
                     )
@@ -6659,18 +6659,18 @@
                   (call $qa)
                   (block
                     (i32.store offset=20
+                      (get_local $5)
                       (get_local $4)
-                      (get_local $3)
                     )
                     (i32.store offset=24
-                      (get_local $3)
                       (get_local $4)
+                      (get_local $5)
                     )
                     (set_local $2
                       (get_local $0)
                     )
                     (set_local $7
-                      (get_local $5)
+                      (get_local $6)
                     )
                   )
                 )
@@ -6679,7 +6679,7 @@
                     (get_local $0)
                   )
                   (set_local $7
-                    (get_local $5)
+                    (get_local $6)
                   )
                 )
               )
@@ -6689,7 +6689,7 @@
                 (get_local $0)
               )
               (set_local $7
-                (get_local $5)
+                (get_local $6)
               )
             )
           )
@@ -6708,7 +6708,7 @@
         (i32.and
           (tee_local $1
             (i32.load
-              (tee_local $5
+              (tee_local $6
                 (i32.add
                   (get_local $8)
                   (i32.const 4)
@@ -6728,7 +6728,7 @@
       )
       (block
         (i32.store
-          (get_local $5)
+          (get_local $6)
           (i32.and
             (get_local $1)
             (i32.const -2)
@@ -6763,7 +6763,7 @@
           (block
             (i32.store
               (i32.const 1220)
-              (tee_local $4
+              (tee_local $5
                 (i32.add
                   (i32.load
                     (i32.const 1220)
@@ -6779,7 +6779,7 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $4)
+                (get_local $5)
                 (i32.const 1)
               )
             )
@@ -6813,7 +6813,7 @@
           (block
             (i32.store
               (i32.const 1216)
-              (tee_local $4
+              (tee_local $5
                 (i32.add
                   (i32.load
                     (i32.const 1216)
@@ -6829,21 +6829,21 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $4)
+                (get_local $5)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $2)
-                (get_local $4)
+                (get_local $5)
               )
-              (get_local $4)
+              (get_local $5)
             )
             (return)
           )
         )
-        (set_local $4
+        (set_local $5
           (i32.add
             (i32.and
               (get_local $1)
@@ -6865,19 +6865,19 @@
               (i32.const 256)
             )
             (block
-              (set_local $9
+              (set_local $3
                 (i32.load offset=12
                   (get_local $8)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $6
+                  (tee_local $12
                     (i32.load offset=8
                       (get_local $8)
                     )
                   )
-                  (tee_local $3
+                  (tee_local $4
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
@@ -6893,7 +6893,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $6)
+                      (get_local $12)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6903,7 +6903,7 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $6)
+                        (get_local $12)
                       )
                       (get_local $8)
                     )
@@ -6913,8 +6913,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $9)
-                  (get_local $6)
+                  (get_local $3)
+                  (get_local $12)
                 )
                 (block
                   (i32.store
@@ -6937,19 +6937,19 @@
               )
               (if
                 (i32.eq
-                  (get_local $9)
                   (get_local $3)
+                  (get_local $4)
                 )
                 (set_local $17
                   (i32.add
-                    (get_local $9)
+                    (get_local $3)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $9)
+                      (get_local $3)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6959,9 +6959,9 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $3
+                        (tee_local $4
                           (i32.add
-                            (get_local $9)
+                            (get_local $3)
                             (i32.const 8)
                           )
                         )
@@ -6969,23 +6969,23 @@
                       (get_local $8)
                     )
                     (set_local $17
-                      (get_local $3)
+                      (get_local $4)
                     )
                     (call $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $6)
-                (get_local $9)
+                (get_local $12)
+                (get_local $3)
               )
               (i32.store
                 (get_local $17)
-                (get_local $6)
+                (get_local $12)
               )
             )
             (block
-              (set_local $6
+              (set_local $12
                 (i32.load offset=24
                   (get_local $8)
                 )
@@ -6993,7 +6993,7 @@
               (block $do-once6
                 (if
                   (i32.eq
-                    (tee_local $9
+                    (tee_local $3
                       (i32.load offset=12
                         (get_local $8)
                       )
@@ -7002,11 +7002,11 @@
                   )
                   (block
                     (if
-                      (tee_local $10
+                      (tee_local $9
                         (i32.load
                           (tee_local $1
                             (i32.add
-                              (tee_local $3
+                              (tee_local $4
                                 (i32.add
                                   (get_local $8)
                                   (i32.const 16)
@@ -7019,9 +7019,9 @@
                       )
                       (block
                         (set_local $0
-                          (get_local $10)
+                          (get_local $9)
                         )
-                        (set_local $3
+                        (set_local $4
                           (get_local $1)
                         )
                       )
@@ -7029,12 +7029,12 @@
                         (i32.eqz
                           (tee_local $0
                             (i32.load
-                              (get_local $3)
+                              (get_local $4)
                             )
                           )
                         )
                         (block
-                          (set_local $12
+                          (set_local $11
                             (i32.const 0)
                           )
                           (br $do-once6)
@@ -7043,7 +7043,7 @@
                     )
                     (loop $while-in9
                       (if
-                        (tee_local $10
+                        (tee_local $9
                           (i32.load
                             (tee_local $1
                               (i32.add
@@ -7055,16 +7055,16 @@
                         )
                         (block
                           (set_local $0
-                            (get_local $10)
+                            (get_local $9)
                           )
-                          (set_local $3
+                          (set_local $4
                             (get_local $1)
                           )
                           (br $while-in9)
                         )
                       )
                       (if
-                        (tee_local $10
+                        (tee_local $9
                           (i32.load
                             (tee_local $1
                               (i32.add
@@ -7076,9 +7076,9 @@
                         )
                         (block
                           (set_local $0
-                            (get_local $10)
+                            (get_local $9)
                           )
-                          (set_local $3
+                          (set_local $4
                             (get_local $1)
                           )
                           (br $while-in9)
@@ -7087,7 +7087,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $3)
+                        (get_local $4)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7095,10 +7095,10 @@
                       (call $qa)
                       (block
                         (i32.store
-                          (get_local $3)
+                          (get_local $4)
                           (i32.const 0)
                         )
-                        (set_local $12
+                        (set_local $11
                           (get_local $0)
                         )
                       )
@@ -7121,7 +7121,7 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (tee_local $10
+                          (tee_local $9
                             (i32.add
                               (get_local $1)
                               (i32.const 12)
@@ -7135,9 +7135,9 @@
                     (if
                       (i32.eq
                         (i32.load
-                          (tee_local $3
+                          (tee_local $4
                             (i32.add
-                              (get_local $9)
+                              (get_local $3)
                               (i32.const 8)
                             )
                           )
@@ -7146,15 +7146,15 @@
                       )
                       (block
                         (i32.store
-                          (get_local $10)
                           (get_local $9)
+                          (get_local $3)
                         )
                         (i32.store
-                          (get_local $3)
+                          (get_local $4)
                           (get_local $1)
                         )
-                        (set_local $12
-                          (get_local $9)
+                        (set_local $11
+                          (get_local $3)
                         )
                       )
                       (call $qa)
@@ -7163,17 +7163,17 @@
                 )
               )
               (if
-                (get_local $6)
+                (get_local $12)
                 (block
                   (if
                     (i32.eq
                       (get_local $8)
                       (i32.load
-                        (tee_local $5
+                        (tee_local $6
                           (i32.add
                             (i32.const 1512)
                             (i32.shl
-                              (tee_local $9
+                              (tee_local $3
                                 (i32.load offset=28
                                   (get_local $8)
                                 )
@@ -7186,12 +7186,12 @@
                     )
                     (block
                       (i32.store
-                        (get_local $5)
-                        (get_local $12)
+                        (get_local $6)
+                        (get_local $11)
                       )
                       (if
                         (i32.eqz
-                          (get_local $12)
+                          (get_local $11)
                         )
                         (block
                           (i32.store
@@ -7203,7 +7203,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $9)
+                                  (get_local $3)
                                 )
                                 (i32.const -1)
                               )
@@ -7216,7 +7216,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $6)
+                          (get_local $12)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -7226,9 +7226,9 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $9
+                            (tee_local $3
                               (i32.add
-                                (get_local $6)
+                                (get_local $12)
                                 (i32.const 16)
                               )
                             )
@@ -7236,25 +7236,25 @@
                           (get_local $8)
                         )
                         (i32.store
-                          (get_local $9)
-                          (get_local $12)
+                          (get_local $3)
+                          (get_local $11)
                         )
                         (i32.store offset=20
-                          (get_local $6)
                           (get_local $12)
+                          (get_local $11)
                         )
                       )
                       (br_if $do-once4
                         (i32.eqz
-                          (get_local $12)
+                          (get_local $11)
                         )
                       )
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $12)
-                      (tee_local $9
+                      (get_local $11)
+                      (tee_local $3
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7263,13 +7263,13 @@
                     (call $qa)
                   )
                   (i32.store offset=24
+                    (get_local $11)
                     (get_local $12)
-                    (get_local $6)
                   )
                   (if
                     (tee_local $0
                       (i32.load
-                        (tee_local $5
+                        (tee_local $6
                           (i32.add
                             (get_local $8)
                             (i32.const 16)
@@ -7280,17 +7280,17 @@
                     (if
                       (i32.lt_u
                         (get_local $0)
-                        (get_local $9)
+                        (get_local $3)
                       )
                       (call $qa)
                       (block
                         (i32.store offset=16
-                          (get_local $12)
+                          (get_local $11)
                           (get_local $0)
                         )
                         (i32.store offset=24
                           (get_local $0)
-                          (get_local $12)
+                          (get_local $11)
                         )
                       )
                     )
@@ -7298,7 +7298,7 @@
                   (if
                     (tee_local $0
                       (i32.load offset=4
-                        (get_local $5)
+                        (get_local $6)
                       )
                     )
                     (if
@@ -7311,12 +7311,12 @@
                       (call $qa)
                       (block
                         (i32.store offset=20
-                          (get_local $12)
+                          (get_local $11)
                           (get_local $0)
                         )
                         (i32.store offset=24
                           (get_local $0)
-                          (get_local $12)
+                          (get_local $11)
                         )
                       )
                     )
@@ -7329,16 +7329,16 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $4)
+            (get_local $5)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $4)
+            (get_local $5)
           )
-          (get_local $4)
+          (get_local $5)
         )
         (if
           (i32.eq
@@ -7350,12 +7350,12 @@
           (block
             (i32.store
               (i32.const 1216)
-              (get_local $4)
+              (get_local $5)
             )
             (return)
           )
           (set_local $0
-            (get_local $4)
+            (get_local $5)
           )
         )
       )
@@ -7386,12 +7386,12 @@
         )
         (if
           (i32.and
-            (tee_local $5
+            (tee_local $6
               (i32.load
                 (i32.const 1208)
               )
             )
-            (tee_local $4
+            (tee_local $5
               (i32.shl
                 (i32.const 1)
                 (get_local $7)
@@ -7400,9 +7400,9 @@
           )
           (if
             (i32.lt_u
-              (tee_local $5
+              (tee_local $6
                 (i32.load
-                  (tee_local $4
+                  (tee_local $5
                     (i32.add
                       (get_local $1)
                       (i32.const 8)
@@ -7417,10 +7417,10 @@
             (call $qa)
             (block
               (set_local $15
-                (get_local $4)
+                (get_local $5)
               )
               (set_local $13
-                (get_local $5)
+                (get_local $6)
               )
             )
           )
@@ -7428,8 +7428,8 @@
             (i32.store
               (i32.const 1208)
               (i32.or
+                (get_local $6)
                 (get_local $5)
-                (get_local $4)
               )
             )
             (set_local $15
@@ -7462,7 +7462,7 @@
         (return)
       )
     )
-    (set_local $4
+    (set_local $5
       (i32.add
         (i32.const 1512)
         (i32.shl
@@ -7485,7 +7485,7 @@
                     (i32.shr_u
                       (get_local $0)
                       (i32.add
-                        (tee_local $4
+                        (tee_local $5
                           (i32.add
                             (i32.sub
                               (i32.const 14)
@@ -7525,7 +7525,7 @@
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (tee_local $5
+                                        (tee_local $6
                                           (i32.shl
                                             (get_local $15)
                                             (get_local $1)
@@ -7542,7 +7542,7 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $5)
+                                (get_local $6)
                                 (get_local $15)
                               )
                               (i32.const 15)
@@ -7555,7 +7555,7 @@
                     (i32.const 1)
                   )
                   (i32.shl
-                    (get_local $4)
+                    (get_local $5)
                     (i32.const 1)
                   )
                 )
@@ -7586,7 +7586,7 @@
             (i32.const 1212)
           )
         )
-        (tee_local $5
+        (tee_local $6
           (i32.shl
             (i32.const 1)
             (get_local $7)
@@ -7615,7 +7615,7 @@
         )
         (set_local $1
           (i32.load
-            (get_local $4)
+            (get_local $5)
           )
         )
         (loop $while-in15
@@ -7641,7 +7641,7 @@
               )
             )
             (if
-              (tee_local $12
+              (tee_local $11
                 (i32.load
                   (tee_local $7
                     (i32.add
@@ -7668,7 +7668,7 @@
                   )
                 )
                 (set_local $1
-                  (get_local $12)
+                  (get_local $11)
                 )
                 (br $while-in15)
               )
@@ -7736,7 +7736,7 @@
                       )
                     )
                   )
-                  (tee_local $5
+                  (tee_local $6
                     (i32.load
                       (i32.const 1224)
                     )
@@ -7744,7 +7744,7 @@
                 )
                 (i32.ge_u
                   (get_local $16)
-                  (get_local $5)
+                  (get_local $6)
                 )
               )
               (block
@@ -7779,16 +7779,16 @@
           (i32.const 1212)
           (i32.or
             (get_local $15)
-            (get_local $5)
+            (get_local $6)
           )
         )
         (i32.store
-          (get_local $4)
+          (get_local $5)
           (get_local $2)
         )
         (i32.store offset=24
           (get_local $2)
-          (get_local $4)
+          (get_local $5)
         )
         (i32.store offset=12
           (get_local $2)
@@ -8718,16 +8718,16 @@
                     )
                   )
                 )
+                (set_local $0
+                  (get_local $2)
+                )
               )
-            )
-            (set_local $2
-              (get_local $0)
             )
           )
           (call $xa
             (i32.const 1188)
           )
-          (get_local $2)
+          (get_local $0)
         )
       )
     )
@@ -9310,7 +9310,7 @@
     (local $1 i32)
     (local $2 i32)
     (local $3 i32)
-    (set_local $3
+    (set_local $2
       (if i32
         (i32.gt_s
           (i32.load offset=76
@@ -9349,9 +9349,9 @@
               )
               (if
                 (i32.lt_u
-                  (tee_local $2
+                  (tee_local $0
                     (i32.load
-                      (tee_local $0
+                      (tee_local $3
                         (i32.add
                           (get_local $1)
                           (i32.const 20)
@@ -9365,14 +9365,14 @@
                 )
                 (block
                   (i32.store
-                    (get_local $0)
+                    (get_local $3)
                     (i32.add
-                      (get_local $2)
+                      (get_local $0)
                       (i32.const 1)
                     )
                   )
                   (i32.store8
-                    (get_local $2)
+                    (get_local $0)
                     (i32.const 10)
                   )
                   (br $do-once
@@ -9393,7 +9393,7 @@
       )
     )
     (if
-      (get_local $3)
+      (get_local $2)
       (call $Ta
         (get_local $1)
       )


### PR DESCRIPTION
Reordering and getting rid of unneeded locals makes coalesce-locals much faster. Embarrassing we didn't do this before, it makes coalesce-locals almost twice as fast (since simplify-locals gets rid of most of the locals).