### PR TITLE
Add -O0,-O1,etc. options

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -16,8 +16,11 @@ for asm in sorted(os.listdir('test')):
           cmd += ['--imprecise']
           wasm += '.imprecise'
         if not opts:
-          cmd += ['--no-opts']
           wasm += '.no-opts'
+          if precise:
+            cmd += ['-O0'] # test that -O0 does nothing
+        else:
+          cmd += ['-O']
         if precise and opts:
           # test mem init importing
           open('a.mem', 'wb').write(asm)

--- a/check.py
+++ b/check.py
@@ -361,8 +361,11 @@ for asm in tests:
           cmd += ['--imprecise']
           wasm += '.imprecise'
         if not opts:
-          cmd += ['--no-opts']
           wasm += '.no-opts'
+          if precise:
+            cmd += ['-O0'] # test that -O0 does nothing
+        else:
+          cmd += ['-O']
         if precise and opts:
           # test mem init importing
           open('a.mem', 'wb').write(asm)

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -230,6 +230,7 @@ class Asm2WasmBuilder {
   bool memoryGrowth;
   bool debug;
   bool imprecise;
+  PassOptions passOptions;
   bool optimize;
   bool wasmOnly;
 
@@ -330,14 +331,15 @@ private:
   }
 
 public:
- Asm2WasmBuilder(Module& wasm, bool memoryGrowth, bool debug, bool imprecise, bool optimize, bool wasmOnly)
+ Asm2WasmBuilder(Module& wasm, bool memoryGrowth, bool debug, bool imprecise, PassOptions passOptions, bool wasmOnly)
      : wasm(wasm),
        allocator(wasm.allocator),
        builder(wasm),
        memoryGrowth(memoryGrowth),
        debug(debug),
        imprecise(imprecise),
-       optimize(optimize),
+       passOptions(passOptions),
+       optimize(passOptions.optimizeLevel > 0),
        wasmOnly(wasmOnly) {}
 
  void processAsm(Ref ast);
