### PR TITLE
Minor improvements to the wasm-interpreter debug messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ TARGET_LINK_LIBRARIES(binaryen asmjs ${all_passes} support)
 
 SET(wasm-shell_SOURCES
   src/tools/wasm-shell.cpp
+  src/wasm-interpreter.cpp
   src/wasm.cpp
 )
 ADD_EXECUTABLE(wasm-shell

--- a/src/wasm-interpreter.cpp
+++ b/src/wasm-interpreter.cpp
@@ -1,0 +1,24 @@
+#include "wasm-interpreter.h"
+
+namespace wasm {
+
+#ifdef WASM_INTERPRETER_DEBUG
+int Indenter::indentLevel = 0;
+
+Indenter::Indenter(const char* entry) : entryName(entry) {
+  ++indentLevel;
+}
+Indenter::~Indenter() {
+  print();
+  std::cout << "exit " << entryName << '\n';
+  --indentLevel;
+}
+void Indenter::print() {
+  std::cout << indentLevel << ':';
+  for (int i = 0; i <= indentLevel; ++i) {
+    std::cout << ' ';
+  }
+}
+#endif // WASM_INTERPRETER_DEBUG
+
+} // namespace wasm

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -75,11 +75,45 @@ typedef std::vector<Literal> LiteralList;
 
 // Debugging helpers
 #ifdef WASM_INTERPRETER_DEBUG
-#define NOTE_ENTER(x) { std::cout << "visit " << x << " : " << curr << "\n"; }
-#define NOTE_ENTER_(x) { std::cout << "visit " << x << "\n"; }
-#define NOTE_NAME(p0) { std::cout << "name " << '('  << Name(p0) << ")\n"; }
-#define NOTE_EVAL1(p0) { std::cout << "eval " << '('  << p0 << ")\n"; }
-#define NOTE_EVAL2(p0, p1) { std::cout << "eval " << '('  << p0 << ", " << p1 << ")\n"; }
+class Indenter {
+static int indentLevel;
+
+const char* _str;
+
+public:
+  Indenter(const char* str) : _str(str) {
+    ++indentLevel;
+  }
+  ~Indenter() {
+    print();
+    std::cout << "exit " << _str << '\n';
+    --indentLevel;
+  }
+
+  static void print() {
+    std::cout << indentLevel << ':';
+    for (int i = 0; i <= indentLevel; ++i) {
+      std::cout << ' ';
+    }
+  }
+};
+int Indenter::indentLevel = 0;
+
+#define NOTE_ENTER(x) Indenter _int_blah(x); { \
+    Indenter::print(); \
+    std::cout << "visit " << x << " : " << curr << "\n"; }
+#define NOTE_ENTER_(x) Indenter _int_blah(x); { \
+    Indenter::print(); \
+    std::cout << "visit " << x << "\n"; }
+#define NOTE_NAME(p0) { \
+    Indenter::print(); \
+    std::cout << "name " << '(' << Name(p0) << ")\n"; }
+#define NOTE_EVAL1(p0) { \
+    Indenter::print(); \
+    std::cout << "eval " #p0 " (" << p0 << ")\n"; }
+#define NOTE_EVAL2(p0, p1) { \
+    Indenter::print(); \
+    std::cout << "eval " #p0 " (" << p0 << "), " #p1 " (" << p1 << ")\n"; }
 #else // WASM_INTERPRETER_DEBUG
 #define NOTE_ENTER(x)
 #define NOTE_ENTER_(x)
@@ -725,7 +759,12 @@ public:
         NOTE_ENTER("Load");
         Flow flow = visit(curr->ptr);
         if (flow.breaking()) return flow;
-        return instance.externalInterface->load(curr, instance.getFinalAddress(curr, flow.value));
+        NOTE_EVAL1(flow);
+        auto addr = instance.getFinalAddress(curr, flow.value);
+        auto ret = instance.externalInterface->load(curr, addr);
+        NOTE_EVAL1(addr);
+        NOTE_EVAL1(ret);
+        return ret;
       }
       Flow visitStore(Store *curr) {
         NOTE_ENTER("Store");
@@ -733,7 +772,10 @@ public:
         if (ptr.breaking()) return ptr;
         Flow value = visit(curr->value);
         if (value.breaking()) return value;
-        instance.externalInterface->store(curr, instance.getFinalAddress(curr, ptr.value), value.value);
+        auto addr = instance.getFinalAddress(curr, ptr.value);
+        NOTE_EVAL1(addr);
+        NOTE_EVAL1(value);
+        instance.externalInterface->store(curr, addr, value.value);
         return Flow();
       }
 
@@ -781,7 +823,11 @@ public:
     FunctionScope scope(function, arguments);
 
 #ifdef WASM_INTERPRETER_DEBUG
-    std::cout << "entering " << function->name << '\n';
+    std::cout << "entering " << function->name
+              << "\n  with arguments:\n";
+    for (unsigned i = 0; i < arguments.size(); ++i) {
+      std::cout << "    $" << i << ": " << arguments[i] << '\n';
+    }
 #endif
 
     Flow flow = RuntimeExpressionRunner(*this, scope).visit(function->body);

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -27,8 +27,8 @@
 #include <sstream>
 
 #include "support/bits.h"
-#include "pass.h"
 #include "wasm.h"
+#include "wasm-traversal.h"
 
 #ifdef WASM_INTERPRETER_DEBUG
 #include "wasm-printing.h"

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -27,6 +27,7 @@
 #include <sstream>
 
 #include "support/bits.h"
+#include "pass.h"
 #include "wasm.h"
 
 #ifdef WASM_INTERPRETER_DEBUG
@@ -76,28 +77,16 @@ typedef std::vector<Literal> LiteralList;
 // Debugging helpers
 #ifdef WASM_INTERPRETER_DEBUG
 class Indenter {
-static int indentLevel;
+  static int indentLevel;
 
-const char* _str;
+  const char* entryName;
 
 public:
-  Indenter(const char* str) : _str(str) {
-    ++indentLevel;
-  }
-  ~Indenter() {
-    print();
-    std::cout << "exit " << _str << '\n';
-    --indentLevel;
-  }
+  Indenter(const char* entry);
+  ~Indenter();
 
-  static void print() {
-    std::cout << indentLevel << ':';
-    for (int i = 0; i <= indentLevel; ++i) {
-      std::cout << ' ';
-    }
-  }
+  static void print();
 };
-int Indenter::indentLevel = 0;
 
 #define NOTE_ENTER(x) Indenter _int_blah(x); { \
     Indenter::print(); \


### PR DESCRIPTION
1. Indent nested blocks for more readable structure (with numeric labels
to make it even clearer)
2. Print the names of the variables used for NOTE_EVALs
3. Print the values of arguments when entering a function call