### PR TITLE
Add table and memory to metrics

### DIFF
--- a/src/passes/Metrics.cpp
+++ b/src/passes/Metrics.cpp
@@ -57,6 +57,23 @@ struct Metrics : public WalkerPass<PostWalker<Metrics, UnifiedExpressionVisitor<
     // add functions
     keys.push_back("[funcs]");
     counts["[funcs]"] = module->functions.size();
+    // add memory and table
+    if (module->memory.exists) {
+      Index size = 0;
+      for (auto& segment: module->memory.segments) {
+        size += segment.data.size();
+      }
+      keys.push_back("[memory-data]");
+      counts["[memory-data]"] = size;
+    }
+    if (module->table.exists) {
+      Index size = 0;
+      for (auto& segment: module->table.segments) {
+        size += segment.data.size();
+      }
+      keys.push_back("[table-data]");
+      counts["[table-data]"] = size;
+    }
     // sort
     sort(keys.begin(), keys.end(), [](const char* a, const char* b) -> bool {
       return strcmp(b, a) > 0;

--- a/test/passes/metrics.txt
+++ b/test/passes/metrics.txt
@@ -1,5 +1,7 @@
 Counts
  [funcs]        : 1       
+ [memory-data]  : 9       
+ [table-data]   : 3       
  [total]        : 24      
  [vars]         : 1       
  binary         : 1       
@@ -9,7 +11,10 @@ Counts
  if             : 4       
 (module
   (type $0 (func (param i32)))
+  (table 256 256 anyfunc)
+  (elem (i32.const 0) $ifs $ifs $ifs)
   (memory $0 256 256)
+  (data (i32.const 0) "\ff\ef\0f\1f 0@P\99")
   (func $ifs (type $0) (param $x i32)
     (local $y f32)
     (block $block0
@@ -49,4 +54,11 @@ Counts
       )
     )
   )
+)
+Counts
+ [funcs]        : 0       
+ [total]        : 0       
+ [vars]         : 0       
+(module
+  (memory $0 0)
 )

--- a/test/passes/metrics.wast
+++ b/test/passes/metrics.wast
@@ -1,5 +1,8 @@
 (module
   (memory 256 256)
+  (table 256 256 anyfunc)
+  (elem (i32.const 0) $ifs $ifs $ifs)
+  (data (i32.const 0) "\ff\ef\0f\1f\20\30\40\50\99")
   (type $0 (func (param i32)))
   (func $ifs (type $0) (param $x i32)
     (local $y f32)
@@ -40,4 +43,7 @@
       )
     )
   )
+)
+;; module with no table or memory or anything for that matter
+(module
 )


### PR DESCRIPTION
Prints out the total size of table and memory segment contents.