@@ -653,7 +655,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
       if (body[i][0] == DEFUN) numFunctions++;
     }
     optimizingBuilder = make_unique<OptimizingIncrementalModuleBuilder>(&wasm, numFunctions, [&](PassRunner& passRunner) {
-      passRunner.options.setDefaultOptimizationOptions();
+      passRunner.options = passOptions;
       if (debug) {
         passRunner.setDebug(true);
         passRunner.setValidateGlobally(false);

--- a/src/pass.h
+++ b/src/pass.h
@@ -61,12 +61,6 @@ struct PassOptions {
   int optimizeLevel = 0; // 0, 1, 2 correspond to -O0, -O1, -O2, etc.
   int shrinkLevel = 0;   // 0, 1, 2 correspond to -O0, -Os, -Oz
   bool ignoreImplicitTraps = false; // optimize assuming things like div by 0, bad load/store, will not trap
-
-  void setDefaultOptimizationOptions() {
-    optimizeLevel = 2;
-    shrinkLevel = 1;
-    ignoreImplicitTraps = true;
-  }
 };
 
 //

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -31,6 +31,7 @@ using namespace wasm;
 
 int main(int argc, const char *argv[]) {
   PassOptions passOptions;
+  bool runOptimizationPasses = false;
   bool imprecise = false;
   bool wasmOnly = false;
 
@@ -92,7 +93,7 @@ int main(int argc, const char *argv[]) {
   if (options.debug) std::cerr << "wasming..." << std::endl;
   Module wasm;
   wasm.memory.initial = wasm.memory.max = totalMemory / Memory::kPageSize;
-  Asm2WasmBuilder asm2wasm(wasm, pre.memoryGrowth, options.debug, imprecise, passOptions, wasmOnly);
+  Asm2WasmBuilder asm2wasm(wasm, pre.memoryGrowth, options.debug, imprecise, runOptimizationPasses, passOptions, wasmOnly);
   asm2wasm.processAsm(asmjs);
 
   // import mem init file, if provided

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -93,7 +93,7 @@ int main(int argc, const char *argv[]) {
   if (options.debug) std::cerr << "wasming..." << std::endl;
   Module wasm;
   wasm.memory.initial = wasm.memory.max = totalMemory / Memory::kPageSize;
-  Asm2WasmBuilder asm2wasm(wasm, pre.memoryGrowth, options.debug, imprecise, runOptimizationPasses, passOptions, wasmOnly);
+  Asm2WasmBuilder asm2wasm(wasm, pre.memoryGrowth, options.debug, imprecise, passOptions, runOptimizationPasses, wasmOnly);
   asm2wasm.processAsm(asmjs);
 
   // import mem init file, if provided

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -30,7 +30,7 @@ using namespace cashew;
 using namespace wasm;
 
 int main(int argc, const char *argv[]) {
-  bool opts = true;
+  PassOptions passOptions;
   bool imprecise = false;
   bool wasmOnly = false;
 
@@ -54,10 +54,9 @@ int main(int argc, const char *argv[]) {
            [](Options *o, const std::string &argument) {
              o->extra["total memory"] = argument;
            })
+      #include "optimization-options.h"
       .add("--no-opts", "-n", "Disable optimization passes", Options::Arguments::Zero,
-           [&opts](Options *o, const std::string &) {
-             opts = false;
-           })
+           [](Options *o, const std::string &) {})
       .add("--imprecise", "-i", "Imprecise optimizations", Options::Arguments::Zero,
            [&imprecise](Options *o, const std::string &) {
              imprecise = true;
@@ -93,7 +92,7 @@ int main(int argc, const char *argv[]) {
   if (options.debug) std::cerr << "wasming..." << std::endl;
   Module wasm;
   wasm.memory.initial = wasm.memory.max = totalMemory / Memory::kPageSize;
-  Asm2WasmBuilder asm2wasm(wasm, pre.memoryGrowth, options.debug, imprecise, opts, wasmOnly);
+  Asm2WasmBuilder asm2wasm(wasm, pre.memoryGrowth, options.debug, imprecise, passOptions, wasmOnly);
   asm2wasm.processAsm(asmjs);
 
   // import mem init file, if provided

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -56,8 +56,10 @@ int main(int argc, const char *argv[]) {
              o->extra["total memory"] = argument;
            })
       #include "optimization-options.h"
-      .add("--no-opts", "-n", "Disable optimization passes", Options::Arguments::Zero,
-           [](Options *o, const std::string &) {})
+      .add("--no-opts", "-n", "Disable optimization passes (deprecated)", Options::Arguments::Zero,
+           [](Options *o, const std::string &) {
+             std::cerr << "--no-opts is deprecated (use -O0, etc.)\n";
+           })
       .add("--imprecise", "-i", "Imprecise optimizations", Options::Arguments::Zero,
            [&imprecise](Options *o, const std::string &) {
              imprecise = true;

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -73,7 +73,7 @@
              passOptions.ignoreImplicitTraps = true;
              runOptimizationPasses = true;
            })
-      .add("--optimize-level", "-op", "How much to focus on optimizing code",
+      .add("--optimize-level", "-ol", "How much to focus on optimizing code",
            Options::Arguments::One,
            [&passOptions](Options* o, const std::string& argument) {
              passOptions.optimizeLevel = atoi(argument.c_str());

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Shared optimization options for commandline tools
+//
+
+      .add("", "-O", "execute default optimization passes",
+           Options::Arguments::Zero,
+           [&passes, &passOptions](Options*, const std::string&) {
+             passOptions.optimizeLevel = 2;
+             passOptions.shrinkLevel = 1;
+             passOptions.ignoreImplicitTraps = true;
+             passes.push_back("O");
+           })
+      .add("", "-O0", "execute no optimization passes",
+           Options::Arguments::Zero,
+           [&passes, &passOptions](Options*, const std::string&) {
+             passOptions.optimizeLevel = 0;
+             passOptions.shrinkLevel = 0;
+             passOptions.ignoreImplicitTraps = false;
+           })
+      .add("", "-O1", "execute -O1 optimization passes",
+           Options::Arguments::Zero,
+           [&passes, &passOptions](Options*, const std::string&) {
+             passOptions.optimizeLevel = 1;
+             passOptions.shrinkLevel = 0;
+             passOptions.ignoreImplicitTraps = true;
+             passes.push_back("O");
+           })
+      .add("", "-O2", "execute -O2 optimization passes",
+           Options::Arguments::Zero,
+           [&passes, &passOptions](Options*, const std::string&) {
+             passOptions.optimizeLevel = 2;
+             passOptions.shrinkLevel = 0;
+             passOptions.ignoreImplicitTraps = true;
+             passes.push_back("O");
+           })
+      .add("", "-O3", "execute -O3 optimization passes",
+           Options::Arguments::Zero,
+           [&passes, &passOptions](Options*, const std::string&) {
+             passOptions.optimizeLevel = 3;
+             passOptions.shrinkLevel = 0;
+             passOptions.ignoreImplicitTraps = true;
+             passes.push_back("O");
+           })
+      .add("", "-Os", "execute default optimization passes, focusing on code size",
+           Options::Arguments::Zero,
+           [&passes, &passOptions](Options*, const std::string&) {
+             passOptions.optimizeLevel = 2;
+             passOptions.shrinkLevel = 1;
+             passOptions.ignoreImplicitTraps = true;
+             passes.push_back("O");
+           })
+      .add("", "-Oz", "execute default optimization passes, super-focusing on code size",
+           Options::Arguments::Zero,
+           [&passes, &passOptions](Options*, const std::string&) {
+             passOptions.optimizeLevel = 2;
+             passOptions.shrinkLevel = 2;
+             passOptions.ignoreImplicitTraps = true;
+             passes.push_back("O");
+           })
+      .add("--optimize-level", "-op", "How much to focus on optimizing code",
+           Options::Arguments::One,
+           [&passOptions](Options* o, const std::string& argument) {
+             passOptions.optimizeLevel = atoi(argument.c_str());
+           })
+      .add("--shrink-level", "-s", "How much to focus on shrinking code size",
+           Options::Arguments::One,
+           [&passOptions](Options* o, const std::string& argument) {
+             passOptions.shrinkLevel = atoi(argument.c_str());
+           })
+

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -20,58 +20,58 @@
 
       .add("", "-O", "execute default optimization passes",
            Options::Arguments::Zero,
-           [&passes, &passOptions](Options*, const std::string&) {
+           [&runOptimizationPasses, &passOptions](Options*, const std::string&) {
              passOptions.optimizeLevel = 2;
              passOptions.shrinkLevel = 1;
              passOptions.ignoreImplicitTraps = true;
-             passes.push_back("O");
+             runOptimizationPasses = true;
            })
       .add("", "-O0", "execute no optimization passes",
            Options::Arguments::Zero,
-           [&passes, &passOptions](Options*, const std::string&) {
+           [&runOptimizationPasses, &passOptions](Options*, const std::string&) {
              passOptions.optimizeLevel = 0;
              passOptions.shrinkLevel = 0;
              passOptions.ignoreImplicitTraps = false;
            })
       .add("", "-O1", "execute -O1 optimization passes",
            Options::Arguments::Zero,
-           [&passes, &passOptions](Options*, const std::string&) {
+           [&runOptimizationPasses, &passOptions](Options*, const std::string&) {
              passOptions.optimizeLevel = 1;
              passOptions.shrinkLevel = 0;
              passOptions.ignoreImplicitTraps = true;
-             passes.push_back("O");
+             runOptimizationPasses = true;
            })
       .add("", "-O2", "execute -O2 optimization passes",
            Options::Arguments::Zero,
-           [&passes, &passOptions](Options*, const std::string&) {
+           [&runOptimizationPasses, &passOptions](Options*, const std::string&) {
              passOptions.optimizeLevel = 2;
              passOptions.shrinkLevel = 0;
              passOptions.ignoreImplicitTraps = true;
-             passes.push_back("O");
+             runOptimizationPasses = true;
            })
       .add("", "-O3", "execute -O3 optimization passes",
            Options::Arguments::Zero,
-           [&passes, &passOptions](Options*, const std::string&) {
+           [&runOptimizationPasses, &passOptions](Options*, const std::string&) {
              passOptions.optimizeLevel = 3;
              passOptions.shrinkLevel = 0;
              passOptions.ignoreImplicitTraps = true;
-             passes.push_back("O");
+             runOptimizationPasses = true;
            })
       .add("", "-Os", "execute default optimization passes, focusing on code size",
            Options::Arguments::Zero,
-           [&passes, &passOptions](Options*, const std::string&) {
+           [&runOptimizationPasses, &passOptions](Options*, const std::string&) {
              passOptions.optimizeLevel = 2;
              passOptions.shrinkLevel = 1;
              passOptions.ignoreImplicitTraps = true;
-             passes.push_back("O");
+             runOptimizationPasses = true;
            })
       .add("", "-Oz", "execute default optimization passes, super-focusing on code size",
            Options::Arguments::Zero,
-           [&passes, &passOptions](Options*, const std::string&) {
+           [&runOptimizationPasses, &passOptions](Options*, const std::string&) {
              passOptions.optimizeLevel = 2;
              passOptions.shrinkLevel = 2;
              passOptions.ignoreImplicitTraps = true;
-             passes.push_back("O");
+             runOptimizationPasses = true;
            })
       .add("--optimize-level", "-op", "How much to focus on optimizing code",
            Options::Arguments::One,

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -47,24 +47,7 @@ int main(int argc, const char* argv[]) {
              o->extra["output"] = argument;
              Colors::disable();
            })
-      .add("", "-O", "execute default optimization passes",
-           Options::Arguments::Zero,
-           [&passes, &passOptions](Options*, const std::string&) {
-             passOptions.setDefaultOptimizationOptions();
-             passes.push_back("O");
-           })
-      .add("", "-Os", "execute default optimization passes, focusing on code size",
-           Options::Arguments::Zero,
-           [&passes, &passOptions](Options*, const std::string&) {
-             passOptions.setDefaultOptimizationOptions();
-             passOptions.shrinkLevel = 1;
-             passes.push_back("O");
-           })
-      .add("--shrink-level", "-s", "How much to focus on shrinking code size",
-           Options::Arguments::One,
-           [&passOptions](Options* o, const std::string& argument) {
-             passOptions.shrinkLevel = atoi(argument.c_str());
-           })
+      #include "optimization-options.h"
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options* o, const std::string& argument) {
                         o->extra["infile"] = argument;

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -37,6 +37,7 @@ using namespace wasm;
 int main(int argc, const char* argv[]) {
   Name entry;
   std::vector<std::string> passes;
+  bool runOptimizationPasses = false;
   PassOptions passOptions;
 
   Options options("wasm-opt", "Optimize .wast files");
@@ -59,6 +60,10 @@ int main(int argc, const char* argv[]) {
         [&passes, p](Options*, const std::string&) { passes.push_back(p); });
   }
   options.parse(argc, argv);
+
+  if (runOptimizationPasses) {
+    passes.push_back("O");
+  }
 
   auto input(read_file<std::string>(options.extra["infile"], Flags::Text, options.debug ? Flags::Debug : Flags::Release));
 

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -62,7 +62,9 @@ int main(int argc, const char* argv[]) {
   options.parse(argc, argv);
 
   if (runOptimizationPasses) {
-    passes.push_back("O");
+    passes.resize(passes.size() + 1);
+    std::move_backward(passes.begin(), passes.begin() + passes.size() - 1, passes.end());
+    passes[0] = "O";
   }
 
   auto input(read_file<std::string>(options.extra["infile"], Flags::Text, options.debug ? Flags::Debug : Flags::Release));


### PR DESCRIPTION
Adds them to both `wasm-opt` and `asm2wasm`, for a consistent interface (before `asm2wasm` always optimized unless `--no-opts` was passed; this deprecates that old option).