### PR TITLE
Add priority to copies on backedges

### DIFF
--- a/scripts/strip_local_names.py
+++ b/scripts/strip_local_names.py
@@ -4,12 +4,10 @@ Removes local names. When you don't care about local names but do want
 to diff for structural changes, this can help.
 '''
 
-import os
 import sys
 
 for line in open(sys.argv[1]).readlines():
-  if '(tee_local ' in line or '(set_local ' in line or '(get_local '  in line:
+  if '(tee_local ' in line or '(set_local ' in line or '(get_local ' in line:
     print line[:line.find('$')]
   else:
     print line,
-

--- a/scripts/strip_local_names.py
+++ b/scripts/strip_local_names.py
@@ -1,0 +1,15 @@
+
+'''
+Removes local names. When you don't care about local names but do want
+to diff for structural changes, this can help.
+'''
+
+import os
+import sys
+
+for line in open(sys.argv[1]).readlines():
+  if '(tee_local ' in line or '(set_local ' in line or '(get_local '  in line:
+    print line[:line.find('$')]
+  else:
+    print line,
+

--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -54,6 +54,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
   // internal details
 
   std::vector<std::unique_ptr<BasicBlock>> basicBlocks; // all the blocks
+  std::vector<BasicBlock*> loopTops; // blocks that are the tops of loops, i.e., have backedges to them
 
   // traversal state
   BasicBlock* currBasicBlock; // the current block in play during traversal. can be nullptr if unreachable,
@@ -132,6 +133,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
   static void doStartLoop(SubType* self, Expression** currp) {
     auto* last = self->currBasicBlock;
     self->startBasicBlock();
+    self->loopTops.push_back(self->currBasicBlock); // a loop with no backedges would still be counted here, but oh well
     self->link(last, self->currBasicBlock);
     self->loopStack.push_back(self->currBasicBlock);
   }

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -285,6 +285,7 @@ void CoalesceLocals::increaseBackEdgePriorities() {
     auto& in = loopTop->in;
     for (Index i = 1; i < in.size(); i++) {
       auto* arrivingBlock = in[i];
+      if (arrivingBlock->out.size() > 1) continue; // we just want unconditional branches to the loop top, true phi fragments
       for (auto& action : arrivingBlock->contents.actions) {
         if (action.what == Action::Set) {
           auto* set = (*action.origin)->cast<SetLocal>();

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -151,7 +151,7 @@
                       (i32.const 176)
                     )
                   )
-                  (tee_local $6
+                  (tee_local $8
                     (i32.shr_u
                       (tee_local $9
                         (select
@@ -183,14 +183,14 @@
                     (i32.add
                       (tee_local $0
                         (i32.load
-                          (tee_local $7
+                          (tee_local $6
                             (i32.add
                               (tee_local $1
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (tee_local $6
+                                      (tee_local $10
                                         (i32.add
                                           (i32.xor
                                             (i32.and
@@ -199,7 +199,7 @@
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $6)
+                                          (get_local $8)
                                         )
                                       )
                                       (i32.const 1)
@@ -236,7 +236,7 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $8
+                        (tee_local $7
                           (i32.add
                             (get_local $2)
                             (i32.const 12)
@@ -247,11 +247,11 @@
                     )
                     (block
                       (i32.store
-                        (get_local $8)
+                        (get_local $7)
                         (get_local $1)
                       )
                       (i32.store
-                        (get_local $7)
+                        (get_local $6)
                         (get_local $2)
                       )
                     )
@@ -265,7 +265,7 @@
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $6)
+                        (get_local $10)
                       )
                       (i32.const -1)
                     )
@@ -277,7 +277,7 @@
                 (i32.or
                   (tee_local $2
                     (i32.shl
-                      (get_local $6)
+                      (get_local $10)
                       (i32.const 3)
                     )
                   )
@@ -285,7 +285,7 @@
                 )
               )
               (i32.store
-                (tee_local $7
+                (tee_local $6
                   (i32.add
                     (i32.add
                       (get_local $0)
@@ -296,7 +296,7 @@
                 )
                 (i32.or
                   (i32.load
-                    (get_local $7)
+                    (get_local $6)
                   )
                   (i32.const 1)
                 )
@@ -309,7 +309,7 @@
           (if
             (i32.gt_u
               (get_local $9)
-              (tee_local $7
+              (tee_local $6
                 (i32.load
                   (i32.const 184)
                 )
@@ -329,13 +329,13 @@
                                 (i32.and
                                   (i32.shl
                                     (get_local $2)
-                                    (get_local $6)
+                                    (get_local $8)
                                   )
                                   (i32.or
                                     (tee_local $2
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $6)
+                                        (get_local $8)
                                       )
                                     )
                                     (i32.sub
@@ -360,7 +360,7 @@
                   )
                   (set_local $1
                     (i32.load
-                      (tee_local $8
+                      (tee_local $7
                         (i32.add
                           (tee_local $0
                             (i32.load
@@ -380,7 +380,7 @@
                                                       (tee_local $2
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $8
+                                                            (tee_local $7
                                                               (i32.shr_u
                                                                 (get_local $2)
                                                                 (get_local $1)
@@ -393,12 +393,12 @@
                                                       )
                                                       (get_local $1)
                                                     )
-                                                    (tee_local $8
+                                                    (tee_local $7
                                                       (i32.and
                                                         (i32.shr_u
                                                           (tee_local $0
                                                             (i32.shr_u
-                                                              (get_local $8)
+                                                              (get_local $7)
                                                               (get_local $2)
                                                             )
                                                           )
@@ -414,7 +414,7 @@
                                                         (tee_local $11
                                                           (i32.shr_u
                                                             (get_local $0)
-                                                            (get_local $8)
+                                                            (get_local $7)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -520,7 +520,7 @@
                         )
                       )
                       (set_local $17
-                        (get_local $7)
+                        (get_local $6)
                       )
                     )
                   )
@@ -539,7 +539,7 @@
                       )
                     )
                     (i32.or
-                      (tee_local $7
+                      (tee_local $6
                         (i32.sub
                           (i32.shl
                             (get_local $10)
@@ -554,9 +554,9 @@
                   (i32.store
                     (i32.add
                       (get_local $15)
-                      (get_local $7)
+                      (get_local $6)
                     )
-                    (get_local $7)
+                    (get_local $6)
                   )
                   (if
                     (get_local $17)
@@ -585,7 +585,7 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $6
+                          (tee_local $8
                             (i32.load
                               (i32.const 176)
                             )
@@ -627,7 +627,7 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $6)
+                              (get_local $8)
                               (get_local $2)
                             )
                           )
@@ -662,14 +662,14 @@
                   )
                   (i32.store
                     (i32.const 184)
-                    (get_local $7)
+                    (get_local $6)
                   )
                   (i32.store
                     (i32.const 196)
                     (get_local $15)
                   )
                   (return
-                    (get_local $8)
+                    (get_local $7)
                   )
                 )
               )
@@ -683,7 +683,7 @@
                   (set_local $15
                     (i32.and
                       (i32.shr_u
-                        (tee_local $7
+                        (tee_local $6
                           (i32.add
                             (i32.and
                               (get_local $15)
@@ -712,12 +712,12 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (tee_local $7
+                                          (tee_local $6
                                             (i32.and
                                               (i32.shr_u
                                                 (tee_local $11
                                                   (i32.shr_u
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (get_local $15)
                                                   )
                                                 )
@@ -734,7 +734,7 @@
                                               (tee_local $1
                                                 (i32.shr_u
                                                   (get_local $11)
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                               (i32.const 2)
@@ -761,7 +761,7 @@
                                     (tee_local $2
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $6
+                                          (tee_local $8
                                             (i32.shr_u
                                               (get_local $2)
                                               (get_local $1)
@@ -774,7 +774,7 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $6)
+                                    (get_local $8)
                                     (get_local $2)
                                   )
                                 )
@@ -788,7 +788,7 @@
                       (get_local $9)
                     )
                   )
-                  (set_local $6
+                  (set_local $8
                     (get_local $17)
                   )
                   (set_local $1
@@ -799,7 +799,7 @@
                       (if
                         (tee_local $17
                           (i32.load offset=16
-                            (get_local $6)
+                            (get_local $8)
                           )
                         )
                         (set_local $0
@@ -808,7 +808,7 @@
                         (if
                           (tee_local $11
                             (i32.load offset=20
-                              (get_local $6)
+                              (get_local $8)
                             )
                           )
                           (set_local $0
@@ -848,7 +848,7 @@
                           (get_local $11)
                         )
                       )
-                      (set_local $6
+                      (set_local $8
                         (get_local $0)
                       )
                       (set_local $1
@@ -875,7 +875,7 @@
                   (if
                     (i32.ge_u
                       (get_local $5)
-                      (tee_local $6
+                      (tee_local $8
                         (i32.add
                           (get_local $5)
                           (get_local $9)
@@ -892,7 +892,7 @@
                   (block $do-once4
                     (if
                       (i32.eq
-                        (tee_local $8
+                        (tee_local $7
                           (i32.load offset=12
                             (get_local $5)
                           )
@@ -915,7 +915,7 @@
                             (set_local $17
                               (get_local $10)
                             )
-                            (set_local $7
+                            (set_local $6
                               (get_local $0)
                             )
                           )
@@ -930,7 +930,7 @@
                                 )
                               )
                             )
-                            (set_local $7
+                            (set_local $6
                               (get_local $11)
                             )
                             (block
@@ -957,7 +957,7 @@
                               (set_local $17
                                 (get_local $10)
                               )
-                              (set_local $7
+                              (set_local $6
                                 (get_local $0)
                               )
                               (br $while-in7)
@@ -978,7 +978,7 @@
                               (set_local $17
                                 (get_local $10)
                               )
-                              (set_local $7
+                              (set_local $6
                                 (get_local $0)
                               )
                               (br $while-in7)
@@ -987,13 +987,13 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $7)
+                            (get_local $6)
                             (get_local $1)
                           )
                           (call $_abort)
                           (block
                             (i32.store
-                              (get_local $7)
+                              (get_local $6)
                               (i32.const 0)
                             )
                             (set_local $19
@@ -1033,7 +1033,7 @@
                             (i32.load
                               (tee_local $11
                                 (i32.add
-                                  (get_local $8)
+                                  (get_local $7)
                                   (i32.const 8)
                                 )
                               )
@@ -1043,14 +1043,14 @@
                           (block
                             (i32.store
                               (get_local $10)
-                              (get_local $8)
+                              (get_local $7)
                             )
                             (i32.store
                               (get_local $11)
                               (get_local $0)
                             )
                             (set_local $19
-                              (get_local $8)
+                              (get_local $7)
                             )
                           )
                           (call $_abort)
@@ -1070,7 +1070,7 @@
                                 (i32.add
                                   (i32.const 480)
                                   (i32.shl
-                                    (tee_local $8
+                                    (tee_local $7
                                       (i32.load offset=28
                                         (get_local $5)
                                       )
@@ -1100,7 +1100,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $8)
+                                        (get_local $7)
                                       )
                                       (i32.const -1)
                                     )
@@ -1123,7 +1123,7 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $8
+                                  (tee_local $7
                                     (i32.add
                                       (get_local $2)
                                       (i32.const 16)
@@ -1133,7 +1133,7 @@
                                 (get_local $5)
                               )
                               (i32.store
-                                (get_local $8)
+                                (get_local $7)
                                 (get_local $19)
                               )
                               (i32.store offset=20
@@ -1151,7 +1151,7 @@
                         (if
                           (i32.lt_u
                             (get_local $19)
-                            (tee_local $8
+                            (tee_local $7
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1172,7 +1172,7 @@
                           (if
                             (i32.lt_u
                               (get_local $1)
-                              (get_local $8)
+                              (get_local $7)
                             )
                             (call $_abort)
                             (block
@@ -1261,7 +1261,7 @@
                         )
                       )
                       (i32.store offset=4
-                        (get_local $6)
+                        (get_local $8)
                         (i32.or
                           (get_local $3)
                           (i32.const 1)
@@ -1269,7 +1269,7 @@
                       )
                       (i32.store
                         (i32.add
-                          (get_local $6)
+                          (get_local $8)
                           (get_local $3)
                         )
                         (get_local $3)
@@ -1291,7 +1291,7 @@
                               (i32.const 216)
                               (i32.shl
                                 (i32.shl
-                                  (tee_local $8
+                                  (tee_local $7
                                     (i32.shr_u
                                       (get_local $1)
                                       (i32.const 3)
@@ -1313,7 +1313,7 @@
                               (tee_local $11
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $8)
+                                  (get_local $7)
                                 )
                               )
                             )
@@ -1321,7 +1321,7 @@
                               (i32.lt_u
                                 (tee_local $10
                                   (i32.load
-                                    (tee_local $8
+                                    (tee_local $7
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 8)
@@ -1336,7 +1336,7 @@
                               (call $_abort)
                               (block
                                 (set_local $39
-                                  (get_local $8)
+                                  (get_local $7)
                                 )
                                 (set_local $32
                                   (get_local $10)
@@ -1386,7 +1386,7 @@
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $6)
+                        (get_local $8)
                       )
                     )
                   )
@@ -1465,7 +1465,7 @@
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $8
+                                                          (tee_local $7
                                                             (i32.shl
                                                               (get_local $10)
                                                               (tee_local $1
@@ -1491,13 +1491,13 @@
                                                   )
                                                   (get_local $1)
                                                 )
-                                                (tee_local $8
+                                                (tee_local $7
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
                                                         (tee_local $17
                                                           (i32.shl
-                                                            (get_local $8)
+                                                            (get_local $7)
                                                             (get_local $10)
                                                           )
                                                         )
@@ -1513,7 +1513,7 @@
                                             (i32.shr_u
                                               (i32.shl
                                                 (get_local $17)
-                                                (get_local $8)
+                                                (get_local $7)
                                               )
                                               (i32.const 15)
                                             )
@@ -1538,7 +1538,7 @@
                       )
                     )
                     (block
-                      (set_local $8
+                      (set_local $7
                         (get_local $0)
                       )
                       (set_local $17
@@ -1566,7 +1566,7 @@
                       (set_local $10
                         (get_local $15)
                       )
-                      (set_local $7
+                      (set_local $6
                         (i32.const 0)
                       )
                       (loop $while-in14
@@ -1585,7 +1585,7 @@
                                 (get_local $2)
                               )
                             )
-                            (get_local $8)
+                            (get_local $7)
                           )
                           (if
                             (i32.eq
@@ -1602,16 +1602,16 @@
                               (set_local $29
                                 (get_local $10)
                               )
-                              (set_local $8
+                              (set_local $7
                                 (i32.const 90)
                               )
                               (br $label$break$L123)
                             )
                             (block
-                              (set_local $8
+                              (set_local $7
                                 (get_local $0)
                               )
-                              (set_local $7
+                              (set_local $6
                                 (get_local $10)
                               )
                             )
@@ -1660,15 +1660,15 @@
                           )
                           (block
                             (set_local $33
-                              (get_local $8)
-                            )
-                            (set_local $6
-                              (get_local $19)
-                            )
-                            (set_local $30
                               (get_local $7)
                             )
                             (set_local $8
+                              (get_local $19)
+                            )
+                            (set_local $30
+                              (get_local $6)
+                            )
+                            (set_local $7
                               (i32.const 86)
                             )
                           )
@@ -1697,13 +1697,13 @@
                       (set_local $33
                         (get_local $0)
                       )
-                      (set_local $6
+                      (set_local $8
                         (i32.const 0)
                       )
                       (set_local $30
                         (i32.const 0)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 86)
                       )
                     )
@@ -1711,7 +1711,7 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $7)
                     (i32.const 86)
                   )
                   (if
@@ -1719,7 +1719,7 @@
                       (if i32
                         (i32.and
                           (i32.eqz
-                            (get_local $6)
+                            (get_local $8)
                           )
                           (i32.eqz
                             (get_local $30)
@@ -1799,7 +1799,7 @@
                                       (tee_local $9
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $6
+                                            (tee_local $8
                                               (i32.shr_u
                                                 (get_local $9)
                                                 (get_local $15)
@@ -1811,12 +1811,12 @@
                                         )
                                       )
                                     )
-                                    (tee_local $6
+                                    (tee_local $8
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $7
+                                          (tee_local $6
                                             (i32.shr_u
-                                              (get_local $6)
+                                              (get_local $8)
                                               (get_local $9)
                                             )
                                           )
@@ -1826,13 +1826,13 @@
                                       )
                                     )
                                   )
-                                  (tee_local $7
+                                  (tee_local $6
                                     (i32.and
                                       (i32.shr_u
                                         (tee_local $1
                                           (i32.shr_u
-                                            (get_local $7)
                                             (get_local $6)
+                                            (get_local $8)
                                           )
                                         )
                                         (i32.const 1)
@@ -1843,14 +1843,14 @@
                                 )
                                 (i32.shr_u
                                   (get_local $1)
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                               )
                               (i32.const 2)
                             )
                           )
                         )
-                        (get_local $6)
+                        (get_local $8)
                       )
                     )
                     (block
@@ -1863,7 +1863,7 @@
                       (set_local $29
                         (get_local $30)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 90)
                       )
                     )
@@ -1879,16 +1879,16 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $7)
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $8
+                    (set_local $7
                       (i32.const 0)
                     )
                     (set_local $1
                       (i32.lt_u
-                        (tee_local $7
+                        (tee_local $6
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
@@ -1902,14 +1902,14 @@
                         (get_local $27)
                       )
                     )
-                    (set_local $6
+                    (set_local $8
                       (select
-                        (get_local $7)
+                        (get_local $6)
                         (get_local $27)
                         (get_local $1)
                       )
                     )
-                    (set_local $7
+                    (set_local $6
                       (select
                         (get_local $25)
                         (get_local $29)
@@ -1924,13 +1924,13 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $6)
+                          (get_local $8)
                         )
                         (set_local $25
                           (get_local $1)
                         )
                         (set_local $29
-                          (get_local $7)
+                          (get_local $6)
                         )
                         (br $while-in16)
                       )
@@ -1943,19 +1943,19 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $6)
+                          (get_local $8)
                         )
                         (set_local $29
-                          (get_local $7)
+                          (get_local $6)
                         )
                         (br $while-in16)
                       )
                       (block
                         (set_local $4
-                          (get_local $6)
+                          (get_local $8)
                         )
                         (set_local $12
-                          (get_local $7)
+                          (get_local $6)
                         )
                       )
                     )
@@ -1993,7 +1993,7 @@
                     (if
                       (i32.ge_u
                         (get_local $12)
-                        (tee_local $7
+                        (tee_local $6
                           (i32.add
                             (get_local $12)
                             (get_local $2)
@@ -2002,7 +2002,7 @@
                       )
                       (call $_abort)
                     )
-                    (set_local $6
+                    (set_local $8
                       (i32.load offset=24
                         (get_local $12)
                       )
@@ -2178,7 +2178,7 @@
                     )
                     (block $do-once21
                       (if
-                        (get_local $6)
+                        (get_local $8)
                         (block
                           (if
                             (i32.eq
@@ -2231,7 +2231,7 @@
                             (block
                               (if
                                 (i32.lt_u
-                                  (get_local $6)
+                                  (get_local $8)
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -2243,7 +2243,7 @@
                                   (i32.load
                                     (tee_local $1
                                       (i32.add
-                                        (get_local $6)
+                                        (get_local $8)
                                         (i32.const 16)
                                       )
                                     )
@@ -2255,7 +2255,7 @@
                                   (get_local $5)
                                 )
                                 (i32.store offset=20
-                                  (get_local $6)
+                                  (get_local $8)
                                   (get_local $5)
                                 )
                               )
@@ -2279,7 +2279,7 @@
                           )
                           (i32.store offset=24
                             (get_local $5)
-                            (get_local $6)
+                            (get_local $8)
                           )
                           (if
                             (tee_local $11
@@ -2349,7 +2349,7 @@
                             )
                           )
                           (i32.store offset=4
-                            (get_local $7)
+                            (get_local $6)
                             (i32.or
                               (get_local $4)
                               (i32.const 1)
@@ -2357,12 +2357,12 @@
                           )
                           (i32.store
                             (i32.add
-                              (get_local $7)
+                              (get_local $6)
                               (get_local $4)
                             )
                             (get_local $4)
                           )
-                          (set_local $6
+                          (set_local $8
                             (i32.shr_u
                               (get_local $4)
                               (i32.const 3)
@@ -2379,7 +2379,7 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $6)
+                                      (get_local $8)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -2396,7 +2396,7 @@
                                   (tee_local $9
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $6)
+                                      (get_local $8)
                                     )
                                   )
                                 )
@@ -2404,7 +2404,7 @@
                                   (i32.lt_u
                                     (tee_local $15
                                       (i32.load
-                                        (tee_local $6
+                                        (tee_local $8
                                           (i32.add
                                             (get_local $11)
                                             (i32.const 8)
@@ -2419,7 +2419,7 @@
                                   (call $_abort)
                                   (block
                                     (set_local $16
-                                      (get_local $6)
+                                      (get_local $8)
                                     )
                                     (set_local $26
                                       (get_local $15)
@@ -2447,24 +2447,24 @@
                               )
                               (i32.store
                                 (get_local $16)
-                                (get_local $7)
+                                (get_local $6)
                               )
                               (i32.store offset=12
                                 (get_local $26)
-                                (get_local $7)
+                                (get_local $6)
                               )
                               (i32.store offset=8
-                                (get_local $7)
+                                (get_local $6)
                                 (get_local $26)
                               )
                               (i32.store offset=12
-                                (get_local $7)
+                                (get_local $6)
                                 (get_local $11)
                               )
                               (br $do-once25)
                             )
                           )
-                          (set_local $6
+                          (set_local $8
                             (i32.add
                               (i32.const 480)
                               (i32.shl
@@ -2487,7 +2487,7 @@
                                           (i32.shr_u
                                             (get_local $4)
                                             (i32.add
-                                              (tee_local $6
+                                              (tee_local $8
                                                 (i32.add
                                                   (i32.sub
                                                     (i32.const 14)
@@ -2557,7 +2557,7 @@
                                           (i32.const 1)
                                         )
                                         (i32.shl
-                                          (get_local $6)
+                                          (get_local $8)
                                           (i32.const 1)
                                         )
                                       )
@@ -2570,13 +2570,13 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $7)
+                            (get_local $6)
                             (get_local $10)
                           )
                           (i32.store offset=4
                             (tee_local $1
                               (i32.add
-                                (get_local $7)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                             )
@@ -2611,20 +2611,20 @@
                                 )
                               )
                               (i32.store
+                                (get_local $8)
                                 (get_local $6)
-                                (get_local $7)
                               )
                               (i32.store offset=24
-                                (get_local $7)
                                 (get_local $6)
+                                (get_local $8)
                               )
                               (i32.store offset=12
-                                (get_local $7)
-                                (get_local $7)
+                                (get_local $6)
+                                (get_local $6)
                               )
                               (i32.store offset=8
-                                (get_local $7)
-                                (get_local $7)
+                                (get_local $6)
+                                (get_local $6)
                               )
                               (br $do-once25)
                             )
@@ -2650,7 +2650,7 @@
                           )
                           (set_local $1
                             (i32.load
-                              (get_local $6)
+                              (get_local $8)
                             )
                           )
                           (loop $while-in28
@@ -2669,7 +2669,7 @@
                                   (set_local $14
                                     (get_local $1)
                                   )
-                                  (set_local $8
+                                  (set_local $7
                                     (i32.const 148)
                                   )
                                   (br $while-out27)
@@ -2678,7 +2678,7 @@
                               (if
                                 (tee_local $9
                                   (i32.load
-                                    (tee_local $6
+                                    (tee_local $8
                                       (i32.add
                                         (i32.add
                                           (get_local $1)
@@ -2709,12 +2709,12 @@
                                 )
                                 (block
                                   (set_local $23
-                                    (get_local $6)
+                                    (get_local $8)
                                   )
                                   (set_local $21
                                     (get_local $1)
                                   )
-                                  (set_local $8
+                                  (set_local $7
                                     (i32.const 145)
                                   )
                                 )
@@ -2723,7 +2723,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $8)
+                              (get_local $7)
                               (i32.const 145)
                             )
                             (if
@@ -2737,25 +2737,25 @@
                               (block
                                 (i32.store
                                   (get_local $23)
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=24
-                                  (get_local $7)
+                                  (get_local $6)
                                   (get_local $21)
                                 )
                                 (i32.store offset=12
-                                  (get_local $7)
-                                  (get_local $7)
+                                  (get_local $6)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=8
-                                  (get_local $7)
-                                  (get_local $7)
+                                  (get_local $6)
+                                  (get_local $6)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.const 148)
                               )
                               (if
@@ -2785,22 +2785,22 @@
                                 (block
                                   (i32.store offset=12
                                     (get_local $15)
-                                    (get_local $7)
+                                    (get_local $6)
                                   )
                                   (i32.store
                                     (get_local $1)
-                                    (get_local $7)
+                                    (get_local $6)
                                   )
                                   (i32.store offset=8
-                                    (get_local $7)
+                                    (get_local $6)
                                     (get_local $15)
                                   )
                                   (i32.store offset=12
-                                    (get_local $7)
+                                    (get_local $6)
                                     (get_local $14)
                                   )
                                   (i32.store offset=24
-                                    (get_local $7)
+                                    (get_local $6)
                                     (i32.const 0)
                                   )
                                 )
@@ -3166,7 +3166,7 @@
             )
             (i32.const 0)
             (i32.eq
-              (tee_local $8
+              (tee_local $7
                 (block $label$break$L257 i32
                   (if i32
                     (i32.and
@@ -3217,7 +3217,7 @@
                                     (i32.const 0)
                                   )
                                   (block
-                                    (set_local $6
+                                    (set_local $8
                                       (get_local $16)
                                     )
                                     (set_local $1
@@ -3233,7 +3233,7 @@
                                     )
                                   )
                                 )
-                                (set_local $8
+                                (set_local $7
                                   (i32.const 173)
                                 )
                                 (br $label$break$L259)
@@ -3263,7 +3263,7 @@
                                   )
                                   (i32.add
                                     (i32.load
-                                      (get_local $6)
+                                      (get_local $8)
                                     )
                                     (i32.load
                                       (get_local $1)
@@ -3294,14 +3294,14 @@
                                   (set_local $18
                                     (get_local $16)
                                   )
-                                  (set_local $8
+                                  (set_local $7
                                     (i32.const 183)
                                   )
                                 )
                               )
                             )
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.const 173)
                           )
                         )
@@ -3310,7 +3310,7 @@
                         (if
                           (if i32
                             (i32.eq
-                              (get_local $8)
+                              (get_local $7)
                               (i32.const 173)
                             )
                             (i32.ne
@@ -3432,7 +3432,7 @@
                                     (set_local $18
                                       (get_local $0)
                                     )
-                                    (set_local $8
+                                    (set_local $7
                                       (i32.const 183)
                                     )
                                   )
@@ -3445,7 +3445,7 @@
                       (block $label$break$L279
                         (if
                           (i32.eq
-                            (get_local $8)
+                            (get_local $7)
                             (i32.const 183)
                           )
                           (block
@@ -3607,14 +3607,14 @@
         (set_local $22
           (get_local $13)
         )
-        (set_local $8
+        (set_local $7
           (i32.const 193)
         )
       )
     )
     (if
       (i32.eq
-        (get_local $8)
+        (get_local $7)
         (i32.const 193)
       )
       (block
@@ -3688,7 +3688,7 @@
                       (set_local $49
                         (get_local $3)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 203)
                       )
                       (br $do-out)
@@ -3730,7 +3730,7 @@
                     )
                     (i32.const 0)
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 203)
                     )
                   )
@@ -3811,7 +3811,7 @@
                   (br $do-once40)
                 )
               )
-              (set_local $7
+              (set_local $6
                 (if i32
                   (i32.lt_u
                     (get_local $20)
@@ -3856,7 +3856,7 @@
                       (set_local $40
                         (get_local $3)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 211)
                       )
                       (br $while-out42)
@@ -3876,7 +3876,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $8)
+                  (get_local $7)
                   (i32.const 211)
                 )
                 (if
@@ -4026,7 +4026,7 @@
                             )
                           )
                           (i32.store
-                            (tee_local $6
+                            (tee_local $8
                               (i32.add
                                 (if i32
                                   (i32.eq
@@ -4047,7 +4047,7 @@
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $6
+                                    (set_local $8
                                       (i32.shr_u
                                         (get_local $0)
                                         (i32.const 3)
@@ -4164,7 +4164,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $5)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (call $_abort)
                                                   (block
@@ -4186,7 +4186,7 @@
                                                         (get_local $4)
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (call $_abort)
                                                 )
@@ -4415,7 +4415,7 @@
                                                     (i32.const 216)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $6)
+                                                        (get_local $8)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4427,7 +4427,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $5)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (call $_abort)
                                                 )
@@ -4458,7 +4458,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $6)
+                                                      (get_local $8)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4483,7 +4483,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $21)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (call $_abort)
                                                 )
@@ -4539,7 +4539,7 @@
                             )
                             (i32.and
                               (i32.load
-                                (get_local $6)
+                                (get_local $8)
                               )
                               (i32.const -2)
                             )
@@ -4558,7 +4558,7 @@
                             )
                             (get_local $14)
                           )
-                          (set_local $6
+                          (set_local $8
                             (i32.shr_u
                               (get_local $14)
                               (i32.const 3)
@@ -4575,7 +4575,7 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $6)
+                                      (get_local $8)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4593,7 +4593,7 @@
                                     (tee_local $2
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $6)
+                                        (get_local $8)
                                       )
                                     )
                                   )
@@ -4602,7 +4602,7 @@
                                       (i32.ge_u
                                         (tee_local $10
                                           (i32.load
-                                            (tee_local $6
+                                            (tee_local $8
                                               (i32.add
                                                 (get_local $0)
                                                 (i32.const 8)
@@ -4616,7 +4616,7 @@
                                       )
                                       (block
                                         (set_local $42
-                                          (get_local $6)
+                                          (get_local $8)
                                         )
                                         (set_local $34
                                           (get_local $10)
@@ -4733,7 +4733,7 @@
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $6
+                                                                (tee_local $8
                                                                   (i32.shl
                                                                     (get_local $1)
                                                                     (get_local $10)
@@ -4750,7 +4750,7 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $6)
+                                                        (get_local $8)
                                                         (get_local $1)
                                                       )
                                                       (i32.const 15)
@@ -4876,7 +4876,7 @@
                                   (set_local $35
                                     (get_local $0)
                                   )
-                                  (set_local $8
+                                  (set_local $7
                                     (i32.const 281)
                                   )
                                   (br $while-out63)
@@ -4921,7 +4921,7 @@
                                   (set_local $51
                                     (get_local $0)
                                   )
-                                  (set_local $8
+                                  (set_local $7
                                     (i32.const 278)
                                   )
                                 )
@@ -4930,7 +4930,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $8)
+                              (get_local $7)
                               (i32.const 278)
                             )
                             (if
@@ -4962,7 +4962,7 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.const 281)
                               )
                               (if
@@ -5606,7 +5606,7 @@
                           (set_local $37
                             (get_local $0)
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.const 307)
                           )
                           (br $while-out69)
@@ -5651,7 +5651,7 @@
                           (set_local $52
                             (get_local $0)
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.const 304)
                           )
                         )
@@ -5660,7 +5660,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 304)
                     )
                     (if
@@ -5692,7 +5692,7 @@
                     )
                     (if
                       (i32.eq
-                        (get_local $8)
+                        (get_local $7)
                         (i32.const 307)
                       )
                       (if
@@ -5997,7 +5997,7 @@
       (i32.eq
         (tee_local $0
           (i32.and
-            (tee_local $3
+            (tee_local $4
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -6017,7 +6017,7 @@
         (get_local $1)
         (tee_local $5
           (i32.and
-            (get_local $3)
+            (get_local $4)
             (i32.const -8)
           )
         )
@@ -6026,14 +6026,14 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $3)
+          (get_local $4)
           (i32.const 1)
         )
         (block
           (set_local $2
             (get_local $1)
           )
-          (set_local $4
+          (set_local $3
             (get_local $5)
           )
         )
@@ -6057,7 +6057,7 @@
           )
           (if
             (i32.lt_u
-              (tee_local $3
+              (tee_local $1
                 (i32.add
                   (get_local $1)
                   (i32.sub
@@ -6072,7 +6072,7 @@
           )
           (if
             (i32.eq
-              (get_local $3)
+              (get_local $1)
               (i32.load
                 (i32.const 196)
               )
@@ -6097,9 +6097,9 @@
                 )
                 (block
                   (set_local $2
-                    (get_local $3)
+                    (get_local $1)
                   )
-                  (set_local $4
+                  (set_local $3
                     (get_local $5)
                   )
                   (br $do-once)
@@ -6117,7 +6117,7 @@
                 )
               )
               (i32.store offset=4
-                (get_local $3)
+                (get_local $1)
                 (i32.or
                   (get_local $5)
                   (i32.const 1)
@@ -6125,7 +6125,7 @@
               )
               (i32.store
                 (i32.add
-                  (get_local $3)
+                  (get_local $1)
                   (get_local $5)
                 )
                 (get_local $5)
@@ -6147,17 +6147,17 @@
             (block
               (set_local $0
                 (i32.load offset=12
-                  (get_local $3)
+                  (get_local $1)
                 )
               )
               (if
                 (i32.ne
                   (tee_local $11
                     (i32.load offset=8
-                      (get_local $3)
+                      (get_local $1)
                     )
                   )
-                  (tee_local $1
+                  (tee_local $4
                     (i32.add
                       (i32.const 216)
                       (i32.shl
@@ -6183,7 +6183,7 @@
                       (i32.load offset=12
                         (get_local $11)
                       )
-                      (get_local $3)
+                      (get_local $1)
                     )
                     (call $_abort)
                   )
@@ -6211,9 +6211,9 @@
                     )
                   )
                   (set_local $2
-                    (get_local $3)
+                    (get_local $1)
                   )
-                  (set_local $4
+                  (set_local $3
                     (get_local $5)
                   )
                   (br $do-once)
@@ -6222,7 +6222,7 @@
               (if
                 (i32.ne
                   (get_local $0)
-                  (get_local $1)
+                  (get_local $4)
                 )
                 (block
                   (if
@@ -6235,17 +6235,17 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $1
+                        (tee_local $4
                           (i32.add
                             (get_local $0)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $3)
+                      (get_local $1)
                     )
                     (set_local $10
-                      (get_local $1)
+                      (get_local $4)
                     )
                     (call $_abort)
                   )
@@ -6266,9 +6266,9 @@
                 (get_local $11)
               )
               (set_local $2
-                (get_local $3)
+                (get_local $1)
               )
-              (set_local $4
+              (set_local $3
                 (get_local $5)
               )
               (br $do-once)
@@ -6276,7 +6276,7 @@
           )
           (set_local $11
             (i32.load offset=24
-              (get_local $3)
+              (get_local $1)
             )
           )
           (block $do-once0
@@ -6284,10 +6284,10 @@
               (i32.eq
                 (tee_local $0
                   (i32.load offset=12
-                    (get_local $3)
+                    (get_local $1)
                   )
                 )
-                (get_local $3)
+                (get_local $1)
               )
               (block
                 (if
@@ -6295,9 +6295,9 @@
                     (i32.load
                       (tee_local $7
                         (i32.add
-                          (tee_local $1
+                          (tee_local $4
                             (i32.add
-                              (get_local $3)
+                              (get_local $1)
                               (i32.const 16)
                             )
                           )
@@ -6310,7 +6310,7 @@
                     (set_local $0
                       (get_local $10)
                     )
-                    (set_local $1
+                    (set_local $4
                       (get_local $7)
                     )
                   )
@@ -6318,7 +6318,7 @@
                     (i32.eqz
                       (tee_local $0
                         (i32.load
-                          (get_local $1)
+                          (get_local $4)
                         )
                       )
                     )
@@ -6346,7 +6346,7 @@
                       (set_local $0
                         (get_local $10)
                       )
-                      (set_local $1
+                      (set_local $4
                         (get_local $7)
                       )
                       (br $while-in)
@@ -6367,7 +6367,7 @@
                       (set_local $0
                         (get_local $10)
                       )
-                      (set_local $1
+                      (set_local $4
                         (get_local $7)
                       )
                       (br $while-in)
@@ -6377,7 +6377,7 @@
                         (get_local $0)
                       )
                       (set_local $9
-                        (get_local $1)
+                        (get_local $4)
                       )
                     )
                   )
@@ -6404,7 +6404,7 @@
                   (i32.lt_u
                     (tee_local $7
                       (i32.load offset=8
-                        (get_local $3)
+                        (get_local $1)
                       )
                     )
                     (get_local $14)
@@ -6421,21 +6421,21 @@
                         )
                       )
                     )
-                    (get_local $3)
+                    (get_local $1)
                   )
                   (call $_abort)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $1
+                      (tee_local $4
                         (i32.add
                           (get_local $0)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $3)
+                    (get_local $1)
                   )
                   (block
                     (i32.store
@@ -6443,7 +6443,7 @@
                       (get_local $0)
                     )
                     (i32.store
-                      (get_local $1)
+                      (get_local $4)
                       (get_local $7)
                     )
                     (set_local $6
@@ -6460,7 +6460,7 @@
             (block
               (if
                 (i32.eq
-                  (get_local $3)
+                  (get_local $1)
                   (i32.load
                     (tee_local $7
                       (i32.add
@@ -6468,7 +6468,7 @@
                         (i32.shl
                           (tee_local $0
                             (i32.load offset=28
-                              (get_local $3)
+                              (get_local $1)
                             )
                           )
                           (i32.const 2)
@@ -6503,9 +6503,9 @@
                         )
                       )
                       (set_local $2
-                        (get_local $3)
+                        (get_local $1)
                       )
-                      (set_local $4
+                      (set_local $3
                         (get_local $5)
                       )
                       (br $do-once)
@@ -6532,7 +6532,7 @@
                           )
                         )
                       )
-                      (get_local $3)
+                      (get_local $1)
                     )
                     (i32.store
                       (get_local $0)
@@ -6549,9 +6549,9 @@
                     )
                     (block
                       (set_local $2
-                        (get_local $3)
+                        (get_local $1)
                       )
-                      (set_local $4
+                      (set_local $3
                         (get_local $5)
                       )
                       (br $do-once)
@@ -6575,11 +6575,11 @@
                 (get_local $11)
               )
               (if
-                (tee_local $1
+                (tee_local $4
                   (i32.load
                     (tee_local $7
                       (i32.add
-                        (get_local $3)
+                        (get_local $1)
                         (i32.const 16)
                       )
                     )
@@ -6587,31 +6587,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $1)
+                    (get_local $4)
                     (get_local $0)
                   )
                   (call $_abort)
                   (block
                     (i32.store offset=16
                       (get_local $6)
-                      (get_local $1)
+                      (get_local $4)
                     )
                     (i32.store offset=24
-                      (get_local $1)
+                      (get_local $4)
                       (get_local $6)
                     )
                   )
                 )
               )
               (if
-                (tee_local $1
+                (tee_local $4
                   (i32.load offset=4
                     (get_local $7)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $1)
+                    (get_local $4)
                     (i32.load
                       (i32.const 192)
                     )
@@ -6620,25 +6620,25 @@
                   (block
                     (i32.store offset=20
                       (get_local $6)
-                      (get_local $1)
+                      (get_local $4)
                     )
                     (i32.store offset=24
-                      (get_local $1)
+                      (get_local $4)
                       (get_local $6)
                     )
                     (set_local $2
-                      (get_local $3)
+                      (get_local $1)
                     )
-                    (set_local $4
+                    (set_local $3
                       (get_local $5)
                     )
                   )
                 )
                 (block
                   (set_local $2
-                    (get_local $3)
+                    (get_local $1)
                   )
-                  (set_local $4
+                  (set_local $3
                     (get_local $5)
                   )
                 )
@@ -6646,9 +6646,9 @@
             )
             (block
               (set_local $2
-                (get_local $3)
+                (get_local $1)
               )
-              (set_local $4
+              (set_local $3
                 (get_local $5)
               )
             )
@@ -6697,19 +6697,19 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $4)
+            (get_local $3)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $4)
+            (get_local $3)
           )
-          (get_local $4)
+          (get_local $3)
         )
         (set_local $0
-          (get_local $4)
+          (get_local $3)
         )
       )
       (block
@@ -6728,7 +6728,7 @@
                   (i32.load
                     (i32.const 188)
                   )
-                  (get_local $4)
+                  (get_local $3)
                 )
               )
             )
@@ -6778,7 +6778,7 @@
                   (i32.load
                     (i32.const 184)
                   )
-                  (get_local $4)
+                  (get_local $3)
                 )
               )
             )
@@ -6809,7 +6809,7 @@
               (get_local $1)
               (i32.const -8)
             )
-            (get_local $4)
+            (get_local $3)
           )
         )
         (set_local $14
@@ -6846,7 +6846,7 @@
                         (i32.load
                           (tee_local $0
                             (i32.add
-                              (tee_local $1
+                              (tee_local $4
                                 (i32.add
                                   (get_local $8)
                                   (i32.const 16)
@@ -6858,20 +6858,20 @@
                         )
                       )
                       (block
-                        (set_local $4
+                        (set_local $3
                           (get_local $10)
                         )
-                        (set_local $1
+                        (set_local $4
                           (get_local $0)
                         )
                       )
                       (if
                         (tee_local $0
                           (i32.load
-                            (get_local $1)
+                            (get_local $4)
                           )
                         )
-                        (set_local $4
+                        (set_local $3
                           (get_local $0)
                         )
                         (block
@@ -6888,17 +6888,17 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $4)
+                                (get_local $3)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $4
+                          (set_local $3
                             (get_local $10)
                           )
-                          (set_local $1
+                          (set_local $4
                             (get_local $0)
                           )
                           (br $while-in9)
@@ -6909,17 +6909,17 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $4)
+                                (get_local $3)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $4
+                          (set_local $3
                             (get_local $10)
                           )
-                          (set_local $1
+                          (set_local $4
                             (get_local $0)
                           )
                           (br $while-in9)
@@ -6928,7 +6928,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $4)
                         (i32.load
                           (i32.const 192)
                         )
@@ -6936,11 +6936,11 @@
                       (call $_abort)
                       (block
                         (i32.store
-                          (get_local $1)
+                          (get_local $4)
                           (i32.const 0)
                         )
                         (set_local $12
-                          (get_local $4)
+                          (get_local $3)
                         )
                       )
                     )
@@ -6976,7 +6976,7 @@
                     (if
                       (i32.eq
                         (i32.load
-                          (tee_local $1
+                          (tee_local $4
                             (i32.add
                               (get_local $9)
                               (i32.const 8)
@@ -6991,7 +6991,7 @@
                           (get_local $9)
                         )
                         (i32.store
-                          (get_local $1)
+                          (get_local $4)
                           (get_local $0)
                         )
                         (set_local $12
@@ -7108,7 +7108,7 @@
                     (get_local $7)
                   )
                   (if
-                    (tee_local $3
+                    (tee_local $1
                       (i32.load
                         (tee_local $5
                           (i32.add
@@ -7120,31 +7120,31 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $3)
+                        (get_local $1)
                         (get_local $9)
                       )
                       (call $_abort)
                       (block
                         (i32.store offset=16
                           (get_local $12)
-                          (get_local $3)
+                          (get_local $1)
                         )
                         (i32.store offset=24
-                          (get_local $3)
+                          (get_local $1)
                           (get_local $12)
                         )
                       )
                     )
                   )
                   (if
-                    (tee_local $3
+                    (tee_local $1
                       (i32.load offset=4
                         (get_local $5)
                       )
                     )
                     (if
                       (i32.lt_u
-                        (get_local $3)
+                        (get_local $1)
                         (i32.load
                           (i32.const 192)
                         )
@@ -7153,10 +7153,10 @@
                       (block
                         (i32.store offset=20
                           (get_local $12)
-                          (get_local $3)
+                          (get_local $1)
                         )
                         (i32.store offset=24
-                          (get_local $3)
+                          (get_local $1)
                           (get_local $12)
                         )
                       )
@@ -7173,7 +7173,7 @@
               )
               (if
                 (i32.ne
-                  (tee_local $3
+                  (tee_local $1
                     (i32.load offset=8
                       (get_local $8)
                     )
@@ -7194,7 +7194,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $3)
+                      (get_local $1)
                       (i32.load
                         (i32.const 192)
                       )
@@ -7204,7 +7204,7 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $3)
+                        (get_local $1)
                       )
                       (get_local $8)
                     )
@@ -7215,7 +7215,7 @@
               (if
                 (i32.eq
                   (get_local $9)
-                  (get_local $3)
+                  (get_local $1)
                 )
                 (block
                   (i32.store
@@ -7277,12 +7277,12 @@
                 )
               )
               (i32.store offset=12
-                (get_local $3)
+                (get_local $1)
                 (get_local $9)
               )
               (i32.store
                 (get_local $16)
-                (get_local $3)
+                (get_local $1)
               )
             )
           )
@@ -7321,7 +7321,7 @@
         )
       )
     )
-    (set_local $4
+    (set_local $3
       (i32.shr_u
         (get_local $0)
         (i32.const 3)
@@ -7338,7 +7338,7 @@
             (i32.const 216)
             (i32.shl
               (i32.shl
-                (get_local $4)
+                (get_local $3)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -7355,7 +7355,7 @@
             (tee_local $6
               (i32.shl
                 (i32.const 1)
-                (get_local $4)
+                (get_local $3)
               )
             )
           )
@@ -7363,7 +7363,7 @@
             (i32.lt_u
               (tee_local $16
                 (i32.load
-                  (tee_local $4
+                  (tee_local $3
                     (i32.add
                       (get_local $1)
                       (i32.const 8)
@@ -7378,7 +7378,7 @@
             (call $_abort)
             (block
               (set_local $15
-                (get_local $4)
+                (get_local $3)
               )
               (set_local $13
                 (get_local $16)
@@ -7427,7 +7427,7 @@
       (i32.add
         (i32.const 480)
         (i32.shl
-          (tee_local $4
+          (tee_local $3
             (if i32
               (tee_local $1
                 (i32.shr_u
@@ -7530,7 +7530,7 @@
     )
     (i32.store offset=28
       (get_local $2)
-      (get_local $4)
+      (get_local $3)
     )
     (i32.store offset=20
       (get_local $2)
@@ -7550,7 +7550,7 @@
         (tee_local $6
           (i32.shl
             (i32.const 1)
-            (get_local $4)
+            (get_local $3)
           )
         )
       )
@@ -7563,12 +7563,12 @@
               (i32.sub
                 (i32.const 25)
                 (i32.shr_u
-                  (get_local $4)
+                  (get_local $3)
                   (i32.const 1)
                 )
               )
               (i32.eq
-                (get_local $4)
+                (get_local $3)
                 (i32.const 31)
               )
             )
@@ -7602,7 +7602,7 @@
               )
             )
             (if
-              (tee_local $4
+              (tee_local $3
                 (i32.load
                   (tee_local $16
                     (i32.add
@@ -7629,7 +7629,7 @@
                   )
                 )
                 (set_local $1
-                  (get_local $4)
+                  (get_local $3)
                 )
                 (br $while-in15)
               )

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -144,16 +144,16 @@
         (block
           (if
             (i32.and
-              (tee_local $1
+              (tee_local $2
                 (i32.shr_u
-                  (tee_local $16
+                  (tee_local $15
                     (i32.load
                       (i32.const 176)
                     )
                   )
                   (tee_local $6
                     (i32.shr_u
-                      (tee_local $8
+                      (tee_local $9
                         (select
                           (i32.const 16)
                           (i32.and
@@ -177,24 +177,24 @@
               (i32.const 3)
             )
             (block
-              (set_local $1
+              (set_local $2
                 (i32.load
                   (tee_local $17
                     (i32.add
-                      (tee_local $3
+                      (tee_local $0
                         (i32.load
                           (tee_local $7
                             (i32.add
-                              (tee_local $0
+                              (tee_local $1
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (tee_local $11
+                                      (tee_local $6
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $1)
+                                              (get_local $2)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
@@ -220,13 +220,13 @@
               )
               (if
                 (i32.ne
-                  (get_local $0)
                   (get_local $1)
+                  (get_local $2)
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $2)
                       (i32.load
                         (i32.const 192)
                       )
@@ -236,23 +236,23 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $5
+                        (tee_local $8
                           (i32.add
-                            (get_local $1)
+                            (get_local $2)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $3)
+                      (get_local $0)
                     )
                     (block
                       (i32.store
-                        (get_local $5)
-                        (get_local $0)
+                        (get_local $8)
+                        (get_local $1)
                       )
                       (i32.store
                         (get_local $7)
-                        (get_local $1)
+                        (get_local $2)
                       )
                     )
                     (call $_abort)
@@ -261,11 +261,11 @@
                 (i32.store
                   (i32.const 176)
                   (i32.and
-                    (get_local $16)
+                    (get_local $15)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $11)
+                        (get_local $6)
                       )
                       (i32.const -1)
                     )
@@ -273,11 +273,11 @@
                 )
               )
               (i32.store offset=4
-                (get_local $3)
+                (get_local $0)
                 (i32.or
-                  (tee_local $1
+                  (tee_local $2
                     (i32.shl
-                      (get_local $11)
+                      (get_local $6)
                       (i32.const 3)
                     )
                   )
@@ -288,8 +288,8 @@
                 (tee_local $7
                   (i32.add
                     (i32.add
-                      (get_local $3)
-                      (get_local $1)
+                      (get_local $0)
+                      (get_local $2)
                     )
                     (i32.const 4)
                   )
@@ -308,7 +308,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $8)
+              (get_local $9)
               (tee_local $7
                 (i32.load
                   (i32.const 184)
@@ -317,22 +317,22 @@
             )
             (block
               (if
-                (get_local $1)
+                (get_local $2)
                 (block
-                  (set_local $0
+                  (set_local $1
                     (i32.and
                       (i32.shr_u
-                        (tee_local $1
+                        (tee_local $2
                           (i32.add
                             (i32.and
-                              (tee_local $0
+                              (tee_local $1
                                 (i32.and
                                   (i32.shl
-                                    (get_local $1)
+                                    (get_local $2)
                                     (get_local $6)
                                   )
                                   (i32.or
-                                    (tee_local $1
+                                    (tee_local $2
                                       (i32.shl
                                         (i32.const 2)
                                         (get_local $6)
@@ -340,14 +340,14 @@
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $1)
+                                      (get_local $2)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $0)
+                                (get_local $1)
                               )
                             )
                             (i32.const -1)
@@ -358,32 +358,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $0
+                  (set_local $1
                     (i32.load
-                      (tee_local $5
+                      (tee_local $8
                         (i32.add
-                          (tee_local $3
+                          (tee_local $0
                             (i32.load
                               (tee_local $19
                                 (i32.add
-                                  (tee_local $10
+                                  (tee_local $11
                                     (i32.add
                                       (i32.const 216)
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $11
+                                          (tee_local $10
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $1
+                                                      (tee_local $2
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $5
+                                                            (tee_local $8
                                                               (i32.shr_u
+                                                                (get_local $2)
                                                                 (get_local $1)
-                                                                (get_local $0)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -391,15 +391,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $0)
+                                                      (get_local $1)
                                                     )
-                                                    (tee_local $5
+                                                    (tee_local $8
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (tee_local $3
+                                                          (tee_local $0
                                                             (i32.shr_u
-                                                              (get_local $5)
-                                                              (get_local $1)
+                                                              (get_local $8)
+                                                              (get_local $2)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -408,13 +408,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (tee_local $3
+                                                  (tee_local $0
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (tee_local $10
+                                                        (tee_local $11
                                                           (i32.shr_u
-                                                            (get_local $3)
-                                                            (get_local $5)
+                                                            (get_local $0)
+                                                            (get_local $8)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -423,13 +423,13 @@
                                                     )
                                                   )
                                                 )
-                                                (tee_local $10
+                                                (tee_local $11
                                                   (i32.and
                                                     (i32.shr_u
                                                       (tee_local $19
                                                         (i32.shr_u
-                                                          (get_local $10)
-                                                          (get_local $3)
+                                                          (get_local $11)
+                                                          (get_local $0)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -440,7 +440,7 @@
                                               )
                                               (i32.shr_u
                                                 (get_local $19)
-                                                (get_local $10)
+                                                (get_local $11)
                                               )
                                             )
                                           )
@@ -462,13 +462,13 @@
                   )
                   (if
                     (i32.ne
-                      (get_local $10)
-                      (get_local $0)
+                      (get_local $11)
+                      (get_local $1)
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $0)
+                          (get_local $1)
                           (i32.load
                             (i32.const 192)
                           )
@@ -478,23 +478,23 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $1
+                            (tee_local $2
                               (i32.add
-                                (get_local $0)
+                                (get_local $1)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $3)
+                          (get_local $0)
                         )
                         (block
                           (i32.store
-                            (get_local $1)
-                            (get_local $10)
+                            (get_local $2)
+                            (get_local $11)
                           )
                           (i32.store
                             (get_local $19)
-                            (get_local $0)
+                            (get_local $1)
                           )
                           (set_local $17
                             (i32.load
@@ -509,11 +509,11 @@
                       (i32.store
                         (i32.const 176)
                         (i32.and
-                          (get_local $16)
+                          (get_local $15)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $11)
+                              (get_local $10)
                             )
                             (i32.const -1)
                           )
@@ -525,27 +525,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $3)
+                    (get_local $0)
                     (i32.or
-                      (get_local $8)
+                      (get_local $9)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $16
+                    (tee_local $15
                       (i32.add
-                        (get_local $3)
-                        (get_local $8)
+                        (get_local $0)
+                        (get_local $9)
                       )
                     )
                     (i32.or
                       (tee_local $7
                         (i32.sub
                           (i32.shl
-                            (get_local $11)
+                            (get_local $10)
                             (i32.const 3)
                           )
-                          (get_local $8)
+                          (get_local $9)
                         )
                       )
                       (i32.const 1)
@@ -553,7 +553,7 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $16)
+                      (get_local $15)
                       (get_local $7)
                     )
                     (get_local $7)
@@ -561,12 +561,12 @@
                   (if
                     (get_local $17)
                     (block
-                      (set_local $0
+                      (set_local $1
                         (i32.load
                           (i32.const 196)
                         )
                       )
-                      (set_local $10
+                      (set_local $11
                         (i32.add
                           (i32.const 216)
                           (i32.shl
@@ -590,7 +590,7 @@
                               (i32.const 176)
                             )
                           )
-                          (tee_local $1
+                          (tee_local $2
                             (i32.shl
                               (i32.const 1)
                               (get_local $19)
@@ -603,7 +603,7 @@
                               (i32.load
                                 (tee_local $19
                                   (i32.add
-                                    (get_local $10)
+                                    (get_local $11)
                                     (i32.const 8)
                                   )
                                 )
@@ -628,35 +628,35 @@
                             (i32.const 176)
                             (i32.or
                               (get_local $6)
-                              (get_local $1)
+                              (get_local $2)
                             )
                           )
                           (set_local $38
                             (i32.add
-                              (get_local $10)
+                              (get_local $11)
                               (i32.const 8)
                             )
                           )
                           (set_local $31
-                            (get_local $10)
+                            (get_local $11)
                           )
                         )
                       )
                       (i32.store
                         (get_local $38)
-                        (get_local $0)
+                        (get_local $1)
                       )
                       (i32.store offset=12
                         (get_local $31)
-                        (get_local $0)
+                        (get_local $1)
                       )
                       (i32.store offset=8
-                        (get_local $0)
+                        (get_local $1)
                         (get_local $31)
                       )
                       (i32.store offset=12
-                        (get_local $0)
-                        (get_local $10)
+                        (get_local $1)
+                        (get_local $11)
                       )
                     )
                   )
@@ -666,30 +666,30 @@
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $16)
+                    (get_local $15)
                   )
                   (return
-                    (get_local $5)
+                    (get_local $8)
                   )
                 )
               )
               (if
-                (tee_local $16
+                (tee_local $15
                   (i32.load
                     (i32.const 180)
                   )
                 )
                 (block
-                  (set_local $16
+                  (set_local $15
                     (i32.and
                       (i32.shr_u
                         (tee_local $7
                           (i32.add
                             (i32.and
-                              (get_local $16)
+                              (get_local $15)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $16)
+                                (get_local $15)
                               )
                             )
                             (i32.const -1)
@@ -700,7 +700,7 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $1
+                  (set_local $2
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
@@ -715,10 +715,10 @@
                                           (tee_local $7
                                             (i32.and
                                               (i32.shr_u
-                                                (tee_local $10
+                                                (tee_local $11
                                                   (i32.shr_u
                                                     (get_local $7)
-                                                    (get_local $16)
+                                                    (get_local $15)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -726,14 +726,14 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $16)
+                                          (get_local $15)
                                         )
-                                        (tee_local $10
+                                        (tee_local $11
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $0
+                                              (tee_local $1
                                                 (i32.shr_u
-                                                  (get_local $10)
+                                                  (get_local $11)
                                                   (get_local $7)
                                                 )
                                               )
@@ -743,13 +743,13 @@
                                           )
                                         )
                                       )
-                                      (tee_local $0
+                                      (tee_local $1
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $1
+                                            (tee_local $2
                                               (i32.shr_u
-                                                (get_local $0)
-                                                (get_local $10)
+                                                (get_local $1)
+                                                (get_local $11)
                                               )
                                             )
                                             (i32.const 1)
@@ -758,13 +758,13 @@
                                         )
                                       )
                                     )
-                                    (tee_local $1
+                                    (tee_local $2
                                       (i32.and
                                         (i32.shr_u
                                           (tee_local $6
                                             (i32.shr_u
+                                              (get_local $2)
                                               (get_local $1)
-                                              (get_local $0)
                                             )
                                           )
                                           (i32.const 1)
@@ -775,7 +775,7 @@
                                   )
                                   (i32.shr_u
                                     (get_local $6)
-                                    (get_local $1)
+                                    (get_local $2)
                                   )
                                 )
                                 (i32.const 2)
@@ -785,13 +785,13 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $8)
+                      (get_local $9)
                     )
                   )
                   (set_local $6
                     (get_local $17)
                   )
-                  (set_local $0
+                  (set_local $1
                     (get_local $17)
                   )
                   (loop $while-in
@@ -802,60 +802,60 @@
                             (get_local $6)
                           )
                         )
-                        (set_local $3
+                        (set_local $0
                           (get_local $17)
                         )
                         (if
-                          (tee_local $10
+                          (tee_local $11
                             (i32.load offset=20
                               (get_local $6)
                             )
                           )
-                          (set_local $3
-                            (get_local $10)
+                          (set_local $0
+                            (get_local $11)
                           )
                           (block
-                            (set_local $7
-                              (get_local $1)
+                            (set_local $3
+                              (get_local $2)
                             )
-                            (set_local $2
-                              (get_local $0)
+                            (set_local $5
+                              (get_local $1)
                             )
                             (br $while-out)
                           )
                         )
                       )
-                      (set_local $10
+                      (set_local $11
                         (i32.lt_u
                           (tee_local $17
                             (i32.sub
                               (i32.and
                                 (i32.load offset=4
-                                  (get_local $3)
+                                  (get_local $0)
                                 )
                                 (i32.const -8)
                               )
-                              (get_local $8)
+                              (get_local $9)
                             )
                           )
-                          (get_local $1)
+                          (get_local $2)
                         )
                       )
-                      (set_local $1
+                      (set_local $2
                         (select
                           (get_local $17)
-                          (get_local $1)
-                          (get_local $10)
+                          (get_local $2)
+                          (get_local $11)
                         )
                       )
                       (set_local $6
-                        (get_local $3)
+                        (get_local $0)
                       )
-                      (set_local $0
+                      (set_local $1
                         (select
-                          (get_local $3)
                           (get_local $0)
-                          (get_local $10)
+                          (get_local $1)
+                          (get_local $11)
                         )
                       )
                       (br $while-in)
@@ -863,8 +863,8 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $2)
-                      (tee_local $0
+                      (get_local $5)
+                      (tee_local $1
                         (i32.load
                           (i32.const 192)
                         )
@@ -874,38 +874,38 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $2)
+                      (get_local $5)
                       (tee_local $6
                         (i32.add
-                          (get_local $2)
-                          (get_local $8)
+                          (get_local $5)
+                          (get_local $9)
                         )
                       )
                     )
                     (call $_abort)
                   )
-                  (set_local $1
+                  (set_local $2
                     (i32.load offset=24
-                      (get_local $2)
+                      (get_local $5)
                     )
                   )
                   (block $do-once4
                     (if
                       (i32.eq
-                        (tee_local $5
+                        (tee_local $8
                           (i32.load offset=12
-                            (get_local $2)
+                            (get_local $5)
                           )
                         )
-                        (get_local $2)
+                        (get_local $5)
                       )
                       (block
                         (if
-                          (tee_local $11
+                          (tee_local $10
                             (i32.load
-                              (tee_local $3
+                              (tee_local $0
                                 (i32.add
-                                  (get_local $2)
+                                  (get_local $5)
                                   (i32.const 20)
                                 )
                               )
@@ -913,25 +913,25 @@
                           )
                           (block
                             (set_local $17
-                              (get_local $11)
+                              (get_local $10)
                             )
-                            (set_local $9
-                              (get_local $3)
+                            (set_local $7
+                              (get_local $0)
                             )
                           )
                           (if
                             (tee_local $17
                               (i32.load
-                                (tee_local $10
+                                (tee_local $11
                                   (i32.add
-                                    (get_local $2)
+                                    (get_local $5)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
-                            (set_local $9
-                              (get_local $10)
+                            (set_local $7
+                              (get_local $11)
                             )
                             (block
                               (set_local $19
@@ -943,9 +943,9 @@
                         )
                         (loop $while-in7
                           (if
-                            (tee_local $11
+                            (tee_local $10
                               (i32.load
-                                (tee_local $3
+                                (tee_local $0
                                   (i32.add
                                     (get_local $17)
                                     (i32.const 20)
@@ -955,18 +955,18 @@
                             )
                             (block
                               (set_local $17
-                                (get_local $11)
+                                (get_local $10)
                               )
-                              (set_local $9
-                                (get_local $3)
+                              (set_local $7
+                                (get_local $0)
                               )
                               (br $while-in7)
                             )
                           )
                           (if
-                            (tee_local $11
+                            (tee_local $10
                               (i32.load
-                                (tee_local $3
+                                (tee_local $0
                                   (i32.add
                                     (get_local $17)
                                     (i32.const 16)
@@ -976,10 +976,10 @@
                             )
                             (block
                               (set_local $17
-                                (get_local $11)
+                                (get_local $10)
                               )
-                              (set_local $9
-                                (get_local $3)
+                              (set_local $7
+                                (get_local $0)
                               )
                               (br $while-in7)
                             )
@@ -987,13 +987,13 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $9)
-                            (get_local $0)
+                            (get_local $7)
+                            (get_local $1)
                           )
                           (call $_abort)
                           (block
                             (i32.store
-                              (get_local $9)
+                              (get_local $7)
                               (i32.const 0)
                             )
                             (set_local $19
@@ -1005,52 +1005,52 @@
                       (block
                         (if
                           (i32.lt_u
-                            (tee_local $3
+                            (tee_local $0
                               (i32.load offset=8
-                                (get_local $2)
+                                (get_local $5)
                               )
                             )
-                            (get_local $0)
+                            (get_local $1)
                           )
                           (call $_abort)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (tee_local $11
+                              (tee_local $10
                                 (i32.add
-                                  (get_local $3)
+                                  (get_local $0)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $2)
+                            (get_local $5)
                           )
                           (call $_abort)
                         )
                         (if
                           (i32.eq
                             (i32.load
-                              (tee_local $10
+                              (tee_local $11
                                 (i32.add
-                                  (get_local $5)
+                                  (get_local $8)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $2)
+                            (get_local $5)
                           )
                           (block
                             (i32.store
-                              (get_local $11)
-                              (get_local $5)
+                              (get_local $10)
+                              (get_local $8)
                             )
                             (i32.store
-                              (get_local $10)
-                              (get_local $3)
+                              (get_local $11)
+                              (get_local $0)
                             )
                             (set_local $19
-                              (get_local $5)
+                              (get_local $8)
                             )
                           )
                           (call $_abort)
@@ -1060,19 +1060,19 @@
                   )
                   (block $do-once8
                     (if
-                      (get_local $1)
+                      (get_local $2)
                       (block
                         (if
                           (i32.eq
-                            (get_local $2)
+                            (get_local $5)
                             (i32.load
-                              (tee_local $0
+                              (tee_local $1
                                 (i32.add
                                   (i32.const 480)
                                   (i32.shl
-                                    (tee_local $5
+                                    (tee_local $8
                                       (i32.load offset=28
-                                        (get_local $2)
+                                        (get_local $5)
                                       )
                                     )
                                     (i32.const 2)
@@ -1083,7 +1083,7 @@
                           )
                           (block
                             (i32.store
-                              (get_local $0)
+                              (get_local $1)
                               (get_local $19)
                             )
                             (if
@@ -1100,7 +1100,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $5)
+                                        (get_local $8)
                                       )
                                       (i32.const -1)
                                     )
@@ -1113,7 +1113,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $1)
+                                (get_local $2)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -1123,21 +1123,21 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $5
+                                  (tee_local $8
                                     (i32.add
-                                      (get_local $1)
+                                      (get_local $2)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $2)
+                                (get_local $5)
                               )
                               (i32.store
-                                (get_local $5)
+                                (get_local $8)
                                 (get_local $19)
                               )
                               (i32.store offset=20
-                                (get_local $1)
+                                (get_local $2)
                                 (get_local $19)
                               )
                             )
@@ -1151,7 +1151,7 @@
                         (if
                           (i32.lt_u
                             (get_local $19)
-                            (tee_local $5
+                            (tee_local $8
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1161,41 +1161,41 @@
                         )
                         (i32.store offset=24
                           (get_local $19)
-                          (get_local $1)
+                          (get_local $2)
                         )
                         (if
-                          (tee_local $0
+                          (tee_local $1
                             (i32.load offset=16
-                              (get_local $2)
+                              (get_local $5)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $0)
-                              (get_local $5)
+                              (get_local $1)
+                              (get_local $8)
                             )
                             (call $_abort)
                             (block
                               (i32.store offset=16
                                 (get_local $19)
-                                (get_local $0)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $0)
+                                (get_local $1)
                                 (get_local $19)
                               )
                             )
                           )
                         )
                         (if
-                          (tee_local $0
+                          (tee_local $1
                             (i32.load offset=20
-                              (get_local $2)
+                              (get_local $5)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $0)
+                              (get_local $1)
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1204,10 +1204,10 @@
                             (block
                               (i32.store offset=20
                                 (get_local $19)
-                                (get_local $0)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $0)
+                                (get_local $1)
                                 (get_local $19)
                               )
                             )
@@ -1218,35 +1218,35 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $3)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $2)
+                        (get_local $5)
                         (i32.or
-                          (tee_local $1
+                          (tee_local $2
                             (i32.add
-                              (get_local $7)
-                              (get_local $8)
+                              (get_local $3)
+                              (get_local $9)
                             )
                           )
                           (i32.const 3)
                         )
                       )
                       (i32.store
-                        (tee_local $0
+                        (tee_local $1
                           (i32.add
                             (i32.add
+                              (get_local $5)
                               (get_local $2)
-                              (get_local $1)
                             )
                             (i32.const 4)
                           )
                         )
                         (i32.or
                           (i32.load
-                            (get_local $0)
+                            (get_local $1)
                           )
                           (i32.const 1)
                         )
@@ -1254,46 +1254,46 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $2)
+                        (get_local $5)
                         (i32.or
-                          (get_local $8)
+                          (get_local $9)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
                         (get_local $6)
                         (i32.or
-                          (get_local $7)
+                          (get_local $3)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
                           (get_local $6)
-                          (get_local $7)
+                          (get_local $3)
                         )
-                        (get_local $7)
+                        (get_local $3)
                       )
                       (if
-                        (tee_local $0
+                        (tee_local $1
                           (i32.load
                             (i32.const 184)
                           )
                         )
                         (block
-                          (set_local $1
+                          (set_local $2
                             (i32.load
                               (i32.const 196)
                             )
                           )
-                          (set_local $0
+                          (set_local $1
                             (i32.add
                               (i32.const 216)
                               (i32.shl
                                 (i32.shl
-                                  (tee_local $5
+                                  (tee_local $8
                                     (i32.shr_u
-                                      (get_local $0)
+                                      (get_local $1)
                                       (i32.const 3)
                                     )
                                   )
@@ -1305,25 +1305,25 @@
                           )
                           (if
                             (i32.and
-                              (tee_local $3
+                              (tee_local $0
                                 (i32.load
                                   (i32.const 176)
                                 )
                               )
-                              (tee_local $10
+                              (tee_local $11
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $5)
+                                  (get_local $8)
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (tee_local $11
+                                (tee_local $10
                                   (i32.load
-                                    (tee_local $5
+                                    (tee_local $8
                                       (i32.add
-                                        (get_local $0)
+                                        (get_local $1)
                                         (i32.const 8)
                                       )
                                     )
@@ -1336,10 +1336,10 @@
                               (call $_abort)
                               (block
                                 (set_local $39
-                                  (get_local $5)
+                                  (get_local $8)
                                 )
                                 (set_local $32
-                                  (get_local $11)
+                                  (get_local $10)
                                 )
                               )
                             )
@@ -1347,42 +1347,42 @@
                               (i32.store
                                 (i32.const 176)
                                 (i32.or
-                                  (get_local $3)
-                                  (get_local $10)
+                                  (get_local $0)
+                                  (get_local $11)
                                 )
                               )
                               (set_local $39
                                 (i32.add
-                                  (get_local $0)
+                                  (get_local $1)
                                   (i32.const 8)
                                 )
                               )
                               (set_local $32
-                                (get_local $0)
+                                (get_local $1)
                               )
                             )
                           )
                           (i32.store
                             (get_local $39)
-                            (get_local $1)
+                            (get_local $2)
                           )
                           (i32.store offset=12
                             (get_local $32)
-                            (get_local $1)
+                            (get_local $2)
                           )
                           (i32.store offset=8
-                            (get_local $1)
+                            (get_local $2)
                             (get_local $32)
                           )
                           (i32.store offset=12
+                            (get_local $2)
                             (get_local $1)
-                            (get_local $0)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $7)
+                        (get_local $3)
                       )
                       (i32.store
                         (i32.const 196)
@@ -1392,7 +1392,7 @@
                   )
                   (return
                     (i32.add
-                      (get_local $2)
+                      (get_local $5)
                       (i32.const 8)
                     )
                   )
@@ -1407,9 +1407,9 @@
             (i32.const -65)
           )
           (block
-            (set_local $1
+            (set_local $2
               (i32.and
-                (tee_local $0
+                (tee_local $1
                   (i32.add
                     (get_local $0)
                     (i32.const 11)
@@ -1419,60 +1419,60 @@
               )
             )
             (if
-              (tee_local $10
+              (tee_local $11
                 (i32.load
                   (i32.const 180)
                 )
               )
               (block
-                (set_local $3
+                (set_local $0
                   (i32.sub
                     (i32.const 0)
-                    (get_local $1)
+                    (get_local $2)
                   )
                 )
                 (block $label$break$L123
                   (if
-                    (tee_local $16
+                    (tee_local $15
                       (i32.load offset=480
                         (i32.shl
-                          (tee_local $8
+                          (tee_local $9
                             (if i32
-                              (tee_local $11
+                              (tee_local $10
                                 (i32.shr_u
-                                  (get_local $0)
+                                  (get_local $1)
                                   (i32.const 8)
                                 )
                               )
                               (if i32
                                 (i32.gt_u
-                                  (get_local $1)
+                                  (get_local $2)
                                   (i32.const 16777215)
                                 )
                                 (i32.const 31)
                                 (i32.or
                                   (i32.and
                                     (i32.shr_u
-                                      (get_local $1)
+                                      (get_local $2)
                                       (i32.add
-                                        (tee_local $16
+                                        (tee_local $15
                                           (i32.add
                                             (i32.sub
                                               (i32.const 14)
                                               (i32.or
                                                 (i32.or
-                                                  (tee_local $11
+                                                  (tee_local $10
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $5
+                                                          (tee_local $8
                                                             (i32.shl
-                                                              (get_local $11)
-                                                              (tee_local $0
+                                                              (get_local $10)
+                                                              (tee_local $1
                                                                 (i32.and
                                                                   (i32.shr_u
                                                                     (i32.add
-                                                                      (get_local $11)
+                                                                      (get_local $10)
                                                                       (i32.const 1048320)
                                                                     )
                                                                     (i32.const 16)
@@ -1489,16 +1489,16 @@
                                                       (i32.const 4)
                                                     )
                                                   )
-                                                  (get_local $0)
+                                                  (get_local $1)
                                                 )
-                                                (tee_local $5
+                                                (tee_local $8
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
                                                         (tee_local $17
                                                           (i32.shl
-                                                            (get_local $5)
-                                                            (get_local $11)
+                                                            (get_local $8)
+                                                            (get_local $10)
                                                           )
                                                         )
                                                         (i32.const 245760)
@@ -1513,7 +1513,7 @@
                                             (i32.shr_u
                                               (i32.shl
                                                 (get_local $17)
-                                                (get_local $5)
+                                                (get_local $8)
                                               )
                                               (i32.const 15)
                                             )
@@ -1525,7 +1525,7 @@
                                     (i32.const 1)
                                   )
                                   (i32.shl
-                                    (get_local $16)
+                                    (get_local $15)
                                     (i32.const 1)
                                   )
                                 )
@@ -1538,33 +1538,33 @@
                       )
                     )
                     (block
-                      (set_local $5
-                        (get_local $3)
+                      (set_local $8
+                        (get_local $0)
                       )
                       (set_local $17
                         (i32.const 0)
                       )
-                      (set_local $0
+                      (set_local $1
                         (i32.shl
-                          (get_local $1)
+                          (get_local $2)
                           (select
                             (i32.const 0)
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $8)
+                                (get_local $9)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $8)
+                              (get_local $9)
                               (i32.const 31)
                             )
                           )
                         )
                       )
-                      (set_local $11
-                        (get_local $16)
+                      (set_local $10
+                        (get_local $15)
                       )
                       (set_local $7
                         (i32.const 0)
@@ -1572,47 +1572,47 @@
                       (loop $while-in14
                         (if
                           (i32.lt_u
-                            (tee_local $3
+                            (tee_local $0
                               (i32.sub
                                 (tee_local $19
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $11)
+                                      (get_local $10)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $1)
+                                (get_local $2)
                               )
                             )
-                            (get_local $5)
+                            (get_local $8)
                           )
                           (if
                             (i32.eq
                               (get_local $19)
-                              (get_local $1)
+                              (get_local $2)
                             )
                             (block
                               (set_local $27
-                                (get_local $3)
+                                (get_local $0)
                               )
                               (set_local $25
-                                (get_local $11)
+                                (get_local $10)
                               )
                               (set_local $29
-                                (get_local $11)
+                                (get_local $10)
                               )
-                              (set_local $5
+                              (set_local $8
                                 (i32.const 90)
                               )
                               (br $label$break$L123)
                             )
                             (block
-                              (set_local $5
-                                (get_local $3)
+                              (set_local $8
+                                (get_local $0)
                               )
                               (set_local $7
-                                (get_local $11)
+                                (get_local $10)
                               )
                             )
                           )
@@ -1620,27 +1620,27 @@
                         (set_local $19
                           (select
                             (get_local $17)
-                            (tee_local $3
+                            (tee_local $0
                               (i32.load offset=20
-                                (get_local $11)
+                                (get_local $10)
                               )
                             )
                             (i32.or
                               (i32.eqz
-                                (get_local $3)
+                                (get_local $0)
                               )
                               (i32.eq
-                                (get_local $3)
-                                (tee_local $11
+                                (get_local $0)
+                                (tee_local $10
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $11)
+                                        (get_local $10)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $0)
+                                          (get_local $1)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -1653,14 +1653,14 @@
                           )
                         )
                         (if
-                          (tee_local $3
+                          (tee_local $0
                             (i32.eqz
-                              (get_local $11)
+                              (get_local $10)
                             )
                           )
                           (block
                             (set_local $33
-                              (get_local $5)
+                              (get_local $8)
                             )
                             (set_local $6
                               (get_local $19)
@@ -1668,7 +1668,7 @@
                             (set_local $30
                               (get_local $7)
                             )
-                            (set_local $5
+                            (set_local $8
                               (i32.const 86)
                             )
                           )
@@ -1676,12 +1676,12 @@
                             (set_local $17
                               (get_local $19)
                             )
-                            (set_local $0
+                            (set_local $1
                               (i32.shl
-                                (get_local $0)
+                                (get_local $1)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $3)
+                                    (get_local $0)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
@@ -1695,7 +1695,7 @@
                     )
                     (block
                       (set_local $33
-                        (get_local $3)
+                        (get_local $0)
                       )
                       (set_local $6
                         (i32.const 0)
@@ -1703,7 +1703,7 @@
                       (set_local $30
                         (i32.const 0)
                       )
-                      (set_local $5
+                      (set_local $8
                         (i32.const 86)
                       )
                     )
@@ -1711,7 +1711,7 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $5)
+                    (get_local $8)
                     (i32.const 86)
                   )
                   (if
@@ -1728,41 +1728,41 @@
                         (block i32
                           (if
                             (i32.eqz
-                              (tee_local $3
+                              (tee_local $0
                                 (i32.and
-                                  (get_local $10)
+                                  (get_local $11)
                                   (i32.or
-                                    (tee_local $16
+                                    (tee_local $15
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $8)
+                                        (get_local $9)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $16)
+                                      (get_local $15)
                                     )
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $8
-                                (get_local $1)
+                              (set_local $9
+                                (get_local $2)
                               )
                               (br $do-once)
                             )
                           )
-                          (set_local $3
+                          (set_local $0
                             (i32.and
                               (i32.shr_u
-                                (tee_local $16
+                                (tee_local $15
                                   (i32.add
                                     (i32.and
-                                      (get_local $3)
+                                      (get_local $0)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $3)
+                                        (get_local $0)
                                       )
                                     )
                                     (i32.const -1)
@@ -1780,13 +1780,13 @@
                                   (i32.or
                                     (i32.or
                                       (i32.or
-                                        (tee_local $16
+                                        (tee_local $15
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $8
+                                              (tee_local $9
                                                 (i32.shr_u
-                                                  (get_local $16)
-                                                  (get_local $3)
+                                                  (get_local $15)
+                                                  (get_local $0)
                                                 )
                                               )
                                               (i32.const 5)
@@ -1794,15 +1794,15 @@
                                             (i32.const 8)
                                           )
                                         )
-                                        (get_local $3)
+                                        (get_local $0)
                                       )
-                                      (tee_local $8
+                                      (tee_local $9
                                         (i32.and
                                           (i32.shr_u
                                             (tee_local $6
                                               (i32.shr_u
-                                                (get_local $8)
-                                                (get_local $16)
+                                                (get_local $9)
+                                                (get_local $15)
                                               )
                                             )
                                             (i32.const 2)
@@ -1817,7 +1817,7 @@
                                           (tee_local $7
                                             (i32.shr_u
                                               (get_local $6)
-                                              (get_local $8)
+                                              (get_local $9)
                                             )
                                           )
                                           (i32.const 1)
@@ -1829,7 +1829,7 @@
                                   (tee_local $7
                                     (i32.and
                                       (i32.shr_u
-                                        (tee_local $0
+                                        (tee_local $1
                                           (i32.shr_u
                                             (get_local $7)
                                             (get_local $6)
@@ -1842,7 +1842,7 @@
                                   )
                                 )
                                 (i32.shr_u
-                                  (get_local $0)
+                                  (get_local $1)
                                   (get_local $7)
                                 )
                               )
@@ -1863,7 +1863,7 @@
                       (set_local $29
                         (get_local $30)
                       )
-                      (set_local $5
+                      (set_local $8
                         (i32.const 90)
                       )
                     )
@@ -1879,14 +1879,14 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $5)
+                    (get_local $8)
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $5
+                    (set_local $8
                       (i32.const 0)
                     )
-                    (set_local $0
+                    (set_local $1
                       (i32.lt_u
                         (tee_local $7
                           (i32.sub
@@ -1896,7 +1896,7 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $1)
+                            (get_local $2)
                           )
                         )
                         (get_local $27)
@@ -1906,18 +1906,18 @@
                       (select
                         (get_local $7)
                         (get_local $27)
-                        (get_local $0)
+                        (get_local $1)
                       )
                     )
                     (set_local $7
                       (select
                         (get_local $25)
                         (get_local $29)
-                        (get_local $0)
+                        (get_local $1)
                       )
                     )
                     (if
-                      (tee_local $0
+                      (tee_local $1
                         (i32.load offset=16
                           (get_local $25)
                         )
@@ -1927,7 +1927,7 @@
                           (get_local $6)
                         )
                         (set_local $25
-                          (get_local $0)
+                          (get_local $1)
                         )
                         (set_local $29
                           (get_local $7)
@@ -1969,7 +1969,7 @@
                         (i32.load
                           (i32.const 184)
                         )
-                        (get_local $1)
+                        (get_local $2)
                       )
                     )
                     (i32.const 0)
@@ -1982,7 +1982,7 @@
                     (if
                       (i32.lt_u
                         (get_local $12)
-                        (tee_local $10
+                        (tee_local $11
                           (i32.load
                             (i32.const 192)
                           )
@@ -1996,7 +1996,7 @@
                         (tee_local $7
                           (i32.add
                             (get_local $12)
-                            (get_local $1)
+                            (get_local $2)
                           )
                         )
                       )
@@ -2010,7 +2010,7 @@
                     (block $do-once17
                       (if
                         (i32.eq
-                          (tee_local $0
+                          (tee_local $1
                             (i32.load offset=12
                               (get_local $12)
                             )
@@ -2019,9 +2019,9 @@
                         )
                         (block
                           (if
-                            (tee_local $3
+                            (tee_local $0
                               (i32.load
-                                (tee_local $8
+                                (tee_local $9
                                   (i32.add
                                     (get_local $12)
                                     (i32.const 20)
@@ -2031,16 +2031,16 @@
                             )
                             (block
                               (set_local $17
-                                (get_local $3)
+                                (get_local $0)
                               )
-                              (set_local $0
-                                (get_local $8)
+                              (set_local $1
+                                (get_local $9)
                               )
                             )
                             (if
                               (tee_local $17
                                 (i32.load
-                                  (tee_local $16
+                                  (tee_local $15
                                     (i32.add
                                       (get_local $12)
                                       (i32.const 16)
@@ -2048,11 +2048,11 @@
                                   )
                                 )
                               )
-                              (set_local $0
-                                (get_local $16)
+                              (set_local $1
+                                (get_local $15)
                               )
                               (block
-                                (set_local $9
+                                (set_local $5
                                   (i32.const 0)
                                 )
                                 (br $do-once17)
@@ -2061,9 +2061,9 @@
                           )
                           (loop $while-in20
                             (if
-                              (tee_local $3
+                              (tee_local $0
                                 (i32.load
-                                  (tee_local $8
+                                  (tee_local $9
                                     (i32.add
                                       (get_local $17)
                                       (i32.const 20)
@@ -2073,18 +2073,18 @@
                               )
                               (block
                                 (set_local $17
-                                  (get_local $3)
+                                  (get_local $0)
                                 )
-                                (set_local $0
-                                  (get_local $8)
+                                (set_local $1
+                                  (get_local $9)
                                 )
                                 (br $while-in20)
                               )
                             )
                             (if
-                              (tee_local $3
+                              (tee_local $0
                                 (i32.load
-                                  (tee_local $8
+                                  (tee_local $9
                                     (i32.add
                                       (get_local $17)
                                       (i32.const 16)
@@ -2094,10 +2094,10 @@
                               )
                               (block
                                 (set_local $17
-                                  (get_local $3)
+                                  (get_local $0)
                                 )
-                                (set_local $0
-                                  (get_local $8)
+                                (set_local $1
+                                  (get_local $9)
                                 )
                                 (br $while-in20)
                               )
@@ -2105,16 +2105,16 @@
                           )
                           (if
                             (i32.lt_u
-                              (get_local $0)
-                              (get_local $10)
+                              (get_local $1)
+                              (get_local $11)
                             )
                             (call $_abort)
                             (block
                               (i32.store
-                                (get_local $0)
+                                (get_local $1)
                                 (i32.const 0)
                               )
-                              (set_local $9
+                              (set_local $5
                                 (get_local $17)
                               )
                             )
@@ -2123,21 +2123,21 @@
                         (block
                           (if
                             (i32.lt_u
-                              (tee_local $8
+                              (tee_local $9
                                 (i32.load offset=8
                                   (get_local $12)
                                 )
                               )
-                              (get_local $10)
+                              (get_local $11)
                             )
                             (call $_abort)
                           )
                           (if
                             (i32.ne
                               (i32.load
-                                (tee_local $3
+                                (tee_local $0
                                   (i32.add
-                                    (get_local $8)
+                                    (get_local $9)
                                     (i32.const 12)
                                   )
                                 )
@@ -2149,9 +2149,9 @@
                           (if
                             (i32.eq
                               (i32.load
-                                (tee_local $16
+                                (tee_local $15
                                   (i32.add
-                                    (get_local $0)
+                                    (get_local $1)
                                     (i32.const 8)
                                   )
                                 )
@@ -2160,15 +2160,15 @@
                             )
                             (block
                               (i32.store
-                                (get_local $3)
                                 (get_local $0)
+                                (get_local $1)
                               )
                               (i32.store
-                                (get_local $16)
-                                (get_local $8)
+                                (get_local $15)
+                                (get_local $9)
                               )
-                              (set_local $9
-                                (get_local $0)
+                              (set_local $5
+                                (get_local $1)
                               )
                             )
                             (call $_abort)
@@ -2184,11 +2184,11 @@
                             (i32.eq
                               (get_local $12)
                               (i32.load
-                                (tee_local $10
+                                (tee_local $11
                                   (i32.add
                                     (i32.const 480)
                                     (i32.shl
-                                      (tee_local $0
+                                      (tee_local $1
                                         (i32.load offset=28
                                           (get_local $12)
                                         )
@@ -2201,12 +2201,12 @@
                             )
                             (block
                               (i32.store
-                                (get_local $10)
-                                (get_local $9)
+                                (get_local $11)
+                                (get_local $5)
                               )
                               (if
                                 (i32.eqz
-                                  (get_local $9)
+                                  (get_local $5)
                                 )
                                 (block
                                   (i32.store
@@ -2218,7 +2218,7 @@
                                       (i32.xor
                                         (i32.shl
                                           (i32.const 1)
-                                          (get_local $0)
+                                          (get_local $1)
                                         )
                                         (i32.const -1)
                                       )
@@ -2241,7 +2241,7 @@
                               (if
                                 (i32.eq
                                   (i32.load
-                                    (tee_local $0
+                                    (tee_local $1
                                       (i32.add
                                         (get_local $6)
                                         (i32.const 16)
@@ -2251,25 +2251,25 @@
                                   (get_local $12)
                                 )
                                 (i32.store
-                                  (get_local $0)
-                                  (get_local $9)
+                                  (get_local $1)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=20
                                   (get_local $6)
-                                  (get_local $9)
+                                  (get_local $5)
                                 )
                               )
                               (br_if $do-once21
                                 (i32.eqz
-                                  (get_local $9)
+                                  (get_local $5)
                                 )
                               )
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $9)
-                              (tee_local $0
+                              (get_local $5)
+                              (tee_local $1
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -2278,42 +2278,42 @@
                             (call $_abort)
                           )
                           (i32.store offset=24
-                            (get_local $9)
+                            (get_local $5)
                             (get_local $6)
                           )
                           (if
-                            (tee_local $10
+                            (tee_local $11
                               (i32.load offset=16
                                 (get_local $12)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $10)
-                                (get_local $0)
+                                (get_local $11)
+                                (get_local $1)
                               )
                               (call $_abort)
                               (block
                                 (i32.store offset=16
-                                  (get_local $9)
-                                  (get_local $10)
+                                  (get_local $5)
+                                  (get_local $11)
                                 )
                                 (i32.store offset=24
-                                  (get_local $10)
-                                  (get_local $9)
+                                  (get_local $11)
+                                  (get_local $5)
                                 )
                               )
                             )
                           )
                           (if
-                            (tee_local $10
+                            (tee_local $11
                               (i32.load offset=20
                                 (get_local $12)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $10)
+                                (get_local $11)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -2321,12 +2321,12 @@
                               (call $_abort)
                               (block
                                 (i32.store offset=20
-                                  (get_local $9)
-                                  (get_local $10)
+                                  (get_local $5)
+                                  (get_local $11)
                                 )
                                 (i32.store offset=24
-                                  (get_local $10)
-                                  (get_local $9)
+                                  (get_local $11)
+                                  (get_local $5)
                                 )
                               )
                             )
@@ -2344,7 +2344,7 @@
                           (i32.store offset=4
                             (get_local $12)
                             (i32.or
-                              (get_local $1)
+                              (get_local $2)
                               (i32.const 3)
                             )
                           )
@@ -2374,7 +2374,7 @@
                               (i32.const 256)
                             )
                             (block
-                              (set_local $10
+                              (set_local $11
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
@@ -2388,12 +2388,12 @@
                               )
                               (if
                                 (i32.and
-                                  (tee_local $0
+                                  (tee_local $1
                                     (i32.load
                                       (i32.const 176)
                                     )
                                   )
-                                  (tee_local $8
+                                  (tee_local $9
                                     (i32.shl
                                       (i32.const 1)
                                       (get_local $6)
@@ -2402,11 +2402,11 @@
                                 )
                                 (if
                                   (i32.lt_u
-                                    (tee_local $16
+                                    (tee_local $15
                                       (i32.load
                                         (tee_local $6
                                           (i32.add
-                                            (get_local $10)
+                                            (get_local $11)
                                             (i32.const 8)
                                           )
                                         )
@@ -2418,11 +2418,11 @@
                                   )
                                   (call $_abort)
                                   (block
-                                    (set_local $14
+                                    (set_local $16
                                       (get_local $6)
                                     )
                                     (set_local $26
-                                      (get_local $16)
+                                      (get_local $15)
                                     )
                                   )
                                 )
@@ -2430,23 +2430,23 @@
                                   (i32.store
                                     (i32.const 176)
                                     (i32.or
-                                      (get_local $0)
-                                      (get_local $8)
+                                      (get_local $1)
+                                      (get_local $9)
                                     )
                                   )
-                                  (set_local $14
+                                  (set_local $16
                                     (i32.add
-                                      (get_local $10)
+                                      (get_local $11)
                                       (i32.const 8)
                                     )
                                   )
                                   (set_local $26
-                                    (get_local $10)
+                                    (get_local $11)
                                   )
                                 )
                               )
                               (i32.store
-                                (get_local $14)
+                                (get_local $16)
                                 (get_local $7)
                               )
                               (i32.store offset=12
@@ -2459,7 +2459,7 @@
                               )
                               (i32.store offset=12
                                 (get_local $7)
-                                (get_local $10)
+                                (get_local $11)
                               )
                               (br $do-once25)
                             )
@@ -2468,9 +2468,9 @@
                             (i32.add
                               (i32.const 480)
                               (i32.shl
-                                (tee_local $3
+                                (tee_local $10
                                   (if i32
-                                    (tee_local $10
+                                    (tee_local $11
                                       (i32.shr_u
                                         (get_local $4)
                                         (i32.const 8)
@@ -2493,18 +2493,18 @@
                                                     (i32.const 14)
                                                     (i32.or
                                                       (i32.or
-                                                        (tee_local $10
+                                                        (tee_local $11
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $0
+                                                                (tee_local $1
                                                                   (i32.shl
-                                                                    (get_local $10)
-                                                                    (tee_local $8
+                                                                    (get_local $11)
+                                                                    (tee_local $9
                                                                       (i32.and
                                                                         (i32.shr_u
                                                                           (i32.add
-                                                                            (get_local $10)
+                                                                            (get_local $11)
                                                                             (i32.const 1048320)
                                                                           )
                                                                           (i32.const 16)
@@ -2521,16 +2521,16 @@
                                                             (i32.const 4)
                                                           )
                                                         )
-                                                        (get_local $8)
+                                                        (get_local $9)
                                                       )
-                                                      (tee_local $0
+                                                      (tee_local $1
                                                         (i32.and
                                                           (i32.shr_u
                                                             (i32.add
-                                                              (tee_local $16
+                                                              (tee_local $15
                                                                 (i32.shl
-                                                                  (get_local $0)
-                                                                  (get_local $10)
+                                                                  (get_local $1)
+                                                                  (get_local $11)
                                                                 )
                                                               )
                                                               (i32.const 245760)
@@ -2544,8 +2544,8 @@
                                                   )
                                                   (i32.shr_u
                                                     (i32.shl
-                                                      (get_local $16)
-                                                      (get_local $0)
+                                                      (get_local $15)
+                                                      (get_local $1)
                                                     )
                                                     (i32.const 15)
                                                   )
@@ -2571,10 +2571,10 @@
                           )
                           (i32.store offset=28
                             (get_local $7)
-                            (get_local $3)
+                            (get_local $10)
                           )
                           (i32.store offset=4
-                            (tee_local $0
+                            (tee_local $1
                               (i32.add
                                 (get_local $7)
                                 (i32.const 16)
@@ -2583,21 +2583,21 @@
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $0)
+                            (get_local $1)
                             (i32.const 0)
                           )
                           (if
                             (i32.eqz
                               (i32.and
-                                (tee_local $0
+                                (tee_local $1
                                   (i32.load
                                     (i32.const 180)
                                   )
                                 )
-                                (tee_local $16
+                                (tee_local $15
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $3)
+                                    (get_local $10)
                                   )
                                 )
                               )
@@ -2606,8 +2606,8 @@
                               (i32.store
                                 (i32.const 180)
                                 (i32.or
-                                  (get_local $0)
-                                  (get_local $16)
+                                  (get_local $1)
+                                  (get_local $15)
                                 )
                               )
                               (i32.store
@@ -2629,7 +2629,7 @@
                               (br $do-once25)
                             )
                           )
-                          (set_local $16
+                          (set_local $15
                             (i32.shl
                               (get_local $4)
                               (select
@@ -2637,18 +2637,18 @@
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $3)
+                                    (get_local $10)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $3)
+                                  (get_local $10)
                                   (i32.const 31)
                                 )
                               )
                             )
                           )
-                          (set_local $0
+                          (set_local $1
                             (i32.load
                               (get_local $6)
                             )
@@ -2659,34 +2659,34 @@
                                 (i32.eq
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $0)
+                                      (get_local $1)
                                     )
                                     (i32.const -8)
                                   )
                                   (get_local $4)
                                 )
                                 (block
-                                  (set_local $15
-                                    (get_local $0)
+                                  (set_local $14
+                                    (get_local $1)
                                   )
-                                  (set_local $5
+                                  (set_local $8
                                     (i32.const 148)
                                   )
                                   (br $while-out27)
                                 )
                               )
                               (if
-                                (tee_local $8
+                                (tee_local $9
                                   (i32.load
                                     (tee_local $6
                                       (i32.add
                                         (i32.add
-                                          (get_local $0)
+                                          (get_local $1)
                                           (i32.const 16)
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $16)
+                                            (get_local $15)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -2696,14 +2696,14 @@
                                   )
                                 )
                                 (block
-                                  (set_local $16
+                                  (set_local $15
                                     (i32.shl
-                                      (get_local $16)
+                                      (get_local $15)
                                       (i32.const 1)
                                     )
                                   )
-                                  (set_local $0
-                                    (get_local $8)
+                                  (set_local $1
+                                    (get_local $9)
                                   )
                                   (br $while-in28)
                                 )
@@ -2712,9 +2712,9 @@
                                     (get_local $6)
                                   )
                                   (set_local $21
-                                    (get_local $0)
+                                    (get_local $1)
                                   )
-                                  (set_local $5
+                                  (set_local $8
                                     (i32.const 145)
                                   )
                                 )
@@ -2723,7 +2723,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $5)
+                              (get_local $8)
                               (i32.const 145)
                             )
                             (if
@@ -2755,49 +2755,49 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $5)
+                                (get_local $8)
                                 (i32.const 148)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (tee_local $16
+                                    (tee_local $15
                                       (i32.load
-                                        (tee_local $0
+                                        (tee_local $1
                                           (i32.add
-                                            (get_local $15)
+                                            (get_local $14)
                                             (i32.const 8)
                                           )
                                         )
                                       )
                                     )
-                                    (tee_local $8
+                                    (tee_local $9
                                       (i32.load
                                         (i32.const 192)
                                       )
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $15)
-                                    (get_local $8)
+                                    (get_local $14)
+                                    (get_local $9)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $16)
+                                    (get_local $15)
                                     (get_local $7)
                                   )
                                   (i32.store
-                                    (get_local $0)
+                                    (get_local $1)
                                     (get_local $7)
                                   )
                                   (i32.store offset=8
                                     (get_local $7)
-                                    (get_local $16)
+                                    (get_local $15)
                                   )
                                   (i32.store offset=12
                                     (get_local $7)
-                                    (get_local $15)
+                                    (get_local $14)
                                   )
                                   (i32.store offset=24
                                     (get_local $7)
@@ -2813,28 +2813,28 @@
                           (i32.store offset=4
                             (get_local $12)
                             (i32.or
-                              (tee_local $16
+                              (tee_local $15
                                 (i32.add
                                   (get_local $4)
-                                  (get_local $1)
+                                  (get_local $2)
                                 )
                               )
                               (i32.const 3)
                             )
                           )
                           (i32.store
-                            (tee_local $0
+                            (tee_local $1
                               (i32.add
                                 (i32.add
                                   (get_local $12)
-                                  (get_local $16)
+                                  (get_local $15)
                                 )
                                 (i32.const 4)
                               )
                             )
                             (i32.or
                               (i32.load
-                                (get_local $0)
+                                (get_local $1)
                               )
                               (i32.const 1)
                             )
@@ -2849,17 +2849,17 @@
                       )
                     )
                   )
-                  (set_local $8
-                    (get_local $1)
+                  (set_local $9
+                    (get_local $2)
                   )
                 )
               )
-              (set_local $8
-                (get_local $1)
+              (set_local $9
+                (get_local $2)
               )
             )
           )
-          (set_local $8
+          (set_local $9
             (i32.const -1)
           )
         )
@@ -2872,10 +2872,10 @@
             (i32.const 184)
           )
         )
-        (get_local $8)
+        (get_local $9)
       )
       (block
-        (set_local $15
+        (set_local $14
           (i32.load
             (i32.const 196)
           )
@@ -2885,7 +2885,7 @@
             (tee_local $4
               (i32.sub
                 (get_local $12)
-                (get_local $8)
+                (get_local $9)
               )
             )
             (i32.const 15)
@@ -2895,8 +2895,8 @@
               (i32.const 196)
               (tee_local $21
                 (i32.add
-                  (get_local $15)
-                  (get_local $8)
+                  (get_local $14)
+                  (get_local $9)
                 )
               )
             )
@@ -2919,9 +2919,9 @@
               (get_local $4)
             )
             (i32.store offset=4
-              (get_local $15)
+              (get_local $14)
               (i32.or
-                (get_local $8)
+                (get_local $9)
                 (i32.const 3)
               )
             )
@@ -2936,7 +2936,7 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $15)
+              (get_local $14)
               (i32.or
                 (get_local $12)
                 (i32.const 3)
@@ -2946,7 +2946,7 @@
               (tee_local $4
                 (i32.add
                   (i32.add
-                    (get_local $15)
+                    (get_local $14)
                     (get_local $12)
                   )
                   (i32.const 4)
@@ -2963,7 +2963,7 @@
         )
         (return
           (i32.add
-            (get_local $15)
+            (get_local $14)
             (i32.const 8)
           )
         )
@@ -2971,20 +2971,20 @@
     )
     (if
       (i32.gt_u
-        (tee_local $15
+        (tee_local $14
           (i32.load
             (i32.const 188)
           )
         )
-        (get_local $8)
+        (get_local $9)
       )
       (block
         (i32.store
           (i32.const 188)
           (tee_local $4
             (i32.sub
-              (get_local $15)
-              (get_local $8)
+              (get_local $14)
+              (get_local $9)
             )
           )
         )
@@ -2992,12 +2992,12 @@
           (i32.const 200)
           (tee_local $12
             (i32.add
-              (tee_local $15
+              (tee_local $14
                 (i32.load
                   (i32.const 200)
                 )
               )
-              (get_local $8)
+              (get_local $9)
             )
           )
         )
@@ -3009,15 +3009,15 @@
           )
         )
         (i32.store offset=4
-          (get_local $15)
+          (get_local $14)
           (i32.or
-            (get_local $8)
+            (get_local $9)
             (i32.const 3)
           )
         )
         (return
           (i32.add
-            (get_local $15)
+            (get_local $14)
             (i32.const 8)
           )
         )
@@ -3032,24 +3032,24 @@
       (if
         (i32.and
           (i32.add
-            (tee_local $15
+            (tee_local $14
               (call $_sysconf
                 (i32.const 30)
               )
             )
             (i32.const -1)
           )
-          (get_local $15)
+          (get_local $14)
         )
         (call $_abort)
         (block
           (i32.store
             (i32.const 656)
-            (get_local $15)
+            (get_local $14)
           )
           (i32.store
             (i32.const 652)
-            (get_local $15)
+            (get_local $14)
           )
           (i32.store
             (i32.const 660)
@@ -3082,9 +3082,9 @@
         )
       )
     )
-    (set_local $15
+    (set_local $14
       (i32.add
-        (get_local $8)
+        (get_local $9)
         (i32.const 48)
       )
     )
@@ -3101,7 +3101,7 @@
                 )
                 (tee_local $12
                   (i32.add
-                    (get_local $8)
+                    (get_local $9)
                     (i32.const 47)
                   )
                 )
@@ -3115,7 +3115,7 @@
             )
           )
         )
-        (get_local $8)
+        (get_local $9)
       )
       (return
         (i32.const 0)
@@ -3124,7 +3124,7 @@
     (if
       (if i32
         (i32.ne
-          (tee_local $3
+          (tee_local $10
             (i32.load
               (i32.const 616)
             )
@@ -3133,7 +3133,7 @@
         )
         (i32.or
           (i32.le_u
-            (tee_local $14
+            (tee_local $16
               (i32.add
                 (tee_local $26
                   (i32.load
@@ -3146,8 +3146,8 @@
             (get_local $26)
           )
           (i32.gt_u
-            (get_local $14)
-            (get_local $3)
+            (get_local $16)
+            (get_local $10)
           )
         )
         (i32.const 0)
@@ -3166,7 +3166,7 @@
             )
             (i32.const 0)
             (i32.eq
-              (tee_local $5
+              (tee_local $8
                 (block $label$break$L257 i32
                   (if i32
                     (i32.and
@@ -3179,13 +3179,13 @@
                     (block i32
                       (block $label$break$L259
                         (if
-                          (tee_local $3
+                          (tee_local $10
                             (i32.load
                               (i32.const 200)
                             )
                           )
                           (block
-                            (set_local $14
+                            (set_local $16
                               (i32.const 624)
                             )
                             (loop $while-in34
@@ -3195,45 +3195,45 @@
                                     (i32.le_u
                                       (tee_local $26
                                         (i32.load
-                                          (get_local $14)
+                                          (get_local $16)
                                         )
                                       )
-                                      (get_local $3)
+                                      (get_local $10)
                                     )
                                     (i32.gt_u
                                       (i32.add
                                         (get_local $26)
                                         (i32.load
-                                          (tee_local $9
+                                          (tee_local $5
                                             (i32.add
-                                              (get_local $14)
+                                              (get_local $16)
                                               (i32.const 4)
                                             )
                                           )
                                         )
                                       )
-                                      (get_local $3)
+                                      (get_local $10)
                                     )
                                     (i32.const 0)
                                   )
                                   (block
                                     (set_local $6
-                                      (get_local $14)
+                                      (get_local $16)
                                     )
-                                    (set_local $11
-                                      (get_local $9)
+                                    (set_local $1
+                                      (get_local $5)
                                     )
                                     (br $while-out33)
                                   )
                                 )
                                 (br_if $while-in34
-                                  (tee_local $14
+                                  (tee_local $16
                                     (i32.load offset=8
-                                      (get_local $14)
+                                      (get_local $16)
                                     )
                                   )
                                 )
-                                (set_local $5
+                                (set_local $8
                                   (i32.const 173)
                                 )
                                 (br $label$break$L259)
@@ -3241,7 +3241,7 @@
                             )
                             (if
                               (i32.lt_u
-                                (tee_local $14
+                                (tee_local $16
                                   (i32.and
                                     (i32.sub
                                       (get_local $21)
@@ -3256,9 +3256,9 @@
                               )
                               (if
                                 (i32.eq
-                                  (tee_local $9
+                                  (tee_local $5
                                     (call $_sbrk
-                                      (get_local $14)
+                                      (get_local $16)
                                     )
                                   )
                                   (i32.add
@@ -3266,21 +3266,21 @@
                                       (get_local $6)
                                     )
                                     (i32.load
-                                      (get_local $11)
+                                      (get_local $1)
                                     )
                                   )
                                 )
                                 (if
                                   (i32.ne
-                                    (get_local $9)
+                                    (get_local $5)
                                     (i32.const -1)
                                   )
                                   (block
                                     (set_local $20
-                                      (get_local $9)
+                                      (get_local $5)
                                     )
                                     (set_local $22
-                                      (get_local $14)
+                                      (get_local $16)
                                     )
                                     (br $label$break$L257
                                       (i32.const 193)
@@ -3289,19 +3289,19 @@
                                 )
                                 (block
                                   (set_local $13
-                                    (get_local $9)
+                                    (get_local $5)
                                   )
                                   (set_local $18
-                                    (get_local $14)
+                                    (get_local $16)
                                   )
-                                  (set_local $5
+                                  (set_local $8
                                     (i32.const 183)
                                   )
                                 )
                               )
                             )
                           )
-                          (set_local $5
+                          (set_local $8
                             (i32.const 173)
                           )
                         )
@@ -3310,11 +3310,11 @@
                         (if
                           (if i32
                             (i32.eq
-                              (get_local $5)
+                              (get_local $8)
                               (i32.const 173)
                             )
                             (i32.ne
-                              (tee_local $3
+                              (tee_local $10
                                 (call $_sbrk
                                   (i32.const 0)
                                 )
@@ -3327,9 +3327,9 @@
                             (set_local $0
                               (if i32
                                 (i32.and
-                                  (tee_local $9
+                                  (tee_local $5
                                     (i32.add
-                                      (tee_local $14
+                                      (tee_local $16
                                         (i32.load
                                           (i32.const 652)
                                         )
@@ -3337,32 +3337,32 @@
                                       (i32.const -1)
                                     )
                                   )
-                                  (tee_local $1
-                                    (get_local $3)
+                                  (tee_local $2
+                                    (get_local $10)
                                   )
                                 )
                                 (i32.add
                                   (i32.sub
                                     (get_local $4)
-                                    (get_local $1)
+                                    (get_local $2)
                                   )
                                   (i32.and
                                     (i32.add
-                                      (get_local $9)
-                                      (get_local $1)
+                                      (get_local $5)
+                                      (get_local $2)
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $14)
+                                      (get_local $16)
                                     )
                                   )
                                 )
                                 (get_local $4)
                               )
                             )
-                            (set_local $1
+                            (set_local $2
                               (i32.add
-                                (tee_local $14
+                                (tee_local $16
                                   (i32.load
                                     (i32.const 608)
                                   )
@@ -3374,7 +3374,7 @@
                               (i32.and
                                 (i32.gt_u
                                   (get_local $0)
-                                  (get_local $8)
+                                  (get_local $9)
                                 )
                                 (i32.lt_u
                                   (get_local $0)
@@ -3386,12 +3386,12 @@
                                   (select
                                     (i32.or
                                       (i32.le_u
-                                        (get_local $1)
-                                        (get_local $14)
+                                        (get_local $2)
+                                        (get_local $16)
                                       )
                                       (i32.gt_u
-                                        (get_local $1)
-                                        (tee_local $9
+                                        (get_local $2)
+                                        (tee_local $5
                                           (i32.load
                                             (i32.const 616)
                                           )
@@ -3400,23 +3400,23 @@
                                     )
                                     (i32.const 0)
                                     (i32.ne
-                                      (get_local $9)
+                                      (get_local $5)
                                       (i32.const 0)
                                     )
                                   )
                                 )
                                 (if
                                   (i32.eq
-                                    (tee_local $9
+                                    (tee_local $5
                                       (call $_sbrk
                                         (get_local $0)
                                       )
                                     )
-                                    (get_local $3)
+                                    (get_local $10)
                                   )
                                   (block
                                     (set_local $20
-                                      (get_local $3)
+                                      (get_local $10)
                                     )
                                     (set_local $22
                                       (get_local $0)
@@ -3427,12 +3427,12 @@
                                   )
                                   (block
                                     (set_local $13
-                                      (get_local $9)
+                                      (get_local $5)
                                     )
                                     (set_local $18
                                       (get_local $0)
                                     )
-                                    (set_local $5
+                                    (set_local $8
                                       (i32.const 183)
                                     )
                                   )
@@ -3445,11 +3445,11 @@
                       (block $label$break$L279
                         (if
                           (i32.eq
-                            (get_local $5)
+                            (get_local $8)
                             (i32.const 183)
                           )
                           (block
-                            (set_local $9
+                            (set_local $5
                               (i32.sub
                                 (i32.const 0)
                                 (get_local $18)
@@ -3459,7 +3459,7 @@
                               (if i32
                                 (i32.and
                                   (i32.gt_u
-                                    (get_local $15)
+                                    (get_local $14)
                                     (get_local $18)
                                   )
                                   (i32.and
@@ -3474,14 +3474,14 @@
                                   )
                                 )
                                 (i32.lt_u
-                                  (tee_local $1
+                                  (tee_local $2
                                     (i32.and
                                       (i32.add
                                         (i32.sub
                                           (get_local $12)
                                           (get_local $18)
                                         )
-                                        (tee_local $3
+                                        (tee_local $10
                                           (i32.load
                                             (i32.const 656)
                                           )
@@ -3489,7 +3489,7 @@
                                       )
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $3)
+                                        (get_local $10)
                                       )
                                     )
                                   )
@@ -3500,26 +3500,26 @@
                               (if
                                 (i32.eq
                                   (call $_sbrk
-                                    (get_local $1)
+                                    (get_local $2)
                                   )
                                   (i32.const -1)
                                 )
                                 (block
                                   (drop
                                     (call $_sbrk
-                                      (get_local $9)
+                                      (get_local $5)
                                     )
                                   )
                                   (br $label$break$L279)
                                 )
-                                (set_local $2
+                                (set_local $3
                                   (i32.add
-                                    (get_local $1)
+                                    (get_local $2)
                                     (get_local $18)
                                   )
                                 )
                               )
-                              (set_local $2
+                              (set_local $3
                                 (get_local $18)
                               )
                             )
@@ -3533,7 +3533,7 @@
                                   (get_local $13)
                                 )
                                 (set_local $22
-                                  (get_local $2)
+                                  (get_local $3)
                                 )
                                 (br $label$break$L257
                                   (i32.const 193)
@@ -3562,7 +3562,7 @@
           )
           (i32.and
             (i32.lt_u
-              (tee_local $2
+              (tee_local $3
                 (call $_sbrk
                   (get_local $4)
                 )
@@ -3575,7 +3575,7 @@
             )
             (i32.and
               (i32.ne
-                (get_local $2)
+                (get_local $3)
                 (i32.const -1)
               )
               (i32.ne
@@ -3590,11 +3590,11 @@
           (tee_local $13
             (i32.sub
               (get_local $4)
-              (get_local $2)
+              (get_local $3)
             )
           )
           (i32.add
-            (get_local $8)
+            (get_local $9)
             (i32.const 40)
           )
         )
@@ -3602,19 +3602,19 @@
       )
       (block
         (set_local $20
-          (get_local $2)
+          (get_local $3)
         )
         (set_local $22
           (get_local $13)
         )
-        (set_local $5
+        (set_local $8
           (i32.const 193)
         )
       )
     )
     (if
       (i32.eq
-        (get_local $5)
+        (get_local $8)
         (i32.const 193)
       )
       (block
@@ -3649,7 +3649,7 @@
               )
             )
             (block
-              (set_local $2
+              (set_local $3
                 (i32.const 624)
               )
               (loop $do-in
@@ -3660,14 +3660,14 @@
                       (i32.add
                         (tee_local $4
                           (i32.load
-                            (get_local $2)
+                            (get_local $3)
                           )
                         )
                         (tee_local $12
                           (i32.load
                             (tee_local $18
                               (i32.add
-                                (get_local $2)
+                                (get_local $3)
                                 (i32.const 4)
                               )
                             )
@@ -3686,9 +3686,9 @@
                         (get_local $12)
                       )
                       (set_local $49
-                        (get_local $2)
+                        (get_local $3)
                       )
-                      (set_local $5
+                      (set_local $8
                         (i32.const 203)
                       )
                       (br $do-out)
@@ -3696,9 +3696,9 @@
                   )
                   (br_if $do-in
                     (i32.ne
-                      (tee_local $2
+                      (tee_local $3
                         (i32.load offset=8
-                          (get_local $2)
+                          (get_local $3)
                         )
                       )
                       (i32.const 0)
@@ -3730,7 +3730,7 @@
                     )
                     (i32.const 0)
                     (i32.eq
-                      (get_local $5)
+                      (get_local $8)
                       (i32.const 203)
                     )
                   )
@@ -3743,7 +3743,7 @@
                       (get_local $22)
                     )
                   )
-                  (set_local $2
+                  (set_local $3
                     (i32.add
                       (get_local $13)
                       (tee_local $12
@@ -3751,7 +3751,7 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $2
+                              (tee_local $3
                                 (i32.add
                                   (get_local $13)
                                   (i32.const 8)
@@ -3762,7 +3762,7 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $2)
+                            (get_local $3)
                             (i32.const 7)
                           )
                         )
@@ -3782,14 +3782,14 @@
                   )
                   (i32.store
                     (i32.const 200)
-                    (get_local $2)
+                    (get_local $3)
                   )
                   (i32.store
                     (i32.const 188)
                     (get_local $18)
                   )
                   (i32.store offset=4
-                    (get_local $2)
+                    (get_local $3)
                     (i32.or
                       (get_local $18)
                       (i32.const 1)
@@ -3797,7 +3797,7 @@
                   )
                   (i32.store offset=4
                     (i32.add
-                      (get_local $2)
+                      (get_local $3)
                       (get_local $18)
                     )
                     (i32.const 40)
@@ -3811,7 +3811,7 @@
                   (br $do-once40)
                 )
               )
-              (set_local $17
+              (set_local $7
                 (if i32
                   (i32.lt_u
                     (get_local $20)
@@ -3837,7 +3837,7 @@
                   (get_local $22)
                 )
               )
-              (set_local $2
+              (set_local $3
                 (i32.const 624)
               )
               (loop $while-in43
@@ -3845,27 +3845,27 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $2)
+                        (get_local $3)
                       )
                       (get_local $18)
                     )
                     (block
                       (set_local $50
-                        (get_local $2)
+                        (get_local $3)
                       )
                       (set_local $40
-                        (get_local $2)
+                        (get_local $3)
                       )
-                      (set_local $5
+                      (set_local $8
                         (i32.const 211)
                       )
                       (br $while-out42)
                     )
                   )
                   (br_if $while-in43
-                    (tee_local $2
+                    (tee_local $3
                       (i32.load offset=8
-                        (get_local $2)
+                        (get_local $3)
                       )
                     )
                   )
@@ -3876,7 +3876,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $5)
+                  (get_local $8)
                   (i32.const 211)
                 )
                 (if
@@ -3895,7 +3895,7 @@
                       (get_local $20)
                     )
                     (i32.store
-                      (tee_local $2
+                      (tee_local $3
                         (i32.add
                           (get_local $40)
                           (i32.const 4)
@@ -3903,7 +3903,7 @@
                       )
                       (i32.add
                         (i32.load
-                          (get_local $2)
+                          (get_local $3)
                         )
                         (get_local $22)
                       )
@@ -3915,7 +3915,7 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $2
+                              (tee_local $3
                                 (i32.add
                                   (get_local $20)
                                   (i32.const 8)
@@ -3926,7 +3926,7 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $2)
+                            (get_local $3)
                             (i32.const 7)
                           )
                         )
@@ -3939,7 +3939,7 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $2
+                              (tee_local $3
                                 (i32.add
                                   (get_local $18)
                                   (i32.const 8)
@@ -3950,31 +3950,31 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $2)
+                            (get_local $3)
                             (i32.const 7)
                           )
                         )
                       )
                     )
-                    (set_local $2
+                    (set_local $3
                       (i32.add
                         (get_local $12)
-                        (get_local $8)
+                        (get_local $9)
                       )
                     )
-                    (set_local $15
+                    (set_local $14
                       (i32.sub
                         (i32.sub
                           (get_local $4)
                           (get_local $12)
                         )
-                        (get_local $8)
+                        (get_local $9)
                       )
                     )
                     (i32.store offset=4
                       (get_local $12)
                       (i32.or
-                        (get_local $8)
+                        (get_local $9)
                         (i32.const 3)
                       )
                     )
@@ -4000,16 +4000,16 @@
                                     (i32.load
                                       (i32.const 184)
                                     )
-                                    (get_local $15)
+                                    (get_local $14)
                                   )
                                 )
                               )
                               (i32.store
                                 (i32.const 196)
-                                (get_local $2)
+                                (get_local $3)
                               )
                               (i32.store offset=4
-                                (get_local $2)
+                                (get_local $3)
                                 (i32.or
                                   (get_local $0)
                                   (i32.const 1)
@@ -4017,7 +4017,7 @@
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $2)
+                                  (get_local $3)
                                   (get_local $0)
                                 )
                                 (get_local $0)
@@ -4041,7 +4041,7 @@
                                     (i32.const 1)
                                   )
                                   (block i32
-                                    (set_local $11
+                                    (set_local $1
                                       (i32.and
                                         (get_local $0)
                                         (i32.const -8)
@@ -4077,11 +4077,11 @@
                                               )
                                               (block
                                                 (if
-                                                  (tee_local $3
+                                                  (tee_local $10
                                                     (i32.load
-                                                      (tee_local $1
+                                                      (tee_local $2
                                                         (i32.add
-                                                          (tee_local $9
+                                                          (tee_local $5
                                                             (i32.add
                                                               (get_local $4)
                                                               (i32.const 16)
@@ -4093,20 +4093,21 @@
                                                     )
                                                   )
                                                   (block
-                                                    (set_local $14
-                                                      (get_local $3)
+                                                    (set_local $0
+                                                      (get_local $10)
                                                     )
-                                                    (set_local $9
-                                                      (get_local $1)
+                                                    (set_local $5
+                                                      (get_local $2)
                                                     )
                                                   )
                                                   (if
-                                                    (i32.eqz
-                                                      (tee_local $14
-                                                        (i32.load
-                                                          (get_local $9)
-                                                        )
+                                                    (tee_local $16
+                                                      (i32.load
+                                                        (get_local $5)
                                                       )
+                                                    )
+                                                    (set_local $0
+                                                      (get_local $16)
                                                     )
                                                     (block
                                                       (set_local $24
@@ -4118,43 +4119,43 @@
                                                 )
                                                 (loop $while-in50
                                                   (if
-                                                    (tee_local $3
+                                                    (tee_local $10
                                                       (i32.load
-                                                        (tee_local $1
+                                                        (tee_local $2
                                                           (i32.add
-                                                            (get_local $14)
+                                                            (get_local $0)
                                                             (i32.const 20)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $14
-                                                        (get_local $3)
+                                                      (set_local $0
+                                                        (get_local $10)
                                                       )
-                                                      (set_local $9
-                                                        (get_local $1)
+                                                      (set_local $5
+                                                        (get_local $2)
                                                       )
                                                       (br $while-in50)
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $3
+                                                    (tee_local $10
                                                       (i32.load
-                                                        (tee_local $1
+                                                        (tee_local $2
                                                           (i32.add
-                                                            (get_local $14)
+                                                            (get_local $0)
                                                             (i32.const 16)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $14
-                                                        (get_local $3)
+                                                      (set_local $0
+                                                        (get_local $10)
                                                       )
-                                                      (set_local $9
-                                                        (get_local $1)
+                                                      (set_local $5
+                                                        (get_local $2)
                                                       )
                                                       (br $while-in50)
                                                     )
@@ -4162,17 +4163,17 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $9)
-                                                    (get_local $17)
+                                                    (get_local $5)
+                                                    (get_local $7)
                                                   )
                                                   (call $_abort)
                                                   (block
                                                     (i32.store
-                                                      (get_local $9)
+                                                      (get_local $5)
                                                       (i32.const 0)
                                                     )
                                                     (set_local $24
-                                                      (get_local $14)
+                                                      (get_local $0)
                                                     )
                                                   )
                                                 )
@@ -4180,21 +4181,21 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (tee_local $1
+                                                    (tee_local $2
                                                       (i32.load offset=8
                                                         (get_local $4)
                                                       )
                                                     )
-                                                    (get_local $17)
+                                                    (get_local $7)
                                                   )
                                                   (call $_abort)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (tee_local $3
+                                                      (tee_local $10
                                                         (i32.add
-                                                          (get_local $1)
+                                                          (get_local $2)
                                                           (i32.const 12)
                                                         )
                                                       )
@@ -4206,7 +4207,7 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $9
+                                                      (tee_local $5
                                                         (i32.add
                                                           (get_local $21)
                                                           (i32.const 8)
@@ -4217,12 +4218,12 @@
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $3)
+                                                      (get_local $10)
                                                       (get_local $21)
                                                     )
                                                     (i32.store
-                                                      (get_local $9)
-                                                      (get_local $1)
+                                                      (get_local $5)
+                                                      (get_local $2)
                                                     )
                                                     (set_local $24
                                                       (get_local $21)
@@ -4243,7 +4244,7 @@
                                               (i32.ne
                                                 (get_local $4)
                                                 (i32.load
-                                                  (tee_local $1
+                                                  (tee_local $2
                                                     (i32.add
                                                       (i32.const 480)
                                                       (i32.shl
@@ -4271,7 +4272,7 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $9
+                                                      (tee_local $5
                                                         (i32.add
                                                           (get_local $23)
                                                           (i32.const 16)
@@ -4281,7 +4282,7 @@
                                                     (get_local $4)
                                                   )
                                                   (i32.store
-                                                    (get_local $9)
+                                                    (get_local $5)
                                                     (get_local $24)
                                                   )
                                                   (i32.store offset=20
@@ -4297,7 +4298,7 @@
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $1)
+                                                  (get_local $2)
                                                   (get_local $24)
                                                 )
                                                 (br_if $do-once51
@@ -4338,9 +4339,9 @@
                                             (get_local $23)
                                           )
                                           (if
-                                            (tee_local $9
+                                            (tee_local $5
                                               (i32.load
-                                                (tee_local $1
+                                                (tee_local $2
                                                   (i32.add
                                                     (get_local $4)
                                                     (i32.const 16)
@@ -4350,17 +4351,17 @@
                                             )
                                             (if
                                               (i32.lt_u
-                                                (get_local $9)
+                                                (get_local $5)
                                                 (get_local $21)
                                               )
                                               (call $_abort)
                                               (block
                                                 (i32.store offset=16
                                                   (get_local $24)
-                                                  (get_local $9)
+                                                  (get_local $5)
                                                 )
                                                 (i32.store offset=24
-                                                  (get_local $9)
+                                                  (get_local $5)
                                                   (get_local $24)
                                                 )
                                               )
@@ -4368,16 +4369,16 @@
                                           )
                                           (br_if $label$break$L331
                                             (i32.eqz
-                                              (tee_local $9
+                                              (tee_local $5
                                                 (i32.load offset=4
-                                                  (get_local $1)
+                                                  (get_local $2)
                                                 )
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $9)
+                                              (get_local $5)
                                               (i32.load
                                                 (i32.const 192)
                                               )
@@ -4386,10 +4387,10 @@
                                             (block
                                               (i32.store offset=20
                                                 (get_local $24)
-                                                (get_local $9)
+                                                (get_local $5)
                                               )
                                               (i32.store offset=24
-                                                (get_local $9)
+                                                (get_local $5)
                                                 (get_local $24)
                                               )
                                             )
@@ -4404,7 +4405,7 @@
                                           (block $do-once55
                                             (if
                                               (i32.ne
-                                                (tee_local $9
+                                                (tee_local $5
                                                   (i32.load offset=8
                                                     (get_local $4)
                                                   )
@@ -4425,15 +4426,15 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $9)
-                                                    (get_local $17)
+                                                    (get_local $5)
+                                                    (get_local $7)
                                                   )
                                                   (call $_abort)
                                                 )
                                                 (br_if $do-once55
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $9)
+                                                      (get_local $5)
                                                     )
                                                     (get_local $4)
                                                   )
@@ -4445,7 +4446,7 @@
                                           (if
                                             (i32.eq
                                               (get_local $21)
-                                              (get_local $9)
+                                              (get_local $5)
                                             )
                                             (block
                                               (i32.store
@@ -4482,14 +4483,14 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $21)
-                                                    (get_local $17)
+                                                    (get_local $7)
                                                   )
                                                   (call $_abort)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $1
+                                                      (tee_local $2
                                                         (i32.add
                                                           (get_local $21)
                                                           (i32.const 8)
@@ -4500,7 +4501,7 @@
                                                   )
                                                   (block
                                                     (set_local $41
-                                                      (get_local $1)
+                                                      (get_local $2)
                                                     )
                                                     (br $do-once57)
                                                   )
@@ -4510,25 +4511,25 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $9)
+                                            (get_local $5)
                                             (get_local $21)
                                           )
                                           (i32.store
                                             (get_local $41)
-                                            (get_local $9)
+                                            (get_local $5)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $15
+                                    (set_local $14
                                       (i32.add
-                                        (get_local $11)
-                                        (get_local $15)
+                                        (get_local $1)
+                                        (get_local $14)
                                       )
                                     )
                                     (i32.add
                                       (get_local $4)
-                                      (get_local $11)
+                                      (get_local $1)
                                     )
                                   )
                                   (get_local $4)
@@ -4544,28 +4545,28 @@
                             )
                           )
                           (i32.store offset=4
-                            (get_local $2)
+                            (get_local $3)
                             (i32.or
-                              (get_local $15)
+                              (get_local $14)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $2)
-                              (get_local $15)
+                              (get_local $3)
+                              (get_local $14)
                             )
-                            (get_local $15)
+                            (get_local $14)
                           )
                           (set_local $6
                             (i32.shr_u
-                              (get_local $15)
+                              (get_local $14)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $15)
+                              (get_local $14)
                               (i32.const 256)
                             )
                             (block
@@ -4589,7 +4590,7 @@
                                         (i32.const 176)
                                       )
                                     )
-                                    (tee_local $1
+                                    (tee_local $2
                                       (i32.shl
                                         (i32.const 1)
                                         (get_local $6)
@@ -4599,7 +4600,7 @@
                                   (block
                                     (if
                                       (i32.ge_u
-                                        (tee_local $3
+                                        (tee_local $10
                                           (i32.load
                                             (tee_local $6
                                               (i32.add
@@ -4618,7 +4619,7 @@
                                           (get_local $6)
                                         )
                                         (set_local $34
-                                          (get_local $3)
+                                          (get_local $10)
                                         )
                                         (br $do-once59)
                                       )
@@ -4630,7 +4631,7 @@
                                       (i32.const 176)
                                       (i32.or
                                         (get_local $23)
-                                        (get_local $1)
+                                        (get_local $2)
                                       )
                                     )
                                     (set_local $42
@@ -4647,33 +4648,33 @@
                               )
                               (i32.store
                                 (get_local $42)
-                                (get_local $2)
+                                (get_local $3)
                               )
                               (i32.store offset=12
                                 (get_local $34)
-                                (get_local $2)
+                                (get_local $3)
                               )
                               (i32.store offset=8
-                                (get_local $2)
+                                (get_local $3)
                                 (get_local $34)
                               )
                               (i32.store offset=12
-                                (get_local $2)
+                                (get_local $3)
                                 (get_local $0)
                               )
                               (br $do-once44)
                             )
                           )
-                          (set_local $1
+                          (set_local $2
                             (i32.add
                               (i32.const 480)
                               (i32.shl
-                                (tee_local $3
+                                (tee_local $1
                                   (block $do-once61 i32
                                     (if i32
-                                      (tee_local $1
+                                      (tee_local $2
                                         (i32.shr_u
-                                          (get_local $15)
+                                          (get_local $14)
                                           (i32.const 8)
                                         )
                                       )
@@ -4682,7 +4683,7 @@
                                           (br_if $do-once61
                                             (i32.const 31)
                                             (i32.gt_u
-                                              (get_local $15)
+                                              (get_local $14)
                                               (i32.const 16777215)
                                             )
                                           )
@@ -4690,26 +4691,26 @@
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $15)
+                                              (get_local $14)
                                               (i32.add
-                                                (tee_local $14
+                                                (tee_local $16
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (tee_local $3
+                                                          (tee_local $10
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (tee_local $11
+                                                                  (tee_local $1
                                                                     (i32.shl
-                                                                      (get_local $1)
+                                                                      (get_local $2)
                                                                       (tee_local $23
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $1)
+                                                                              (get_local $2)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -4728,14 +4729,14 @@
                                                           )
                                                           (get_local $23)
                                                         )
-                                                        (tee_local $11
+                                                        (tee_local $1
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
                                                                 (tee_local $6
                                                                   (i32.shl
-                                                                    (get_local $11)
-                                                                    (get_local $3)
+                                                                    (get_local $1)
+                                                                    (get_local $10)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -4750,7 +4751,7 @@
                                                     (i32.shr_u
                                                       (i32.shl
                                                         (get_local $6)
-                                                        (get_local $11)
+                                                        (get_local $1)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4762,7 +4763,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $14)
+                                            (get_local $16)
                                             (i32.const 1)
                                           )
                                         )
@@ -4776,13 +4777,13 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $2)
                             (get_local $3)
+                            (get_local $1)
                           )
                           (i32.store offset=4
                             (tee_local $0
                               (i32.add
-                                (get_local $2)
+                                (get_local $3)
                                 (i32.const 16)
                               )
                             )
@@ -4800,10 +4801,10 @@
                                     (i32.const 180)
                                   )
                                 )
-                                (tee_local $14
+                                (tee_local $16
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $3)
+                                    (get_local $1)
                                   )
                                 )
                               )
@@ -4813,42 +4814,42 @@
                                 (i32.const 180)
                                 (i32.or
                                   (get_local $0)
-                                  (get_local $14)
+                                  (get_local $16)
                                 )
                               )
                               (i32.store
-                                (get_local $1)
                                 (get_local $2)
+                                (get_local $3)
                               )
                               (i32.store offset=24
+                                (get_local $3)
                                 (get_local $2)
-                                (get_local $1)
                               )
                               (i32.store offset=12
-                                (get_local $2)
-                                (get_local $2)
+                                (get_local $3)
+                                (get_local $3)
                               )
                               (i32.store offset=8
-                                (get_local $2)
-                                (get_local $2)
+                                (get_local $3)
+                                (get_local $3)
                               )
                               (br $do-once44)
                             )
                           )
-                          (set_local $14
+                          (set_local $16
                             (i32.shl
-                              (get_local $15)
+                              (get_local $14)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $3)
+                                    (get_local $1)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $3)
+                                  (get_local $1)
                                   (i32.const 31)
                                 )
                               )
@@ -4856,7 +4857,7 @@
                           )
                           (set_local $0
                             (i32.load
-                              (get_local $1)
+                              (get_local $2)
                             )
                           )
                           (loop $while-in64
@@ -4869,22 +4870,22 @@
                                     )
                                     (i32.const -8)
                                   )
-                                  (get_local $15)
+                                  (get_local $14)
                                 )
                                 (block
                                   (set_local $35
                                     (get_local $0)
                                   )
-                                  (set_local $5
+                                  (set_local $8
                                     (i32.const 281)
                                   )
                                   (br $while-out63)
                                 )
                               )
                               (if
-                                (tee_local $11
+                                (tee_local $1
                                   (i32.load
-                                    (tee_local $1
+                                    (tee_local $2
                                       (i32.add
                                         (i32.add
                                           (get_local $0)
@@ -4892,7 +4893,7 @@
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $14)
+                                            (get_local $16)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -4902,25 +4903,25 @@
                                   )
                                 )
                                 (block
-                                  (set_local $14
+                                  (set_local $16
                                     (i32.shl
-                                      (get_local $14)
+                                      (get_local $16)
                                       (i32.const 1)
                                     )
                                   )
                                   (set_local $0
-                                    (get_local $11)
+                                    (get_local $1)
                                   )
                                   (br $while-in64)
                                 )
                                 (block
                                   (set_local $43
-                                    (get_local $1)
+                                    (get_local $2)
                                   )
                                   (set_local $51
                                     (get_local $0)
                                   )
-                                  (set_local $5
+                                  (set_local $8
                                     (i32.const 278)
                                   )
                                 )
@@ -4929,7 +4930,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $5)
+                              (get_local $8)
                               (i32.const 278)
                             )
                             (if
@@ -4943,31 +4944,31 @@
                               (block
                                 (i32.store
                                   (get_local $43)
-                                  (get_local $2)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=24
-                                  (get_local $2)
+                                  (get_local $3)
                                   (get_local $51)
                                 )
                                 (i32.store offset=12
-                                  (get_local $2)
-                                  (get_local $2)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=8
-                                  (get_local $2)
-                                  (get_local $2)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $5)
+                                (get_local $8)
                                 (i32.const 281)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (tee_local $14
+                                    (tee_local $16
                                       (i32.load
                                         (tee_local $0
                                           (i32.add
@@ -4977,7 +4978,7 @@
                                         )
                                       )
                                     )
-                                    (tee_local $11
+                                    (tee_local $1
                                       (i32.load
                                         (i32.const 192)
                                       )
@@ -4985,28 +4986,28 @@
                                   )
                                   (i32.ge_u
                                     (get_local $35)
-                                    (get_local $11)
+                                    (get_local $1)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $14)
-                                    (get_local $2)
+                                    (get_local $16)
+                                    (get_local $3)
                                   )
                                   (i32.store
                                     (get_local $0)
-                                    (get_local $2)
+                                    (get_local $3)
                                   )
                                   (i32.store offset=8
-                                    (get_local $2)
-                                    (get_local $14)
+                                    (get_local $3)
+                                    (get_local $16)
                                   )
                                   (i32.store offset=12
-                                    (get_local $2)
+                                    (get_local $3)
                                     (get_local $35)
                                   )
                                   (i32.store offset=24
-                                    (get_local $2)
+                                    (get_local $3)
                                     (i32.const 0)
                                   )
                                 )
@@ -5018,23 +5019,23 @@
                         (block
                           (i32.store
                             (i32.const 188)
-                            (tee_local $14
+                            (tee_local $16
                               (i32.add
                                 (i32.load
                                   (i32.const 188)
                                 )
-                                (get_local $15)
+                                (get_local $14)
                               )
                             )
                           )
                           (i32.store
                             (i32.const 200)
-                            (get_local $2)
+                            (get_local $3)
                           )
                           (i32.store offset=4
-                            (get_local $2)
+                            (get_local $3)
                             (i32.or
-                              (get_local $14)
+                              (get_local $16)
                               (i32.const 1)
                             )
                           )
@@ -5054,7 +5055,7 @@
                 (if
                   (if i32
                     (i32.le_u
-                      (tee_local $2
+                      (tee_local $3
                         (i32.load
                           (get_local $28)
                         )
@@ -5062,9 +5063,9 @@
                       (get_local $13)
                     )
                     (i32.gt_u
-                      (tee_local $15
+                      (tee_local $14
                         (i32.add
-                          (get_local $2)
+                          (get_local $3)
                           (i32.load offset=4
                             (get_local $28)
                           )
@@ -5075,7 +5076,7 @@
                     (i32.const 0)
                   )
                   (set_local $0
-                    (get_local $15)
+                    (get_local $14)
                   )
                   (block
                     (set_local $28
@@ -5087,7 +5088,7 @@
                   )
                 )
               )
-              (set_local $15
+              (set_local $14
                 (i32.add
                   (tee_local $12
                     (i32.add
@@ -5098,33 +5099,33 @@
                   (i32.const 8)
                 )
               )
-              (set_local $2
+              (set_local $3
                 (i32.add
                   (tee_local $12
                     (select
                       (get_local $13)
-                      (tee_local $2
+                      (tee_local $3
                         (i32.add
                           (get_local $12)
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $15)
+                                (get_local $14)
                               )
                               (i32.const 7)
                             )
                             (i32.const 0)
                             (i32.and
-                              (get_local $15)
+                              (get_local $14)
                               (i32.const 7)
                             )
                           )
                         )
                       )
                       (i32.lt_u
-                        (get_local $2)
-                        (tee_local $15
+                        (get_local $3)
+                        (tee_local $14
                           (i32.add
                             (get_local $13)
                             (i32.const 16)
@@ -5167,7 +5168,7 @@
               )
               (i32.store
                 (i32.const 188)
-                (tee_local $14
+                (tee_local $16
                   (i32.sub
                     (i32.add
                       (get_local $22)
@@ -5180,14 +5181,14 @@
               (i32.store offset=4
                 (get_local $4)
                 (i32.or
-                  (get_local $14)
+                  (get_local $16)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
                   (get_local $4)
-                  (get_local $14)
+                  (get_local $16)
                 )
                 (i32.const 40)
               )
@@ -5198,7 +5199,7 @@
                 )
               )
               (i32.store
-                (tee_local $14
+                (tee_local $16
                   (i32.add
                     (get_local $12)
                     (i32.const 4)
@@ -5207,25 +5208,25 @@
                 (i32.const 27)
               )
               (i32.store
-                (get_local $2)
+                (get_local $3)
                 (i32.load
                   (i32.const 624)
                 )
               )
               (i32.store offset=4
-                (get_local $2)
+                (get_local $3)
                 (i32.load
                   (i32.const 628)
                 )
               )
               (i32.store offset=8
-                (get_local $2)
+                (get_local $3)
                 (i32.load
                   (i32.const 632)
                 )
               )
               (i32.store offset=12
-                (get_local $2)
+                (get_local $3)
                 (i32.load
                   (i32.const 636)
                 )
@@ -5244,9 +5245,9 @@
               )
               (i32.store
                 (i32.const 632)
-                (get_local $2)
+                (get_local $3)
               )
-              (set_local $2
+              (set_local $3
                 (i32.add
                   (get_local $12)
                   (i32.const 24)
@@ -5254,9 +5255,9 @@
               )
               (loop $do-in68
                 (i32.store
-                  (tee_local $2
+                  (tee_local $3
                     (i32.add
-                      (get_local $2)
+                      (get_local $3)
                       (i32.const 4)
                     )
                   )
@@ -5265,7 +5266,7 @@
                 (br_if $do-in68
                   (i32.lt_u
                     (i32.add
-                      (get_local $2)
+                      (get_local $3)
                       (i32.const 4)
                     )
                     (get_local $0)
@@ -5279,10 +5280,10 @@
                 )
                 (block
                   (i32.store
-                    (get_local $14)
+                    (get_local $16)
                     (i32.and
                       (i32.load
-                        (get_local $14)
+                        (get_local $16)
                       )
                       (i32.const -2)
                     )
@@ -5290,7 +5291,7 @@
                   (i32.store offset=4
                     (get_local $13)
                     (i32.or
-                      (tee_local $2
+                      (tee_local $3
                         (i32.sub
                           (get_local $12)
                           (get_local $13)
@@ -5301,17 +5302,17 @@
                   )
                   (i32.store
                     (get_local $12)
-                    (get_local $2)
+                    (get_local $3)
                   )
                   (set_local $4
                     (i32.shr_u
-                      (get_local $2)
+                      (get_local $3)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $2)
+                      (get_local $3)
                       (i32.const 256)
                     )
                     (block
@@ -5334,7 +5335,7 @@
                               (i32.const 176)
                             )
                           )
-                          (tee_local $11
+                          (tee_local $1
                             (i32.shl
                               (i32.const 1)
                               (get_local $4)
@@ -5343,7 +5344,7 @@
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $1
+                            (tee_local $2
                               (i32.load
                                 (tee_local $4
                                   (i32.add
@@ -5363,7 +5364,7 @@
                               (get_local $4)
                             )
                             (set_local $36
-                              (get_local $1)
+                              (get_local $2)
                             )
                           )
                         )
@@ -5372,7 +5373,7 @@
                             (i32.const 176)
                             (i32.or
                               (get_local $0)
-                              (get_local $11)
+                              (get_local $1)
                             )
                           )
                           (set_local $44
@@ -5409,24 +5410,24 @@
                     (i32.add
                       (i32.const 480)
                       (i32.shl
-                        (tee_local $3
+                        (tee_local $1
                           (if i32
                             (tee_local $18
                               (i32.shr_u
-                                (get_local $2)
+                                (get_local $3)
                                 (i32.const 8)
                               )
                             )
                             (if i32
                               (i32.gt_u
-                                (get_local $2)
+                                (get_local $3)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $2)
+                                    (get_local $3)
                                     (i32.add
                                       (tee_local $4
                                         (i32.add
@@ -5441,7 +5442,7 @@
                                                         (tee_local $0
                                                           (i32.shl
                                                             (get_local $18)
-                                                            (tee_local $11
+                                                            (tee_local $1
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
@@ -5462,13 +5463,13 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $11)
+                                                (get_local $1)
                                               )
                                               (tee_local $0
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (tee_local $1
+                                                      (tee_local $2
                                                         (i32.shl
                                                           (get_local $0)
                                                           (get_local $18)
@@ -5485,7 +5486,7 @@
                                           )
                                           (i32.shr_u
                                             (i32.shl
-                                              (get_local $1)
+                                              (get_local $2)
                                               (get_local $0)
                                             )
                                             (i32.const 15)
@@ -5512,14 +5513,14 @@
                   )
                   (i32.store offset=28
                     (get_local $13)
-                    (get_local $3)
+                    (get_local $1)
                   )
                   (i32.store offset=20
                     (get_local $13)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $15)
+                    (get_local $14)
                     (i32.const 0)
                   )
                   (if
@@ -5530,10 +5531,10 @@
                             (i32.const 180)
                           )
                         )
-                        (tee_local $1
+                        (tee_local $2
                           (i32.shl
                             (i32.const 1)
-                            (get_local $3)
+                            (get_local $1)
                           )
                         )
                       )
@@ -5543,7 +5544,7 @@
                         (i32.const 180)
                         (i32.or
                           (get_local $0)
-                          (get_local $1)
+                          (get_local $2)
                         )
                       )
                       (i32.store
@@ -5565,20 +5566,20 @@
                       (br $do-once40)
                     )
                   )
-                  (set_local $1
+                  (set_local $2
                     (i32.shl
-                      (get_local $2)
+                      (get_local $3)
                       (select
                         (i32.const 0)
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $3)
+                            (get_local $1)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $3)
+                          (get_local $1)
                           (i32.const 31)
                         )
                       )
@@ -5599,20 +5600,20 @@
                             )
                             (i32.const -8)
                           )
-                          (get_local $2)
+                          (get_local $3)
                         )
                         (block
                           (set_local $37
                             (get_local $0)
                           )
-                          (set_local $5
+                          (set_local $8
                             (i32.const 307)
                           )
                           (br $while-out69)
                         )
                       )
                       (if
-                        (tee_local $11
+                        (tee_local $1
                           (i32.load
                             (tee_local $4
                               (i32.add
@@ -5622,7 +5623,7 @@
                                 )
                                 (i32.shl
                                   (i32.shr_u
-                                    (get_local $1)
+                                    (get_local $2)
                                     (i32.const 31)
                                   )
                                   (i32.const 2)
@@ -5632,14 +5633,14 @@
                           )
                         )
                         (block
-                          (set_local $1
+                          (set_local $2
                             (i32.shl
-                              (get_local $1)
+                              (get_local $2)
                               (i32.const 1)
                             )
                           )
                           (set_local $0
-                            (get_local $11)
+                            (get_local $1)
                           )
                           (br $while-in70)
                         )
@@ -5650,7 +5651,7 @@
                           (set_local $52
                             (get_local $0)
                           )
-                          (set_local $5
+                          (set_local $8
                             (i32.const 304)
                           )
                         )
@@ -5659,7 +5660,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $5)
+                      (get_local $8)
                       (i32.const 304)
                     )
                     (if
@@ -5691,13 +5692,13 @@
                     )
                     (if
                       (i32.eq
-                        (get_local $5)
+                        (get_local $8)
                         (i32.const 307)
                       )
                       (if
                         (i32.and
                           (i32.ge_u
-                            (tee_local $1
+                            (tee_local $2
                               (i32.load
                                 (tee_local $0
                                   (i32.add
@@ -5707,7 +5708,7 @@
                                 )
                               )
                             )
-                            (tee_local $2
+                            (tee_local $3
                               (i32.load
                                 (i32.const 192)
                               )
@@ -5715,12 +5716,12 @@
                           )
                           (i32.ge_u
                             (get_local $37)
-                            (get_local $2)
+                            (get_local $3)
                           )
                         )
                         (block
                           (i32.store offset=12
-                            (get_local $1)
+                            (get_local $2)
                             (get_local $13)
                           )
                           (i32.store
@@ -5729,7 +5730,7 @@
                           )
                           (i32.store offset=8
                             (get_local $13)
-                            (get_local $1)
+                            (get_local $2)
                           )
                           (i32.store offset=12
                             (get_local $13)
@@ -5751,7 +5752,7 @@
               (if
                 (i32.or
                   (i32.eqz
-                    (tee_local $1
+                    (tee_local $2
                       (i32.load
                         (i32.const 192)
                       )
@@ -5759,7 +5760,7 @@
                   )
                   (i32.lt_u
                     (get_local $20)
-                    (get_local $1)
+                    (get_local $2)
                   )
                 )
                 (i32.store
@@ -5789,7 +5790,7 @@
                 (i32.const 208)
                 (i32.const -1)
               )
-              (set_local $1
+              (set_local $2
                 (i32.const 0)
               )
               (loop $do-in72
@@ -5799,7 +5800,7 @@
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $1)
+                          (get_local $2)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -5814,9 +5815,9 @@
                 )
                 (br_if $do-in72
                   (i32.ne
-                    (tee_local $1
+                    (tee_local $2
                       (i32.add
-                        (get_local $1)
+                        (get_local $2)
                         (i32.const 1)
                       )
                     )
@@ -5826,7 +5827,7 @@
               )
               (i32.store
                 (i32.const 200)
-                (tee_local $1
+                (tee_local $2
                   (i32.add
                     (get_local $20)
                     (tee_local $0
@@ -5834,7 +5835,7 @@
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (tee_local $1
+                            (tee_local $2
                               (i32.add
                                 (get_local $20)
                                 (i32.const 8)
@@ -5845,7 +5846,7 @@
                         )
                         (i32.const 0)
                         (i32.and
-                          (get_local $1)
+                          (get_local $2)
                           (i32.const 7)
                         )
                       )
@@ -5855,7 +5856,7 @@
               )
               (i32.store
                 (i32.const 188)
-                (tee_local $2
+                (tee_local $3
                   (i32.sub
                     (i32.add
                       (get_local $22)
@@ -5866,16 +5867,16 @@
                 )
               )
               (i32.store offset=4
-                (get_local $1)
+                (get_local $2)
                 (i32.or
-                  (get_local $2)
+                  (get_local $3)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $1)
                   (get_local $2)
+                  (get_local $3)
                 )
                 (i32.const 40)
               )
@@ -5895,7 +5896,7 @@
                 (i32.const 188)
               )
             )
-            (get_local $8)
+            (get_local $9)
           )
           (block
             (i32.store
@@ -5903,7 +5904,7 @@
               (tee_local $20
                 (i32.sub
                   (get_local $22)
-                  (get_local $8)
+                  (get_local $9)
                 )
               )
             )
@@ -5916,7 +5917,7 @@
                       (i32.const 200)
                     )
                   )
-                  (get_local $8)
+                  (get_local $9)
                 )
               )
             )
@@ -5930,7 +5931,7 @@
             (i32.store offset=4
               (get_local $22)
               (i32.or
-                (get_local $8)
+                (get_local $9)
                 (i32.const 3)
               )
             )
@@ -6014,7 +6015,7 @@
     (set_local $8
       (i32.add
         (get_local $1)
-        (tee_local $4
+        (tee_local $5
           (i32.and
             (get_local $3)
             (i32.const -8)
@@ -6032,8 +6033,8 @@
           (set_local $2
             (get_local $1)
           )
-          (set_local $7
-            (get_local $4)
+          (set_local $4
+            (get_local $5)
           )
         )
         (block
@@ -6048,15 +6049,15 @@
             )
             (return)
           )
-          (set_local $4
+          (set_local $5
             (i32.add
               (get_local $11)
-              (get_local $4)
+              (get_local $5)
             )
           )
           (if
             (i32.lt_u
-              (tee_local $0
+              (tee_local $3
                 (i32.add
                   (get_local $1)
                   (i32.sub
@@ -6071,7 +6072,7 @@
           )
           (if
             (i32.eq
-              (get_local $0)
+              (get_local $3)
               (i32.load
                 (i32.const 196)
               )
@@ -6080,9 +6081,9 @@
               (if
                 (i32.ne
                   (i32.and
-                    (tee_local $6
+                    (tee_local $7
                       (i32.load
-                        (tee_local $1
+                        (tee_local $0
                           (i32.add
                             (get_local $8)
                             (i32.const 4)
@@ -6096,43 +6097,43 @@
                 )
                 (block
                   (set_local $2
-                    (get_local $0)
+                    (get_local $3)
                   )
-                  (set_local $7
-                    (get_local $4)
+                  (set_local $4
+                    (get_local $5)
                   )
                   (br $do-once)
                 )
               )
               (i32.store
                 (i32.const 184)
-                (get_local $4)
+                (get_local $5)
               )
               (i32.store
-                (get_local $1)
+                (get_local $0)
                 (i32.and
-                  (get_local $6)
+                  (get_local $7)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $0)
+                (get_local $3)
                 (i32.or
-                  (get_local $4)
+                  (get_local $5)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
-                  (get_local $0)
-                  (get_local $4)
+                  (get_local $3)
+                  (get_local $5)
                 )
-                (get_local $4)
+                (get_local $5)
               )
               (return)
             )
           )
-          (set_local $6
+          (set_local $7
             (i32.shr_u
               (get_local $11)
               (i32.const 3)
@@ -6144,24 +6145,24 @@
               (i32.const 256)
             )
             (block
-              (set_local $1
+              (set_local $0
                 (i32.load offset=12
-                  (get_local $0)
+                  (get_local $3)
                 )
               )
               (if
                 (i32.ne
                   (tee_local $11
                     (i32.load offset=8
-                      (get_local $0)
+                      (get_local $3)
                     )
                   )
-                  (tee_local $3
+                  (tee_local $1
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $6)
+                          (get_local $7)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6182,7 +6183,7 @@
                       (i32.load offset=12
                         (get_local $11)
                       )
-                      (get_local $0)
+                      (get_local $3)
                     )
                     (call $_abort)
                   )
@@ -6190,7 +6191,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $1)
+                  (get_local $0)
                   (get_local $11)
                 )
                 (block
@@ -6203,30 +6204,30 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $6)
+                          (get_local $7)
                         )
                         (i32.const -1)
                       )
                     )
                   )
                   (set_local $2
-                    (get_local $0)
+                    (get_local $3)
                   )
-                  (set_local $7
-                    (get_local $4)
+                  (set_local $4
+                    (get_local $5)
                   )
                   (br $do-once)
                 )
               )
               (if
                 (i32.ne
+                  (get_local $0)
                   (get_local $1)
-                  (get_local $3)
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $0)
                       (get_local $14)
                     )
                     (call $_abort)
@@ -6234,69 +6235,69 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $3
+                        (tee_local $1
                           (i32.add
-                            (get_local $1)
+                            (get_local $0)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $0)
+                      (get_local $3)
                     )
                     (set_local $10
-                      (get_local $3)
+                      (get_local $1)
                     )
                     (call $_abort)
                   )
                 )
                 (set_local $10
                   (i32.add
-                    (get_local $1)
+                    (get_local $0)
                     (i32.const 8)
                   )
                 )
               )
               (i32.store offset=12
                 (get_local $11)
-                (get_local $1)
+                (get_local $0)
               )
               (i32.store
                 (get_local $10)
                 (get_local $11)
               )
               (set_local $2
-                (get_local $0)
+                (get_local $3)
               )
-              (set_local $7
-                (get_local $4)
+              (set_local $4
+                (get_local $5)
               )
               (br $do-once)
             )
           )
           (set_local $11
             (i32.load offset=24
-              (get_local $0)
+              (get_local $3)
             )
           )
           (block $do-once0
             (if
               (i32.eq
-                (tee_local $1
+                (tee_local $0
                   (i32.load offset=12
-                    (get_local $0)
+                    (get_local $3)
                   )
                 )
-                (get_local $0)
+                (get_local $3)
               )
               (block
                 (if
                   (tee_local $10
                     (i32.load
-                      (tee_local $6
+                      (tee_local $7
                         (i32.add
-                          (tee_local $3
+                          (tee_local $1
                             (i32.add
-                              (get_local $0)
+                              (get_local $3)
                               (i32.const 16)
                             )
                           )
@@ -6306,23 +6307,23 @@
                     )
                   )
                   (block
-                    (set_local $1
+                    (set_local $0
                       (get_local $10)
                     )
-                    (set_local $3
-                      (get_local $6)
+                    (set_local $1
+                      (get_local $7)
                     )
                   )
                   (if
                     (i32.eqz
-                      (tee_local $1
+                      (tee_local $0
                         (i32.load
-                          (get_local $3)
+                          (get_local $1)
                         )
                       )
                     )
                     (block
-                      (set_local $5
+                      (set_local $6
                         (i32.const 0)
                       )
                       (br $do-once0)
@@ -6333,20 +6334,20 @@
                   (if
                     (tee_local $10
                       (i32.load
-                        (tee_local $6
+                        (tee_local $7
                           (i32.add
-                            (get_local $1)
+                            (get_local $0)
                             (i32.const 20)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $1
+                      (set_local $0
                         (get_local $10)
                       )
-                      (set_local $3
-                        (get_local $6)
+                      (set_local $1
+                        (get_local $7)
                       )
                       (br $while-in)
                     )
@@ -6354,29 +6355,29 @@
                   (if
                     (tee_local $10
                       (i32.load
-                        (tee_local $6
+                        (tee_local $7
                           (i32.add
-                            (get_local $1)
+                            (get_local $0)
                             (i32.const 16)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $1
+                      (set_local $0
                         (get_local $10)
                       )
-                      (set_local $3
-                        (get_local $6)
+                      (set_local $1
+                        (get_local $7)
                       )
                       (br $while-in)
                     )
                     (block
-                      (set_local $6
-                        (get_local $1)
+                      (set_local $7
+                        (get_local $0)
                       )
                       (set_local $9
-                        (get_local $3)
+                        (get_local $1)
                       )
                     )
                   )
@@ -6392,8 +6393,8 @@
                       (get_local $9)
                       (i32.const 0)
                     )
-                    (set_local $5
-                      (get_local $6)
+                    (set_local $6
+                      (get_local $7)
                     )
                   )
                 )
@@ -6401,9 +6402,9 @@
               (block
                 (if
                   (i32.lt_u
-                    (tee_local $6
+                    (tee_local $7
                       (i32.load offset=8
-                        (get_local $0)
+                        (get_local $3)
                       )
                     )
                     (get_local $14)
@@ -6415,38 +6416,38 @@
                     (i32.load
                       (tee_local $10
                         (i32.add
-                          (get_local $6)
+                          (get_local $7)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $3)
                   )
                   (call $_abort)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $3
+                      (tee_local $1
                         (i32.add
-                          (get_local $1)
+                          (get_local $0)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $3)
                   )
                   (block
                     (i32.store
                       (get_local $10)
-                      (get_local $1)
+                      (get_local $0)
                     )
                     (i32.store
-                      (get_local $3)
-                      (get_local $6)
-                    )
-                    (set_local $5
                       (get_local $1)
+                      (get_local $7)
+                    )
+                    (set_local $6
+                      (get_local $0)
                     )
                   )
                   (call $_abort)
@@ -6459,15 +6460,15 @@
             (block
               (if
                 (i32.eq
-                  (get_local $0)
+                  (get_local $3)
                   (i32.load
-                    (tee_local $6
+                    (tee_local $7
                       (i32.add
                         (i32.const 480)
                         (i32.shl
-                          (tee_local $1
+                          (tee_local $0
                             (i32.load offset=28
-                              (get_local $0)
+                              (get_local $3)
                             )
                           )
                           (i32.const 2)
@@ -6478,12 +6479,12 @@
                 )
                 (block
                   (i32.store
+                    (get_local $7)
                     (get_local $6)
-                    (get_local $5)
                   )
                   (if
                     (i32.eqz
-                      (get_local $5)
+                      (get_local $6)
                     )
                     (block
                       (i32.store
@@ -6495,17 +6496,17 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $1)
+                              (get_local $0)
                             )
                             (i32.const -1)
                           )
                         )
                       )
                       (set_local $2
-                        (get_local $0)
+                        (get_local $3)
                       )
-                      (set_local $7
-                        (get_local $4)
+                      (set_local $4
+                        (get_local $5)
                       )
                       (br $do-once)
                     )
@@ -6524,34 +6525,34 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $1
+                        (tee_local $0
                           (i32.add
                             (get_local $11)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $0)
+                      (get_local $3)
                     )
                     (i32.store
-                      (get_local $1)
-                      (get_local $5)
+                      (get_local $0)
+                      (get_local $6)
                     )
                     (i32.store offset=20
                       (get_local $11)
-                      (get_local $5)
+                      (get_local $6)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $5)
+                      (get_local $6)
                     )
                     (block
                       (set_local $2
-                        (get_local $0)
+                        (get_local $3)
                       )
-                      (set_local $7
-                        (get_local $4)
+                      (set_local $4
+                        (get_local $5)
                       )
                       (br $do-once)
                     )
@@ -6560,8 +6561,8 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $5)
-                  (tee_local $1
+                  (get_local $6)
+                  (tee_local $0
                     (i32.load
                       (i32.const 192)
                     )
@@ -6570,15 +6571,15 @@
                 (call $_abort)
               )
               (i32.store offset=24
-                (get_local $5)
+                (get_local $6)
                 (get_local $11)
               )
               (if
-                (tee_local $3
+                (tee_local $1
                   (i32.load
-                    (tee_local $6
+                    (tee_local $7
                       (i32.add
-                        (get_local $0)
+                        (get_local $3)
                         (i32.const 16)
                       )
                     )
@@ -6586,31 +6587,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $3)
                     (get_local $1)
+                    (get_local $0)
                   )
                   (call $_abort)
                   (block
                     (i32.store offset=16
-                      (get_local $5)
-                      (get_local $3)
+                      (get_local $6)
+                      (get_local $1)
                     )
                     (i32.store offset=24
-                      (get_local $3)
-                      (get_local $5)
+                      (get_local $1)
+                      (get_local $6)
                     )
                   )
                 )
               )
               (if
-                (tee_local $3
+                (tee_local $1
                   (i32.load offset=4
-                    (get_local $6)
+                    (get_local $7)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $3)
+                    (get_local $1)
                     (i32.load
                       (i32.const 192)
                     )
@@ -6618,37 +6619,37 @@
                   (call $_abort)
                   (block
                     (i32.store offset=20
-                      (get_local $5)
-                      (get_local $3)
+                      (get_local $6)
+                      (get_local $1)
                     )
                     (i32.store offset=24
-                      (get_local $3)
-                      (get_local $5)
+                      (get_local $1)
+                      (get_local $6)
                     )
                     (set_local $2
-                      (get_local $0)
+                      (get_local $3)
                     )
-                    (set_local $7
-                      (get_local $4)
+                    (set_local $4
+                      (get_local $5)
                     )
                   )
                 )
                 (block
                   (set_local $2
-                    (get_local $0)
+                    (get_local $3)
                   )
-                  (set_local $7
-                    (get_local $4)
+                  (set_local $4
+                    (get_local $5)
                   )
                 )
               )
             )
             (block
               (set_local $2
-                (get_local $0)
+                (get_local $3)
               )
-              (set_local $7
-                (get_local $4)
+              (set_local $4
+                (get_local $5)
               )
             )
           )
@@ -6667,7 +6668,7 @@
         (i32.and
           (tee_local $1
             (i32.load
-              (tee_local $4
+              (tee_local $5
                 (i32.add
                   (get_local $8)
                   (i32.const 4)
@@ -6687,7 +6688,7 @@
       )
       (block
         (i32.store
-          (get_local $4)
+          (get_local $5)
           (i32.and
             (get_local $1)
             (i32.const -2)
@@ -6696,19 +6697,19 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $7)
+            (get_local $4)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $7)
+            (get_local $4)
           )
-          (get_local $7)
+          (get_local $4)
         )
         (set_local $0
-          (get_local $7)
+          (get_local $4)
         )
       )
       (block
@@ -6722,12 +6723,12 @@
           (block
             (i32.store
               (i32.const 188)
-              (tee_local $5
+              (tee_local $6
                 (i32.add
                   (i32.load
                     (i32.const 188)
                   )
-                  (get_local $7)
+                  (get_local $4)
                 )
               )
             )
@@ -6738,7 +6739,7 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $5)
+                (get_local $6)
                 (i32.const 1)
               )
             )
@@ -6772,12 +6773,12 @@
           (block
             (i32.store
               (i32.const 184)
-              (tee_local $5
+              (tee_local $6
                 (i32.add
                   (i32.load
                     (i32.const 184)
                   )
-                  (get_local $7)
+                  (get_local $4)
                 )
               )
             )
@@ -6788,27 +6789,27 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $5)
+                (get_local $6)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $2)
-                (get_local $5)
+                (get_local $6)
               )
-              (get_local $5)
+              (get_local $6)
             )
             (return)
           )
         )
-        (set_local $5
+        (set_local $6
           (i32.add
             (i32.and
               (get_local $1)
               (i32.const -8)
             )
-            (get_local $7)
+            (get_local $4)
           )
         )
         (set_local $14
@@ -6824,7 +6825,7 @@
               (i32.const 256)
             )
             (block
-              (set_local $6
+              (set_local $7
                 (i32.load offset=24
                   (get_local $8)
                 )
@@ -6843,9 +6844,9 @@
                     (if
                       (tee_local $10
                         (i32.load
-                          (tee_local $1
+                          (tee_local $0
                             (i32.add
-                              (tee_local $3
+                              (tee_local $1
                                 (i32.add
                                   (get_local $8)
                                   (i32.const 16)
@@ -6857,20 +6858,21 @@
                         )
                       )
                       (block
-                        (set_local $0
+                        (set_local $4
                           (get_local $10)
                         )
-                        (set_local $3
-                          (get_local $1)
+                        (set_local $1
+                          (get_local $0)
                         )
                       )
                       (if
-                        (i32.eqz
-                          (tee_local $0
-                            (i32.load
-                              (get_local $3)
-                            )
+                        (tee_local $0
+                          (i32.load
+                            (get_local $1)
                           )
+                        )
+                        (set_local $4
+                          (get_local $0)
                         )
                         (block
                           (set_local $12
@@ -6884,20 +6886,20 @@
                       (if
                         (tee_local $10
                           (i32.load
-                            (tee_local $1
+                            (tee_local $0
                               (i32.add
-                                (get_local $0)
+                                (get_local $4)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $0
+                          (set_local $4
                             (get_local $10)
                           )
-                          (set_local $3
-                            (get_local $1)
+                          (set_local $1
+                            (get_local $0)
                           )
                           (br $while-in9)
                         )
@@ -6905,20 +6907,20 @@
                       (if
                         (tee_local $10
                           (i32.load
-                            (tee_local $1
+                            (tee_local $0
                               (i32.add
-                                (get_local $0)
+                                (get_local $4)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $0
+                          (set_local $4
                             (get_local $10)
                           )
-                          (set_local $3
-                            (get_local $1)
+                          (set_local $1
+                            (get_local $0)
                           )
                           (br $while-in9)
                         )
@@ -6926,7 +6928,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $3)
+                        (get_local $1)
                         (i32.load
                           (i32.const 192)
                         )
@@ -6934,11 +6936,11 @@
                       (call $_abort)
                       (block
                         (i32.store
-                          (get_local $3)
+                          (get_local $1)
                           (i32.const 0)
                         )
                         (set_local $12
-                          (get_local $0)
+                          (get_local $4)
                         )
                       )
                     )
@@ -6946,7 +6948,7 @@
                   (block
                     (if
                       (i32.lt_u
-                        (tee_local $1
+                        (tee_local $0
                           (i32.load offset=8
                             (get_local $8)
                           )
@@ -6962,7 +6964,7 @@
                         (i32.load
                           (tee_local $10
                             (i32.add
-                              (get_local $1)
+                              (get_local $0)
                               (i32.const 12)
                             )
                           )
@@ -6974,7 +6976,7 @@
                     (if
                       (i32.eq
                         (i32.load
-                          (tee_local $3
+                          (tee_local $1
                             (i32.add
                               (get_local $9)
                               (i32.const 8)
@@ -6989,8 +6991,8 @@
                           (get_local $9)
                         )
                         (i32.store
-                          (get_local $3)
                           (get_local $1)
+                          (get_local $0)
                         )
                         (set_local $12
                           (get_local $9)
@@ -7002,13 +7004,13 @@
                 )
               )
               (if
-                (get_local $6)
+                (get_local $7)
                 (block
                   (if
                     (i32.eq
                       (get_local $8)
                       (i32.load
-                        (tee_local $4
+                        (tee_local $5
                           (i32.add
                             (i32.const 480)
                             (i32.shl
@@ -7025,7 +7027,7 @@
                     )
                     (block
                       (i32.store
-                        (get_local $4)
+                        (get_local $5)
                         (get_local $12)
                       )
                       (if
@@ -7055,7 +7057,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $6)
+                          (get_local $7)
                           (i32.load
                             (i32.const 192)
                           )
@@ -7067,7 +7069,7 @@
                           (i32.load
                             (tee_local $9
                               (i32.add
-                                (get_local $6)
+                                (get_local $7)
                                 (i32.const 16)
                               )
                             )
@@ -7079,7 +7081,7 @@
                           (get_local $12)
                         )
                         (i32.store offset=20
-                          (get_local $6)
+                          (get_local $7)
                           (get_local $12)
                         )
                       )
@@ -7103,12 +7105,12 @@
                   )
                   (i32.store offset=24
                     (get_local $12)
-                    (get_local $6)
+                    (get_local $7)
                   )
                   (if
-                    (tee_local $0
+                    (tee_local $3
                       (i32.load
-                        (tee_local $4
+                        (tee_local $5
                           (i32.add
                             (get_local $8)
                             (i32.const 16)
@@ -7118,31 +7120,31 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $0)
+                        (get_local $3)
                         (get_local $9)
                       )
                       (call $_abort)
                       (block
                         (i32.store offset=16
                           (get_local $12)
-                          (get_local $0)
+                          (get_local $3)
                         )
                         (i32.store offset=24
-                          (get_local $0)
+                          (get_local $3)
                           (get_local $12)
                         )
                       )
                     )
                   )
                   (if
-                    (tee_local $0
+                    (tee_local $3
                       (i32.load offset=4
-                        (get_local $4)
+                        (get_local $5)
                       )
                     )
                     (if
                       (i32.lt_u
-                        (get_local $0)
+                        (get_local $3)
                         (i32.load
                           (i32.const 192)
                         )
@@ -7151,10 +7153,10 @@
                       (block
                         (i32.store offset=20
                           (get_local $12)
-                          (get_local $0)
+                          (get_local $3)
                         )
                         (i32.store offset=24
-                          (get_local $0)
+                          (get_local $3)
                           (get_local $12)
                         )
                       )
@@ -7171,12 +7173,12 @@
               )
               (if
                 (i32.ne
-                  (tee_local $0
+                  (tee_local $3
                     (i32.load offset=8
                       (get_local $8)
                     )
                   )
-                  (tee_local $6
+                  (tee_local $7
                     (i32.add
                       (i32.const 216)
                       (i32.shl
@@ -7192,7 +7194,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $0)
+                      (get_local $3)
                       (i32.load
                         (i32.const 192)
                       )
@@ -7202,7 +7204,7 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $0)
+                        (get_local $3)
                       )
                       (get_local $8)
                     )
@@ -7213,7 +7215,7 @@
               (if
                 (i32.eq
                   (get_local $9)
-                  (get_local $0)
+                  (get_local $3)
                 )
                 (block
                   (i32.store
@@ -7237,7 +7239,7 @@
               (if
                 (i32.ne
                   (get_local $9)
-                  (get_local $6)
+                  (get_local $7)
                 )
                 (block
                   (if
@@ -7252,7 +7254,7 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $6
+                        (tee_local $7
                           (i32.add
                             (get_local $9)
                             (i32.const 8)
@@ -7262,7 +7264,7 @@
                       (get_local $8)
                     )
                     (set_local $16
-                      (get_local $6)
+                      (get_local $7)
                     )
                     (call $_abort)
                   )
@@ -7275,12 +7277,12 @@
                 )
               )
               (i32.store offset=12
-                (get_local $0)
+                (get_local $3)
                 (get_local $9)
               )
               (i32.store
                 (get_local $16)
-                (get_local $0)
+                (get_local $3)
               )
             )
           )
@@ -7288,16 +7290,16 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $5)
+            (get_local $6)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $5)
+            (get_local $6)
           )
-          (get_local $5)
+          (get_local $6)
         )
         (if
           (i32.eq
@@ -7309,17 +7311,17 @@
           (block
             (i32.store
               (i32.const 184)
-              (get_local $5)
+              (get_local $6)
             )
             (return)
           )
           (set_local $0
-            (get_local $5)
+            (get_local $6)
           )
         )
       )
     )
-    (set_local $7
+    (set_local $4
       (i32.shr_u
         (get_local $0)
         (i32.const 3)
@@ -7336,7 +7338,7 @@
             (i32.const 216)
             (i32.shl
               (i32.shl
-                (get_local $7)
+                (get_local $4)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -7345,15 +7347,15 @@
         )
         (if
           (i32.and
-            (tee_local $4
+            (tee_local $5
               (i32.load
                 (i32.const 176)
               )
             )
-            (tee_local $5
+            (tee_local $6
               (i32.shl
                 (i32.const 1)
-                (get_local $7)
+                (get_local $4)
               )
             )
           )
@@ -7361,7 +7363,7 @@
             (i32.lt_u
               (tee_local $16
                 (i32.load
-                  (tee_local $7
+                  (tee_local $4
                     (i32.add
                       (get_local $1)
                       (i32.const 8)
@@ -7376,7 +7378,7 @@
             (call $_abort)
             (block
               (set_local $15
-                (get_local $7)
+                (get_local $4)
               )
               (set_local $13
                 (get_local $16)
@@ -7387,8 +7389,8 @@
             (i32.store
               (i32.const 176)
               (i32.or
-                (get_local $4)
                 (get_local $5)
+                (get_local $6)
               )
             )
             (set_local $15
@@ -7421,11 +7423,11 @@
         (return)
       )
     )
-    (set_local $4
+    (set_local $5
       (i32.add
         (i32.const 480)
         (i32.shl
-          (tee_local $7
+          (tee_local $4
             (if i32
               (tee_local $1
                 (i32.shr_u
@@ -7444,7 +7446,7 @@
                     (i32.shr_u
                       (get_local $0)
                       (i32.add
-                        (tee_local $4
+                        (tee_local $5
                           (i32.add
                             (i32.sub
                               (i32.const 14)
@@ -7484,7 +7486,7 @@
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (tee_local $5
+                                        (tee_local $6
                                           (i32.shl
                                             (get_local $15)
                                             (get_local $1)
@@ -7501,7 +7503,7 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $5)
+                                (get_local $6)
                                 (get_local $15)
                               )
                               (i32.const 15)
@@ -7514,7 +7516,7 @@
                     (i32.const 1)
                   )
                   (i32.shl
-                    (get_local $4)
+                    (get_local $5)
                     (i32.const 1)
                   )
                 )
@@ -7528,7 +7530,7 @@
     )
     (i32.store offset=28
       (get_local $2)
-      (get_local $7)
+      (get_local $4)
     )
     (i32.store offset=20
       (get_local $2)
@@ -7545,10 +7547,10 @@
             (i32.const 180)
           )
         )
-        (tee_local $5
+        (tee_local $6
           (i32.shl
             (i32.const 1)
-            (get_local $7)
+            (get_local $4)
           )
         )
       )
@@ -7561,12 +7563,12 @@
               (i32.sub
                 (i32.const 25)
                 (i32.shr_u
-                  (get_local $7)
+                  (get_local $4)
                   (i32.const 1)
                 )
               )
               (i32.eq
-                (get_local $7)
+                (get_local $4)
                 (i32.const 31)
               )
             )
@@ -7574,7 +7576,7 @@
         )
         (set_local $1
           (i32.load
-            (get_local $4)
+            (get_local $5)
           )
         )
         (loop $while-in15
@@ -7600,7 +7602,7 @@
               )
             )
             (if
-              (tee_local $7
+              (tee_local $4
                 (i32.load
                   (tee_local $16
                     (i32.add
@@ -7627,7 +7629,7 @@
                   )
                 )
                 (set_local $1
-                  (get_local $7)
+                  (get_local $4)
                 )
                 (br $while-in15)
               )
@@ -7695,7 +7697,7 @@
                       )
                     )
                   )
-                  (tee_local $4
+                  (tee_local $5
                     (i32.load
                       (i32.const 192)
                     )
@@ -7703,7 +7705,7 @@
                 )
                 (i32.ge_u
                   (get_local $17)
-                  (get_local $4)
+                  (get_local $5)
                 )
               )
               (block
@@ -7738,16 +7740,16 @@
           (i32.const 180)
           (i32.or
             (get_local $15)
-            (get_local $5)
+            (get_local $6)
           )
         )
         (i32.store
-          (get_local $4)
+          (get_local $5)
           (get_local $2)
         )
         (i32.store offset=24
           (get_local $2)
-          (get_local $4)
+          (get_local $5)
         )
         (i32.store offset=12
           (get_local $2)

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -142,16 +142,16 @@
         (block
           (if
             (i32.and
-              (tee_local $1
+              (tee_local $2
                 (i32.shr_u
-                  (tee_local $16
+                  (tee_local $15
                     (i32.load
                       (i32.const 176)
                     )
                   )
                   (tee_local $6
                     (i32.shr_u
-                      (tee_local $8
+                      (tee_local $9
                         (select
                           (i32.const 16)
                           (i32.and
@@ -175,24 +175,24 @@
               (i32.const 3)
             )
             (block
-              (set_local $1
+              (set_local $2
                 (i32.load
                   (tee_local $17
                     (i32.add
-                      (tee_local $3
+                      (tee_local $0
                         (i32.load
                           (tee_local $7
                             (i32.add
-                              (tee_local $0
+                              (tee_local $1
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (tee_local $11
+                                      (tee_local $6
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $1)
+                                              (get_local $2)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
@@ -218,13 +218,13 @@
               )
               (if
                 (i32.ne
-                  (get_local $0)
                   (get_local $1)
+                  (get_local $2)
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $2)
                       (i32.load
                         (i32.const 192)
                       )
@@ -234,23 +234,23 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $5
+                        (tee_local $8
                           (i32.add
-                            (get_local $1)
+                            (get_local $2)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $3)
+                      (get_local $0)
                     )
                     (block
                       (i32.store
-                        (get_local $5)
-                        (get_local $0)
+                        (get_local $8)
+                        (get_local $1)
                       )
                       (i32.store
                         (get_local $7)
-                        (get_local $1)
+                        (get_local $2)
                       )
                     )
                     (call $_abort)
@@ -259,11 +259,11 @@
                 (i32.store
                   (i32.const 176)
                   (i32.and
-                    (get_local $16)
+                    (get_local $15)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $11)
+                        (get_local $6)
                       )
                       (i32.const -1)
                     )
@@ -271,11 +271,11 @@
                 )
               )
               (i32.store offset=4
-                (get_local $3)
+                (get_local $0)
                 (i32.or
-                  (tee_local $1
+                  (tee_local $2
                     (i32.shl
-                      (get_local $11)
+                      (get_local $6)
                       (i32.const 3)
                     )
                   )
@@ -286,8 +286,8 @@
                 (tee_local $7
                   (i32.add
                     (i32.add
-                      (get_local $3)
-                      (get_local $1)
+                      (get_local $0)
+                      (get_local $2)
                     )
                     (i32.const 4)
                   )
@@ -306,7 +306,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $8)
+              (get_local $9)
               (tee_local $7
                 (i32.load
                   (i32.const 184)
@@ -315,22 +315,22 @@
             )
             (block
               (if
-                (get_local $1)
+                (get_local $2)
                 (block
-                  (set_local $0
+                  (set_local $1
                     (i32.and
                       (i32.shr_u
-                        (tee_local $1
+                        (tee_local $2
                           (i32.add
                             (i32.and
-                              (tee_local $0
+                              (tee_local $1
                                 (i32.and
                                   (i32.shl
-                                    (get_local $1)
+                                    (get_local $2)
                                     (get_local $6)
                                   )
                                   (i32.or
-                                    (tee_local $1
+                                    (tee_local $2
                                       (i32.shl
                                         (i32.const 2)
                                         (get_local $6)
@@ -338,14 +338,14 @@
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $1)
+                                      (get_local $2)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $0)
+                                (get_local $1)
                               )
                             )
                             (i32.const -1)
@@ -356,32 +356,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $0
+                  (set_local $1
                     (i32.load
-                      (tee_local $5
+                      (tee_local $8
                         (i32.add
-                          (tee_local $3
+                          (tee_local $0
                             (i32.load
                               (tee_local $19
                                 (i32.add
-                                  (tee_local $10
+                                  (tee_local $11
                                     (i32.add
                                       (i32.const 216)
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $11
+                                          (tee_local $10
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $1
+                                                      (tee_local $2
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $5
+                                                            (tee_local $8
                                                               (i32.shr_u
+                                                                (get_local $2)
                                                                 (get_local $1)
-                                                                (get_local $0)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -389,15 +389,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $0)
+                                                      (get_local $1)
                                                     )
-                                                    (tee_local $5
+                                                    (tee_local $8
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (tee_local $3
+                                                          (tee_local $0
                                                             (i32.shr_u
-                                                              (get_local $5)
-                                                              (get_local $1)
+                                                              (get_local $8)
+                                                              (get_local $2)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -406,13 +406,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (tee_local $3
+                                                  (tee_local $0
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (tee_local $10
+                                                        (tee_local $11
                                                           (i32.shr_u
-                                                            (get_local $3)
-                                                            (get_local $5)
+                                                            (get_local $0)
+                                                            (get_local $8)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -421,13 +421,13 @@
                                                     )
                                                   )
                                                 )
-                                                (tee_local $10
+                                                (tee_local $11
                                                   (i32.and
                                                     (i32.shr_u
                                                       (tee_local $19
                                                         (i32.shr_u
-                                                          (get_local $10)
-                                                          (get_local $3)
+                                                          (get_local $11)
+                                                          (get_local $0)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -438,7 +438,7 @@
                                               )
                                               (i32.shr_u
                                                 (get_local $19)
-                                                (get_local $10)
+                                                (get_local $11)
                                               )
                                             )
                                           )
@@ -460,13 +460,13 @@
                   )
                   (if
                     (i32.ne
-                      (get_local $10)
-                      (get_local $0)
+                      (get_local $11)
+                      (get_local $1)
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $0)
+                          (get_local $1)
                           (i32.load
                             (i32.const 192)
                           )
@@ -476,23 +476,23 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $1
+                            (tee_local $2
                               (i32.add
-                                (get_local $0)
+                                (get_local $1)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $3)
+                          (get_local $0)
                         )
                         (block
                           (i32.store
-                            (get_local $1)
-                            (get_local $10)
+                            (get_local $2)
+                            (get_local $11)
                           )
                           (i32.store
                             (get_local $19)
-                            (get_local $0)
+                            (get_local $1)
                           )
                           (set_local $17
                             (i32.load
@@ -507,11 +507,11 @@
                       (i32.store
                         (i32.const 176)
                         (i32.and
-                          (get_local $16)
+                          (get_local $15)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $11)
+                              (get_local $10)
                             )
                             (i32.const -1)
                           )
@@ -523,27 +523,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $3)
+                    (get_local $0)
                     (i32.or
-                      (get_local $8)
+                      (get_local $9)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $16
+                    (tee_local $15
                       (i32.add
-                        (get_local $3)
-                        (get_local $8)
+                        (get_local $0)
+                        (get_local $9)
                       )
                     )
                     (i32.or
                       (tee_local $7
                         (i32.sub
                           (i32.shl
-                            (get_local $11)
+                            (get_local $10)
                             (i32.const 3)
                           )
-                          (get_local $8)
+                          (get_local $9)
                         )
                       )
                       (i32.const 1)
@@ -551,7 +551,7 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $16)
+                      (get_local $15)
                       (get_local $7)
                     )
                     (get_local $7)
@@ -559,12 +559,12 @@
                   (if
                     (get_local $17)
                     (block
-                      (set_local $0
+                      (set_local $1
                         (i32.load
                           (i32.const 196)
                         )
                       )
-                      (set_local $10
+                      (set_local $11
                         (i32.add
                           (i32.const 216)
                           (i32.shl
@@ -588,7 +588,7 @@
                               (i32.const 176)
                             )
                           )
-                          (tee_local $1
+                          (tee_local $2
                             (i32.shl
                               (i32.const 1)
                               (get_local $19)
@@ -601,7 +601,7 @@
                               (i32.load
                                 (tee_local $19
                                   (i32.add
-                                    (get_local $10)
+                                    (get_local $11)
                                     (i32.const 8)
                                   )
                                 )
@@ -626,35 +626,35 @@
                             (i32.const 176)
                             (i32.or
                               (get_local $6)
-                              (get_local $1)
+                              (get_local $2)
                             )
                           )
                           (set_local $38
                             (i32.add
-                              (get_local $10)
+                              (get_local $11)
                               (i32.const 8)
                             )
                           )
                           (set_local $31
-                            (get_local $10)
+                            (get_local $11)
                           )
                         )
                       )
                       (i32.store
                         (get_local $38)
-                        (get_local $0)
+                        (get_local $1)
                       )
                       (i32.store offset=12
                         (get_local $31)
-                        (get_local $0)
+                        (get_local $1)
                       )
                       (i32.store offset=8
-                        (get_local $0)
+                        (get_local $1)
                         (get_local $31)
                       )
                       (i32.store offset=12
-                        (get_local $0)
-                        (get_local $10)
+                        (get_local $1)
+                        (get_local $11)
                       )
                     )
                   )
@@ -664,30 +664,30 @@
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $16)
+                    (get_local $15)
                   )
                   (return
-                    (get_local $5)
+                    (get_local $8)
                   )
                 )
               )
               (if
-                (tee_local $16
+                (tee_local $15
                   (i32.load
                     (i32.const 180)
                   )
                 )
                 (block
-                  (set_local $16
+                  (set_local $15
                     (i32.and
                       (i32.shr_u
                         (tee_local $7
                           (i32.add
                             (i32.and
-                              (get_local $16)
+                              (get_local $15)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $16)
+                                (get_local $15)
                               )
                             )
                             (i32.const -1)
@@ -698,7 +698,7 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $1
+                  (set_local $2
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
@@ -713,10 +713,10 @@
                                           (tee_local $7
                                             (i32.and
                                               (i32.shr_u
-                                                (tee_local $10
+                                                (tee_local $11
                                                   (i32.shr_u
                                                     (get_local $7)
-                                                    (get_local $16)
+                                                    (get_local $15)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -724,14 +724,14 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $16)
+                                          (get_local $15)
                                         )
-                                        (tee_local $10
+                                        (tee_local $11
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $0
+                                              (tee_local $1
                                                 (i32.shr_u
-                                                  (get_local $10)
+                                                  (get_local $11)
                                                   (get_local $7)
                                                 )
                                               )
@@ -741,13 +741,13 @@
                                           )
                                         )
                                       )
-                                      (tee_local $0
+                                      (tee_local $1
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $1
+                                            (tee_local $2
                                               (i32.shr_u
-                                                (get_local $0)
-                                                (get_local $10)
+                                                (get_local $1)
+                                                (get_local $11)
                                               )
                                             )
                                             (i32.const 1)
@@ -756,13 +756,13 @@
                                         )
                                       )
                                     )
-                                    (tee_local $1
+                                    (tee_local $2
                                       (i32.and
                                         (i32.shr_u
                                           (tee_local $6
                                             (i32.shr_u
+                                              (get_local $2)
                                               (get_local $1)
-                                              (get_local $0)
                                             )
                                           )
                                           (i32.const 1)
@@ -773,7 +773,7 @@
                                   )
                                   (i32.shr_u
                                     (get_local $6)
-                                    (get_local $1)
+                                    (get_local $2)
                                   )
                                 )
                                 (i32.const 2)
@@ -783,13 +783,13 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $8)
+                      (get_local $9)
                     )
                   )
                   (set_local $6
                     (get_local $17)
                   )
-                  (set_local $0
+                  (set_local $1
                     (get_local $17)
                   )
                   (loop $while-in
@@ -800,60 +800,60 @@
                             (get_local $6)
                           )
                         )
-                        (set_local $3
+                        (set_local $0
                           (get_local $17)
                         )
                         (if
-                          (tee_local $10
+                          (tee_local $11
                             (i32.load offset=20
                               (get_local $6)
                             )
                           )
-                          (set_local $3
-                            (get_local $10)
+                          (set_local $0
+                            (get_local $11)
                           )
                           (block
-                            (set_local $7
-                              (get_local $1)
+                            (set_local $3
+                              (get_local $2)
                             )
-                            (set_local $2
-                              (get_local $0)
+                            (set_local $5
+                              (get_local $1)
                             )
                             (br $while-out)
                           )
                         )
                       )
-                      (set_local $10
+                      (set_local $11
                         (i32.lt_u
                           (tee_local $17
                             (i32.sub
                               (i32.and
                                 (i32.load offset=4
-                                  (get_local $3)
+                                  (get_local $0)
                                 )
                                 (i32.const -8)
                               )
-                              (get_local $8)
+                              (get_local $9)
                             )
                           )
-                          (get_local $1)
+                          (get_local $2)
                         )
                       )
-                      (set_local $1
+                      (set_local $2
                         (select
                           (get_local $17)
-                          (get_local $1)
-                          (get_local $10)
+                          (get_local $2)
+                          (get_local $11)
                         )
                       )
                       (set_local $6
-                        (get_local $3)
+                        (get_local $0)
                       )
-                      (set_local $0
+                      (set_local $1
                         (select
-                          (get_local $3)
                           (get_local $0)
-                          (get_local $10)
+                          (get_local $1)
+                          (get_local $11)
                         )
                       )
                       (br $while-in)
@@ -861,8 +861,8 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $2)
-                      (tee_local $0
+                      (get_local $5)
+                      (tee_local $1
                         (i32.load
                           (i32.const 192)
                         )
@@ -872,38 +872,38 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $2)
+                      (get_local $5)
                       (tee_local $6
                         (i32.add
-                          (get_local $2)
-                          (get_local $8)
+                          (get_local $5)
+                          (get_local $9)
                         )
                       )
                     )
                     (call $_abort)
                   )
-                  (set_local $1
+                  (set_local $2
                     (i32.load offset=24
-                      (get_local $2)
+                      (get_local $5)
                     )
                   )
                   (block $do-once4
                     (if
                       (i32.eq
-                        (tee_local $5
+                        (tee_local $8
                           (i32.load offset=12
-                            (get_local $2)
+                            (get_local $5)
                           )
                         )
-                        (get_local $2)
+                        (get_local $5)
                       )
                       (block
                         (if
-                          (tee_local $11
+                          (tee_local $10
                             (i32.load
-                              (tee_local $3
+                              (tee_local $0
                                 (i32.add
-                                  (get_local $2)
+                                  (get_local $5)
                                   (i32.const 20)
                                 )
                               )
@@ -911,25 +911,25 @@
                           )
                           (block
                             (set_local $17
-                              (get_local $11)
+                              (get_local $10)
                             )
-                            (set_local $9
-                              (get_local $3)
+                            (set_local $7
+                              (get_local $0)
                             )
                           )
                           (if
                             (tee_local $17
                               (i32.load
-                                (tee_local $10
+                                (tee_local $11
                                   (i32.add
-                                    (get_local $2)
+                                    (get_local $5)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
-                            (set_local $9
-                              (get_local $10)
+                            (set_local $7
+                              (get_local $11)
                             )
                             (block
                               (set_local $19
@@ -941,9 +941,9 @@
                         )
                         (loop $while-in7
                           (if
-                            (tee_local $11
+                            (tee_local $10
                               (i32.load
-                                (tee_local $3
+                                (tee_local $0
                                   (i32.add
                                     (get_local $17)
                                     (i32.const 20)
@@ -953,18 +953,18 @@
                             )
                             (block
                               (set_local $17
-                                (get_local $11)
+                                (get_local $10)
                               )
-                              (set_local $9
-                                (get_local $3)
+                              (set_local $7
+                                (get_local $0)
                               )
                               (br $while-in7)
                             )
                           )
                           (if
-                            (tee_local $11
+                            (tee_local $10
                               (i32.load
-                                (tee_local $3
+                                (tee_local $0
                                   (i32.add
                                     (get_local $17)
                                     (i32.const 16)
@@ -974,10 +974,10 @@
                             )
                             (block
                               (set_local $17
-                                (get_local $11)
+                                (get_local $10)
                               )
-                              (set_local $9
-                                (get_local $3)
+                              (set_local $7
+                                (get_local $0)
                               )
                               (br $while-in7)
                             )
@@ -985,13 +985,13 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $9)
-                            (get_local $0)
+                            (get_local $7)
+                            (get_local $1)
                           )
                           (call $_abort)
                           (block
                             (i32.store
-                              (get_local $9)
+                              (get_local $7)
                               (i32.const 0)
                             )
                             (set_local $19
@@ -1003,52 +1003,52 @@
                       (block
                         (if
                           (i32.lt_u
-                            (tee_local $3
+                            (tee_local $0
                               (i32.load offset=8
-                                (get_local $2)
+                                (get_local $5)
                               )
                             )
-                            (get_local $0)
+                            (get_local $1)
                           )
                           (call $_abort)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (tee_local $11
+                              (tee_local $10
                                 (i32.add
-                                  (get_local $3)
+                                  (get_local $0)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $2)
+                            (get_local $5)
                           )
                           (call $_abort)
                         )
                         (if
                           (i32.eq
                             (i32.load
-                              (tee_local $10
+                              (tee_local $11
                                 (i32.add
-                                  (get_local $5)
+                                  (get_local $8)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $2)
+                            (get_local $5)
                           )
                           (block
                             (i32.store
-                              (get_local $11)
-                              (get_local $5)
+                              (get_local $10)
+                              (get_local $8)
                             )
                             (i32.store
-                              (get_local $10)
-                              (get_local $3)
+                              (get_local $11)
+                              (get_local $0)
                             )
                             (set_local $19
-                              (get_local $5)
+                              (get_local $8)
                             )
                           )
                           (call $_abort)
@@ -1058,19 +1058,19 @@
                   )
                   (block $do-once8
                     (if
-                      (get_local $1)
+                      (get_local $2)
                       (block
                         (if
                           (i32.eq
-                            (get_local $2)
+                            (get_local $5)
                             (i32.load
-                              (tee_local $0
+                              (tee_local $1
                                 (i32.add
                                   (i32.const 480)
                                   (i32.shl
-                                    (tee_local $5
+                                    (tee_local $8
                                       (i32.load offset=28
-                                        (get_local $2)
+                                        (get_local $5)
                                       )
                                     )
                                     (i32.const 2)
@@ -1081,7 +1081,7 @@
                           )
                           (block
                             (i32.store
-                              (get_local $0)
+                              (get_local $1)
                               (get_local $19)
                             )
                             (if
@@ -1098,7 +1098,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $5)
+                                        (get_local $8)
                                       )
                                       (i32.const -1)
                                     )
@@ -1111,7 +1111,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $1)
+                                (get_local $2)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -1121,21 +1121,21 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $5
+                                  (tee_local $8
                                     (i32.add
-                                      (get_local $1)
+                                      (get_local $2)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $2)
+                                (get_local $5)
                               )
                               (i32.store
-                                (get_local $5)
+                                (get_local $8)
                                 (get_local $19)
                               )
                               (i32.store offset=20
-                                (get_local $1)
+                                (get_local $2)
                                 (get_local $19)
                               )
                             )
@@ -1149,7 +1149,7 @@
                         (if
                           (i32.lt_u
                             (get_local $19)
-                            (tee_local $5
+                            (tee_local $8
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1159,41 +1159,41 @@
                         )
                         (i32.store offset=24
                           (get_local $19)
-                          (get_local $1)
+                          (get_local $2)
                         )
                         (if
-                          (tee_local $0
+                          (tee_local $1
                             (i32.load offset=16
-                              (get_local $2)
+                              (get_local $5)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $0)
-                              (get_local $5)
+                              (get_local $1)
+                              (get_local $8)
                             )
                             (call $_abort)
                             (block
                               (i32.store offset=16
                                 (get_local $19)
-                                (get_local $0)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $0)
+                                (get_local $1)
                                 (get_local $19)
                               )
                             )
                           )
                         )
                         (if
-                          (tee_local $0
+                          (tee_local $1
                             (i32.load offset=20
-                              (get_local $2)
+                              (get_local $5)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $0)
+                              (get_local $1)
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1202,10 +1202,10 @@
                             (block
                               (i32.store offset=20
                                 (get_local $19)
-                                (get_local $0)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $0)
+                                (get_local $1)
                                 (get_local $19)
                               )
                             )
@@ -1216,35 +1216,35 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $3)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $2)
+                        (get_local $5)
                         (i32.or
-                          (tee_local $1
+                          (tee_local $2
                             (i32.add
-                              (get_local $7)
-                              (get_local $8)
+                              (get_local $3)
+                              (get_local $9)
                             )
                           )
                           (i32.const 3)
                         )
                       )
                       (i32.store
-                        (tee_local $0
+                        (tee_local $1
                           (i32.add
                             (i32.add
+                              (get_local $5)
                               (get_local $2)
-                              (get_local $1)
                             )
                             (i32.const 4)
                           )
                         )
                         (i32.or
                           (i32.load
-                            (get_local $0)
+                            (get_local $1)
                           )
                           (i32.const 1)
                         )
@@ -1252,46 +1252,46 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $2)
+                        (get_local $5)
                         (i32.or
-                          (get_local $8)
+                          (get_local $9)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
                         (get_local $6)
                         (i32.or
-                          (get_local $7)
+                          (get_local $3)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
                           (get_local $6)
-                          (get_local $7)
+                          (get_local $3)
                         )
-                        (get_local $7)
+                        (get_local $3)
                       )
                       (if
-                        (tee_local $0
+                        (tee_local $1
                           (i32.load
                             (i32.const 184)
                           )
                         )
                         (block
-                          (set_local $1
+                          (set_local $2
                             (i32.load
                               (i32.const 196)
                             )
                           )
-                          (set_local $0
+                          (set_local $1
                             (i32.add
                               (i32.const 216)
                               (i32.shl
                                 (i32.shl
-                                  (tee_local $5
+                                  (tee_local $8
                                     (i32.shr_u
-                                      (get_local $0)
+                                      (get_local $1)
                                       (i32.const 3)
                                     )
                                   )
@@ -1303,25 +1303,25 @@
                           )
                           (if
                             (i32.and
-                              (tee_local $3
+                              (tee_local $0
                                 (i32.load
                                   (i32.const 176)
                                 )
                               )
-                              (tee_local $10
+                              (tee_local $11
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $5)
+                                  (get_local $8)
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (tee_local $11
+                                (tee_local $10
                                   (i32.load
-                                    (tee_local $5
+                                    (tee_local $8
                                       (i32.add
-                                        (get_local $0)
+                                        (get_local $1)
                                         (i32.const 8)
                                       )
                                     )
@@ -1334,10 +1334,10 @@
                               (call $_abort)
                               (block
                                 (set_local $39
-                                  (get_local $5)
+                                  (get_local $8)
                                 )
                                 (set_local $32
-                                  (get_local $11)
+                                  (get_local $10)
                                 )
                               )
                             )
@@ -1345,42 +1345,42 @@
                               (i32.store
                                 (i32.const 176)
                                 (i32.or
-                                  (get_local $3)
-                                  (get_local $10)
+                                  (get_local $0)
+                                  (get_local $11)
                                 )
                               )
                               (set_local $39
                                 (i32.add
-                                  (get_local $0)
+                                  (get_local $1)
                                   (i32.const 8)
                                 )
                               )
                               (set_local $32
-                                (get_local $0)
+                                (get_local $1)
                               )
                             )
                           )
                           (i32.store
                             (get_local $39)
-                            (get_local $1)
+                            (get_local $2)
                           )
                           (i32.store offset=12
                             (get_local $32)
-                            (get_local $1)
+                            (get_local $2)
                           )
                           (i32.store offset=8
-                            (get_local $1)
+                            (get_local $2)
                             (get_local $32)
                           )
                           (i32.store offset=12
+                            (get_local $2)
                             (get_local $1)
-                            (get_local $0)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $7)
+                        (get_local $3)
                       )
                       (i32.store
                         (i32.const 196)
@@ -1390,7 +1390,7 @@
                   )
                   (return
                     (i32.add
-                      (get_local $2)
+                      (get_local $5)
                       (i32.const 8)
                     )
                   )
@@ -1405,9 +1405,9 @@
             (i32.const -65)
           )
           (block
-            (set_local $1
+            (set_local $2
               (i32.and
-                (tee_local $0
+                (tee_local $1
                   (i32.add
                     (get_local $0)
                     (i32.const 11)
@@ -1417,60 +1417,60 @@
               )
             )
             (if
-              (tee_local $10
+              (tee_local $11
                 (i32.load
                   (i32.const 180)
                 )
               )
               (block
-                (set_local $3
+                (set_local $0
                   (i32.sub
                     (i32.const 0)
-                    (get_local $1)
+                    (get_local $2)
                   )
                 )
                 (block $label$break$L123
                   (if
-                    (tee_local $16
+                    (tee_local $15
                       (i32.load offset=480
                         (i32.shl
-                          (tee_local $8
+                          (tee_local $9
                             (if i32
-                              (tee_local $11
+                              (tee_local $10
                                 (i32.shr_u
-                                  (get_local $0)
+                                  (get_local $1)
                                   (i32.const 8)
                                 )
                               )
                               (if i32
                                 (i32.gt_u
-                                  (get_local $1)
+                                  (get_local $2)
                                   (i32.const 16777215)
                                 )
                                 (i32.const 31)
                                 (i32.or
                                   (i32.and
                                     (i32.shr_u
-                                      (get_local $1)
+                                      (get_local $2)
                                       (i32.add
-                                        (tee_local $16
+                                        (tee_local $15
                                           (i32.add
                                             (i32.sub
                                               (i32.const 14)
                                               (i32.or
                                                 (i32.or
-                                                  (tee_local $11
+                                                  (tee_local $10
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $5
+                                                          (tee_local $8
                                                             (i32.shl
-                                                              (get_local $11)
-                                                              (tee_local $0
+                                                              (get_local $10)
+                                                              (tee_local $1
                                                                 (i32.and
                                                                   (i32.shr_u
                                                                     (i32.add
-                                                                      (get_local $11)
+                                                                      (get_local $10)
                                                                       (i32.const 1048320)
                                                                     )
                                                                     (i32.const 16)
@@ -1487,16 +1487,16 @@
                                                       (i32.const 4)
                                                     )
                                                   )
-                                                  (get_local $0)
+                                                  (get_local $1)
                                                 )
-                                                (tee_local $5
+                                                (tee_local $8
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
                                                         (tee_local $17
                                                           (i32.shl
-                                                            (get_local $5)
-                                                            (get_local $11)
+                                                            (get_local $8)
+                                                            (get_local $10)
                                                           )
                                                         )
                                                         (i32.const 245760)
@@ -1511,7 +1511,7 @@
                                             (i32.shr_u
                                               (i32.shl
                                                 (get_local $17)
-                                                (get_local $5)
+                                                (get_local $8)
                                               )
                                               (i32.const 15)
                                             )
@@ -1523,7 +1523,7 @@
                                     (i32.const 1)
                                   )
                                   (i32.shl
-                                    (get_local $16)
+                                    (get_local $15)
                                     (i32.const 1)
                                   )
                                 )
@@ -1536,33 +1536,33 @@
                       )
                     )
                     (block
-                      (set_local $5
-                        (get_local $3)
+                      (set_local $8
+                        (get_local $0)
                       )
                       (set_local $17
                         (i32.const 0)
                       )
-                      (set_local $0
+                      (set_local $1
                         (i32.shl
-                          (get_local $1)
+                          (get_local $2)
                           (select
                             (i32.const 0)
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $8)
+                                (get_local $9)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $8)
+                              (get_local $9)
                               (i32.const 31)
                             )
                           )
                         )
                       )
-                      (set_local $11
-                        (get_local $16)
+                      (set_local $10
+                        (get_local $15)
                       )
                       (set_local $7
                         (i32.const 0)
@@ -1570,47 +1570,47 @@
                       (loop $while-in14
                         (if
                           (i32.lt_u
-                            (tee_local $3
+                            (tee_local $0
                               (i32.sub
                                 (tee_local $19
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $11)
+                                      (get_local $10)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $1)
+                                (get_local $2)
                               )
                             )
-                            (get_local $5)
+                            (get_local $8)
                           )
                           (if
                             (i32.eq
                               (get_local $19)
-                              (get_local $1)
+                              (get_local $2)
                             )
                             (block
                               (set_local $27
-                                (get_local $3)
+                                (get_local $0)
                               )
                               (set_local $25
-                                (get_local $11)
+                                (get_local $10)
                               )
                               (set_local $29
-                                (get_local $11)
+                                (get_local $10)
                               )
-                              (set_local $5
+                              (set_local $8
                                 (i32.const 90)
                               )
                               (br $label$break$L123)
                             )
                             (block
-                              (set_local $5
-                                (get_local $3)
+                              (set_local $8
+                                (get_local $0)
                               )
                               (set_local $7
-                                (get_local $11)
+                                (get_local $10)
                               )
                             )
                           )
@@ -1618,27 +1618,27 @@
                         (set_local $19
                           (select
                             (get_local $17)
-                            (tee_local $3
+                            (tee_local $0
                               (i32.load offset=20
-                                (get_local $11)
+                                (get_local $10)
                               )
                             )
                             (i32.or
                               (i32.eqz
-                                (get_local $3)
+                                (get_local $0)
                               )
                               (i32.eq
-                                (get_local $3)
-                                (tee_local $11
+                                (get_local $0)
+                                (tee_local $10
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $11)
+                                        (get_local $10)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $0)
+                                          (get_local $1)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -1651,14 +1651,14 @@
                           )
                         )
                         (if
-                          (tee_local $3
+                          (tee_local $0
                             (i32.eqz
-                              (get_local $11)
+                              (get_local $10)
                             )
                           )
                           (block
                             (set_local $33
-                              (get_local $5)
+                              (get_local $8)
                             )
                             (set_local $6
                               (get_local $19)
@@ -1666,7 +1666,7 @@
                             (set_local $30
                               (get_local $7)
                             )
-                            (set_local $5
+                            (set_local $8
                               (i32.const 86)
                             )
                           )
@@ -1674,12 +1674,12 @@
                             (set_local $17
                               (get_local $19)
                             )
-                            (set_local $0
+                            (set_local $1
                               (i32.shl
-                                (get_local $0)
+                                (get_local $1)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $3)
+                                    (get_local $0)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
@@ -1693,7 +1693,7 @@
                     )
                     (block
                       (set_local $33
-                        (get_local $3)
+                        (get_local $0)
                       )
                       (set_local $6
                         (i32.const 0)
@@ -1701,7 +1701,7 @@
                       (set_local $30
                         (i32.const 0)
                       )
-                      (set_local $5
+                      (set_local $8
                         (i32.const 86)
                       )
                     )
@@ -1709,7 +1709,7 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $5)
+                    (get_local $8)
                     (i32.const 86)
                   )
                   (if
@@ -1726,41 +1726,41 @@
                         (block i32
                           (if
                             (i32.eqz
-                              (tee_local $3
+                              (tee_local $0
                                 (i32.and
-                                  (get_local $10)
+                                  (get_local $11)
                                   (i32.or
-                                    (tee_local $16
+                                    (tee_local $15
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $8)
+                                        (get_local $9)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $16)
+                                      (get_local $15)
                                     )
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $8
-                                (get_local $1)
+                              (set_local $9
+                                (get_local $2)
                               )
                               (br $do-once)
                             )
                           )
-                          (set_local $3
+                          (set_local $0
                             (i32.and
                               (i32.shr_u
-                                (tee_local $16
+                                (tee_local $15
                                   (i32.add
                                     (i32.and
-                                      (get_local $3)
+                                      (get_local $0)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $3)
+                                        (get_local $0)
                                       )
                                     )
                                     (i32.const -1)
@@ -1778,13 +1778,13 @@
                                   (i32.or
                                     (i32.or
                                       (i32.or
-                                        (tee_local $16
+                                        (tee_local $15
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $8
+                                              (tee_local $9
                                                 (i32.shr_u
-                                                  (get_local $16)
-                                                  (get_local $3)
+                                                  (get_local $15)
+                                                  (get_local $0)
                                                 )
                                               )
                                               (i32.const 5)
@@ -1792,15 +1792,15 @@
                                             (i32.const 8)
                                           )
                                         )
-                                        (get_local $3)
+                                        (get_local $0)
                                       )
-                                      (tee_local $8
+                                      (tee_local $9
                                         (i32.and
                                           (i32.shr_u
                                             (tee_local $6
                                               (i32.shr_u
-                                                (get_local $8)
-                                                (get_local $16)
+                                                (get_local $9)
+                                                (get_local $15)
                                               )
                                             )
                                             (i32.const 2)
@@ -1815,7 +1815,7 @@
                                           (tee_local $7
                                             (i32.shr_u
                                               (get_local $6)
-                                              (get_local $8)
+                                              (get_local $9)
                                             )
                                           )
                                           (i32.const 1)
@@ -1827,7 +1827,7 @@
                                   (tee_local $7
                                     (i32.and
                                       (i32.shr_u
-                                        (tee_local $0
+                                        (tee_local $1
                                           (i32.shr_u
                                             (get_local $7)
                                             (get_local $6)
@@ -1840,7 +1840,7 @@
                                   )
                                 )
                                 (i32.shr_u
-                                  (get_local $0)
+                                  (get_local $1)
                                   (get_local $7)
                                 )
                               )
@@ -1861,7 +1861,7 @@
                       (set_local $29
                         (get_local $30)
                       )
-                      (set_local $5
+                      (set_local $8
                         (i32.const 90)
                       )
                     )
@@ -1877,14 +1877,14 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $5)
+                    (get_local $8)
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $5
+                    (set_local $8
                       (i32.const 0)
                     )
-                    (set_local $0
+                    (set_local $1
                       (i32.lt_u
                         (tee_local $7
                           (i32.sub
@@ -1894,7 +1894,7 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $1)
+                            (get_local $2)
                           )
                         )
                         (get_local $27)
@@ -1904,18 +1904,18 @@
                       (select
                         (get_local $7)
                         (get_local $27)
-                        (get_local $0)
+                        (get_local $1)
                       )
                     )
                     (set_local $7
                       (select
                         (get_local $25)
                         (get_local $29)
-                        (get_local $0)
+                        (get_local $1)
                       )
                     )
                     (if
-                      (tee_local $0
+                      (tee_local $1
                         (i32.load offset=16
                           (get_local $25)
                         )
@@ -1925,7 +1925,7 @@
                           (get_local $6)
                         )
                         (set_local $25
-                          (get_local $0)
+                          (get_local $1)
                         )
                         (set_local $29
                           (get_local $7)
@@ -1967,7 +1967,7 @@
                         (i32.load
                           (i32.const 184)
                         )
-                        (get_local $1)
+                        (get_local $2)
                       )
                     )
                     (i32.const 0)
@@ -1980,7 +1980,7 @@
                     (if
                       (i32.lt_u
                         (get_local $12)
-                        (tee_local $10
+                        (tee_local $11
                           (i32.load
                             (i32.const 192)
                           )
@@ -1994,7 +1994,7 @@
                         (tee_local $7
                           (i32.add
                             (get_local $12)
-                            (get_local $1)
+                            (get_local $2)
                           )
                         )
                       )
@@ -2008,7 +2008,7 @@
                     (block $do-once17
                       (if
                         (i32.eq
-                          (tee_local $0
+                          (tee_local $1
                             (i32.load offset=12
                               (get_local $12)
                             )
@@ -2017,9 +2017,9 @@
                         )
                         (block
                           (if
-                            (tee_local $3
+                            (tee_local $0
                               (i32.load
-                                (tee_local $8
+                                (tee_local $9
                                   (i32.add
                                     (get_local $12)
                                     (i32.const 20)
@@ -2029,16 +2029,16 @@
                             )
                             (block
                               (set_local $17
-                                (get_local $3)
+                                (get_local $0)
                               )
-                              (set_local $0
-                                (get_local $8)
+                              (set_local $1
+                                (get_local $9)
                               )
                             )
                             (if
                               (tee_local $17
                                 (i32.load
-                                  (tee_local $16
+                                  (tee_local $15
                                     (i32.add
                                       (get_local $12)
                                       (i32.const 16)
@@ -2046,11 +2046,11 @@
                                   )
                                 )
                               )
-                              (set_local $0
-                                (get_local $16)
+                              (set_local $1
+                                (get_local $15)
                               )
                               (block
-                                (set_local $9
+                                (set_local $5
                                   (i32.const 0)
                                 )
                                 (br $do-once17)
@@ -2059,9 +2059,9 @@
                           )
                           (loop $while-in20
                             (if
-                              (tee_local $3
+                              (tee_local $0
                                 (i32.load
-                                  (tee_local $8
+                                  (tee_local $9
                                     (i32.add
                                       (get_local $17)
                                       (i32.const 20)
@@ -2071,18 +2071,18 @@
                               )
                               (block
                                 (set_local $17
-                                  (get_local $3)
+                                  (get_local $0)
                                 )
-                                (set_local $0
-                                  (get_local $8)
+                                (set_local $1
+                                  (get_local $9)
                                 )
                                 (br $while-in20)
                               )
                             )
                             (if
-                              (tee_local $3
+                              (tee_local $0
                                 (i32.load
-                                  (tee_local $8
+                                  (tee_local $9
                                     (i32.add
                                       (get_local $17)
                                       (i32.const 16)
@@ -2092,10 +2092,10 @@
                               )
                               (block
                                 (set_local $17
-                                  (get_local $3)
+                                  (get_local $0)
                                 )
-                                (set_local $0
-                                  (get_local $8)
+                                (set_local $1
+                                  (get_local $9)
                                 )
                                 (br $while-in20)
                               )
@@ -2103,16 +2103,16 @@
                           )
                           (if
                             (i32.lt_u
-                              (get_local $0)
-                              (get_local $10)
+                              (get_local $1)
+                              (get_local $11)
                             )
                             (call $_abort)
                             (block
                               (i32.store
-                                (get_local $0)
+                                (get_local $1)
                                 (i32.const 0)
                               )
-                              (set_local $9
+                              (set_local $5
                                 (get_local $17)
                               )
                             )
@@ -2121,21 +2121,21 @@
                         (block
                           (if
                             (i32.lt_u
-                              (tee_local $8
+                              (tee_local $9
                                 (i32.load offset=8
                                   (get_local $12)
                                 )
                               )
-                              (get_local $10)
+                              (get_local $11)
                             )
                             (call $_abort)
                           )
                           (if
                             (i32.ne
                               (i32.load
-                                (tee_local $3
+                                (tee_local $0
                                   (i32.add
-                                    (get_local $8)
+                                    (get_local $9)
                                     (i32.const 12)
                                   )
                                 )
@@ -2147,9 +2147,9 @@
                           (if
                             (i32.eq
                               (i32.load
-                                (tee_local $16
+                                (tee_local $15
                                   (i32.add
-                                    (get_local $0)
+                                    (get_local $1)
                                     (i32.const 8)
                                   )
                                 )
@@ -2158,15 +2158,15 @@
                             )
                             (block
                               (i32.store
-                                (get_local $3)
                                 (get_local $0)
+                                (get_local $1)
                               )
                               (i32.store
-                                (get_local $16)
-                                (get_local $8)
+                                (get_local $15)
+                                (get_local $9)
                               )
-                              (set_local $9
-                                (get_local $0)
+                              (set_local $5
+                                (get_local $1)
                               )
                             )
                             (call $_abort)
@@ -2182,11 +2182,11 @@
                             (i32.eq
                               (get_local $12)
                               (i32.load
-                                (tee_local $10
+                                (tee_local $11
                                   (i32.add
                                     (i32.const 480)
                                     (i32.shl
-                                      (tee_local $0
+                                      (tee_local $1
                                         (i32.load offset=28
                                           (get_local $12)
                                         )
@@ -2199,12 +2199,12 @@
                             )
                             (block
                               (i32.store
-                                (get_local $10)
-                                (get_local $9)
+                                (get_local $11)
+                                (get_local $5)
                               )
                               (if
                                 (i32.eqz
-                                  (get_local $9)
+                                  (get_local $5)
                                 )
                                 (block
                                   (i32.store
@@ -2216,7 +2216,7 @@
                                       (i32.xor
                                         (i32.shl
                                           (i32.const 1)
-                                          (get_local $0)
+                                          (get_local $1)
                                         )
                                         (i32.const -1)
                                       )
@@ -2239,7 +2239,7 @@
                               (if
                                 (i32.eq
                                   (i32.load
-                                    (tee_local $0
+                                    (tee_local $1
                                       (i32.add
                                         (get_local $6)
                                         (i32.const 16)
@@ -2249,25 +2249,25 @@
                                   (get_local $12)
                                 )
                                 (i32.store
-                                  (get_local $0)
-                                  (get_local $9)
+                                  (get_local $1)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=20
                                   (get_local $6)
-                                  (get_local $9)
+                                  (get_local $5)
                                 )
                               )
                               (br_if $do-once21
                                 (i32.eqz
-                                  (get_local $9)
+                                  (get_local $5)
                                 )
                               )
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $9)
-                              (tee_local $0
+                              (get_local $5)
+                              (tee_local $1
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -2276,42 +2276,42 @@
                             (call $_abort)
                           )
                           (i32.store offset=24
-                            (get_local $9)
+                            (get_local $5)
                             (get_local $6)
                           )
                           (if
-                            (tee_local $10
+                            (tee_local $11
                               (i32.load offset=16
                                 (get_local $12)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $10)
-                                (get_local $0)
+                                (get_local $11)
+                                (get_local $1)
                               )
                               (call $_abort)
                               (block
                                 (i32.store offset=16
-                                  (get_local $9)
-                                  (get_local $10)
+                                  (get_local $5)
+                                  (get_local $11)
                                 )
                                 (i32.store offset=24
-                                  (get_local $10)
-                                  (get_local $9)
+                                  (get_local $11)
+                                  (get_local $5)
                                 )
                               )
                             )
                           )
                           (if
-                            (tee_local $10
+                            (tee_local $11
                               (i32.load offset=20
                                 (get_local $12)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $10)
+                                (get_local $11)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -2319,12 +2319,12 @@
                               (call $_abort)
                               (block
                                 (i32.store offset=20
-                                  (get_local $9)
-                                  (get_local $10)
+                                  (get_local $5)
+                                  (get_local $11)
                                 )
                                 (i32.store offset=24
-                                  (get_local $10)
-                                  (get_local $9)
+                                  (get_local $11)
+                                  (get_local $5)
                                 )
                               )
                             )
@@ -2342,7 +2342,7 @@
                           (i32.store offset=4
                             (get_local $12)
                             (i32.or
-                              (get_local $1)
+                              (get_local $2)
                               (i32.const 3)
                             )
                           )
@@ -2372,7 +2372,7 @@
                               (i32.const 256)
                             )
                             (block
-                              (set_local $10
+                              (set_local $11
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
@@ -2386,12 +2386,12 @@
                               )
                               (if
                                 (i32.and
-                                  (tee_local $0
+                                  (tee_local $1
                                     (i32.load
                                       (i32.const 176)
                                     )
                                   )
-                                  (tee_local $8
+                                  (tee_local $9
                                     (i32.shl
                                       (i32.const 1)
                                       (get_local $6)
@@ -2400,11 +2400,11 @@
                                 )
                                 (if
                                   (i32.lt_u
-                                    (tee_local $16
+                                    (tee_local $15
                                       (i32.load
                                         (tee_local $6
                                           (i32.add
-                                            (get_local $10)
+                                            (get_local $11)
                                             (i32.const 8)
                                           )
                                         )
@@ -2416,11 +2416,11 @@
                                   )
                                   (call $_abort)
                                   (block
-                                    (set_local $14
+                                    (set_local $16
                                       (get_local $6)
                                     )
                                     (set_local $26
-                                      (get_local $16)
+                                      (get_local $15)
                                     )
                                   )
                                 )
@@ -2428,23 +2428,23 @@
                                   (i32.store
                                     (i32.const 176)
                                     (i32.or
-                                      (get_local $0)
-                                      (get_local $8)
+                                      (get_local $1)
+                                      (get_local $9)
                                     )
                                   )
-                                  (set_local $14
+                                  (set_local $16
                                     (i32.add
-                                      (get_local $10)
+                                      (get_local $11)
                                       (i32.const 8)
                                     )
                                   )
                                   (set_local $26
-                                    (get_local $10)
+                                    (get_local $11)
                                   )
                                 )
                               )
                               (i32.store
-                                (get_local $14)
+                                (get_local $16)
                                 (get_local $7)
                               )
                               (i32.store offset=12
@@ -2457,7 +2457,7 @@
                               )
                               (i32.store offset=12
                                 (get_local $7)
-                                (get_local $10)
+                                (get_local $11)
                               )
                               (br $do-once25)
                             )
@@ -2466,9 +2466,9 @@
                             (i32.add
                               (i32.const 480)
                               (i32.shl
-                                (tee_local $3
+                                (tee_local $10
                                   (if i32
-                                    (tee_local $10
+                                    (tee_local $11
                                       (i32.shr_u
                                         (get_local $4)
                                         (i32.const 8)
@@ -2491,18 +2491,18 @@
                                                     (i32.const 14)
                                                     (i32.or
                                                       (i32.or
-                                                        (tee_local $10
+                                                        (tee_local $11
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $0
+                                                                (tee_local $1
                                                                   (i32.shl
-                                                                    (get_local $10)
-                                                                    (tee_local $8
+                                                                    (get_local $11)
+                                                                    (tee_local $9
                                                                       (i32.and
                                                                         (i32.shr_u
                                                                           (i32.add
-                                                                            (get_local $10)
+                                                                            (get_local $11)
                                                                             (i32.const 1048320)
                                                                           )
                                                                           (i32.const 16)
@@ -2519,16 +2519,16 @@
                                                             (i32.const 4)
                                                           )
                                                         )
-                                                        (get_local $8)
+                                                        (get_local $9)
                                                       )
-                                                      (tee_local $0
+                                                      (tee_local $1
                                                         (i32.and
                                                           (i32.shr_u
                                                             (i32.add
-                                                              (tee_local $16
+                                                              (tee_local $15
                                                                 (i32.shl
-                                                                  (get_local $0)
-                                                                  (get_local $10)
+                                                                  (get_local $1)
+                                                                  (get_local $11)
                                                                 )
                                                               )
                                                               (i32.const 245760)
@@ -2542,8 +2542,8 @@
                                                   )
                                                   (i32.shr_u
                                                     (i32.shl
-                                                      (get_local $16)
-                                                      (get_local $0)
+                                                      (get_local $15)
+                                                      (get_local $1)
                                                     )
                                                     (i32.const 15)
                                                   )
@@ -2569,10 +2569,10 @@
                           )
                           (i32.store offset=28
                             (get_local $7)
-                            (get_local $3)
+                            (get_local $10)
                           )
                           (i32.store offset=4
-                            (tee_local $0
+                            (tee_local $1
                               (i32.add
                                 (get_local $7)
                                 (i32.const 16)
@@ -2581,21 +2581,21 @@
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $0)
+                            (get_local $1)
                             (i32.const 0)
                           )
                           (if
                             (i32.eqz
                               (i32.and
-                                (tee_local $0
+                                (tee_local $1
                                   (i32.load
                                     (i32.const 180)
                                   )
                                 )
-                                (tee_local $16
+                                (tee_local $15
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $3)
+                                    (get_local $10)
                                   )
                                 )
                               )
@@ -2604,8 +2604,8 @@
                               (i32.store
                                 (i32.const 180)
                                 (i32.or
-                                  (get_local $0)
-                                  (get_local $16)
+                                  (get_local $1)
+                                  (get_local $15)
                                 )
                               )
                               (i32.store
@@ -2627,7 +2627,7 @@
                               (br $do-once25)
                             )
                           )
-                          (set_local $16
+                          (set_local $15
                             (i32.shl
                               (get_local $4)
                               (select
@@ -2635,18 +2635,18 @@
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $3)
+                                    (get_local $10)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $3)
+                                  (get_local $10)
                                   (i32.const 31)
                                 )
                               )
                             )
                           )
-                          (set_local $0
+                          (set_local $1
                             (i32.load
                               (get_local $6)
                             )
@@ -2657,34 +2657,34 @@
                                 (i32.eq
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $0)
+                                      (get_local $1)
                                     )
                                     (i32.const -8)
                                   )
                                   (get_local $4)
                                 )
                                 (block
-                                  (set_local $15
-                                    (get_local $0)
+                                  (set_local $14
+                                    (get_local $1)
                                   )
-                                  (set_local $5
+                                  (set_local $8
                                     (i32.const 148)
                                   )
                                   (br $while-out27)
                                 )
                               )
                               (if
-                                (tee_local $8
+                                (tee_local $9
                                   (i32.load
                                     (tee_local $6
                                       (i32.add
                                         (i32.add
-                                          (get_local $0)
+                                          (get_local $1)
                                           (i32.const 16)
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $16)
+                                            (get_local $15)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -2694,14 +2694,14 @@
                                   )
                                 )
                                 (block
-                                  (set_local $16
+                                  (set_local $15
                                     (i32.shl
-                                      (get_local $16)
+                                      (get_local $15)
                                       (i32.const 1)
                                     )
                                   )
-                                  (set_local $0
-                                    (get_local $8)
+                                  (set_local $1
+                                    (get_local $9)
                                   )
                                   (br $while-in28)
                                 )
@@ -2710,9 +2710,9 @@
                                     (get_local $6)
                                   )
                                   (set_local $21
-                                    (get_local $0)
+                                    (get_local $1)
                                   )
-                                  (set_local $5
+                                  (set_local $8
                                     (i32.const 145)
                                   )
                                 )
@@ -2721,7 +2721,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $5)
+                              (get_local $8)
                               (i32.const 145)
                             )
                             (if
@@ -2753,49 +2753,49 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $5)
+                                (get_local $8)
                                 (i32.const 148)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (tee_local $16
+                                    (tee_local $15
                                       (i32.load
-                                        (tee_local $0
+                                        (tee_local $1
                                           (i32.add
-                                            (get_local $15)
+                                            (get_local $14)
                                             (i32.const 8)
                                           )
                                         )
                                       )
                                     )
-                                    (tee_local $8
+                                    (tee_local $9
                                       (i32.load
                                         (i32.const 192)
                                       )
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $15)
-                                    (get_local $8)
+                                    (get_local $14)
+                                    (get_local $9)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $16)
+                                    (get_local $15)
                                     (get_local $7)
                                   )
                                   (i32.store
-                                    (get_local $0)
+                                    (get_local $1)
                                     (get_local $7)
                                   )
                                   (i32.store offset=8
                                     (get_local $7)
-                                    (get_local $16)
+                                    (get_local $15)
                                   )
                                   (i32.store offset=12
                                     (get_local $7)
-                                    (get_local $15)
+                                    (get_local $14)
                                   )
                                   (i32.store offset=24
                                     (get_local $7)
@@ -2811,28 +2811,28 @@
                           (i32.store offset=4
                             (get_local $12)
                             (i32.or
-                              (tee_local $16
+                              (tee_local $15
                                 (i32.add
                                   (get_local $4)
-                                  (get_local $1)
+                                  (get_local $2)
                                 )
                               )
                               (i32.const 3)
                             )
                           )
                           (i32.store
-                            (tee_local $0
+                            (tee_local $1
                               (i32.add
                                 (i32.add
                                   (get_local $12)
-                                  (get_local $16)
+                                  (get_local $15)
                                 )
                                 (i32.const 4)
                               )
                             )
                             (i32.or
                               (i32.load
-                                (get_local $0)
+                                (get_local $1)
                               )
                               (i32.const 1)
                             )
@@ -2847,17 +2847,17 @@
                       )
                     )
                   )
-                  (set_local $8
-                    (get_local $1)
+                  (set_local $9
+                    (get_local $2)
                   )
                 )
               )
-              (set_local $8
-                (get_local $1)
+              (set_local $9
+                (get_local $2)
               )
             )
           )
-          (set_local $8
+          (set_local $9
             (i32.const -1)
           )
         )
@@ -2870,10 +2870,10 @@
             (i32.const 184)
           )
         )
-        (get_local $8)
+        (get_local $9)
       )
       (block
-        (set_local $15
+        (set_local $14
           (i32.load
             (i32.const 196)
           )
@@ -2883,7 +2883,7 @@
             (tee_local $4
               (i32.sub
                 (get_local $12)
-                (get_local $8)
+                (get_local $9)
               )
             )
             (i32.const 15)
@@ -2893,8 +2893,8 @@
               (i32.const 196)
               (tee_local $21
                 (i32.add
-                  (get_local $15)
-                  (get_local $8)
+                  (get_local $14)
+                  (get_local $9)
                 )
               )
             )
@@ -2917,9 +2917,9 @@
               (get_local $4)
             )
             (i32.store offset=4
-              (get_local $15)
+              (get_local $14)
               (i32.or
-                (get_local $8)
+                (get_local $9)
                 (i32.const 3)
               )
             )
@@ -2934,7 +2934,7 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $15)
+              (get_local $14)
               (i32.or
                 (get_local $12)
                 (i32.const 3)
@@ -2944,7 +2944,7 @@
               (tee_local $4
                 (i32.add
                   (i32.add
-                    (get_local $15)
+                    (get_local $14)
                     (get_local $12)
                   )
                   (i32.const 4)
@@ -2961,7 +2961,7 @@
         )
         (return
           (i32.add
-            (get_local $15)
+            (get_local $14)
             (i32.const 8)
           )
         )
@@ -2969,20 +2969,20 @@
     )
     (if
       (i32.gt_u
-        (tee_local $15
+        (tee_local $14
           (i32.load
             (i32.const 188)
           )
         )
-        (get_local $8)
+        (get_local $9)
       )
       (block
         (i32.store
           (i32.const 188)
           (tee_local $4
             (i32.sub
-              (get_local $15)
-              (get_local $8)
+              (get_local $14)
+              (get_local $9)
             )
           )
         )
@@ -2990,12 +2990,12 @@
           (i32.const 200)
           (tee_local $12
             (i32.add
-              (tee_local $15
+              (tee_local $14
                 (i32.load
                   (i32.const 200)
                 )
               )
-              (get_local $8)
+              (get_local $9)
             )
           )
         )
@@ -3007,15 +3007,15 @@
           )
         )
         (i32.store offset=4
-          (get_local $15)
+          (get_local $14)
           (i32.or
-            (get_local $8)
+            (get_local $9)
             (i32.const 3)
           )
         )
         (return
           (i32.add
-            (get_local $15)
+            (get_local $14)
             (i32.const 8)
           )
         )
@@ -3030,24 +3030,24 @@
       (if
         (i32.and
           (i32.add
-            (tee_local $15
+            (tee_local $14
               (call $_sysconf
                 (i32.const 30)
               )
             )
             (i32.const -1)
           )
-          (get_local $15)
+          (get_local $14)
         )
         (call $_abort)
         (block
           (i32.store
             (i32.const 656)
-            (get_local $15)
+            (get_local $14)
           )
           (i32.store
             (i32.const 652)
-            (get_local $15)
+            (get_local $14)
           )
           (i32.store
             (i32.const 660)
@@ -3080,9 +3080,9 @@
         )
       )
     )
-    (set_local $15
+    (set_local $14
       (i32.add
-        (get_local $8)
+        (get_local $9)
         (i32.const 48)
       )
     )
@@ -3099,7 +3099,7 @@
                 )
                 (tee_local $12
                   (i32.add
-                    (get_local $8)
+                    (get_local $9)
                     (i32.const 47)
                   )
                 )
@@ -3113,7 +3113,7 @@
             )
           )
         )
-        (get_local $8)
+        (get_local $9)
       )
       (return
         (i32.const 0)
@@ -3122,7 +3122,7 @@
     (if
       (if i32
         (i32.ne
-          (tee_local $3
+          (tee_local $10
             (i32.load
               (i32.const 616)
             )
@@ -3131,7 +3131,7 @@
         )
         (i32.or
           (i32.le_u
-            (tee_local $14
+            (tee_local $16
               (i32.add
                 (tee_local $26
                   (i32.load
@@ -3144,8 +3144,8 @@
             (get_local $26)
           )
           (i32.gt_u
-            (get_local $14)
-            (get_local $3)
+            (get_local $16)
+            (get_local $10)
           )
         )
         (i32.const 0)
@@ -3164,7 +3164,7 @@
             )
             (i32.const 0)
             (i32.eq
-              (tee_local $5
+              (tee_local $8
                 (block $label$break$L257 i32
                   (if i32
                     (i32.and
@@ -3177,13 +3177,13 @@
                     (block i32
                       (block $label$break$L259
                         (if
-                          (tee_local $3
+                          (tee_local $10
                             (i32.load
                               (i32.const 200)
                             )
                           )
                           (block
-                            (set_local $14
+                            (set_local $16
                               (i32.const 624)
                             )
                             (loop $while-in34
@@ -3193,45 +3193,45 @@
                                     (i32.le_u
                                       (tee_local $26
                                         (i32.load
-                                          (get_local $14)
+                                          (get_local $16)
                                         )
                                       )
-                                      (get_local $3)
+                                      (get_local $10)
                                     )
                                     (i32.gt_u
                                       (i32.add
                                         (get_local $26)
                                         (i32.load
-                                          (tee_local $9
+                                          (tee_local $5
                                             (i32.add
-                                              (get_local $14)
+                                              (get_local $16)
                                               (i32.const 4)
                                             )
                                           )
                                         )
                                       )
-                                      (get_local $3)
+                                      (get_local $10)
                                     )
                                     (i32.const 0)
                                   )
                                   (block
                                     (set_local $6
-                                      (get_local $14)
+                                      (get_local $16)
                                     )
-                                    (set_local $11
-                                      (get_local $9)
+                                    (set_local $1
+                                      (get_local $5)
                                     )
                                     (br $while-out33)
                                   )
                                 )
                                 (br_if $while-in34
-                                  (tee_local $14
+                                  (tee_local $16
                                     (i32.load offset=8
-                                      (get_local $14)
+                                      (get_local $16)
                                     )
                                   )
                                 )
-                                (set_local $5
+                                (set_local $8
                                   (i32.const 173)
                                 )
                                 (br $label$break$L259)
@@ -3239,7 +3239,7 @@
                             )
                             (if
                               (i32.lt_u
-                                (tee_local $14
+                                (tee_local $16
                                   (i32.and
                                     (i32.sub
                                       (get_local $21)
@@ -3254,9 +3254,9 @@
                               )
                               (if
                                 (i32.eq
-                                  (tee_local $9
+                                  (tee_local $5
                                     (call $_sbrk
-                                      (get_local $14)
+                                      (get_local $16)
                                     )
                                   )
                                   (i32.add
@@ -3264,21 +3264,21 @@
                                       (get_local $6)
                                     )
                                     (i32.load
-                                      (get_local $11)
+                                      (get_local $1)
                                     )
                                   )
                                 )
                                 (if
                                   (i32.ne
-                                    (get_local $9)
+                                    (get_local $5)
                                     (i32.const -1)
                                   )
                                   (block
                                     (set_local $20
-                                      (get_local $9)
+                                      (get_local $5)
                                     )
                                     (set_local $22
-                                      (get_local $14)
+                                      (get_local $16)
                                     )
                                     (br $label$break$L257
                                       (i32.const 193)
@@ -3287,19 +3287,19 @@
                                 )
                                 (block
                                   (set_local $13
-                                    (get_local $9)
+                                    (get_local $5)
                                   )
                                   (set_local $18
-                                    (get_local $14)
+                                    (get_local $16)
                                   )
-                                  (set_local $5
+                                  (set_local $8
                                     (i32.const 183)
                                   )
                                 )
                               )
                             )
                           )
-                          (set_local $5
+                          (set_local $8
                             (i32.const 173)
                           )
                         )
@@ -3308,11 +3308,11 @@
                         (if
                           (if i32
                             (i32.eq
-                              (get_local $5)
+                              (get_local $8)
                               (i32.const 173)
                             )
                             (i32.ne
-                              (tee_local $3
+                              (tee_local $10
                                 (call $_sbrk
                                   (i32.const 0)
                                 )
@@ -3325,9 +3325,9 @@
                             (set_local $0
                               (if i32
                                 (i32.and
-                                  (tee_local $9
+                                  (tee_local $5
                                     (i32.add
-                                      (tee_local $14
+                                      (tee_local $16
                                         (i32.load
                                           (i32.const 652)
                                         )
@@ -3335,32 +3335,32 @@
                                       (i32.const -1)
                                     )
                                   )
-                                  (tee_local $1
-                                    (get_local $3)
+                                  (tee_local $2
+                                    (get_local $10)
                                   )
                                 )
                                 (i32.add
                                   (i32.sub
                                     (get_local $4)
-                                    (get_local $1)
+                                    (get_local $2)
                                   )
                                   (i32.and
                                     (i32.add
-                                      (get_local $9)
-                                      (get_local $1)
+                                      (get_local $5)
+                                      (get_local $2)
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $14)
+                                      (get_local $16)
                                     )
                                   )
                                 )
                                 (get_local $4)
                               )
                             )
-                            (set_local $1
+                            (set_local $2
                               (i32.add
-                                (tee_local $14
+                                (tee_local $16
                                   (i32.load
                                     (i32.const 608)
                                   )
@@ -3372,7 +3372,7 @@
                               (i32.and
                                 (i32.gt_u
                                   (get_local $0)
-                                  (get_local $8)
+                                  (get_local $9)
                                 )
                                 (i32.lt_u
                                   (get_local $0)
@@ -3384,12 +3384,12 @@
                                   (select
                                     (i32.or
                                       (i32.le_u
-                                        (get_local $1)
-                                        (get_local $14)
+                                        (get_local $2)
+                                        (get_local $16)
                                       )
                                       (i32.gt_u
-                                        (get_local $1)
-                                        (tee_local $9
+                                        (get_local $2)
+                                        (tee_local $5
                                           (i32.load
                                             (i32.const 616)
                                           )
@@ -3398,23 +3398,23 @@
                                     )
                                     (i32.const 0)
                                     (i32.ne
-                                      (get_local $9)
+                                      (get_local $5)
                                       (i32.const 0)
                                     )
                                   )
                                 )
                                 (if
                                   (i32.eq
-                                    (tee_local $9
+                                    (tee_local $5
                                       (call $_sbrk
                                         (get_local $0)
                                       )
                                     )
-                                    (get_local $3)
+                                    (get_local $10)
                                   )
                                   (block
                                     (set_local $20
-                                      (get_local $3)
+                                      (get_local $10)
                                     )
                                     (set_local $22
                                       (get_local $0)
@@ -3425,12 +3425,12 @@
                                   )
                                   (block
                                     (set_local $13
-                                      (get_local $9)
+                                      (get_local $5)
                                     )
                                     (set_local $18
                                       (get_local $0)
                                     )
-                                    (set_local $5
+                                    (set_local $8
                                       (i32.const 183)
                                     )
                                   )
@@ -3443,11 +3443,11 @@
                       (block $label$break$L279
                         (if
                           (i32.eq
-                            (get_local $5)
+                            (get_local $8)
                             (i32.const 183)
                           )
                           (block
-                            (set_local $9
+                            (set_local $5
                               (i32.sub
                                 (i32.const 0)
                                 (get_local $18)
@@ -3457,7 +3457,7 @@
                               (if i32
                                 (i32.and
                                   (i32.gt_u
-                                    (get_local $15)
+                                    (get_local $14)
                                     (get_local $18)
                                   )
                                   (i32.and
@@ -3472,14 +3472,14 @@
                                   )
                                 )
                                 (i32.lt_u
-                                  (tee_local $1
+                                  (tee_local $2
                                     (i32.and
                                       (i32.add
                                         (i32.sub
                                           (get_local $12)
                                           (get_local $18)
                                         )
-                                        (tee_local $3
+                                        (tee_local $10
                                           (i32.load
                                             (i32.const 656)
                                           )
@@ -3487,7 +3487,7 @@
                                       )
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $3)
+                                        (get_local $10)
                                       )
                                     )
                                   )
@@ -3498,26 +3498,26 @@
                               (if
                                 (i32.eq
                                   (call $_sbrk
-                                    (get_local $1)
+                                    (get_local $2)
                                   )
                                   (i32.const -1)
                                 )
                                 (block
                                   (drop
                                     (call $_sbrk
-                                      (get_local $9)
+                                      (get_local $5)
                                     )
                                   )
                                   (br $label$break$L279)
                                 )
-                                (set_local $2
+                                (set_local $3
                                   (i32.add
-                                    (get_local $1)
+                                    (get_local $2)
                                     (get_local $18)
                                   )
                                 )
                               )
-                              (set_local $2
+                              (set_local $3
                                 (get_local $18)
                               )
                             )
@@ -3531,7 +3531,7 @@
                                   (get_local $13)
                                 )
                                 (set_local $22
-                                  (get_local $2)
+                                  (get_local $3)
                                 )
                                 (br $label$break$L257
                                   (i32.const 193)
@@ -3560,7 +3560,7 @@
           )
           (i32.and
             (i32.lt_u
-              (tee_local $2
+              (tee_local $3
                 (call $_sbrk
                   (get_local $4)
                 )
@@ -3573,7 +3573,7 @@
             )
             (i32.and
               (i32.ne
-                (get_local $2)
+                (get_local $3)
                 (i32.const -1)
               )
               (i32.ne
@@ -3588,11 +3588,11 @@
           (tee_local $13
             (i32.sub
               (get_local $4)
-              (get_local $2)
+              (get_local $3)
             )
           )
           (i32.add
-            (get_local $8)
+            (get_local $9)
             (i32.const 40)
           )
         )
@@ -3600,19 +3600,19 @@
       )
       (block
         (set_local $20
-          (get_local $2)
+          (get_local $3)
         )
         (set_local $22
           (get_local $13)
         )
-        (set_local $5
+        (set_local $8
           (i32.const 193)
         )
       )
     )
     (if
       (i32.eq
-        (get_local $5)
+        (get_local $8)
         (i32.const 193)
       )
       (block
@@ -3647,7 +3647,7 @@
               )
             )
             (block
-              (set_local $2
+              (set_local $3
                 (i32.const 624)
               )
               (loop $do-in
@@ -3658,14 +3658,14 @@
                       (i32.add
                         (tee_local $4
                           (i32.load
-                            (get_local $2)
+                            (get_local $3)
                           )
                         )
                         (tee_local $12
                           (i32.load
                             (tee_local $18
                               (i32.add
-                                (get_local $2)
+                                (get_local $3)
                                 (i32.const 4)
                               )
                             )
@@ -3684,9 +3684,9 @@
                         (get_local $12)
                       )
                       (set_local $49
-                        (get_local $2)
+                        (get_local $3)
                       )
-                      (set_local $5
+                      (set_local $8
                         (i32.const 203)
                       )
                       (br $do-out)
@@ -3694,9 +3694,9 @@
                   )
                   (br_if $do-in
                     (i32.ne
-                      (tee_local $2
+                      (tee_local $3
                         (i32.load offset=8
-                          (get_local $2)
+                          (get_local $3)
                         )
                       )
                       (i32.const 0)
@@ -3728,7 +3728,7 @@
                     )
                     (i32.const 0)
                     (i32.eq
-                      (get_local $5)
+                      (get_local $8)
                       (i32.const 203)
                     )
                   )
@@ -3741,7 +3741,7 @@
                       (get_local $22)
                     )
                   )
-                  (set_local $2
+                  (set_local $3
                     (i32.add
                       (get_local $13)
                       (tee_local $12
@@ -3749,7 +3749,7 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $2
+                              (tee_local $3
                                 (i32.add
                                   (get_local $13)
                                   (i32.const 8)
@@ -3760,7 +3760,7 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $2)
+                            (get_local $3)
                             (i32.const 7)
                           )
                         )
@@ -3780,14 +3780,14 @@
                   )
                   (i32.store
                     (i32.const 200)
-                    (get_local $2)
+                    (get_local $3)
                   )
                   (i32.store
                     (i32.const 188)
                     (get_local $18)
                   )
                   (i32.store offset=4
-                    (get_local $2)
+                    (get_local $3)
                     (i32.or
                       (get_local $18)
                       (i32.const 1)
@@ -3795,7 +3795,7 @@
                   )
                   (i32.store offset=4
                     (i32.add
-                      (get_local $2)
+                      (get_local $3)
                       (get_local $18)
                     )
                     (i32.const 40)
@@ -3809,7 +3809,7 @@
                   (br $do-once40)
                 )
               )
-              (set_local $17
+              (set_local $7
                 (if i32
                   (i32.lt_u
                     (get_local $20)
@@ -3835,7 +3835,7 @@
                   (get_local $22)
                 )
               )
-              (set_local $2
+              (set_local $3
                 (i32.const 624)
               )
               (loop $while-in43
@@ -3843,27 +3843,27 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $2)
+                        (get_local $3)
                       )
                       (get_local $18)
                     )
                     (block
                       (set_local $50
-                        (get_local $2)
+                        (get_local $3)
                       )
                       (set_local $40
-                        (get_local $2)
+                        (get_local $3)
                       )
-                      (set_local $5
+                      (set_local $8
                         (i32.const 211)
                       )
                       (br $while-out42)
                     )
                   )
                   (br_if $while-in43
-                    (tee_local $2
+                    (tee_local $3
                       (i32.load offset=8
-                        (get_local $2)
+                        (get_local $3)
                       )
                     )
                   )
@@ -3874,7 +3874,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $5)
+                  (get_local $8)
                   (i32.const 211)
                 )
                 (if
@@ -3893,7 +3893,7 @@
                       (get_local $20)
                     )
                     (i32.store
-                      (tee_local $2
+                      (tee_local $3
                         (i32.add
                           (get_local $40)
                           (i32.const 4)
@@ -3901,7 +3901,7 @@
                       )
                       (i32.add
                         (i32.load
-                          (get_local $2)
+                          (get_local $3)
                         )
                         (get_local $22)
                       )
@@ -3913,7 +3913,7 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $2
+                              (tee_local $3
                                 (i32.add
                                   (get_local $20)
                                   (i32.const 8)
@@ -3924,7 +3924,7 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $2)
+                            (get_local $3)
                             (i32.const 7)
                           )
                         )
@@ -3937,7 +3937,7 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $2
+                              (tee_local $3
                                 (i32.add
                                   (get_local $18)
                                   (i32.const 8)
@@ -3948,31 +3948,31 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $2)
+                            (get_local $3)
                             (i32.const 7)
                           )
                         )
                       )
                     )
-                    (set_local $2
+                    (set_local $3
                       (i32.add
                         (get_local $12)
-                        (get_local $8)
+                        (get_local $9)
                       )
                     )
-                    (set_local $15
+                    (set_local $14
                       (i32.sub
                         (i32.sub
                           (get_local $4)
                           (get_local $12)
                         )
-                        (get_local $8)
+                        (get_local $9)
                       )
                     )
                     (i32.store offset=4
                       (get_local $12)
                       (i32.or
-                        (get_local $8)
+                        (get_local $9)
                         (i32.const 3)
                       )
                     )
@@ -3998,16 +3998,16 @@
                                     (i32.load
                                       (i32.const 184)
                                     )
-                                    (get_local $15)
+                                    (get_local $14)
                                   )
                                 )
                               )
                               (i32.store
                                 (i32.const 196)
-                                (get_local $2)
+                                (get_local $3)
                               )
                               (i32.store offset=4
-                                (get_local $2)
+                                (get_local $3)
                                 (i32.or
                                   (get_local $0)
                                   (i32.const 1)
@@ -4015,7 +4015,7 @@
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $2)
+                                  (get_local $3)
                                   (get_local $0)
                                 )
                                 (get_local $0)
@@ -4039,7 +4039,7 @@
                                     (i32.const 1)
                                   )
                                   (block i32
-                                    (set_local $11
+                                    (set_local $1
                                       (i32.and
                                         (get_local $0)
                                         (i32.const -8)
@@ -4075,11 +4075,11 @@
                                               )
                                               (block
                                                 (if
-                                                  (tee_local $3
+                                                  (tee_local $10
                                                     (i32.load
-                                                      (tee_local $1
+                                                      (tee_local $2
                                                         (i32.add
-                                                          (tee_local $9
+                                                          (tee_local $5
                                                             (i32.add
                                                               (get_local $4)
                                                               (i32.const 16)
@@ -4091,20 +4091,21 @@
                                                     )
                                                   )
                                                   (block
-                                                    (set_local $14
-                                                      (get_local $3)
+                                                    (set_local $0
+                                                      (get_local $10)
                                                     )
-                                                    (set_local $9
-                                                      (get_local $1)
+                                                    (set_local $5
+                                                      (get_local $2)
                                                     )
                                                   )
                                                   (if
-                                                    (i32.eqz
-                                                      (tee_local $14
-                                                        (i32.load
-                                                          (get_local $9)
-                                                        )
+                                                    (tee_local $16
+                                                      (i32.load
+                                                        (get_local $5)
                                                       )
+                                                    )
+                                                    (set_local $0
+                                                      (get_local $16)
                                                     )
                                                     (block
                                                       (set_local $24
@@ -4116,43 +4117,43 @@
                                                 )
                                                 (loop $while-in50
                                                   (if
-                                                    (tee_local $3
+                                                    (tee_local $10
                                                       (i32.load
-                                                        (tee_local $1
+                                                        (tee_local $2
                                                           (i32.add
-                                                            (get_local $14)
+                                                            (get_local $0)
                                                             (i32.const 20)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $14
-                                                        (get_local $3)
+                                                      (set_local $0
+                                                        (get_local $10)
                                                       )
-                                                      (set_local $9
-                                                        (get_local $1)
+                                                      (set_local $5
+                                                        (get_local $2)
                                                       )
                                                       (br $while-in50)
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $3
+                                                    (tee_local $10
                                                       (i32.load
-                                                        (tee_local $1
+                                                        (tee_local $2
                                                           (i32.add
-                                                            (get_local $14)
+                                                            (get_local $0)
                                                             (i32.const 16)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $14
-                                                        (get_local $3)
+                                                      (set_local $0
+                                                        (get_local $10)
                                                       )
-                                                      (set_local $9
-                                                        (get_local $1)
+                                                      (set_local $5
+                                                        (get_local $2)
                                                       )
                                                       (br $while-in50)
                                                     )
@@ -4160,17 +4161,17 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $9)
-                                                    (get_local $17)
+                                                    (get_local $5)
+                                                    (get_local $7)
                                                   )
                                                   (call $_abort)
                                                   (block
                                                     (i32.store
-                                                      (get_local $9)
+                                                      (get_local $5)
                                                       (i32.const 0)
                                                     )
                                                     (set_local $24
-                                                      (get_local $14)
+                                                      (get_local $0)
                                                     )
                                                   )
                                                 )
@@ -4178,21 +4179,21 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (tee_local $1
+                                                    (tee_local $2
                                                       (i32.load offset=8
                                                         (get_local $4)
                                                       )
                                                     )
-                                                    (get_local $17)
+                                                    (get_local $7)
                                                   )
                                                   (call $_abort)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (tee_local $3
+                                                      (tee_local $10
                                                         (i32.add
-                                                          (get_local $1)
+                                                          (get_local $2)
                                                           (i32.const 12)
                                                         )
                                                       )
@@ -4204,7 +4205,7 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $9
+                                                      (tee_local $5
                                                         (i32.add
                                                           (get_local $21)
                                                           (i32.const 8)
@@ -4215,12 +4216,12 @@
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $3)
+                                                      (get_local $10)
                                                       (get_local $21)
                                                     )
                                                     (i32.store
-                                                      (get_local $9)
-                                                      (get_local $1)
+                                                      (get_local $5)
+                                                      (get_local $2)
                                                     )
                                                     (set_local $24
                                                       (get_local $21)
@@ -4241,7 +4242,7 @@
                                               (i32.ne
                                                 (get_local $4)
                                                 (i32.load
-                                                  (tee_local $1
+                                                  (tee_local $2
                                                     (i32.add
                                                       (i32.const 480)
                                                       (i32.shl
@@ -4269,7 +4270,7 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $9
+                                                      (tee_local $5
                                                         (i32.add
                                                           (get_local $23)
                                                           (i32.const 16)
@@ -4279,7 +4280,7 @@
                                                     (get_local $4)
                                                   )
                                                   (i32.store
-                                                    (get_local $9)
+                                                    (get_local $5)
                                                     (get_local $24)
                                                   )
                                                   (i32.store offset=20
@@ -4295,7 +4296,7 @@
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $1)
+                                                  (get_local $2)
                                                   (get_local $24)
                                                 )
                                                 (br_if $do-once51
@@ -4336,9 +4337,9 @@
                                             (get_local $23)
                                           )
                                           (if
-                                            (tee_local $9
+                                            (tee_local $5
                                               (i32.load
-                                                (tee_local $1
+                                                (tee_local $2
                                                   (i32.add
                                                     (get_local $4)
                                                     (i32.const 16)
@@ -4348,17 +4349,17 @@
                                             )
                                             (if
                                               (i32.lt_u
-                                                (get_local $9)
+                                                (get_local $5)
                                                 (get_local $21)
                                               )
                                               (call $_abort)
                                               (block
                                                 (i32.store offset=16
                                                   (get_local $24)
-                                                  (get_local $9)
+                                                  (get_local $5)
                                                 )
                                                 (i32.store offset=24
-                                                  (get_local $9)
+                                                  (get_local $5)
                                                   (get_local $24)
                                                 )
                                               )
@@ -4366,16 +4367,16 @@
                                           )
                                           (br_if $label$break$L331
                                             (i32.eqz
-                                              (tee_local $9
+                                              (tee_local $5
                                                 (i32.load offset=4
-                                                  (get_local $1)
+                                                  (get_local $2)
                                                 )
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $9)
+                                              (get_local $5)
                                               (i32.load
                                                 (i32.const 192)
                                               )
@@ -4384,10 +4385,10 @@
                                             (block
                                               (i32.store offset=20
                                                 (get_local $24)
-                                                (get_local $9)
+                                                (get_local $5)
                                               )
                                               (i32.store offset=24
-                                                (get_local $9)
+                                                (get_local $5)
                                                 (get_local $24)
                                               )
                                             )
@@ -4402,7 +4403,7 @@
                                           (block $do-once55
                                             (if
                                               (i32.ne
-                                                (tee_local $9
+                                                (tee_local $5
                                                   (i32.load offset=8
                                                     (get_local $4)
                                                   )
@@ -4423,15 +4424,15 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $9)
-                                                    (get_local $17)
+                                                    (get_local $5)
+                                                    (get_local $7)
                                                   )
                                                   (call $_abort)
                                                 )
                                                 (br_if $do-once55
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $9)
+                                                      (get_local $5)
                                                     )
                                                     (get_local $4)
                                                   )
@@ -4443,7 +4444,7 @@
                                           (if
                                             (i32.eq
                                               (get_local $21)
-                                              (get_local $9)
+                                              (get_local $5)
                                             )
                                             (block
                                               (i32.store
@@ -4480,14 +4481,14 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $21)
-                                                    (get_local $17)
+                                                    (get_local $7)
                                                   )
                                                   (call $_abort)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $1
+                                                      (tee_local $2
                                                         (i32.add
                                                           (get_local $21)
                                                           (i32.const 8)
@@ -4498,7 +4499,7 @@
                                                   )
                                                   (block
                                                     (set_local $41
-                                                      (get_local $1)
+                                                      (get_local $2)
                                                     )
                                                     (br $do-once57)
                                                   )
@@ -4508,25 +4509,25 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $9)
+                                            (get_local $5)
                                             (get_local $21)
                                           )
                                           (i32.store
                                             (get_local $41)
-                                            (get_local $9)
+                                            (get_local $5)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $15
+                                    (set_local $14
                                       (i32.add
-                                        (get_local $11)
-                                        (get_local $15)
+                                        (get_local $1)
+                                        (get_local $14)
                                       )
                                     )
                                     (i32.add
                                       (get_local $4)
-                                      (get_local $11)
+                                      (get_local $1)
                                     )
                                   )
                                   (get_local $4)
@@ -4542,28 +4543,28 @@
                             )
                           )
                           (i32.store offset=4
-                            (get_local $2)
+                            (get_local $3)
                             (i32.or
-                              (get_local $15)
+                              (get_local $14)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $2)
-                              (get_local $15)
+                              (get_local $3)
+                              (get_local $14)
                             )
-                            (get_local $15)
+                            (get_local $14)
                           )
                           (set_local $6
                             (i32.shr_u
-                              (get_local $15)
+                              (get_local $14)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $15)
+                              (get_local $14)
                               (i32.const 256)
                             )
                             (block
@@ -4587,7 +4588,7 @@
                                         (i32.const 176)
                                       )
                                     )
-                                    (tee_local $1
+                                    (tee_local $2
                                       (i32.shl
                                         (i32.const 1)
                                         (get_local $6)
@@ -4597,7 +4598,7 @@
                                   (block
                                     (if
                                       (i32.ge_u
-                                        (tee_local $3
+                                        (tee_local $10
                                           (i32.load
                                             (tee_local $6
                                               (i32.add
@@ -4616,7 +4617,7 @@
                                           (get_local $6)
                                         )
                                         (set_local $34
-                                          (get_local $3)
+                                          (get_local $10)
                                         )
                                         (br $do-once59)
                                       )
@@ -4628,7 +4629,7 @@
                                       (i32.const 176)
                                       (i32.or
                                         (get_local $23)
-                                        (get_local $1)
+                                        (get_local $2)
                                       )
                                     )
                                     (set_local $42
@@ -4645,33 +4646,33 @@
                               )
                               (i32.store
                                 (get_local $42)
-                                (get_local $2)
+                                (get_local $3)
                               )
                               (i32.store offset=12
                                 (get_local $34)
-                                (get_local $2)
+                                (get_local $3)
                               )
                               (i32.store offset=8
-                                (get_local $2)
+                                (get_local $3)
                                 (get_local $34)
                               )
                               (i32.store offset=12
-                                (get_local $2)
+                                (get_local $3)
                                 (get_local $0)
                               )
                               (br $do-once44)
                             )
                           )
-                          (set_local $1
+                          (set_local $2
                             (i32.add
                               (i32.const 480)
                               (i32.shl
-                                (tee_local $3
+                                (tee_local $1
                                   (block $do-once61 i32
                                     (if i32
-                                      (tee_local $1
+                                      (tee_local $2
                                         (i32.shr_u
-                                          (get_local $15)
+                                          (get_local $14)
                                           (i32.const 8)
                                         )
                                       )
@@ -4680,7 +4681,7 @@
                                           (br_if $do-once61
                                             (i32.const 31)
                                             (i32.gt_u
-                                              (get_local $15)
+                                              (get_local $14)
                                               (i32.const 16777215)
                                             )
                                           )
@@ -4688,26 +4689,26 @@
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $15)
+                                              (get_local $14)
                                               (i32.add
-                                                (tee_local $14
+                                                (tee_local $16
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (tee_local $3
+                                                          (tee_local $10
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (tee_local $11
+                                                                  (tee_local $1
                                                                     (i32.shl
-                                                                      (get_local $1)
+                                                                      (get_local $2)
                                                                       (tee_local $23
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $1)
+                                                                              (get_local $2)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -4726,14 +4727,14 @@
                                                           )
                                                           (get_local $23)
                                                         )
-                                                        (tee_local $11
+                                                        (tee_local $1
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
                                                                 (tee_local $6
                                                                   (i32.shl
-                                                                    (get_local $11)
-                                                                    (get_local $3)
+                                                                    (get_local $1)
+                                                                    (get_local $10)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -4748,7 +4749,7 @@
                                                     (i32.shr_u
                                                       (i32.shl
                                                         (get_local $6)
-                                                        (get_local $11)
+                                                        (get_local $1)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4760,7 +4761,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $14)
+                                            (get_local $16)
                                             (i32.const 1)
                                           )
                                         )
@@ -4774,13 +4775,13 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $2)
                             (get_local $3)
+                            (get_local $1)
                           )
                           (i32.store offset=4
                             (tee_local $0
                               (i32.add
-                                (get_local $2)
+                                (get_local $3)
                                 (i32.const 16)
                               )
                             )
@@ -4798,10 +4799,10 @@
                                     (i32.const 180)
                                   )
                                 )
-                                (tee_local $14
+                                (tee_local $16
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $3)
+                                    (get_local $1)
                                   )
                                 )
                               )
@@ -4811,42 +4812,42 @@
                                 (i32.const 180)
                                 (i32.or
                                   (get_local $0)
-                                  (get_local $14)
+                                  (get_local $16)
                                 )
                               )
                               (i32.store
-                                (get_local $1)
                                 (get_local $2)
+                                (get_local $3)
                               )
                               (i32.store offset=24
+                                (get_local $3)
                                 (get_local $2)
-                                (get_local $1)
                               )
                               (i32.store offset=12
-                                (get_local $2)
-                                (get_local $2)
+                                (get_local $3)
+                                (get_local $3)
                               )
                               (i32.store offset=8
-                                (get_local $2)
-                                (get_local $2)
+                                (get_local $3)
+                                (get_local $3)
                               )
                               (br $do-once44)
                             )
                           )
-                          (set_local $14
+                          (set_local $16
                             (i32.shl
-                              (get_local $15)
+                              (get_local $14)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $3)
+                                    (get_local $1)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $3)
+                                  (get_local $1)
                                   (i32.const 31)
                                 )
                               )
@@ -4854,7 +4855,7 @@
                           )
                           (set_local $0
                             (i32.load
-                              (get_local $1)
+                              (get_local $2)
                             )
                           )
                           (loop $while-in64
@@ -4867,22 +4868,22 @@
                                     )
                                     (i32.const -8)
                                   )
-                                  (get_local $15)
+                                  (get_local $14)
                                 )
                                 (block
                                   (set_local $35
                                     (get_local $0)
                                   )
-                                  (set_local $5
+                                  (set_local $8
                                     (i32.const 281)
                                   )
                                   (br $while-out63)
                                 )
                               )
                               (if
-                                (tee_local $11
+                                (tee_local $1
                                   (i32.load
-                                    (tee_local $1
+                                    (tee_local $2
                                       (i32.add
                                         (i32.add
                                           (get_local $0)
@@ -4890,7 +4891,7 @@
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $14)
+                                            (get_local $16)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -4900,25 +4901,25 @@
                                   )
                                 )
                                 (block
-                                  (set_local $14
+                                  (set_local $16
                                     (i32.shl
-                                      (get_local $14)
+                                      (get_local $16)
                                       (i32.const 1)
                                     )
                                   )
                                   (set_local $0
-                                    (get_local $11)
+                                    (get_local $1)
                                   )
                                   (br $while-in64)
                                 )
                                 (block
                                   (set_local $43
-                                    (get_local $1)
+                                    (get_local $2)
                                   )
                                   (set_local $51
                                     (get_local $0)
                                   )
-                                  (set_local $5
+                                  (set_local $8
                                     (i32.const 278)
                                   )
                                 )
@@ -4927,7 +4928,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $5)
+                              (get_local $8)
                               (i32.const 278)
                             )
                             (if
@@ -4941,31 +4942,31 @@
                               (block
                                 (i32.store
                                   (get_local $43)
-                                  (get_local $2)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=24
-                                  (get_local $2)
+                                  (get_local $3)
                                   (get_local $51)
                                 )
                                 (i32.store offset=12
-                                  (get_local $2)
-                                  (get_local $2)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=8
-                                  (get_local $2)
-                                  (get_local $2)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $5)
+                                (get_local $8)
                                 (i32.const 281)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (tee_local $14
+                                    (tee_local $16
                                       (i32.load
                                         (tee_local $0
                                           (i32.add
@@ -4975,7 +4976,7 @@
                                         )
                                       )
                                     )
-                                    (tee_local $11
+                                    (tee_local $1
                                       (i32.load
                                         (i32.const 192)
                                       )
@@ -4983,28 +4984,28 @@
                                   )
                                   (i32.ge_u
                                     (get_local $35)
-                                    (get_local $11)
+                                    (get_local $1)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $14)
-                                    (get_local $2)
+                                    (get_local $16)
+                                    (get_local $3)
                                   )
                                   (i32.store
                                     (get_local $0)
-                                    (get_local $2)
+                                    (get_local $3)
                                   )
                                   (i32.store offset=8
-                                    (get_local $2)
-                                    (get_local $14)
+                                    (get_local $3)
+                                    (get_local $16)
                                   )
                                   (i32.store offset=12
-                                    (get_local $2)
+                                    (get_local $3)
                                     (get_local $35)
                                   )
                                   (i32.store offset=24
-                                    (get_local $2)
+                                    (get_local $3)
                                     (i32.const 0)
                                   )
                                 )
@@ -5016,23 +5017,23 @@
                         (block
                           (i32.store
                             (i32.const 188)
-                            (tee_local $14
+                            (tee_local $16
                               (i32.add
                                 (i32.load
                                   (i32.const 188)
                                 )
-                                (get_local $15)
+                                (get_local $14)
                               )
                             )
                           )
                           (i32.store
                             (i32.const 200)
-                            (get_local $2)
+                            (get_local $3)
                           )
                           (i32.store offset=4
-                            (get_local $2)
+                            (get_local $3)
                             (i32.or
-                              (get_local $14)
+                              (get_local $16)
                               (i32.const 1)
                             )
                           )
@@ -5052,7 +5053,7 @@
                 (if
                   (if i32
                     (i32.le_u
-                      (tee_local $2
+                      (tee_local $3
                         (i32.load
                           (get_local $28)
                         )
@@ -5060,9 +5061,9 @@
                       (get_local $13)
                     )
                     (i32.gt_u
-                      (tee_local $15
+                      (tee_local $14
                         (i32.add
-                          (get_local $2)
+                          (get_local $3)
                           (i32.load offset=4
                             (get_local $28)
                           )
@@ -5073,7 +5074,7 @@
                     (i32.const 0)
                   )
                   (set_local $0
-                    (get_local $15)
+                    (get_local $14)
                   )
                   (block
                     (set_local $28
@@ -5085,7 +5086,7 @@
                   )
                 )
               )
-              (set_local $15
+              (set_local $14
                 (i32.add
                   (tee_local $12
                     (i32.add
@@ -5096,33 +5097,33 @@
                   (i32.const 8)
                 )
               )
-              (set_local $2
+              (set_local $3
                 (i32.add
                   (tee_local $12
                     (select
                       (get_local $13)
-                      (tee_local $2
+                      (tee_local $3
                         (i32.add
                           (get_local $12)
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $15)
+                                (get_local $14)
                               )
                               (i32.const 7)
                             )
                             (i32.const 0)
                             (i32.and
-                              (get_local $15)
+                              (get_local $14)
                               (i32.const 7)
                             )
                           )
                         )
                       )
                       (i32.lt_u
-                        (get_local $2)
-                        (tee_local $15
+                        (get_local $3)
+                        (tee_local $14
                           (i32.add
                             (get_local $13)
                             (i32.const 16)
@@ -5165,7 +5166,7 @@
               )
               (i32.store
                 (i32.const 188)
-                (tee_local $14
+                (tee_local $16
                   (i32.sub
                     (i32.add
                       (get_local $22)
@@ -5178,14 +5179,14 @@
               (i32.store offset=4
                 (get_local $4)
                 (i32.or
-                  (get_local $14)
+                  (get_local $16)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
                   (get_local $4)
-                  (get_local $14)
+                  (get_local $16)
                 )
                 (i32.const 40)
               )
@@ -5196,7 +5197,7 @@
                 )
               )
               (i32.store
-                (tee_local $14
+                (tee_local $16
                   (i32.add
                     (get_local $12)
                     (i32.const 4)
@@ -5205,25 +5206,25 @@
                 (i32.const 27)
               )
               (i32.store
-                (get_local $2)
+                (get_local $3)
                 (i32.load
                   (i32.const 624)
                 )
               )
               (i32.store offset=4
-                (get_local $2)
+                (get_local $3)
                 (i32.load
                   (i32.const 628)
                 )
               )
               (i32.store offset=8
-                (get_local $2)
+                (get_local $3)
                 (i32.load
                   (i32.const 632)
                 )
               )
               (i32.store offset=12
-                (get_local $2)
+                (get_local $3)
                 (i32.load
                   (i32.const 636)
                 )
@@ -5242,9 +5243,9 @@
               )
               (i32.store
                 (i32.const 632)
-                (get_local $2)
+                (get_local $3)
               )
-              (set_local $2
+              (set_local $3
                 (i32.add
                   (get_local $12)
                   (i32.const 24)
@@ -5252,9 +5253,9 @@
               )
               (loop $do-in68
                 (i32.store
-                  (tee_local $2
+                  (tee_local $3
                     (i32.add
-                      (get_local $2)
+                      (get_local $3)
                       (i32.const 4)
                     )
                   )
@@ -5263,7 +5264,7 @@
                 (br_if $do-in68
                   (i32.lt_u
                     (i32.add
-                      (get_local $2)
+                      (get_local $3)
                       (i32.const 4)
                     )
                     (get_local $0)
@@ -5277,10 +5278,10 @@
                 )
                 (block
                   (i32.store
-                    (get_local $14)
+                    (get_local $16)
                     (i32.and
                       (i32.load
-                        (get_local $14)
+                        (get_local $16)
                       )
                       (i32.const -2)
                     )
@@ -5288,7 +5289,7 @@
                   (i32.store offset=4
                     (get_local $13)
                     (i32.or
-                      (tee_local $2
+                      (tee_local $3
                         (i32.sub
                           (get_local $12)
                           (get_local $13)
@@ -5299,17 +5300,17 @@
                   )
                   (i32.store
                     (get_local $12)
-                    (get_local $2)
+                    (get_local $3)
                   )
                   (set_local $4
                     (i32.shr_u
-                      (get_local $2)
+                      (get_local $3)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $2)
+                      (get_local $3)
                       (i32.const 256)
                     )
                     (block
@@ -5332,7 +5333,7 @@
                               (i32.const 176)
                             )
                           )
-                          (tee_local $11
+                          (tee_local $1
                             (i32.shl
                               (i32.const 1)
                               (get_local $4)
@@ -5341,7 +5342,7 @@
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $1
+                            (tee_local $2
                               (i32.load
                                 (tee_local $4
                                   (i32.add
@@ -5361,7 +5362,7 @@
                               (get_local $4)
                             )
                             (set_local $36
-                              (get_local $1)
+                              (get_local $2)
                             )
                           )
                         )
@@ -5370,7 +5371,7 @@
                             (i32.const 176)
                             (i32.or
                               (get_local $0)
-                              (get_local $11)
+                              (get_local $1)
                             )
                           )
                           (set_local $44
@@ -5407,24 +5408,24 @@
                     (i32.add
                       (i32.const 480)
                       (i32.shl
-                        (tee_local $3
+                        (tee_local $1
                           (if i32
                             (tee_local $18
                               (i32.shr_u
-                                (get_local $2)
+                                (get_local $3)
                                 (i32.const 8)
                               )
                             )
                             (if i32
                               (i32.gt_u
-                                (get_local $2)
+                                (get_local $3)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $2)
+                                    (get_local $3)
                                     (i32.add
                                       (tee_local $4
                                         (i32.add
@@ -5439,7 +5440,7 @@
                                                         (tee_local $0
                                                           (i32.shl
                                                             (get_local $18)
-                                                            (tee_local $11
+                                                            (tee_local $1
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
@@ -5460,13 +5461,13 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $11)
+                                                (get_local $1)
                                               )
                                               (tee_local $0
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (tee_local $1
+                                                      (tee_local $2
                                                         (i32.shl
                                                           (get_local $0)
                                                           (get_local $18)
@@ -5483,7 +5484,7 @@
                                           )
                                           (i32.shr_u
                                             (i32.shl
-                                              (get_local $1)
+                                              (get_local $2)
                                               (get_local $0)
                                             )
                                             (i32.const 15)
@@ -5510,14 +5511,14 @@
                   )
                   (i32.store offset=28
                     (get_local $13)
-                    (get_local $3)
+                    (get_local $1)
                   )
                   (i32.store offset=20
                     (get_local $13)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $15)
+                    (get_local $14)
                     (i32.const 0)
                   )
                   (if
@@ -5528,10 +5529,10 @@
                             (i32.const 180)
                           )
                         )
-                        (tee_local $1
+                        (tee_local $2
                           (i32.shl
                             (i32.const 1)
-                            (get_local $3)
+                            (get_local $1)
                           )
                         )
                       )
@@ -5541,7 +5542,7 @@
                         (i32.const 180)
                         (i32.or
                           (get_local $0)
-                          (get_local $1)
+                          (get_local $2)
                         )
                       )
                       (i32.store
@@ -5563,20 +5564,20 @@
                       (br $do-once40)
                     )
                   )
-                  (set_local $1
+                  (set_local $2
                     (i32.shl
-                      (get_local $2)
+                      (get_local $3)
                       (select
                         (i32.const 0)
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $3)
+                            (get_local $1)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $3)
+                          (get_local $1)
                           (i32.const 31)
                         )
                       )
@@ -5597,20 +5598,20 @@
                             )
                             (i32.const -8)
                           )
-                          (get_local $2)
+                          (get_local $3)
                         )
                         (block
                           (set_local $37
                             (get_local $0)
                           )
-                          (set_local $5
+                          (set_local $8
                             (i32.const 307)
                           )
                           (br $while-out69)
                         )
                       )
                       (if
-                        (tee_local $11
+                        (tee_local $1
                           (i32.load
                             (tee_local $4
                               (i32.add
@@ -5620,7 +5621,7 @@
                                 )
                                 (i32.shl
                                   (i32.shr_u
-                                    (get_local $1)
+                                    (get_local $2)
                                     (i32.const 31)
                                   )
                                   (i32.const 2)
@@ -5630,14 +5631,14 @@
                           )
                         )
                         (block
-                          (set_local $1
+                          (set_local $2
                             (i32.shl
-                              (get_local $1)
+                              (get_local $2)
                               (i32.const 1)
                             )
                           )
                           (set_local $0
-                            (get_local $11)
+                            (get_local $1)
                           )
                           (br $while-in70)
                         )
@@ -5648,7 +5649,7 @@
                           (set_local $52
                             (get_local $0)
                           )
-                          (set_local $5
+                          (set_local $8
                             (i32.const 304)
                           )
                         )
@@ -5657,7 +5658,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $5)
+                      (get_local $8)
                       (i32.const 304)
                     )
                     (if
@@ -5689,13 +5690,13 @@
                     )
                     (if
                       (i32.eq
-                        (get_local $5)
+                        (get_local $8)
                         (i32.const 307)
                       )
                       (if
                         (i32.and
                           (i32.ge_u
-                            (tee_local $1
+                            (tee_local $2
                               (i32.load
                                 (tee_local $0
                                   (i32.add
@@ -5705,7 +5706,7 @@
                                 )
                               )
                             )
-                            (tee_local $2
+                            (tee_local $3
                               (i32.load
                                 (i32.const 192)
                               )
@@ -5713,12 +5714,12 @@
                           )
                           (i32.ge_u
                             (get_local $37)
-                            (get_local $2)
+                            (get_local $3)
                           )
                         )
                         (block
                           (i32.store offset=12
-                            (get_local $1)
+                            (get_local $2)
                             (get_local $13)
                           )
                           (i32.store
@@ -5727,7 +5728,7 @@
                           )
                           (i32.store offset=8
                             (get_local $13)
-                            (get_local $1)
+                            (get_local $2)
                           )
                           (i32.store offset=12
                             (get_local $13)
@@ -5749,7 +5750,7 @@
               (if
                 (i32.or
                   (i32.eqz
-                    (tee_local $1
+                    (tee_local $2
                       (i32.load
                         (i32.const 192)
                       )
@@ -5757,7 +5758,7 @@
                   )
                   (i32.lt_u
                     (get_local $20)
-                    (get_local $1)
+                    (get_local $2)
                   )
                 )
                 (i32.store
@@ -5787,7 +5788,7 @@
                 (i32.const 208)
                 (i32.const -1)
               )
-              (set_local $1
+              (set_local $2
                 (i32.const 0)
               )
               (loop $do-in72
@@ -5797,7 +5798,7 @@
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $1)
+                          (get_local $2)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -5812,9 +5813,9 @@
                 )
                 (br_if $do-in72
                   (i32.ne
-                    (tee_local $1
+                    (tee_local $2
                       (i32.add
-                        (get_local $1)
+                        (get_local $2)
                         (i32.const 1)
                       )
                     )
@@ -5824,7 +5825,7 @@
               )
               (i32.store
                 (i32.const 200)
-                (tee_local $1
+                (tee_local $2
                   (i32.add
                     (get_local $20)
                     (tee_local $0
@@ -5832,7 +5833,7 @@
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (tee_local $1
+                            (tee_local $2
                               (i32.add
                                 (get_local $20)
                                 (i32.const 8)
@@ -5843,7 +5844,7 @@
                         )
                         (i32.const 0)
                         (i32.and
-                          (get_local $1)
+                          (get_local $2)
                           (i32.const 7)
                         )
                       )
@@ -5853,7 +5854,7 @@
               )
               (i32.store
                 (i32.const 188)
-                (tee_local $2
+                (tee_local $3
                   (i32.sub
                     (i32.add
                       (get_local $22)
@@ -5864,16 +5865,16 @@
                 )
               )
               (i32.store offset=4
-                (get_local $1)
+                (get_local $2)
                 (i32.or
-                  (get_local $2)
+                  (get_local $3)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $1)
                   (get_local $2)
+                  (get_local $3)
                 )
                 (i32.const 40)
               )
@@ -5893,7 +5894,7 @@
                 (i32.const 188)
               )
             )
-            (get_local $8)
+            (get_local $9)
           )
           (block
             (i32.store
@@ -5901,7 +5902,7 @@
               (tee_local $20
                 (i32.sub
                   (get_local $22)
-                  (get_local $8)
+                  (get_local $9)
                 )
               )
             )
@@ -5914,7 +5915,7 @@
                       (i32.const 200)
                     )
                   )
-                  (get_local $8)
+                  (get_local $9)
                 )
               )
             )
@@ -5928,7 +5929,7 @@
             (i32.store offset=4
               (get_local $22)
               (i32.or
-                (get_local $8)
+                (get_local $9)
                 (i32.const 3)
               )
             )
@@ -6012,7 +6013,7 @@
     (set_local $8
       (i32.add
         (get_local $1)
-        (tee_local $4
+        (tee_local $5
           (i32.and
             (get_local $3)
             (i32.const -8)
@@ -6030,8 +6031,8 @@
           (set_local $2
             (get_local $1)
           )
-          (set_local $7
-            (get_local $4)
+          (set_local $4
+            (get_local $5)
           )
         )
         (block
@@ -6046,15 +6047,15 @@
             )
             (return)
           )
-          (set_local $4
+          (set_local $5
             (i32.add
               (get_local $11)
-              (get_local $4)
+              (get_local $5)
             )
           )
           (if
             (i32.lt_u
-              (tee_local $0
+              (tee_local $3
                 (i32.add
                   (get_local $1)
                   (i32.sub
@@ -6069,7 +6070,7 @@
           )
           (if
             (i32.eq
-              (get_local $0)
+              (get_local $3)
               (i32.load
                 (i32.const 196)
               )
@@ -6078,9 +6079,9 @@
               (if
                 (i32.ne
                   (i32.and
-                    (tee_local $6
+                    (tee_local $7
                       (i32.load
-                        (tee_local $1
+                        (tee_local $0
                           (i32.add
                             (get_local $8)
                             (i32.const 4)
@@ -6094,43 +6095,43 @@
                 )
                 (block
                   (set_local $2
-                    (get_local $0)
+                    (get_local $3)
                   )
-                  (set_local $7
-                    (get_local $4)
+                  (set_local $4
+                    (get_local $5)
                   )
                   (br $do-once)
                 )
               )
               (i32.store
                 (i32.const 184)
-                (get_local $4)
+                (get_local $5)
               )
               (i32.store
-                (get_local $1)
+                (get_local $0)
                 (i32.and
-                  (get_local $6)
+                  (get_local $7)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $0)
+                (get_local $3)
                 (i32.or
-                  (get_local $4)
+                  (get_local $5)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
-                  (get_local $0)
-                  (get_local $4)
+                  (get_local $3)
+                  (get_local $5)
                 )
-                (get_local $4)
+                (get_local $5)
               )
               (return)
             )
           )
-          (set_local $6
+          (set_local $7
             (i32.shr_u
               (get_local $11)
               (i32.const 3)
@@ -6142,24 +6143,24 @@
               (i32.const 256)
             )
             (block
-              (set_local $1
+              (set_local $0
                 (i32.load offset=12
-                  (get_local $0)
+                  (get_local $3)
                 )
               )
               (if
                 (i32.ne
                   (tee_local $11
                     (i32.load offset=8
-                      (get_local $0)
+                      (get_local $3)
                     )
                   )
-                  (tee_local $3
+                  (tee_local $1
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $6)
+                          (get_local $7)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6180,7 +6181,7 @@
                       (i32.load offset=12
                         (get_local $11)
                       )
-                      (get_local $0)
+                      (get_local $3)
                     )
                     (call $_abort)
                   )
@@ -6188,7 +6189,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $1)
+                  (get_local $0)
                   (get_local $11)
                 )
                 (block
@@ -6201,30 +6202,30 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $6)
+                          (get_local $7)
                         )
                         (i32.const -1)
                       )
                     )
                   )
                   (set_local $2
-                    (get_local $0)
+                    (get_local $3)
                   )
-                  (set_local $7
-                    (get_local $4)
+                  (set_local $4
+                    (get_local $5)
                   )
                   (br $do-once)
                 )
               )
               (if
                 (i32.ne
+                  (get_local $0)
                   (get_local $1)
-                  (get_local $3)
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $0)
                       (get_local $14)
                     )
                     (call $_abort)
@@ -6232,69 +6233,69 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $3
+                        (tee_local $1
                           (i32.add
-                            (get_local $1)
+                            (get_local $0)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $0)
+                      (get_local $3)
                     )
                     (set_local $10
-                      (get_local $3)
+                      (get_local $1)
                     )
                     (call $_abort)
                   )
                 )
                 (set_local $10
                   (i32.add
-                    (get_local $1)
+                    (get_local $0)
                     (i32.const 8)
                   )
                 )
               )
               (i32.store offset=12
                 (get_local $11)
-                (get_local $1)
+                (get_local $0)
               )
               (i32.store
                 (get_local $10)
                 (get_local $11)
               )
               (set_local $2
-                (get_local $0)
+                (get_local $3)
               )
-              (set_local $7
-                (get_local $4)
+              (set_local $4
+                (get_local $5)
               )
               (br $do-once)
             )
           )
           (set_local $11
             (i32.load offset=24
-              (get_local $0)
+              (get_local $3)
             )
           )
           (block $do-once0
             (if
               (i32.eq
-                (tee_local $1
+                (tee_local $0
                   (i32.load offset=12
-                    (get_local $0)
+                    (get_local $3)
                   )
                 )
-                (get_local $0)
+                (get_local $3)
               )
               (block
                 (if
                   (tee_local $10
                     (i32.load
-                      (tee_local $6
+                      (tee_local $7
                         (i32.add
-                          (tee_local $3
+                          (tee_local $1
                             (i32.add
-                              (get_local $0)
+                              (get_local $3)
                               (i32.const 16)
                             )
                           )
@@ -6304,23 +6305,23 @@
                     )
                   )
                   (block
-                    (set_local $1
+                    (set_local $0
                       (get_local $10)
                     )
-                    (set_local $3
-                      (get_local $6)
+                    (set_local $1
+                      (get_local $7)
                     )
                   )
                   (if
                     (i32.eqz
-                      (tee_local $1
+                      (tee_local $0
                         (i32.load
-                          (get_local $3)
+                          (get_local $1)
                         )
                       )
                     )
                     (block
-                      (set_local $5
+                      (set_local $6
                         (i32.const 0)
                       )
                       (br $do-once0)
@@ -6331,20 +6332,20 @@
                   (if
                     (tee_local $10
                       (i32.load
-                        (tee_local $6
+                        (tee_local $7
                           (i32.add
-                            (get_local $1)
+                            (get_local $0)
                             (i32.const 20)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $1
+                      (set_local $0
                         (get_local $10)
                       )
-                      (set_local $3
-                        (get_local $6)
+                      (set_local $1
+                        (get_local $7)
                       )
                       (br $while-in)
                     )
@@ -6352,29 +6353,29 @@
                   (if
                     (tee_local $10
                       (i32.load
-                        (tee_local $6
+                        (tee_local $7
                           (i32.add
-                            (get_local $1)
+                            (get_local $0)
                             (i32.const 16)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $1
+                      (set_local $0
                         (get_local $10)
                       )
-                      (set_local $3
-                        (get_local $6)
+                      (set_local $1
+                        (get_local $7)
                       )
                       (br $while-in)
                     )
                     (block
-                      (set_local $6
-                        (get_local $1)
+                      (set_local $7
+                        (get_local $0)
                       )
                       (set_local $9
-                        (get_local $3)
+                        (get_local $1)
                       )
                     )
                   )
@@ -6390,8 +6391,8 @@
                       (get_local $9)
                       (i32.const 0)
                     )
-                    (set_local $5
-                      (get_local $6)
+                    (set_local $6
+                      (get_local $7)
                     )
                   )
                 )
@@ -6399,9 +6400,9 @@
               (block
                 (if
                   (i32.lt_u
-                    (tee_local $6
+                    (tee_local $7
                       (i32.load offset=8
-                        (get_local $0)
+                        (get_local $3)
                       )
                     )
                     (get_local $14)
@@ -6413,38 +6414,38 @@
                     (i32.load
                       (tee_local $10
                         (i32.add
-                          (get_local $6)
+                          (get_local $7)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $3)
                   )
                   (call $_abort)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $3
+                      (tee_local $1
                         (i32.add
-                          (get_local $1)
+                          (get_local $0)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $3)
                   )
                   (block
                     (i32.store
                       (get_local $10)
-                      (get_local $1)
+                      (get_local $0)
                     )
                     (i32.store
-                      (get_local $3)
-                      (get_local $6)
-                    )
-                    (set_local $5
                       (get_local $1)
+                      (get_local $7)
+                    )
+                    (set_local $6
+                      (get_local $0)
                     )
                   )
                   (call $_abort)
@@ -6457,15 +6458,15 @@
             (block
               (if
                 (i32.eq
-                  (get_local $0)
+                  (get_local $3)
                   (i32.load
-                    (tee_local $6
+                    (tee_local $7
                       (i32.add
                         (i32.const 480)
                         (i32.shl
-                          (tee_local $1
+                          (tee_local $0
                             (i32.load offset=28
-                              (get_local $0)
+                              (get_local $3)
                             )
                           )
                           (i32.const 2)
@@ -6476,12 +6477,12 @@
                 )
                 (block
                   (i32.store
+                    (get_local $7)
                     (get_local $6)
-                    (get_local $5)
                   )
                   (if
                     (i32.eqz
-                      (get_local $5)
+                      (get_local $6)
                     )
                     (block
                       (i32.store
@@ -6493,17 +6494,17 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $1)
+                              (get_local $0)
                             )
                             (i32.const -1)
                           )
                         )
                       )
                       (set_local $2
-                        (get_local $0)
+                        (get_local $3)
                       )
-                      (set_local $7
-                        (get_local $4)
+                      (set_local $4
+                        (get_local $5)
                       )
                       (br $do-once)
                     )
@@ -6522,34 +6523,34 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $1
+                        (tee_local $0
                           (i32.add
                             (get_local $11)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $0)
+                      (get_local $3)
                     )
                     (i32.store
-                      (get_local $1)
-                      (get_local $5)
+                      (get_local $0)
+                      (get_local $6)
                     )
                     (i32.store offset=20
                       (get_local $11)
-                      (get_local $5)
+                      (get_local $6)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $5)
+                      (get_local $6)
                     )
                     (block
                       (set_local $2
-                        (get_local $0)
+                        (get_local $3)
                       )
-                      (set_local $7
-                        (get_local $4)
+                      (set_local $4
+                        (get_local $5)
                       )
                       (br $do-once)
                     )
@@ -6558,8 +6559,8 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $5)
-                  (tee_local $1
+                  (get_local $6)
+                  (tee_local $0
                     (i32.load
                       (i32.const 192)
                     )
@@ -6568,15 +6569,15 @@
                 (call $_abort)
               )
               (i32.store offset=24
-                (get_local $5)
+                (get_local $6)
                 (get_local $11)
               )
               (if
-                (tee_local $3
+                (tee_local $1
                   (i32.load
-                    (tee_local $6
+                    (tee_local $7
                       (i32.add
-                        (get_local $0)
+                        (get_local $3)
                         (i32.const 16)
                       )
                     )
@@ -6584,31 +6585,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $3)
                     (get_local $1)
+                    (get_local $0)
                   )
                   (call $_abort)
                   (block
                     (i32.store offset=16
-                      (get_local $5)
-                      (get_local $3)
+                      (get_local $6)
+                      (get_local $1)
                     )
                     (i32.store offset=24
-                      (get_local $3)
-                      (get_local $5)
+                      (get_local $1)
+                      (get_local $6)
                     )
                   )
                 )
               )
               (if
-                (tee_local $3
+                (tee_local $1
                   (i32.load offset=4
-                    (get_local $6)
+                    (get_local $7)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $3)
+                    (get_local $1)
                     (i32.load
                       (i32.const 192)
                     )
@@ -6616,37 +6617,37 @@
                   (call $_abort)
                   (block
                     (i32.store offset=20
-                      (get_local $5)
-                      (get_local $3)
+                      (get_local $6)
+                      (get_local $1)
                     )
                     (i32.store offset=24
-                      (get_local $3)
-                      (get_local $5)
+                      (get_local $1)
+                      (get_local $6)
                     )
                     (set_local $2
-                      (get_local $0)
+                      (get_local $3)
                     )
-                    (set_local $7
-                      (get_local $4)
+                    (set_local $4
+                      (get_local $5)
                     )
                   )
                 )
                 (block
                   (set_local $2
-                    (get_local $0)
+                    (get_local $3)
                   )
-                  (set_local $7
-                    (get_local $4)
+                  (set_local $4
+                    (get_local $5)
                   )
                 )
               )
             )
             (block
               (set_local $2
-                (get_local $0)
+                (get_local $3)
               )
-              (set_local $7
-                (get_local $4)
+              (set_local $4
+                (get_local $5)
               )
             )
           )
@@ -6665,7 +6666,7 @@
         (i32.and
           (tee_local $1
             (i32.load
-              (tee_local $4
+              (tee_local $5
                 (i32.add
                   (get_local $8)
                   (i32.const 4)
@@ -6685,7 +6686,7 @@
       )
       (block
         (i32.store
-          (get_local $4)
+          (get_local $5)
           (i32.and
             (get_local $1)
             (i32.const -2)
@@ -6694,19 +6695,19 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $7)
+            (get_local $4)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $7)
+            (get_local $4)
           )
-          (get_local $7)
+          (get_local $4)
         )
         (set_local $0
-          (get_local $7)
+          (get_local $4)
         )
       )
       (block
@@ -6720,12 +6721,12 @@
           (block
             (i32.store
               (i32.const 188)
-              (tee_local $5
+              (tee_local $6
                 (i32.add
                   (i32.load
                     (i32.const 188)
                   )
-                  (get_local $7)
+                  (get_local $4)
                 )
               )
             )
@@ -6736,7 +6737,7 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $5)
+                (get_local $6)
                 (i32.const 1)
               )
             )
@@ -6770,12 +6771,12 @@
           (block
             (i32.store
               (i32.const 184)
-              (tee_local $5
+              (tee_local $6
                 (i32.add
                   (i32.load
                     (i32.const 184)
                   )
-                  (get_local $7)
+                  (get_local $4)
                 )
               )
             )
@@ -6786,27 +6787,27 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $5)
+                (get_local $6)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $2)
-                (get_local $5)
+                (get_local $6)
               )
-              (get_local $5)
+              (get_local $6)
             )
             (return)
           )
         )
-        (set_local $5
+        (set_local $6
           (i32.add
             (i32.and
               (get_local $1)
               (i32.const -8)
             )
-            (get_local $7)
+            (get_local $4)
           )
         )
         (set_local $14
@@ -6822,7 +6823,7 @@
               (i32.const 256)
             )
             (block
-              (set_local $6
+              (set_local $7
                 (i32.load offset=24
                   (get_local $8)
                 )
@@ -6841,9 +6842,9 @@
                     (if
                       (tee_local $10
                         (i32.load
-                          (tee_local $1
+                          (tee_local $0
                             (i32.add
-                              (tee_local $3
+                              (tee_local $1
                                 (i32.add
                                   (get_local $8)
                                   (i32.const 16)
@@ -6855,20 +6856,21 @@
                         )
                       )
                       (block
-                        (set_local $0
+                        (set_local $4
                           (get_local $10)
                         )
-                        (set_local $3
-                          (get_local $1)
+                        (set_local $1
+                          (get_local $0)
                         )
                       )
                       (if
-                        (i32.eqz
-                          (tee_local $0
-                            (i32.load
-                              (get_local $3)
-                            )
+                        (tee_local $0
+                          (i32.load
+                            (get_local $1)
                           )
+                        )
+                        (set_local $4
+                          (get_local $0)
                         )
                         (block
                           (set_local $12
@@ -6882,20 +6884,20 @@
                       (if
                         (tee_local $10
                           (i32.load
-                            (tee_local $1
+                            (tee_local $0
                               (i32.add
-                                (get_local $0)
+                                (get_local $4)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $0
+                          (set_local $4
                             (get_local $10)
                           )
-                          (set_local $3
-                            (get_local $1)
+                          (set_local $1
+                            (get_local $0)
                           )
                           (br $while-in9)
                         )
@@ -6903,20 +6905,20 @@
                       (if
                         (tee_local $10
                           (i32.load
-                            (tee_local $1
+                            (tee_local $0
                               (i32.add
-                                (get_local $0)
+                                (get_local $4)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $0
+                          (set_local $4
                             (get_local $10)
                           )
-                          (set_local $3
-                            (get_local $1)
+                          (set_local $1
+                            (get_local $0)
                           )
                           (br $while-in9)
                         )
@@ -6924,7 +6926,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $3)
+                        (get_local $1)
                         (i32.load
                           (i32.const 192)
                         )
@@ -6932,11 +6934,11 @@
                       (call $_abort)
                       (block
                         (i32.store
-                          (get_local $3)
+                          (get_local $1)
                           (i32.const 0)
                         )
                         (set_local $12
-                          (get_local $0)
+                          (get_local $4)
                         )
                       )
                     )
@@ -6944,7 +6946,7 @@
                   (block
                     (if
                       (i32.lt_u
-                        (tee_local $1
+                        (tee_local $0
                           (i32.load offset=8
                             (get_local $8)
                           )
@@ -6960,7 +6962,7 @@
                         (i32.load
                           (tee_local $10
                             (i32.add
-                              (get_local $1)
+                              (get_local $0)
                               (i32.const 12)
                             )
                           )
@@ -6972,7 +6974,7 @@
                     (if
                       (i32.eq
                         (i32.load
-                          (tee_local $3
+                          (tee_local $1
                             (i32.add
                               (get_local $9)
                               (i32.const 8)
@@ -6987,8 +6989,8 @@
                           (get_local $9)
                         )
                         (i32.store
-                          (get_local $3)
                           (get_local $1)
+                          (get_local $0)
                         )
                         (set_local $12
                           (get_local $9)
@@ -7000,13 +7002,13 @@
                 )
               )
               (if
-                (get_local $6)
+                (get_local $7)
                 (block
                   (if
                     (i32.eq
                       (get_local $8)
                       (i32.load
-                        (tee_local $4
+                        (tee_local $5
                           (i32.add
                             (i32.const 480)
                             (i32.shl
@@ -7023,7 +7025,7 @@
                     )
                     (block
                       (i32.store
-                        (get_local $4)
+                        (get_local $5)
                         (get_local $12)
                       )
                       (if
@@ -7053,7 +7055,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $6)
+                          (get_local $7)
                           (i32.load
                             (i32.const 192)
                           )
@@ -7065,7 +7067,7 @@
                           (i32.load
                             (tee_local $9
                               (i32.add
-                                (get_local $6)
+                                (get_local $7)
                                 (i32.const 16)
                               )
                             )
@@ -7077,7 +7079,7 @@
                           (get_local $12)
                         )
                         (i32.store offset=20
-                          (get_local $6)
+                          (get_local $7)
                           (get_local $12)
                         )
                       )
@@ -7101,12 +7103,12 @@
                   )
                   (i32.store offset=24
                     (get_local $12)
-                    (get_local $6)
+                    (get_local $7)
                   )
                   (if
-                    (tee_local $0
+                    (tee_local $3
                       (i32.load
-                        (tee_local $4
+                        (tee_local $5
                           (i32.add
                             (get_local $8)
                             (i32.const 16)
@@ -7116,31 +7118,31 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $0)
+                        (get_local $3)
                         (get_local $9)
                       )
                       (call $_abort)
                       (block
                         (i32.store offset=16
                           (get_local $12)
-                          (get_local $0)
+                          (get_local $3)
                         )
                         (i32.store offset=24
-                          (get_local $0)
+                          (get_local $3)
                           (get_local $12)
                         )
                       )
                     )
                   )
                   (if
-                    (tee_local $0
+                    (tee_local $3
                       (i32.load offset=4
-                        (get_local $4)
+                        (get_local $5)
                       )
                     )
                     (if
                       (i32.lt_u
-                        (get_local $0)
+                        (get_local $3)
                         (i32.load
                           (i32.const 192)
                         )
@@ -7149,10 +7151,10 @@
                       (block
                         (i32.store offset=20
                           (get_local $12)
-                          (get_local $0)
+                          (get_local $3)
                         )
                         (i32.store offset=24
-                          (get_local $0)
+                          (get_local $3)
                           (get_local $12)
                         )
                       )
@@ -7169,12 +7171,12 @@
               )
               (if
                 (i32.ne
-                  (tee_local $0
+                  (tee_local $3
                     (i32.load offset=8
                       (get_local $8)
                     )
                   )
-                  (tee_local $6
+                  (tee_local $7
                     (i32.add
                       (i32.const 216)
                       (i32.shl
@@ -7190,7 +7192,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $0)
+                      (get_local $3)
                       (i32.load
                         (i32.const 192)
                       )
@@ -7200,7 +7202,7 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $0)
+                        (get_local $3)
                       )
                       (get_local $8)
                     )
@@ -7211,7 +7213,7 @@
               (if
                 (i32.eq
                   (get_local $9)
-                  (get_local $0)
+                  (get_local $3)
                 )
                 (block
                   (i32.store
@@ -7235,7 +7237,7 @@
               (if
                 (i32.ne
                   (get_local $9)
-                  (get_local $6)
+                  (get_local $7)
                 )
                 (block
                   (if
@@ -7250,7 +7252,7 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $6
+                        (tee_local $7
                           (i32.add
                             (get_local $9)
                             (i32.const 8)
@@ -7260,7 +7262,7 @@
                       (get_local $8)
                     )
                     (set_local $16
-                      (get_local $6)
+                      (get_local $7)
                     )
                     (call $_abort)
                   )
@@ -7273,12 +7275,12 @@
                 )
               )
               (i32.store offset=12
-                (get_local $0)
+                (get_local $3)
                 (get_local $9)
               )
               (i32.store
                 (get_local $16)
-                (get_local $0)
+                (get_local $3)
               )
             )
           )
@@ -7286,16 +7288,16 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $5)
+            (get_local $6)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $5)
+            (get_local $6)
           )
-          (get_local $5)
+          (get_local $6)
         )
         (if
           (i32.eq
@@ -7307,17 +7309,17 @@
           (block
             (i32.store
               (i32.const 184)
-              (get_local $5)
+              (get_local $6)
             )
             (return)
           )
           (set_local $0
-            (get_local $5)
+            (get_local $6)
           )
         )
       )
     )
-    (set_local $7
+    (set_local $4
       (i32.shr_u
         (get_local $0)
         (i32.const 3)
@@ -7334,7 +7336,7 @@
             (i32.const 216)
             (i32.shl
               (i32.shl
-                (get_local $7)
+                (get_local $4)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -7343,15 +7345,15 @@
         )
         (if
           (i32.and
-            (tee_local $4
+            (tee_local $5
               (i32.load
                 (i32.const 176)
               )
             )
-            (tee_local $5
+            (tee_local $6
               (i32.shl
                 (i32.const 1)
-                (get_local $7)
+                (get_local $4)
               )
             )
           )
@@ -7359,7 +7361,7 @@
             (i32.lt_u
               (tee_local $16
                 (i32.load
-                  (tee_local $7
+                  (tee_local $4
                     (i32.add
                       (get_local $1)
                       (i32.const 8)
@@ -7374,7 +7376,7 @@
             (call $_abort)
             (block
               (set_local $15
-                (get_local $7)
+                (get_local $4)
               )
               (set_local $13
                 (get_local $16)
@@ -7385,8 +7387,8 @@
             (i32.store
               (i32.const 176)
               (i32.or
-                (get_local $4)
                 (get_local $5)
+                (get_local $6)
               )
             )
             (set_local $15
@@ -7419,11 +7421,11 @@
         (return)
       )
     )
-    (set_local $4
+    (set_local $5
       (i32.add
         (i32.const 480)
         (i32.shl
-          (tee_local $7
+          (tee_local $4
             (if i32
               (tee_local $1
                 (i32.shr_u
@@ -7442,7 +7444,7 @@
                     (i32.shr_u
                       (get_local $0)
                       (i32.add
-                        (tee_local $4
+                        (tee_local $5
                           (i32.add
                             (i32.sub
                               (i32.const 14)
@@ -7482,7 +7484,7 @@
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (tee_local $5
+                                        (tee_local $6
                                           (i32.shl
                                             (get_local $15)
                                             (get_local $1)
@@ -7499,7 +7501,7 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $5)
+                                (get_local $6)
                                 (get_local $15)
                               )
                               (i32.const 15)
@@ -7512,7 +7514,7 @@
                     (i32.const 1)
                   )
                   (i32.shl
-                    (get_local $4)
+                    (get_local $5)
                     (i32.const 1)
                   )
                 )
@@ -7526,7 +7528,7 @@
     )
     (i32.store offset=28
       (get_local $2)
-      (get_local $7)
+      (get_local $4)
     )
     (i32.store offset=20
       (get_local $2)
@@ -7543,10 +7545,10 @@
             (i32.const 180)
           )
         )
-        (tee_local $5
+        (tee_local $6
           (i32.shl
             (i32.const 1)
-            (get_local $7)
+            (get_local $4)
           )
         )
       )
@@ -7559,12 +7561,12 @@
               (i32.sub
                 (i32.const 25)
                 (i32.shr_u
-                  (get_local $7)
+                  (get_local $4)
                   (i32.const 1)
                 )
               )
               (i32.eq
-                (get_local $7)
+                (get_local $4)
                 (i32.const 31)
               )
             )
@@ -7572,7 +7574,7 @@
         )
         (set_local $1
           (i32.load
-            (get_local $4)
+            (get_local $5)
           )
         )
         (loop $while-in15
@@ -7598,7 +7600,7 @@
               )
             )
             (if
-              (tee_local $7
+              (tee_local $4
                 (i32.load
                   (tee_local $16
                     (i32.add
@@ -7625,7 +7627,7 @@
                   )
                 )
                 (set_local $1
-                  (get_local $7)
+                  (get_local $4)
                 )
                 (br $while-in15)
               )
@@ -7693,7 +7695,7 @@
                       )
                     )
                   )
-                  (tee_local $4
+                  (tee_local $5
                     (i32.load
                       (i32.const 192)
                     )
@@ -7701,7 +7703,7 @@
                 )
                 (i32.ge_u
                   (get_local $17)
-                  (get_local $4)
+                  (get_local $5)
                 )
               )
               (block
@@ -7736,16 +7738,16 @@
           (i32.const 180)
           (i32.or
             (get_local $15)
-            (get_local $5)
+            (get_local $6)
           )
         )
         (i32.store
-          (get_local $4)
+          (get_local $5)
           (get_local $2)
         )
         (i32.store offset=24
           (get_local $2)
-          (get_local $4)
+          (get_local $5)
         )
         (i32.store offset=12
           (get_local $2)

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -149,7 +149,7 @@
                       (i32.const 176)
                     )
                   )
-                  (tee_local $6
+                  (tee_local $8
                     (i32.shr_u
                       (tee_local $9
                         (select
@@ -181,14 +181,14 @@
                     (i32.add
                       (tee_local $0
                         (i32.load
-                          (tee_local $7
+                          (tee_local $6
                             (i32.add
                               (tee_local $1
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (tee_local $6
+                                      (tee_local $10
                                         (i32.add
                                           (i32.xor
                                             (i32.and
@@ -197,7 +197,7 @@
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $6)
+                                          (get_local $8)
                                         )
                                       )
                                       (i32.const 1)
@@ -234,7 +234,7 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $8
+                        (tee_local $7
                           (i32.add
                             (get_local $2)
                             (i32.const 12)
@@ -245,11 +245,11 @@
                     )
                     (block
                       (i32.store
-                        (get_local $8)
+                        (get_local $7)
                         (get_local $1)
                       )
                       (i32.store
-                        (get_local $7)
+                        (get_local $6)
                         (get_local $2)
                       )
                     )
@@ -263,7 +263,7 @@
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $6)
+                        (get_local $10)
                       )
                       (i32.const -1)
                     )
@@ -275,7 +275,7 @@
                 (i32.or
                   (tee_local $2
                     (i32.shl
-                      (get_local $6)
+                      (get_local $10)
                       (i32.const 3)
                     )
                   )
@@ -283,7 +283,7 @@
                 )
               )
               (i32.store
-                (tee_local $7
+                (tee_local $6
                   (i32.add
                     (i32.add
                       (get_local $0)
@@ -294,7 +294,7 @@
                 )
                 (i32.or
                   (i32.load
-                    (get_local $7)
+                    (get_local $6)
                   )
                   (i32.const 1)
                 )
@@ -307,7 +307,7 @@
           (if
             (i32.gt_u
               (get_local $9)
-              (tee_local $7
+              (tee_local $6
                 (i32.load
                   (i32.const 184)
                 )
@@ -327,13 +327,13 @@
                                 (i32.and
                                   (i32.shl
                                     (get_local $2)
-                                    (get_local $6)
+                                    (get_local $8)
                                   )
                                   (i32.or
                                     (tee_local $2
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $6)
+                                        (get_local $8)
                                       )
                                     )
                                     (i32.sub
@@ -358,7 +358,7 @@
                   )
                   (set_local $1
                     (i32.load
-                      (tee_local $8
+                      (tee_local $7
                         (i32.add
                           (tee_local $0
                             (i32.load
@@ -378,7 +378,7 @@
                                                       (tee_local $2
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $8
+                                                            (tee_local $7
                                                               (i32.shr_u
                                                                 (get_local $2)
                                                                 (get_local $1)
@@ -391,12 +391,12 @@
                                                       )
                                                       (get_local $1)
                                                     )
-                                                    (tee_local $8
+                                                    (tee_local $7
                                                       (i32.and
                                                         (i32.shr_u
                                                           (tee_local $0
                                                             (i32.shr_u
-                                                              (get_local $8)
+                                                              (get_local $7)
                                                               (get_local $2)
                                                             )
                                                           )
@@ -412,7 +412,7 @@
                                                         (tee_local $11
                                                           (i32.shr_u
                                                             (get_local $0)
-                                                            (get_local $8)
+                                                            (get_local $7)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -518,7 +518,7 @@
                         )
                       )
                       (set_local $17
-                        (get_local $7)
+                        (get_local $6)
                       )
                     )
                   )
@@ -537,7 +537,7 @@
                       )
                     )
                     (i32.or
-                      (tee_local $7
+                      (tee_local $6
                         (i32.sub
                           (i32.shl
                             (get_local $10)
@@ -552,9 +552,9 @@
                   (i32.store
                     (i32.add
                       (get_local $15)
-                      (get_local $7)
+                      (get_local $6)
                     )
-                    (get_local $7)
+                    (get_local $6)
                   )
                   (if
                     (get_local $17)
@@ -583,7 +583,7 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $6
+                          (tee_local $8
                             (i32.load
                               (i32.const 176)
                             )
@@ -625,7 +625,7 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $6)
+                              (get_local $8)
                               (get_local $2)
                             )
                           )
@@ -660,14 +660,14 @@
                   )
                   (i32.store
                     (i32.const 184)
-                    (get_local $7)
+                    (get_local $6)
                   )
                   (i32.store
                     (i32.const 196)
                     (get_local $15)
                   )
                   (return
-                    (get_local $8)
+                    (get_local $7)
                   )
                 )
               )
@@ -681,7 +681,7 @@
                   (set_local $15
                     (i32.and
                       (i32.shr_u
-                        (tee_local $7
+                        (tee_local $6
                           (i32.add
                             (i32.and
                               (get_local $15)
@@ -710,12 +710,12 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (tee_local $7
+                                          (tee_local $6
                                             (i32.and
                                               (i32.shr_u
                                                 (tee_local $11
                                                   (i32.shr_u
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (get_local $15)
                                                   )
                                                 )
@@ -732,7 +732,7 @@
                                               (tee_local $1
                                                 (i32.shr_u
                                                   (get_local $11)
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                               (i32.const 2)
@@ -759,7 +759,7 @@
                                     (tee_local $2
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $6
+                                          (tee_local $8
                                             (i32.shr_u
                                               (get_local $2)
                                               (get_local $1)
@@ -772,7 +772,7 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $6)
+                                    (get_local $8)
                                     (get_local $2)
                                   )
                                 )
@@ -786,7 +786,7 @@
                       (get_local $9)
                     )
                   )
-                  (set_local $6
+                  (set_local $8
                     (get_local $17)
                   )
                   (set_local $1
@@ -797,7 +797,7 @@
                       (if
                         (tee_local $17
                           (i32.load offset=16
-                            (get_local $6)
+                            (get_local $8)
                           )
                         )
                         (set_local $0
@@ -806,7 +806,7 @@
                         (if
                           (tee_local $11
                             (i32.load offset=20
-                              (get_local $6)
+                              (get_local $8)
                             )
                           )
                           (set_local $0
@@ -846,7 +846,7 @@
                           (get_local $11)
                         )
                       )
-                      (set_local $6
+                      (set_local $8
                         (get_local $0)
                       )
                       (set_local $1
@@ -873,7 +873,7 @@
                   (if
                     (i32.ge_u
                       (get_local $5)
-                      (tee_local $6
+                      (tee_local $8
                         (i32.add
                           (get_local $5)
                           (get_local $9)
@@ -890,7 +890,7 @@
                   (block $do-once4
                     (if
                       (i32.eq
-                        (tee_local $8
+                        (tee_local $7
                           (i32.load offset=12
                             (get_local $5)
                           )
@@ -913,7 +913,7 @@
                             (set_local $17
                               (get_local $10)
                             )
-                            (set_local $7
+                            (set_local $6
                               (get_local $0)
                             )
                           )
@@ -928,7 +928,7 @@
                                 )
                               )
                             )
-                            (set_local $7
+                            (set_local $6
                               (get_local $11)
                             )
                             (block
@@ -955,7 +955,7 @@
                               (set_local $17
                                 (get_local $10)
                               )
-                              (set_local $7
+                              (set_local $6
                                 (get_local $0)
                               )
                               (br $while-in7)
@@ -976,7 +976,7 @@
                               (set_local $17
                                 (get_local $10)
                               )
-                              (set_local $7
+                              (set_local $6
                                 (get_local $0)
                               )
                               (br $while-in7)
@@ -985,13 +985,13 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $7)
+                            (get_local $6)
                             (get_local $1)
                           )
                           (call $_abort)
                           (block
                             (i32.store
-                              (get_local $7)
+                              (get_local $6)
                               (i32.const 0)
                             )
                             (set_local $19
@@ -1031,7 +1031,7 @@
                             (i32.load
                               (tee_local $11
                                 (i32.add
-                                  (get_local $8)
+                                  (get_local $7)
                                   (i32.const 8)
                                 )
                               )
@@ -1041,14 +1041,14 @@
                           (block
                             (i32.store
                               (get_local $10)
-                              (get_local $8)
+                              (get_local $7)
                             )
                             (i32.store
                               (get_local $11)
                               (get_local $0)
                             )
                             (set_local $19
-                              (get_local $8)
+                              (get_local $7)
                             )
                           )
                           (call $_abort)
@@ -1068,7 +1068,7 @@
                                 (i32.add
                                   (i32.const 480)
                                   (i32.shl
-                                    (tee_local $8
+                                    (tee_local $7
                                       (i32.load offset=28
                                         (get_local $5)
                                       )
@@ -1098,7 +1098,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $8)
+                                        (get_local $7)
                                       )
                                       (i32.const -1)
                                     )
@@ -1121,7 +1121,7 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $8
+                                  (tee_local $7
                                     (i32.add
                                       (get_local $2)
                                       (i32.const 16)
@@ -1131,7 +1131,7 @@
                                 (get_local $5)
                               )
                               (i32.store
-                                (get_local $8)
+                                (get_local $7)
                                 (get_local $19)
                               )
                               (i32.store offset=20
@@ -1149,7 +1149,7 @@
                         (if
                           (i32.lt_u
                             (get_local $19)
-                            (tee_local $8
+                            (tee_local $7
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1170,7 +1170,7 @@
                           (if
                             (i32.lt_u
                               (get_local $1)
-                              (get_local $8)
+                              (get_local $7)
                             )
                             (call $_abort)
                             (block
@@ -1259,7 +1259,7 @@
                         )
                       )
                       (i32.store offset=4
-                        (get_local $6)
+                        (get_local $8)
                         (i32.or
                           (get_local $3)
                           (i32.const 1)
@@ -1267,7 +1267,7 @@
                       )
                       (i32.store
                         (i32.add
-                          (get_local $6)
+                          (get_local $8)
                           (get_local $3)
                         )
                         (get_local $3)
@@ -1289,7 +1289,7 @@
                               (i32.const 216)
                               (i32.shl
                                 (i32.shl
-                                  (tee_local $8
+                                  (tee_local $7
                                     (i32.shr_u
                                       (get_local $1)
                                       (i32.const 3)
@@ -1311,7 +1311,7 @@
                               (tee_local $11
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $8)
+                                  (get_local $7)
                                 )
                               )
                             )
@@ -1319,7 +1319,7 @@
                               (i32.lt_u
                                 (tee_local $10
                                   (i32.load
-                                    (tee_local $8
+                                    (tee_local $7
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 8)
@@ -1334,7 +1334,7 @@
                               (call $_abort)
                               (block
                                 (set_local $39
-                                  (get_local $8)
+                                  (get_local $7)
                                 )
                                 (set_local $32
                                   (get_local $10)
@@ -1384,7 +1384,7 @@
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $6)
+                        (get_local $8)
                       )
                     )
                   )
@@ -1463,7 +1463,7 @@
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $8
+                                                          (tee_local $7
                                                             (i32.shl
                                                               (get_local $10)
                                                               (tee_local $1
@@ -1489,13 +1489,13 @@
                                                   )
                                                   (get_local $1)
                                                 )
-                                                (tee_local $8
+                                                (tee_local $7
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
                                                         (tee_local $17
                                                           (i32.shl
-                                                            (get_local $8)
+                                                            (get_local $7)
                                                             (get_local $10)
                                                           )
                                                         )
@@ -1511,7 +1511,7 @@
                                             (i32.shr_u
                                               (i32.shl
                                                 (get_local $17)
-                                                (get_local $8)
+                                                (get_local $7)
                                               )
                                               (i32.const 15)
                                             )
@@ -1536,7 +1536,7 @@
                       )
                     )
                     (block
-                      (set_local $8
+                      (set_local $7
                         (get_local $0)
                       )
                       (set_local $17
@@ -1564,7 +1564,7 @@
                       (set_local $10
                         (get_local $15)
                       )
-                      (set_local $7
+                      (set_local $6
                         (i32.const 0)
                       )
                       (loop $while-in14
@@ -1583,7 +1583,7 @@
                                 (get_local $2)
                               )
                             )
-                            (get_local $8)
+                            (get_local $7)
                           )
                           (if
                             (i32.eq
@@ -1600,16 +1600,16 @@
                               (set_local $29
                                 (get_local $10)
                               )
-                              (set_local $8
+                              (set_local $7
                                 (i32.const 90)
                               )
                               (br $label$break$L123)
                             )
                             (block
-                              (set_local $8
+                              (set_local $7
                                 (get_local $0)
                               )
-                              (set_local $7
+                              (set_local $6
                                 (get_local $10)
                               )
                             )
@@ -1658,15 +1658,15 @@
                           )
                           (block
                             (set_local $33
-                              (get_local $8)
-                            )
-                            (set_local $6
-                              (get_local $19)
-                            )
-                            (set_local $30
                               (get_local $7)
                             )
                             (set_local $8
+                              (get_local $19)
+                            )
+                            (set_local $30
+                              (get_local $6)
+                            )
+                            (set_local $7
                               (i32.const 86)
                             )
                           )
@@ -1695,13 +1695,13 @@
                       (set_local $33
                         (get_local $0)
                       )
-                      (set_local $6
+                      (set_local $8
                         (i32.const 0)
                       )
                       (set_local $30
                         (i32.const 0)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 86)
                       )
                     )
@@ -1709,7 +1709,7 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $7)
                     (i32.const 86)
                   )
                   (if
@@ -1717,7 +1717,7 @@
                       (if i32
                         (i32.and
                           (i32.eqz
-                            (get_local $6)
+                            (get_local $8)
                           )
                           (i32.eqz
                             (get_local $30)
@@ -1797,7 +1797,7 @@
                                       (tee_local $9
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $6
+                                            (tee_local $8
                                               (i32.shr_u
                                                 (get_local $9)
                                                 (get_local $15)
@@ -1809,12 +1809,12 @@
                                         )
                                       )
                                     )
-                                    (tee_local $6
+                                    (tee_local $8
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $7
+                                          (tee_local $6
                                             (i32.shr_u
-                                              (get_local $6)
+                                              (get_local $8)
                                               (get_local $9)
                                             )
                                           )
@@ -1824,13 +1824,13 @@
                                       )
                                     )
                                   )
-                                  (tee_local $7
+                                  (tee_local $6
                                     (i32.and
                                       (i32.shr_u
                                         (tee_local $1
                                           (i32.shr_u
-                                            (get_local $7)
                                             (get_local $6)
+                                            (get_local $8)
                                           )
                                         )
                                         (i32.const 1)
@@ -1841,14 +1841,14 @@
                                 )
                                 (i32.shr_u
                                   (get_local $1)
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                               )
                               (i32.const 2)
                             )
                           )
                         )
-                        (get_local $6)
+                        (get_local $8)
                       )
                     )
                     (block
@@ -1861,7 +1861,7 @@
                       (set_local $29
                         (get_local $30)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 90)
                       )
                     )
@@ -1877,16 +1877,16 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $7)
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $8
+                    (set_local $7
                       (i32.const 0)
                     )
                     (set_local $1
                       (i32.lt_u
-                        (tee_local $7
+                        (tee_local $6
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
@@ -1900,14 +1900,14 @@
                         (get_local $27)
                       )
                     )
-                    (set_local $6
+                    (set_local $8
                       (select
-                        (get_local $7)
+                        (get_local $6)
                         (get_local $27)
                         (get_local $1)
                       )
                     )
-                    (set_local $7
+                    (set_local $6
                       (select
                         (get_local $25)
                         (get_local $29)
@@ -1922,13 +1922,13 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $6)
+                          (get_local $8)
                         )
                         (set_local $25
                           (get_local $1)
                         )
                         (set_local $29
-                          (get_local $7)
+                          (get_local $6)
                         )
                         (br $while-in16)
                       )
@@ -1941,19 +1941,19 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $6)
+                          (get_local $8)
                         )
                         (set_local $29
-                          (get_local $7)
+                          (get_local $6)
                         )
                         (br $while-in16)
                       )
                       (block
                         (set_local $4
-                          (get_local $6)
+                          (get_local $8)
                         )
                         (set_local $12
-                          (get_local $7)
+                          (get_local $6)
                         )
                       )
                     )
@@ -1991,7 +1991,7 @@
                     (if
                       (i32.ge_u
                         (get_local $12)
-                        (tee_local $7
+                        (tee_local $6
                           (i32.add
                             (get_local $12)
                             (get_local $2)
@@ -2000,7 +2000,7 @@
                       )
                       (call $_abort)
                     )
-                    (set_local $6
+                    (set_local $8
                       (i32.load offset=24
                         (get_local $12)
                       )
@@ -2176,7 +2176,7 @@
                     )
                     (block $do-once21
                       (if
-                        (get_local $6)
+                        (get_local $8)
                         (block
                           (if
                             (i32.eq
@@ -2229,7 +2229,7 @@
                             (block
                               (if
                                 (i32.lt_u
-                                  (get_local $6)
+                                  (get_local $8)
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -2241,7 +2241,7 @@
                                   (i32.load
                                     (tee_local $1
                                       (i32.add
-                                        (get_local $6)
+                                        (get_local $8)
                                         (i32.const 16)
                                       )
                                     )
@@ -2253,7 +2253,7 @@
                                   (get_local $5)
                                 )
                                 (i32.store offset=20
-                                  (get_local $6)
+                                  (get_local $8)
                                   (get_local $5)
                                 )
                               )
@@ -2277,7 +2277,7 @@
                           )
                           (i32.store offset=24
                             (get_local $5)
-                            (get_local $6)
+                            (get_local $8)
                           )
                           (if
                             (tee_local $11
@@ -2347,7 +2347,7 @@
                             )
                           )
                           (i32.store offset=4
-                            (get_local $7)
+                            (get_local $6)
                             (i32.or
                               (get_local $4)
                               (i32.const 1)
@@ -2355,12 +2355,12 @@
                           )
                           (i32.store
                             (i32.add
-                              (get_local $7)
+                              (get_local $6)
                               (get_local $4)
                             )
                             (get_local $4)
                           )
-                          (set_local $6
+                          (set_local $8
                             (i32.shr_u
                               (get_local $4)
                               (i32.const 3)
@@ -2377,7 +2377,7 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $6)
+                                      (get_local $8)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -2394,7 +2394,7 @@
                                   (tee_local $9
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $6)
+                                      (get_local $8)
                                     )
                                   )
                                 )
@@ -2402,7 +2402,7 @@
                                   (i32.lt_u
                                     (tee_local $15
                                       (i32.load
-                                        (tee_local $6
+                                        (tee_local $8
                                           (i32.add
                                             (get_local $11)
                                             (i32.const 8)
@@ -2417,7 +2417,7 @@
                                   (call $_abort)
                                   (block
                                     (set_local $16
-                                      (get_local $6)
+                                      (get_local $8)
                                     )
                                     (set_local $26
                                       (get_local $15)
@@ -2445,24 +2445,24 @@
                               )
                               (i32.store
                                 (get_local $16)
-                                (get_local $7)
+                                (get_local $6)
                               )
                               (i32.store offset=12
                                 (get_local $26)
-                                (get_local $7)
+                                (get_local $6)
                               )
                               (i32.store offset=8
-                                (get_local $7)
+                                (get_local $6)
                                 (get_local $26)
                               )
                               (i32.store offset=12
-                                (get_local $7)
+                                (get_local $6)
                                 (get_local $11)
                               )
                               (br $do-once25)
                             )
                           )
-                          (set_local $6
+                          (set_local $8
                             (i32.add
                               (i32.const 480)
                               (i32.shl
@@ -2485,7 +2485,7 @@
                                           (i32.shr_u
                                             (get_local $4)
                                             (i32.add
-                                              (tee_local $6
+                                              (tee_local $8
                                                 (i32.add
                                                   (i32.sub
                                                     (i32.const 14)
@@ -2555,7 +2555,7 @@
                                           (i32.const 1)
                                         )
                                         (i32.shl
-                                          (get_local $6)
+                                          (get_local $8)
                                           (i32.const 1)
                                         )
                                       )
@@ -2568,13 +2568,13 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $7)
+                            (get_local $6)
                             (get_local $10)
                           )
                           (i32.store offset=4
                             (tee_local $1
                               (i32.add
-                                (get_local $7)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                             )
@@ -2609,20 +2609,20 @@
                                 )
                               )
                               (i32.store
+                                (get_local $8)
                                 (get_local $6)
-                                (get_local $7)
                               )
                               (i32.store offset=24
-                                (get_local $7)
                                 (get_local $6)
+                                (get_local $8)
                               )
                               (i32.store offset=12
-                                (get_local $7)
-                                (get_local $7)
+                                (get_local $6)
+                                (get_local $6)
                               )
                               (i32.store offset=8
-                                (get_local $7)
-                                (get_local $7)
+                                (get_local $6)
+                                (get_local $6)
                               )
                               (br $do-once25)
                             )
@@ -2648,7 +2648,7 @@
                           )
                           (set_local $1
                             (i32.load
-                              (get_local $6)
+                              (get_local $8)
                             )
                           )
                           (loop $while-in28
@@ -2667,7 +2667,7 @@
                                   (set_local $14
                                     (get_local $1)
                                   )
-                                  (set_local $8
+                                  (set_local $7
                                     (i32.const 148)
                                   )
                                   (br $while-out27)
@@ -2676,7 +2676,7 @@
                               (if
                                 (tee_local $9
                                   (i32.load
-                                    (tee_local $6
+                                    (tee_local $8
                                       (i32.add
                                         (i32.add
                                           (get_local $1)
@@ -2707,12 +2707,12 @@
                                 )
                                 (block
                                   (set_local $23
-                                    (get_local $6)
+                                    (get_local $8)
                                   )
                                   (set_local $21
                                     (get_local $1)
                                   )
-                                  (set_local $8
+                                  (set_local $7
                                     (i32.const 145)
                                   )
                                 )
@@ -2721,7 +2721,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $8)
+                              (get_local $7)
                               (i32.const 145)
                             )
                             (if
@@ -2735,25 +2735,25 @@
                               (block
                                 (i32.store
                                   (get_local $23)
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=24
-                                  (get_local $7)
+                                  (get_local $6)
                                   (get_local $21)
                                 )
                                 (i32.store offset=12
-                                  (get_local $7)
-                                  (get_local $7)
+                                  (get_local $6)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=8
-                                  (get_local $7)
-                                  (get_local $7)
+                                  (get_local $6)
+                                  (get_local $6)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.const 148)
                               )
                               (if
@@ -2783,22 +2783,22 @@
                                 (block
                                   (i32.store offset=12
                                     (get_local $15)
-                                    (get_local $7)
+                                    (get_local $6)
                                   )
                                   (i32.store
                                     (get_local $1)
-                                    (get_local $7)
+                                    (get_local $6)
                                   )
                                   (i32.store offset=8
-                                    (get_local $7)
+                                    (get_local $6)
                                     (get_local $15)
                                   )
                                   (i32.store offset=12
-                                    (get_local $7)
+                                    (get_local $6)
                                     (get_local $14)
                                   )
                                   (i32.store offset=24
-                                    (get_local $7)
+                                    (get_local $6)
                                     (i32.const 0)
                                   )
                                 )
@@ -3164,7 +3164,7 @@
             )
             (i32.const 0)
             (i32.eq
-              (tee_local $8
+              (tee_local $7
                 (block $label$break$L257 i32
                   (if i32
                     (i32.and
@@ -3215,7 +3215,7 @@
                                     (i32.const 0)
                                   )
                                   (block
-                                    (set_local $6
+                                    (set_local $8
                                       (get_local $16)
                                     )
                                     (set_local $1
@@ -3231,7 +3231,7 @@
                                     )
                                   )
                                 )
-                                (set_local $8
+                                (set_local $7
                                   (i32.const 173)
                                 )
                                 (br $label$break$L259)
@@ -3261,7 +3261,7 @@
                                   )
                                   (i32.add
                                     (i32.load
-                                      (get_local $6)
+                                      (get_local $8)
                                     )
                                     (i32.load
                                       (get_local $1)
@@ -3292,14 +3292,14 @@
                                   (set_local $18
                                     (get_local $16)
                                   )
-                                  (set_local $8
+                                  (set_local $7
                                     (i32.const 183)
                                   )
                                 )
                               )
                             )
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.const 173)
                           )
                         )
@@ -3308,7 +3308,7 @@
                         (if
                           (if i32
                             (i32.eq
-                              (get_local $8)
+                              (get_local $7)
                               (i32.const 173)
                             )
                             (i32.ne
@@ -3430,7 +3430,7 @@
                                     (set_local $18
                                       (get_local $0)
                                     )
-                                    (set_local $8
+                                    (set_local $7
                                       (i32.const 183)
                                     )
                                   )
@@ -3443,7 +3443,7 @@
                       (block $label$break$L279
                         (if
                           (i32.eq
-                            (get_local $8)
+                            (get_local $7)
                             (i32.const 183)
                           )
                           (block
@@ -3605,14 +3605,14 @@
         (set_local $22
           (get_local $13)
         )
-        (set_local $8
+        (set_local $7
           (i32.const 193)
         )
       )
     )
     (if
       (i32.eq
-        (get_local $8)
+        (get_local $7)
         (i32.const 193)
       )
       (block
@@ -3686,7 +3686,7 @@
                       (set_local $49
                         (get_local $3)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 203)
                       )
                       (br $do-out)
@@ -3728,7 +3728,7 @@
                     )
                     (i32.const 0)
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 203)
                     )
                   )
@@ -3809,7 +3809,7 @@
                   (br $do-once40)
                 )
               )
-              (set_local $7
+              (set_local $6
                 (if i32
                   (i32.lt_u
                     (get_local $20)
@@ -3854,7 +3854,7 @@
                       (set_local $40
                         (get_local $3)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 211)
                       )
                       (br $while-out42)
@@ -3874,7 +3874,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $8)
+                  (get_local $7)
                   (i32.const 211)
                 )
                 (if
@@ -4024,7 +4024,7 @@
                             )
                           )
                           (i32.store
-                            (tee_local $6
+                            (tee_local $8
                               (i32.add
                                 (if i32
                                   (i32.eq
@@ -4045,7 +4045,7 @@
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $6
+                                    (set_local $8
                                       (i32.shr_u
                                         (get_local $0)
                                         (i32.const 3)
@@ -4162,7 +4162,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $5)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (call $_abort)
                                                   (block
@@ -4184,7 +4184,7 @@
                                                         (get_local $4)
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (call $_abort)
                                                 )
@@ -4413,7 +4413,7 @@
                                                     (i32.const 216)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $6)
+                                                        (get_local $8)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4425,7 +4425,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $5)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (call $_abort)
                                                 )
@@ -4456,7 +4456,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $6)
+                                                      (get_local $8)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4481,7 +4481,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $21)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (call $_abort)
                                                 )
@@ -4537,7 +4537,7 @@
                             )
                             (i32.and
                               (i32.load
-                                (get_local $6)
+                                (get_local $8)
                               )
                               (i32.const -2)
                             )
@@ -4556,7 +4556,7 @@
                             )
                             (get_local $14)
                           )
-                          (set_local $6
+                          (set_local $8
                             (i32.shr_u
                               (get_local $14)
                               (i32.const 3)
@@ -4573,7 +4573,7 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $6)
+                                      (get_local $8)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4591,7 +4591,7 @@
                                     (tee_local $2
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $6)
+                                        (get_local $8)
                                       )
                                     )
                                   )
@@ -4600,7 +4600,7 @@
                                       (i32.ge_u
                                         (tee_local $10
                                           (i32.load
-                                            (tee_local $6
+                                            (tee_local $8
                                               (i32.add
                                                 (get_local $0)
                                                 (i32.const 8)
@@ -4614,7 +4614,7 @@
                                       )
                                       (block
                                         (set_local $42
-                                          (get_local $6)
+                                          (get_local $8)
                                         )
                                         (set_local $34
                                           (get_local $10)
@@ -4731,7 +4731,7 @@
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $6
+                                                                (tee_local $8
                                                                   (i32.shl
                                                                     (get_local $1)
                                                                     (get_local $10)
@@ -4748,7 +4748,7 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $6)
+                                                        (get_local $8)
                                                         (get_local $1)
                                                       )
                                                       (i32.const 15)
@@ -4874,7 +4874,7 @@
                                   (set_local $35
                                     (get_local $0)
                                   )
-                                  (set_local $8
+                                  (set_local $7
                                     (i32.const 281)
                                   )
                                   (br $while-out63)
@@ -4919,7 +4919,7 @@
                                   (set_local $51
                                     (get_local $0)
                                   )
-                                  (set_local $8
+                                  (set_local $7
                                     (i32.const 278)
                                   )
                                 )
@@ -4928,7 +4928,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $8)
+                              (get_local $7)
                               (i32.const 278)
                             )
                             (if
@@ -4960,7 +4960,7 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.const 281)
                               )
                               (if
@@ -5604,7 +5604,7 @@
                           (set_local $37
                             (get_local $0)
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.const 307)
                           )
                           (br $while-out69)
@@ -5649,7 +5649,7 @@
                           (set_local $52
                             (get_local $0)
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.const 304)
                           )
                         )
@@ -5658,7 +5658,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 304)
                     )
                     (if
@@ -5690,7 +5690,7 @@
                     )
                     (if
                       (i32.eq
-                        (get_local $8)
+                        (get_local $7)
                         (i32.const 307)
                       )
                       (if
@@ -5995,7 +5995,7 @@
       (i32.eq
         (tee_local $0
           (i32.and
-            (tee_local $3
+            (tee_local $4
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -6015,7 +6015,7 @@
         (get_local $1)
         (tee_local $5
           (i32.and
-            (get_local $3)
+            (get_local $4)
             (i32.const -8)
           )
         )
@@ -6024,14 +6024,14 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $3)
+          (get_local $4)
           (i32.const 1)
         )
         (block
           (set_local $2
             (get_local $1)
           )
-          (set_local $4
+          (set_local $3
             (get_local $5)
           )
         )
@@ -6055,7 +6055,7 @@
           )
           (if
             (i32.lt_u
-              (tee_local $3
+              (tee_local $1
                 (i32.add
                   (get_local $1)
                   (i32.sub
@@ -6070,7 +6070,7 @@
           )
           (if
             (i32.eq
-              (get_local $3)
+              (get_local $1)
               (i32.load
                 (i32.const 196)
               )
@@ -6095,9 +6095,9 @@
                 )
                 (block
                   (set_local $2
-                    (get_local $3)
+                    (get_local $1)
                   )
-                  (set_local $4
+                  (set_local $3
                     (get_local $5)
                   )
                   (br $do-once)
@@ -6115,7 +6115,7 @@
                 )
               )
               (i32.store offset=4
-                (get_local $3)
+                (get_local $1)
                 (i32.or
                   (get_local $5)
                   (i32.const 1)
@@ -6123,7 +6123,7 @@
               )
               (i32.store
                 (i32.add
-                  (get_local $3)
+                  (get_local $1)
                   (get_local $5)
                 )
                 (get_local $5)
@@ -6145,17 +6145,17 @@
             (block
               (set_local $0
                 (i32.load offset=12
-                  (get_local $3)
+                  (get_local $1)
                 )
               )
               (if
                 (i32.ne
                   (tee_local $11
                     (i32.load offset=8
-                      (get_local $3)
+                      (get_local $1)
                     )
                   )
-                  (tee_local $1
+                  (tee_local $4
                     (i32.add
                       (i32.const 216)
                       (i32.shl
@@ -6181,7 +6181,7 @@
                       (i32.load offset=12
                         (get_local $11)
                       )
-                      (get_local $3)
+                      (get_local $1)
                     )
                     (call $_abort)
                   )
@@ -6209,9 +6209,9 @@
                     )
                   )
                   (set_local $2
-                    (get_local $3)
+                    (get_local $1)
                   )
-                  (set_local $4
+                  (set_local $3
                     (get_local $5)
                   )
                   (br $do-once)
@@ -6220,7 +6220,7 @@
               (if
                 (i32.ne
                   (get_local $0)
-                  (get_local $1)
+                  (get_local $4)
                 )
                 (block
                   (if
@@ -6233,17 +6233,17 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $1
+                        (tee_local $4
                           (i32.add
                             (get_local $0)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $3)
+                      (get_local $1)
                     )
                     (set_local $10
-                      (get_local $1)
+                      (get_local $4)
                     )
                     (call $_abort)
                   )
@@ -6264,9 +6264,9 @@
                 (get_local $11)
               )
               (set_local $2
-                (get_local $3)
+                (get_local $1)
               )
-              (set_local $4
+              (set_local $3
                 (get_local $5)
               )
               (br $do-once)
@@ -6274,7 +6274,7 @@
           )
           (set_local $11
             (i32.load offset=24
-              (get_local $3)
+              (get_local $1)
             )
           )
           (block $do-once0
@@ -6282,10 +6282,10 @@
               (i32.eq
                 (tee_local $0
                   (i32.load offset=12
-                    (get_local $3)
+                    (get_local $1)
                   )
                 )
-                (get_local $3)
+                (get_local $1)
               )
               (block
                 (if
@@ -6293,9 +6293,9 @@
                     (i32.load
                       (tee_local $7
                         (i32.add
-                          (tee_local $1
+                          (tee_local $4
                             (i32.add
-                              (get_local $3)
+                              (get_local $1)
                               (i32.const 16)
                             )
                           )
@@ -6308,7 +6308,7 @@
                     (set_local $0
                       (get_local $10)
                     )
-                    (set_local $1
+                    (set_local $4
                       (get_local $7)
                     )
                   )
@@ -6316,7 +6316,7 @@
                     (i32.eqz
                       (tee_local $0
                         (i32.load
-                          (get_local $1)
+                          (get_local $4)
                         )
                       )
                     )
@@ -6344,7 +6344,7 @@
                       (set_local $0
                         (get_local $10)
                       )
-                      (set_local $1
+                      (set_local $4
                         (get_local $7)
                       )
                       (br $while-in)
@@ -6365,7 +6365,7 @@
                       (set_local $0
                         (get_local $10)
                       )
-                      (set_local $1
+                      (set_local $4
                         (get_local $7)
                       )
                       (br $while-in)
@@ -6375,7 +6375,7 @@
                         (get_local $0)
                       )
                       (set_local $9
-                        (get_local $1)
+                        (get_local $4)
                       )
                     )
                   )
@@ -6402,7 +6402,7 @@
                   (i32.lt_u
                     (tee_local $7
                       (i32.load offset=8
-                        (get_local $3)
+                        (get_local $1)
                       )
                     )
                     (get_local $14)
@@ -6419,21 +6419,21 @@
                         )
                       )
                     )
-                    (get_local $3)
+                    (get_local $1)
                   )
                   (call $_abort)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $1
+                      (tee_local $4
                         (i32.add
                           (get_local $0)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $3)
+                    (get_local $1)
                   )
                   (block
                     (i32.store
@@ -6441,7 +6441,7 @@
                       (get_local $0)
                     )
                     (i32.store
-                      (get_local $1)
+                      (get_local $4)
                       (get_local $7)
                     )
                     (set_local $6
@@ -6458,7 +6458,7 @@
             (block
               (if
                 (i32.eq
-                  (get_local $3)
+                  (get_local $1)
                   (i32.load
                     (tee_local $7
                       (i32.add
@@ -6466,7 +6466,7 @@
                         (i32.shl
                           (tee_local $0
                             (i32.load offset=28
-                              (get_local $3)
+                              (get_local $1)
                             )
                           )
                           (i32.const 2)
@@ -6501,9 +6501,9 @@
                         )
                       )
                       (set_local $2
-                        (get_local $3)
+                        (get_local $1)
                       )
-                      (set_local $4
+                      (set_local $3
                         (get_local $5)
                       )
                       (br $do-once)
@@ -6530,7 +6530,7 @@
                           )
                         )
                       )
-                      (get_local $3)
+                      (get_local $1)
                     )
                     (i32.store
                       (get_local $0)
@@ -6547,9 +6547,9 @@
                     )
                     (block
                       (set_local $2
-                        (get_local $3)
+                        (get_local $1)
                       )
-                      (set_local $4
+                      (set_local $3
                         (get_local $5)
                       )
                       (br $do-once)
@@ -6573,11 +6573,11 @@
                 (get_local $11)
               )
               (if
-                (tee_local $1
+                (tee_local $4
                   (i32.load
                     (tee_local $7
                       (i32.add
-                        (get_local $3)
+                        (get_local $1)
                         (i32.const 16)
                       )
                     )
@@ -6585,31 +6585,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $1)
+                    (get_local $4)
                     (get_local $0)
                   )
                   (call $_abort)
                   (block
                     (i32.store offset=16
                       (get_local $6)
-                      (get_local $1)
+                      (get_local $4)
                     )
                     (i32.store offset=24
-                      (get_local $1)
+                      (get_local $4)
                       (get_local $6)
                     )
                   )
                 )
               )
               (if
-                (tee_local $1
+                (tee_local $4
                   (i32.load offset=4
                     (get_local $7)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $1)
+                    (get_local $4)
                     (i32.load
                       (i32.const 192)
                     )
@@ -6618,25 +6618,25 @@
                   (block
                     (i32.store offset=20
                       (get_local $6)
-                      (get_local $1)
+                      (get_local $4)
                     )
                     (i32.store offset=24
-                      (get_local $1)
+                      (get_local $4)
                       (get_local $6)
                     )
                     (set_local $2
-                      (get_local $3)
+                      (get_local $1)
                     )
-                    (set_local $4
+                    (set_local $3
                       (get_local $5)
                     )
                   )
                 )
                 (block
                   (set_local $2
-                    (get_local $3)
+                    (get_local $1)
                   )
-                  (set_local $4
+                  (set_local $3
                     (get_local $5)
                   )
                 )
@@ -6644,9 +6644,9 @@
             )
             (block
               (set_local $2
-                (get_local $3)
+                (get_local $1)
               )
-              (set_local $4
+              (set_local $3
                 (get_local $5)
               )
             )
@@ -6695,19 +6695,19 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $4)
+            (get_local $3)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $4)
+            (get_local $3)
           )
-          (get_local $4)
+          (get_local $3)
         )
         (set_local $0
-          (get_local $4)
+          (get_local $3)
         )
       )
       (block
@@ -6726,7 +6726,7 @@
                   (i32.load
                     (i32.const 188)
                   )
-                  (get_local $4)
+                  (get_local $3)
                 )
               )
             )
@@ -6776,7 +6776,7 @@
                   (i32.load
                     (i32.const 184)
                   )
-                  (get_local $4)
+                  (get_local $3)
                 )
               )
             )
@@ -6807,7 +6807,7 @@
               (get_local $1)
               (i32.const -8)
             )
-            (get_local $4)
+            (get_local $3)
           )
         )
         (set_local $14
@@ -6844,7 +6844,7 @@
                         (i32.load
                           (tee_local $0
                             (i32.add
-                              (tee_local $1
+                              (tee_local $4
                                 (i32.add
                                   (get_local $8)
                                   (i32.const 16)
@@ -6856,20 +6856,20 @@
                         )
                       )
                       (block
-                        (set_local $4
+                        (set_local $3
                           (get_local $10)
                         )
-                        (set_local $1
+                        (set_local $4
                           (get_local $0)
                         )
                       )
                       (if
                         (tee_local $0
                           (i32.load
-                            (get_local $1)
+                            (get_local $4)
                           )
                         )
-                        (set_local $4
+                        (set_local $3
                           (get_local $0)
                         )
                         (block
@@ -6886,17 +6886,17 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $4)
+                                (get_local $3)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $4
+                          (set_local $3
                             (get_local $10)
                           )
-                          (set_local $1
+                          (set_local $4
                             (get_local $0)
                           )
                           (br $while-in9)
@@ -6907,17 +6907,17 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $4)
+                                (get_local $3)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $4
+                          (set_local $3
                             (get_local $10)
                           )
-                          (set_local $1
+                          (set_local $4
                             (get_local $0)
                           )
                           (br $while-in9)
@@ -6926,7 +6926,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $4)
                         (i32.load
                           (i32.const 192)
                         )
@@ -6934,11 +6934,11 @@
                       (call $_abort)
                       (block
                         (i32.store
-                          (get_local $1)
+                          (get_local $4)
                           (i32.const 0)
                         )
                         (set_local $12
-                          (get_local $4)
+                          (get_local $3)
                         )
                       )
                     )
@@ -6974,7 +6974,7 @@
                     (if
                       (i32.eq
                         (i32.load
-                          (tee_local $1
+                          (tee_local $4
                             (i32.add
                               (get_local $9)
                               (i32.const 8)
@@ -6989,7 +6989,7 @@
                           (get_local $9)
                         )
                         (i32.store
-                          (get_local $1)
+                          (get_local $4)
                           (get_local $0)
                         )
                         (set_local $12
@@ -7106,7 +7106,7 @@
                     (get_local $7)
                   )
                   (if
-                    (tee_local $3
+                    (tee_local $1
                       (i32.load
                         (tee_local $5
                           (i32.add
@@ -7118,31 +7118,31 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $3)
+                        (get_local $1)
                         (get_local $9)
                       )
                       (call $_abort)
                       (block
                         (i32.store offset=16
                           (get_local $12)
-                          (get_local $3)
+                          (get_local $1)
                         )
                         (i32.store offset=24
-                          (get_local $3)
+                          (get_local $1)
                           (get_local $12)
                         )
                       )
                     )
                   )
                   (if
-                    (tee_local $3
+                    (tee_local $1
                       (i32.load offset=4
                         (get_local $5)
                       )
                     )
                     (if
                       (i32.lt_u
-                        (get_local $3)
+                        (get_local $1)
                         (i32.load
                           (i32.const 192)
                         )
@@ -7151,10 +7151,10 @@
                       (block
                         (i32.store offset=20
                           (get_local $12)
-                          (get_local $3)
+                          (get_local $1)
                         )
                         (i32.store offset=24
-                          (get_local $3)
+                          (get_local $1)
                           (get_local $12)
                         )
                       )
@@ -7171,7 +7171,7 @@
               )
               (if
                 (i32.ne
-                  (tee_local $3
+                  (tee_local $1
                     (i32.load offset=8
                       (get_local $8)
                     )
@@ -7192,7 +7192,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $3)
+                      (get_local $1)
                       (i32.load
                         (i32.const 192)
                       )
@@ -7202,7 +7202,7 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $3)
+                        (get_local $1)
                       )
                       (get_local $8)
                     )
@@ -7213,7 +7213,7 @@
               (if
                 (i32.eq
                   (get_local $9)
-                  (get_local $3)
+                  (get_local $1)
                 )
                 (block
                   (i32.store
@@ -7275,12 +7275,12 @@
                 )
               )
               (i32.store offset=12
-                (get_local $3)
+                (get_local $1)
                 (get_local $9)
               )
               (i32.store
                 (get_local $16)
-                (get_local $3)
+                (get_local $1)
               )
             )
           )
@@ -7319,7 +7319,7 @@
         )
       )
     )
-    (set_local $4
+    (set_local $3
       (i32.shr_u
         (get_local $0)
         (i32.const 3)
@@ -7336,7 +7336,7 @@
             (i32.const 216)
             (i32.shl
               (i32.shl
-                (get_local $4)
+                (get_local $3)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -7353,7 +7353,7 @@
             (tee_local $6
               (i32.shl
                 (i32.const 1)
-                (get_local $4)
+                (get_local $3)
               )
             )
           )
@@ -7361,7 +7361,7 @@
             (i32.lt_u
               (tee_local $16
                 (i32.load
-                  (tee_local $4
+                  (tee_local $3
                     (i32.add
                       (get_local $1)
                       (i32.const 8)
@@ -7376,7 +7376,7 @@
             (call $_abort)
             (block
               (set_local $15
-                (get_local $4)
+                (get_local $3)
               )
               (set_local $13
                 (get_local $16)
@@ -7425,7 +7425,7 @@
       (i32.add
         (i32.const 480)
         (i32.shl
-          (tee_local $4
+          (tee_local $3
             (if i32
               (tee_local $1
                 (i32.shr_u
@@ -7528,7 +7528,7 @@
     )
     (i32.store offset=28
       (get_local $2)
-      (get_local $4)
+      (get_local $3)
     )
     (i32.store offset=20
       (get_local $2)
@@ -7548,7 +7548,7 @@
         (tee_local $6
           (i32.shl
             (i32.const 1)
-            (get_local $4)
+            (get_local $3)
           )
         )
       )
@@ -7561,12 +7561,12 @@
               (i32.sub
                 (i32.const 25)
                 (i32.shr_u
-                  (get_local $4)
+                  (get_local $3)
                   (i32.const 1)
                 )
               )
               (i32.eq
-                (get_local $4)
+                (get_local $3)
                 (i32.const 31)
               )
             )
@@ -7600,7 +7600,7 @@
               )
             )
             (if
-              (tee_local $4
+              (tee_local $3
                 (i32.load
                   (tee_local $16
                     (i32.add
@@ -7627,7 +7627,7 @@
                   )
                 )
                 (set_local $1
-                  (get_local $4)
+                  (get_local $3)
                 )
                 (br $while-in15)
               )

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -798,7 +798,7 @@
     (local $12 i32)
     (local $13 i32)
     (local $14 i32)
-    (set_local $7
+    (set_local $8
       (get_global $STACKTOP)
     )
     (set_global $STACKTOP
@@ -814,23 +814,23 @@
       )
       (call $abort)
     )
-    (set_local $8
+    (set_local $9
       (i32.add
-        (get_local $7)
+        (get_local $8)
         (i32.const 16)
       )
     )
-    (set_local $9
-      (get_local $7)
+    (set_local $10
+      (get_local $8)
     )
     (i32.store
       (tee_local $3
         (i32.add
-          (get_local $7)
+          (get_local $8)
           (i32.const 32)
         )
       )
-      (tee_local $5
+      (tee_local $4
         (i32.load
           (tee_local $6
             (i32.add
@@ -843,17 +843,17 @@
     )
     (i32.store offset=4
       (get_local $3)
-      (tee_local $4
+      (tee_local $7
         (i32.sub
           (i32.load
-            (tee_local $10
+            (tee_local $11
               (i32.add
                 (get_local $0)
                 (i32.const 20)
               )
             )
           )
-          (get_local $5)
+          (get_local $4)
         )
       )
     )
@@ -880,12 +880,12 @@
     (set_local $1
       (get_local $3)
     )
-    (set_local $5
+    (set_local $4
       (i32.const 2)
     )
-    (set_local $11
+    (set_local $7
       (i32.add
-        (get_local $4)
+        (get_local $7)
         (get_local $2)
       )
     )
@@ -896,8 +896,8 @@
             (loop $while-in
               (br_if $jumpthreading$inner$0
                 (i32.eq
-                  (get_local $11)
-                  (tee_local $4
+                  (get_local $7)
+                  (tee_local $5
                     (if i32
                       (i32.load
                         (i32.const 16)
@@ -908,24 +908,24 @@
                           (get_local $0)
                         )
                         (i32.store
-                          (get_local $9)
+                          (get_local $10)
                           (i32.load
                             (get_local $13)
                           )
                         )
                         (i32.store offset=4
-                          (get_local $9)
+                          (get_local $10)
                           (get_local $1)
                         )
                         (i32.store offset=8
-                          (get_local $9)
-                          (get_local $5)
+                          (get_local $10)
+                          (get_local $4)
                         )
                         (set_local $3
                           (call $___syscall_ret
                             (call $___syscall146
                               (i32.const 146)
-                              (get_local $9)
+                              (get_local $10)
                             )
                           )
                         )
@@ -936,23 +936,23 @@
                       )
                       (block i32
                         (i32.store
-                          (get_local $8)
+                          (get_local $9)
                           (i32.load
                             (get_local $13)
                           )
                         )
                         (i32.store offset=4
-                          (get_local $8)
+                          (get_local $9)
                           (get_local $1)
                         )
                         (i32.store offset=8
-                          (get_local $8)
-                          (get_local $5)
+                          (get_local $9)
+                          (get_local $4)
                         )
                         (call $___syscall_ret
                           (call $___syscall146
                             (i32.const 146)
-                            (get_local $8)
+                            (get_local $9)
                           )
                         )
                       )
@@ -962,21 +962,21 @@
               )
               (br_if $jumpthreading$inner$1
                 (i32.lt_s
-                  (get_local $4)
+                  (get_local $5)
                   (i32.const 0)
                 )
               )
               (block
-                (set_local $11
+                (set_local $7
                   (i32.sub
-                    (get_local $11)
-                    (get_local $4)
+                    (get_local $7)
+                    (get_local $5)
                   )
                 )
                 (set_local $1
                   (if i32
                     (i32.gt_u
-                      (get_local $4)
+                      (get_local $5)
                       (tee_local $12
                         (i32.load offset=4
                           (get_local $1)
@@ -993,12 +993,12 @@
                         )
                       )
                       (i32.store
-                        (get_local $10)
+                        (get_local $11)
                         (get_local $3)
                       )
-                      (set_local $4
+                      (set_local $5
                         (i32.sub
-                          (get_local $4)
+                          (get_local $5)
                           (get_local $12)
                         )
                       )
@@ -1008,9 +1008,9 @@
                           (i32.const 8)
                         )
                       )
-                      (set_local $5
+                      (set_local $4
                         (i32.add
-                          (get_local $5)
+                          (get_local $4)
                           (i32.const -1)
                         )
                       )
@@ -1020,7 +1020,7 @@
                     )
                     (if i32
                       (i32.eq
-                        (get_local $5)
+                        (get_local $4)
                         (i32.const 2)
                       )
                       (block i32
@@ -1030,13 +1030,13 @@
                             (i32.load
                               (get_local $6)
                             )
-                            (get_local $4)
+                            (get_local $5)
                           )
                         )
                         (set_local $3
                           (get_local $1)
                         )
-                        (set_local $5
+                        (set_local $4
                           (i32.const 2)
                         )
                         (get_local $12)
@@ -1056,14 +1056,14 @@
                     (i32.load
                       (get_local $3)
                     )
-                    (get_local $4)
+                    (get_local $5)
                   )
                 )
                 (i32.store offset=4
                   (get_local $3)
                   (i32.sub
                     (get_local $1)
-                    (get_local $4)
+                    (get_local $5)
                   )
                 )
                 (set_local $1
@@ -1093,7 +1093,7 @@
             )
           )
           (i32.store
-            (get_local $10)
+            (get_local $11)
             (get_local $0)
           )
           (br $jumpthreading$outer$1
@@ -1109,7 +1109,7 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $10)
+          (get_local $11)
           (i32.const 0)
         )
         (i32.store
@@ -1130,14 +1130,14 @@
             )
           )
           (i32.eq
-            (get_local $5)
+            (get_local $4)
             (i32.const 2)
           )
         )
       )
     )
     (set_global $STACKTOP
-      (get_local $7)
+      (get_local $8)
     )
     (get_local $0)
   )
@@ -1909,7 +1909,7 @@
         (block $jumpthreading$inner$1
           (if
             (i32.and
-              (tee_local $3
+              (tee_local $4
                 (i32.ne
                   (get_local $2)
                   (i32.const 0)
@@ -1930,11 +1930,17 @@
                   (i32.const 255)
                 )
               )
+              (set_local $3
+                (get_local $2)
+              )
+              (set_local $2
+                (get_local $0)
+              )
               (loop $while-in
-                (br_if $jumpthreading$inner$2
+                (if
                   (i32.eq
                     (i32.load8_s
-                      (get_local $0)
+                      (get_local $2)
                     )
                     (i32.shr_s
                       (i32.shl
@@ -1944,14 +1950,20 @@
                       (i32.const 24)
                     )
                   )
+                  (block
+                    (set_local $0
+                      (get_local $3)
+                    )
+                    (br $jumpthreading$inner$2)
+                  )
                 )
                 (br_if $while-in
                   (i32.and
-                    (tee_local $3
+                    (tee_local $0
                       (i32.ne
-                        (tee_local $2
+                        (tee_local $3
                           (i32.add
-                            (get_local $2)
+                            (get_local $3)
                             (i32.const -1)
                           )
                         )
@@ -1960,9 +1972,9 @@
                     )
                     (i32.ne
                       (i32.and
-                        (tee_local $0
+                        (tee_local $2
                           (i32.add
-                            (get_local $0)
+                            (get_local $2)
                             (i32.const 1)
                           )
                         )
@@ -1975,24 +1987,41 @@
                 (br $jumpthreading$inner$1)
               )
             )
+            (block
+              (set_local $3
+                (get_local $2)
+              )
+              (set_local $2
+                (get_local $0)
+              )
+              (set_local $0
+                (get_local $4)
+              )
+            )
           )
         )
-        (br_if $jumpthreading$inner$2
-          (get_local $3)
-        )
-        (set_local $1
-          (i32.const 0)
+        (if
+          (get_local $0)
+          (block
+            (set_local $0
+              (get_local $3)
+            )
+            (br $jumpthreading$inner$2)
+          )
+          (set_local $0
+            (i32.const 0)
+          )
         )
         (br $label$break$L8)
       )
       (if
-        (i32.eq
+        (i32.ne
           (i32.load8_s
-            (get_local $0)
+            (get_local $2)
           )
           (i32.shr_s
             (i32.shl
-              (tee_local $4
+              (tee_local $1
                 (i32.and
                   (get_local $1)
                   (i32.const 255)
@@ -2003,9 +2032,6 @@
             (i32.const 24)
           )
         )
-        (set_local $1
-          (get_local $2)
-        )
         (block
           (set_local $3
             (i32.mul
@@ -2015,69 +2041,52 @@
           )
           (block $jumpthreading$outer$0
             (block $jumpthreading$inner$0
-              (if
-                (i32.gt_u
-                  (get_local $2)
+              (br_if $jumpthreading$inner$0
+                (i32.le_u
+                  (get_local $0)
                   (i32.const 3)
                 )
-                (loop $while-in3
-                  (block $while-out2
-                    (if
-                      (i32.and
-                        (i32.xor
-                          (i32.and
-                            (tee_local $1
-                              (i32.xor
-                                (i32.load
-                                  (get_local $0)
-                                )
-                                (get_local $3)
+              )
+              (loop $while-in3
+                (block $while-out2
+                  (br_if $while-out2
+                    (i32.and
+                      (i32.xor
+                        (i32.and
+                          (tee_local $4
+                            (i32.xor
+                              (i32.load
+                                (get_local $2)
                               )
+                              (get_local $3)
                             )
-                            (i32.const -2139062144)
                           )
                           (i32.const -2139062144)
                         )
-                        (i32.add
-                          (get_local $1)
-                          (i32.const -16843009)
-                        )
+                        (i32.const -2139062144)
                       )
-                      (block
-                        (set_local $1
-                          (get_local $2)
-                        )
-                        (br $while-out2)
-                      )
-                    )
-                    (set_local $0
                       (i32.add
-                        (get_local $0)
-                        (i32.const 4)
+                        (get_local $4)
+                        (i32.const -16843009)
                       )
-                    )
-                    (br_if $jumpthreading$inner$0
-                      (i32.le_u
-                        (tee_local $1
-                          (i32.add
-                            (get_local $2)
-                            (i32.const -4)
-                          )
-                        )
-                        (i32.const 3)
-                      )
-                    )
-                    (block
-                      (set_local $2
-                        (get_local $1)
-                      )
-                      (br $while-in3)
                     )
                   )
-                )
-                (block
-                  (set_local $1
-                    (get_local $2)
+                  (set_local $2
+                    (i32.add
+                      (get_local $2)
+                      (i32.const 4)
+                    )
+                  )
+                  (br_if $while-in3
+                    (i32.gt_u
+                      (tee_local $0
+                        (i32.add
+                          (get_local $0)
+                          (i32.const -4)
+                        )
+                      )
+                      (i32.const 3)
+                    )
                   )
                   (br $jumpthreading$inner$0)
                 )
@@ -2086,10 +2095,10 @@
             )
             (if
               (i32.eqz
-                (get_local $1)
+                (get_local $0)
               )
               (block
-                (set_local $1
+                (set_local $0
                   (i32.const 0)
                 )
                 (br $label$break$L8)
@@ -2100,32 +2109,32 @@
             (br_if $label$break$L8
               (i32.eq
                 (i32.load8_s
-                  (get_local $0)
+                  (get_local $2)
                 )
                 (i32.shr_s
                   (i32.shl
-                    (get_local $4)
+                    (get_local $1)
                     (i32.const 24)
                   )
                   (i32.const 24)
                 )
               )
             )
-            (set_local $0
+            (set_local $2
               (i32.add
-                (get_local $0)
+                (get_local $2)
                 (i32.const 1)
               )
             )
             (br_if $while-in5
-              (tee_local $1
+              (tee_local $0
                 (i32.add
-                  (get_local $1)
+                  (get_local $0)
                   (i32.const -1)
                 )
               )
             )
-            (set_local $1
+            (set_local $0
               (i32.const 0)
             )
           )
@@ -2133,10 +2142,10 @@
       )
     )
     (select
-      (get_local $0)
+      (get_local $2)
       (i32.const 0)
       (i32.ne
-        (get_local $1)
+        (get_local $0)
         (i32.const 0)
       )
     )
@@ -2302,8 +2311,8 @@
     (local $11 i32)
     (local $12 i32)
     (local $13 i32)
-    (local $14 f64)
-    (local $15 i32)
+    (local $14 i32)
+    (local $15 f64)
     (local $16 i32)
     (local $17 i32)
     (local $18 i32)
@@ -2366,10 +2375,10 @@
         (i32.const 16)
       )
     )
-    (set_local $17
+    (set_local $18
       (get_local $25)
     )
-    (set_local $40
+    (set_local $41
       (i32.add
         (get_local $25)
         (i32.const 528)
@@ -2384,7 +2393,7 @@
     (set_local $45
       (tee_local $23
         (i32.add
-          (tee_local $19
+          (tee_local $9
             (i32.add
               (get_local $25)
               (i32.const 536)
@@ -2396,7 +2405,7 @@
     )
     (set_local $46
       (i32.add
-        (get_local $19)
+        (get_local $9)
         (i32.const 39)
       )
     )
@@ -2411,9 +2420,9 @@
         (i32.const 4)
       )
     )
-    (set_local $37
+    (set_local $38
       (i32.add
-        (tee_local $19
+        (tee_local $9
           (i32.add
             (get_local $25)
             (i32.const 576)
@@ -2424,16 +2433,16 @@
     )
     (set_local $48
       (i32.add
-        (get_local $19)
+        (get_local $9)
         (i32.const 11)
       )
     )
     (set_local $51
       (i32.sub
         (tee_local $30
-          (get_local $37)
+          (get_local $38)
         )
-        (tee_local $41
+        (tee_local $42
           (tee_local $24
             (i32.add
               (get_local $25)
@@ -2446,7 +2455,7 @@
     (set_local $52
       (i32.sub
         (i32.const -2)
-        (get_local $41)
+        (get_local $42)
       )
     )
     (set_local $53
@@ -2474,29 +2483,32 @@
         )
       )
     )
-    (set_local $38
+    (set_local $39
       (i32.add
         (get_local $24)
         (i32.const 8)
       )
     )
-    (set_local $15
+    (set_local $16
       (i32.const 0)
+    )
+    (set_local $9
+      (get_local $1)
     )
     (set_local $5
       (i32.const 0)
     )
-    (set_local $19
+    (set_local $1
       (i32.const 0)
     )
     (block $label$break$L343
       (block $jumpthreading$inner$8
         (loop $label$continue$L1
           (block $label$break$L1
-            (set_local $15
+            (set_local $16
               (if i32
                 (i32.gt_s
-                  (get_local $15)
+                  (get_local $16)
                   (i32.const -1)
                 )
                 (if i32
@@ -2504,7 +2516,7 @@
                     (get_local $5)
                     (i32.sub
                       (i32.const 2147483647)
-                      (get_local $15)
+                      (get_local $16)
                     )
                   )
                   (block i32
@@ -2516,19 +2528,19 @@
                   )
                   (i32.add
                     (get_local $5)
-                    (get_local $15)
+                    (get_local $16)
                   )
                 )
-                (get_local $15)
+                (get_local $16)
               )
             )
             (br_if $jumpthreading$inner$8
               (i32.eqz
                 (i32.shr_s
                   (i32.shl
-                    (tee_local $6
+                    (tee_local $7
                       (i32.load8_s
-                        (get_local $1)
+                        (get_local $9)
                       )
                     )
                     (i32.const 24)
@@ -2538,7 +2550,7 @@
               )
             )
             (set_local $5
-              (get_local $1)
+              (get_local $9)
             )
             (loop $label$continue$L9
               (block $label$break$L9
@@ -2549,7 +2561,7 @@
                         (i32.sub
                           (i32.shr_s
                             (i32.shl
-                              (get_local $6)
+                              (get_local $7)
                               (i32.const 24)
                             )
                             (i32.const 24)
@@ -2558,10 +2570,10 @@
                         )
                       )
                     )
-                    (set_local $39
+                    (set_local $40
                       (get_local $5)
                     )
-                    (set_local $42
+                    (set_local $43
                       (get_local $5)
                     )
                     (set_local $26
@@ -2577,7 +2589,7 @@
                   )
                   (br $label$break$L9)
                 )
-                (set_local $6
+                (set_local $7
                   (i32.load8_s
                     (tee_local $5
                       (i32.add
@@ -2603,23 +2615,23 @@
                   (if
                     (i32.ne
                       (i32.load8_s offset=1
-                        (get_local $39)
+                        (get_local $40)
                       )
                       (i32.const 37)
                     )
                     (block
                       (set_local $27
-                        (get_local $39)
+                        (get_local $40)
                       )
                       (set_local $34
-                        (get_local $42)
+                        (get_local $43)
                       )
                       (br $label$break$L12)
                     )
                   )
                   (set_local $34
                     (i32.add
-                      (get_local $42)
+                      (get_local $43)
                       (i32.const 1)
                     )
                   )
@@ -2628,7 +2640,7 @@
                       (i32.load8_s
                         (tee_local $27
                           (i32.add
-                            (get_local $39)
+                            (get_local $40)
                             (i32.const 2)
                           )
                         )
@@ -2636,10 +2648,10 @@
                       (i32.const 37)
                     )
                     (block
-                      (set_local $39
+                      (set_local $40
                         (get_local $27)
                       )
-                      (set_local $42
+                      (set_local $43
                         (get_local $34)
                       )
                       (br $while-in)
@@ -2648,10 +2660,10 @@
                 )
               )
             )
-            (set_local $6
+            (set_local $7
               (i32.sub
                 (get_local $34)
-                (get_local $1)
+                (get_local $9)
               )
             )
             (if
@@ -2667,8 +2679,8 @@
                 )
                 (drop
                   (call $___fwritex
-                    (get_local $1)
-                    (get_local $6)
+                    (get_local $9)
+                    (get_local $7)
                     (get_local $0)
                   )
                 )
@@ -2677,26 +2689,26 @@
             (if
               (i32.ne
                 (get_local $34)
-                (get_local $1)
+                (get_local $9)
               )
               (block
-                (set_local $1
+                (set_local $9
                   (get_local $27)
                 )
                 (set_local $5
-                  (get_local $6)
+                  (get_local $7)
                 )
                 (br $label$continue$L1)
               )
             )
-            (set_local $18
+            (set_local $19
               (if i32
                 (i32.lt_u
-                  (tee_local $8
+                  (tee_local $10
                     (i32.add
                       (i32.shr_s
                         (i32.shl
-                          (tee_local $7
+                          (tee_local $6
                             (i32.load8_s
                               (tee_local $5
                                 (i32.add
@@ -2716,7 +2728,7 @@
                   (i32.const 10)
                 )
                 (block i32
-                  (set_local $7
+                  (set_local $6
                     (i32.load8_s
                       (tee_local $5
                         (select
@@ -2725,7 +2737,7 @@
                             (i32.const 3)
                           )
                           (get_local $5)
-                          (tee_local $11
+                          (tee_local $12
                             (i32.eq
                               (i32.load8_s offset=2
                                 (get_local $27)
@@ -2737,30 +2749,35 @@
                       )
                     )
                   )
-                  (set_local $19
+                  (set_local $8
                     (select
                       (i32.const 1)
-                      (get_local $19)
-                      (get_local $11)
+                      (get_local $1)
+                      (get_local $12)
                     )
                   )
                   (select
-                    (get_local $8)
+                    (get_local $10)
                     (i32.const -1)
-                    (get_local $11)
+                    (get_local $12)
                   )
                 )
-                (i32.const -1)
+                (block i32
+                  (set_local $8
+                    (get_local $1)
+                  )
+                  (i32.const -1)
+                )
               )
             )
             (block $label$break$L25
               (if
                 (i32.eq
                   (i32.and
-                    (tee_local $11
+                    (tee_local $12
                       (i32.shr_s
                         (i32.shl
-                          (get_local $7)
+                          (get_local $6)
                           (i32.const 24)
                         )
                         (i32.const 24)
@@ -2771,41 +2788,35 @@
                   (i32.const 32)
                 )
                 (block
-                  (set_local $8
+                  (set_local $1
+                    (get_local $6)
+                  )
+                  (set_local $6
                     (i32.const 0)
                   )
                   (loop $while-in4
-                    (if
+                    (br_if $label$break$L25
                       (i32.eqz
                         (i32.and
                           (i32.shl
                             (i32.const 1)
                             (i32.add
-                              (get_local $11)
+                              (get_local $12)
                               (i32.const -32)
                             )
                           )
                           (i32.const 75913)
                         )
                       )
-                      (block
-                        (set_local $11
-                          (get_local $7)
-                        )
-                        (set_local $7
-                          (get_local $8)
-                        )
-                        (br $label$break$L25)
-                      )
                     )
-                    (set_local $8
+                    (set_local $6
                       (i32.or
                         (i32.shl
                           (i32.const 1)
                           (i32.add
                             (i32.shr_s
                               (i32.shl
-                                (get_local $7)
+                                (get_local $1)
                                 (i32.const 24)
                               )
                               (i32.const 24)
@@ -2813,16 +2824,16 @@
                             (i32.const -32)
                           )
                         )
-                        (get_local $8)
+                        (get_local $6)
                       )
                     )
                     (br_if $while-in4
                       (i32.eq
                         (i32.and
-                          (tee_local $11
+                          (tee_local $12
                             (i32.shr_s
                               (i32.shl
-                                (tee_local $7
+                                (tee_local $1
                                   (i32.load8_s
                                     (tee_local $5
                                       (i32.add
@@ -2842,21 +2853,13 @@
                         (i32.const 32)
                       )
                     )
-                    (block
-                      (set_local $11
-                        (get_local $7)
-                      )
-                      (set_local $7
-                        (get_local $8)
-                      )
-                    )
                   )
                 )
                 (block
-                  (set_local $11
-                    (get_local $7)
+                  (set_local $1
+                    (get_local $6)
                   )
-                  (set_local $7
+                  (set_local $6
                     (i32.const 0)
                   )
                 )
@@ -2867,7 +2870,7 @@
                 (i32.eq
                   (i32.shr_s
                     (i32.shl
-                      (get_local $11)
+                      (get_local $1)
                       (i32.const 24)
                     )
                     (i32.const 24)
@@ -2875,15 +2878,15 @@
                   (i32.const 42)
                 )
                 (block
-                  (set_local $19
+                  (set_local $1
                     (block $jumpthreading$outer$0 i32
                       (block $jumpthreading$inner$0
                         (br_if $jumpthreading$inner$0
                           (i32.ge_u
-                            (tee_local $11
+                            (tee_local $12
                               (i32.add
                                 (i32.load8_s
-                                  (tee_local $8
+                                  (tee_local $1
                                     (i32.add
                                       (get_local $5)
                                       (i32.const 1)
@@ -2908,19 +2911,19 @@
                           (i32.add
                             (get_local $4)
                             (i32.shl
-                              (get_local $11)
+                              (get_local $12)
                               (i32.const 2)
                             )
                           )
                           (i32.const 10)
                         )
-                        (set_local $19
+                        (set_local $1
                           (i32.add
                             (get_local $3)
                             (i32.shl
                               (i32.add
                                 (i32.load8_s
-                                  (get_local $8)
+                                  (get_local $1)
                                 )
                                 (i32.const -48)
                               )
@@ -2934,9 +2937,9 @@
                             (i32.const 3)
                           )
                         )
-                        (set_local $13
+                        (set_local $14
                           (i32.load
-                            (get_local $19)
+                            (get_local $1)
                           )
                         )
                         (br $jumpthreading$outer$0
@@ -2947,9 +2950,9 @@
                         (i32.const 0)
                       )
                       (if
-                        (get_local $19)
+                        (get_local $8)
                         (block
-                          (set_local $15
+                          (set_local $16
                             (i32.const -1)
                           )
                           (br $label$break$L1)
@@ -2960,24 +2963,24 @@
                           (get_local $32)
                         )
                         (block
-                          (set_local $11
-                            (get_local $7)
+                          (set_local $12
+                            (get_local $6)
                           )
                           (set_local $5
-                            (get_local $8)
+                            (get_local $1)
                           )
-                          (set_local $19
+                          (set_local $1
                             (i32.const 0)
                           )
-                          (set_local $13
+                          (set_local $14
                             (i32.const 0)
                           )
                           (br $do-once5)
                         )
                       )
-                      (set_local $13
+                      (set_local $14
                         (i32.load
-                          (tee_local $19
+                          (tee_local $5
                             (i32.and
                               (i32.add
                                 (i32.load
@@ -2993,45 +2996,45 @@
                       (i32.store
                         (get_local $2)
                         (i32.add
-                          (get_local $19)
+                          (get_local $5)
                           (i32.const 4)
                         )
                       )
                       (set_local $5
-                        (get_local $8)
+                        (get_local $1)
                       )
                       (i32.const 0)
                     )
                   )
-                  (set_local $11
+                  (set_local $12
                     (if i32
                       (i32.lt_s
-                        (get_local $13)
+                        (get_local $14)
                         (i32.const 0)
                       )
                       (block i32
-                        (set_local $13
+                        (set_local $14
                           (i32.sub
                             (i32.const 0)
-                            (get_local $13)
+                            (get_local $14)
                           )
                         )
                         (i32.or
-                          (get_local $7)
+                          (get_local $6)
                           (i32.const 8192)
                         )
                       )
-                      (get_local $7)
+                      (get_local $6)
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (tee_local $11
+                    (tee_local $1
                       (i32.add
                         (i32.shr_s
                           (i32.shl
-                            (get_local $11)
+                            (get_local $1)
                             (i32.const 24)
                           )
                           (i32.const 24)
@@ -3042,22 +3045,22 @@
                     (i32.const 10)
                   )
                   (block
-                    (set_local $8
+                    (set_local $12
                       (i32.const 0)
                     )
                     (loop $while-in8
-                      (set_local $11
+                      (set_local $1
                         (i32.add
                           (i32.mul
-                            (get_local $8)
+                            (get_local $12)
                             (i32.const 10)
                           )
-                          (get_local $11)
+                          (get_local $1)
                         )
                       )
                       (if
                         (i32.lt_u
-                          (tee_local $9
+                          (tee_local $10
                             (i32.add
                               (i32.load8_s
                                 (tee_local $5
@@ -3073,40 +3076,48 @@
                           (i32.const 10)
                         )
                         (block
-                          (set_local $8
-                            (get_local $11)
+                          (set_local $12
+                            (get_local $1)
                           )
-                          (set_local $11
-                            (get_local $9)
+                          (set_local $1
+                            (get_local $10)
                           )
                           (br $while-in8)
                         )
-                        (set_local $13
-                          (get_local $11)
+                        (set_local $14
+                          (get_local $1)
                         )
                       )
                     )
                     (if
                       (i32.lt_s
-                        (get_local $13)
+                        (get_local $14)
                         (i32.const 0)
                       )
                       (block
-                        (set_local $15
+                        (set_local $16
                           (i32.const -1)
                         )
                         (br $label$break$L1)
                       )
-                      (set_local $11
-                        (get_local $7)
+                      (block
+                        (set_local $12
+                          (get_local $6)
+                        )
+                        (set_local $1
+                          (get_local $8)
+                        )
                       )
                     )
                   )
                   (block
-                    (set_local $11
-                      (get_local $7)
+                    (set_local $12
+                      (get_local $6)
                     )
-                    (set_local $13
+                    (set_local $1
+                      (get_local $8)
+                    )
+                    (set_local $14
                       (i32.const 0)
                     )
                   )
@@ -3127,7 +3138,7 @@
                       (i32.ne
                         (i32.shr_s
                           (i32.shl
-                            (tee_local $7
+                            (tee_local $6
                               (i32.load8_s
                                 (tee_local $8
                                   (i32.add
@@ -3146,11 +3157,11 @@
                       (block
                         (if
                           (i32.lt_u
-                            (tee_local $7
+                            (tee_local $6
                               (i32.add
                                 (i32.shr_s
                                   (i32.shl
-                                    (get_local $7)
+                                    (get_local $6)
                                     (i32.const 24)
                                   )
                                   (i32.const 24)
@@ -3169,7 +3180,7 @@
                             )
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (i32.const 0)
                             )
                             (br $label$break$L46
@@ -3178,18 +3189,18 @@
                           )
                         )
                         (loop $while-in11
-                          (set_local $7
+                          (set_local $6
                             (i32.add
                               (i32.mul
                                 (get_local $8)
                                 (i32.const 10)
                               )
-                              (get_local $7)
+                              (get_local $6)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (tee_local $9
+                              (tee_local $10
                                 (i32.add
                                   (i32.load8_s
                                     (tee_local $5
@@ -3206,10 +3217,10 @@
                             )
                             (block
                               (set_local $8
-                                (get_local $7)
+                                (get_local $6)
                               )
-                              (set_local $7
-                                (get_local $9)
+                              (set_local $6
+                                (get_local $10)
                               )
                               (br $while-in11)
                             )
@@ -3222,7 +3233,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (tee_local $7
+                        (tee_local $6
                           (i32.add
                             (i32.load8_s
                               (tee_local $8
@@ -3249,13 +3260,13 @@
                             (i32.add
                               (get_local $4)
                               (i32.shl
-                                (get_local $7)
+                                (get_local $6)
                                 (i32.const 2)
                               )
                             )
                             (i32.const 10)
                           )
-                          (set_local $7
+                          (set_local $6
                             (i32.add
                               (get_local $3)
                               (i32.shl
@@ -3269,9 +3280,9 @@
                               )
                             )
                           )
-                          (set_local $7
+                          (set_local $6
                             (i32.load
-                              (get_local $7)
+                              (get_local $6)
                             )
                           )
                           (br $label$break$L46
@@ -3284,9 +3295,9 @@
                       )
                     )
                     (if
-                      (get_local $19)
+                      (get_local $1)
                       (block
-                        (set_local $15
+                        (set_local $16
                           (i32.const -1)
                         )
                         (br $label$break$L1)
@@ -3295,7 +3306,7 @@
                     (if i32
                       (get_local $32)
                       (block i32
-                        (set_local $7
+                        (set_local $6
                           (i32.load
                             (tee_local $5
                               (i32.and
@@ -3320,7 +3331,7 @@
                         (get_local $8)
                       )
                       (block i32
-                        (set_local $7
+                        (set_local $6
                           (i32.const 0)
                         )
                         (get_local $8)
@@ -3328,7 +3339,7 @@
                     )
                   )
                   (block i32
-                    (set_local $7
+                    (set_local $6
                       (i32.const -1)
                     )
                     (get_local $5)
@@ -3336,13 +3347,13 @@
                 )
               )
             )
-            (set_local $9
+            (set_local $10
               (i32.const 0)
             )
             (loop $while-in13
               (if
                 (i32.gt_u
-                  (tee_local $10
+                  (tee_local $11
                     (i32.add
                       (i32.load8_s
                         (get_local $8)
@@ -3353,7 +3364,7 @@
                   (i32.const 57)
                 )
                 (block
-                  (set_local $15
+                  (set_local $16
                     (i32.const -1)
                   )
                   (br $label$break$L1)
@@ -3368,19 +3379,19 @@
               (if
                 (i32.lt_u
                   (i32.add
-                    (tee_local $10
+                    (tee_local $11
                       (i32.and
-                        (tee_local $12
+                        (tee_local $13
                           (i32.load8_s
                             (i32.add
                               (i32.add
                                 (i32.const 3611)
                                 (i32.mul
-                                  (get_local $9)
+                                  (get_local $10)
                                   (i32.const 58)
                                 )
                               )
-                              (get_local $10)
+                              (get_local $11)
                             )
                           )
                         )
@@ -3395,12 +3406,12 @@
                   (set_local $8
                     (get_local $5)
                   )
-                  (set_local $9
-                    (get_local $10)
+                  (set_local $10
+                    (get_local $11)
                   )
                   (br $while-in13)
                 )
-                (set_local $16
+                (set_local $17
                   (get_local $8)
                 )
               )
@@ -3409,14 +3420,14 @@
               (i32.eqz
                 (i32.shr_s
                   (i32.shl
-                    (get_local $12)
+                    (get_local $13)
                     (i32.const 24)
                   )
                   (i32.const 24)
                 )
               )
               (block
-                (set_local $15
+                (set_local $16
                   (i32.const -1)
                 )
                 (br $label$break$L1)
@@ -3424,7 +3435,7 @@
             )
             (set_local $8
               (i32.gt_s
-                (get_local $18)
+                (get_local $19)
                 (i32.const -1)
               )
             )
@@ -3434,7 +3445,7 @@
                   (i32.eq
                     (i32.shr_s
                       (i32.shl
-                        (get_local $12)
+                        (get_local $13)
                         (i32.const 24)
                       )
                       (i32.const 24)
@@ -3444,7 +3455,7 @@
                   (if
                     (get_local $8)
                     (block
-                      (set_local $15
+                      (set_local $16
                         (i32.const -1)
                       )
                       (br $label$break$L1)
@@ -3459,19 +3470,19 @@
                           (i32.add
                             (get_local $4)
                             (i32.shl
-                              (get_local $18)
+                              (get_local $19)
                               (i32.const 2)
                             )
                           )
-                          (get_local $10)
+                          (get_local $11)
                         )
-                        (set_local $12
+                        (set_local $13
                           (i32.load offset=4
-                            (tee_local $10
+                            (tee_local $11
                               (i32.add
                                 (get_local $3)
                                 (i32.shl
-                                  (get_local $18)
+                                  (get_local $19)
                                   (i32.const 3)
                                 )
                               )
@@ -3480,15 +3491,15 @@
                         )
                         (i32.store
                           (tee_local $8
-                            (get_local $17)
+                            (get_local $18)
                           )
                           (i32.load
-                            (get_local $10)
+                            (get_local $11)
                           )
                         )
                         (i32.store offset=4
                           (get_local $8)
-                          (get_local $12)
+                          (get_local $13)
                         )
                         (br $jumpthreading$inner$1)
                       )
@@ -3498,15 +3509,15 @@
                         (get_local $32)
                       )
                       (block
-                        (set_local $15
+                        (set_local $16
                           (i32.const 0)
                         )
                         (br $label$break$L1)
                       )
                     )
                     (call $_pop_arg_336
-                      (get_local $17)
-                      (get_local $10)
+                      (get_local $18)
+                      (get_local $11)
                       (get_local $2)
                     )
                   )
@@ -3521,27 +3532,27 @@
                   (get_local $32)
                 )
                 (block
-                  (set_local $1
+                  (set_local $9
                     (get_local $5)
                   )
                   (set_local $5
-                    (get_local $6)
+                    (get_local $7)
                   )
                   (br $label$continue$L1)
                 )
               )
             )
-            (set_local $11
+            (set_local $12
               (select
                 (tee_local $8
                   (i32.and
-                    (get_local $11)
+                    (get_local $12)
                     (i32.const -65537)
                   )
                 )
-                (get_local $11)
+                (get_local $12)
                 (i32.and
-                  (get_local $11)
+                  (get_local $12)
                   (i32.const 8192)
                 )
               )
@@ -3568,25 +3579,25 @@
                                                   (block $switch-case27
                                                     (br_table $switch-case42 $switch-default120 $switch-case40 $switch-default120 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case29 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case42 $switch-default120 $switch-case37 $switch-case34 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-case34 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case29 $switch-default120
                                                       (i32.sub
-                                                        (tee_local $12
+                                                        (tee_local $17
                                                           (select
                                                             (i32.and
-                                                              (tee_local $10
+                                                              (tee_local $11
                                                                 (i32.load8_s
-                                                                  (get_local $16)
+                                                                  (get_local $17)
                                                                 )
                                                               )
                                                               (i32.const -33)
                                                             )
-                                                            (get_local $10)
+                                                            (get_local $11)
                                                             (i32.and
                                                               (i32.ne
-                                                                (get_local $9)
+                                                                (get_local $10)
                                                                 (i32.const 0)
                                                               )
                                                               (i32.eq
                                                                 (i32.and
-                                                                  (get_local $10)
+                                                                  (get_local $11)
                                                                   (i32.const 15)
                                                                 )
                                                                 (i32.const 3)
@@ -3608,53 +3619,53 @@
                                                                 (block $switch-case19
                                                                   (br_table $switch-case19 $switch-case20 $switch-case21 $switch-case22 $switch-case23 $switch-default26 $switch-case24 $switch-case25 $switch-default26
                                                                     (i32.sub
-                                                                      (get_local $9)
+                                                                      (get_local $10)
                                                                       (i32.const 0)
                                                                     )
                                                                   )
                                                                 )
                                                                 (i32.store
                                                                   (i32.load
-                                                                    (get_local $17)
+                                                                    (get_local $18)
                                                                   )
-                                                                  (get_local $15)
+                                                                  (get_local $16)
                                                                 )
-                                                                (set_local $1
+                                                                (set_local $9
                                                                   (get_local $5)
                                                                 )
                                                                 (set_local $5
-                                                                  (get_local $6)
+                                                                  (get_local $7)
                                                                 )
                                                                 (br $label$continue$L1)
                                                               )
                                                               (i32.store
                                                                 (i32.load
-                                                                  (get_local $17)
+                                                                  (get_local $18)
                                                                 )
-                                                                (get_local $15)
+                                                                (get_local $16)
                                                               )
-                                                              (set_local $1
+                                                              (set_local $9
                                                                 (get_local $5)
                                                               )
                                                               (set_local $5
-                                                                (get_local $6)
+                                                                (get_local $7)
                                                               )
                                                               (br $label$continue$L1)
                                                             )
                                                             (i32.store
-                                                              (tee_local $1
+                                                              (tee_local $9
                                                                 (i32.load
-                                                                  (get_local $17)
+                                                                  (get_local $18)
                                                                 )
                                                               )
-                                                              (get_local $15)
+                                                              (get_local $16)
                                                             )
                                                             (i32.store offset=4
-                                                              (get_local $1)
+                                                              (get_local $9)
                                                               (i32.shr_s
                                                                 (i32.shl
                                                                   (i32.lt_s
-                                                                    (get_local $15)
+                                                                    (get_local $16)
                                                                     (i32.const 0)
                                                                   )
                                                                   (i32.const 31)
@@ -3662,70 +3673,70 @@
                                                                 (i32.const 31)
                                                               )
                                                             )
-                                                            (set_local $1
+                                                            (set_local $9
                                                               (get_local $5)
                                                             )
                                                             (set_local $5
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                             )
                                                             (br $label$continue$L1)
                                                           )
                                                           (i32.store16
                                                             (i32.load
-                                                              (get_local $17)
+                                                              (get_local $18)
                                                             )
-                                                            (get_local $15)
+                                                            (get_local $16)
                                                           )
-                                                          (set_local $1
+                                                          (set_local $9
                                                             (get_local $5)
                                                           )
                                                           (set_local $5
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                           )
                                                           (br $label$continue$L1)
                                                         )
                                                         (i32.store8
                                                           (i32.load
-                                                            (get_local $17)
+                                                            (get_local $18)
                                                           )
-                                                          (get_local $15)
+                                                          (get_local $16)
                                                         )
-                                                        (set_local $1
+                                                        (set_local $9
                                                           (get_local $5)
                                                         )
                                                         (set_local $5
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                         )
                                                         (br $label$continue$L1)
                                                       )
                                                       (i32.store
                                                         (i32.load
-                                                          (get_local $17)
+                                                          (get_local $18)
                                                         )
-                                                        (get_local $15)
+                                                        (get_local $16)
                                                       )
-                                                      (set_local $1
+                                                      (set_local $9
                                                         (get_local $5)
                                                       )
                                                       (set_local $5
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                       )
                                                       (br $label$continue$L1)
                                                     )
                                                     (i32.store
-                                                      (tee_local $1
+                                                      (tee_local $9
                                                         (i32.load
-                                                          (get_local $17)
+                                                          (get_local $18)
                                                         )
                                                       )
-                                                      (get_local $15)
+                                                      (get_local $16)
                                                     )
                                                     (i32.store offset=4
-                                                      (get_local $1)
+                                                      (get_local $9)
                                                       (i32.shr_s
                                                         (i32.shl
                                                           (i32.lt_s
-                                                            (get_local $15)
+                                                            (get_local $16)
                                                             (i32.const 0)
                                                           )
                                                           (i32.const 31)
@@ -3733,55 +3744,55 @@
                                                         (i32.const 31)
                                                       )
                                                     )
-                                                    (set_local $1
+                                                    (set_local $9
                                                       (get_local $5)
                                                     )
                                                     (set_local $5
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                     )
                                                     (br $label$continue$L1)
                                                   )
-                                                  (set_local $1
+                                                  (set_local $9
                                                     (get_local $5)
                                                   )
                                                   (set_local $5
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (br $label$continue$L1)
                                                 )
-                                                (set_local $1
+                                                (set_local $9
                                                   (i32.or
-                                                    (get_local $11)
+                                                    (get_local $12)
                                                     (i32.const 8)
                                                   )
                                                 )
-                                                (set_local $7
+                                                (set_local $6
                                                   (select
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 8)
                                                     (i32.gt_u
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 8)
                                                     )
                                                   )
                                                 )
-                                                (set_local $12
+                                                (set_local $17
                                                   (i32.const 120)
                                                 )
                                                 (br $jumpthreading$inner$2)
                                               )
-                                              (set_local $1
-                                                (get_local $11)
+                                              (set_local $9
+                                                (get_local $12)
                                               )
                                               (br $jumpthreading$inner$2)
                                             )
                                             (if
                                               (i32.and
                                                 (i32.eqz
-                                                  (tee_local $6
+                                                  (tee_local $7
                                                     (i32.load
-                                                      (tee_local $1
-                                                        (get_local $17)
+                                                      (tee_local $9
+                                                        (get_local $18)
                                                       )
                                                     )
                                                   )
@@ -3789,7 +3800,7 @@
                                                 (i32.eqz
                                                   (tee_local $8
                                                     (i32.load offset=4
-                                                      (get_local $1)
+                                                      (get_local $9)
                                                     )
                                                   )
                                                 )
@@ -3798,10 +3809,10 @@
                                                 (get_local $23)
                                               )
                                               (block
-                                                (set_local $1
-                                                  (get_local $6)
+                                                (set_local $9
+                                                  (get_local $7)
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (get_local $8)
                                                 )
                                                 (set_local $8
@@ -3817,7 +3828,7 @@
                                                     )
                                                     (i32.or
                                                       (i32.and
-                                                        (get_local $1)
+                                                        (get_local $9)
                                                         (i32.const 7)
                                                       )
                                                       (i32.const 48)
@@ -3827,16 +3838,16 @@
                                                     (i32.eqz
                                                       (i32.and
                                                         (i32.eqz
-                                                          (tee_local $1
+                                                          (tee_local $9
                                                             (call $_bitshift64Lshr
-                                                              (get_local $1)
-                                                              (get_local $6)
+                                                              (get_local $9)
+                                                              (get_local $7)
                                                               (i32.const 3)
                                                             )
                                                           )
                                                         )
                                                         (i32.eqz
-                                                          (tee_local $6
+                                                          (tee_local $7
                                                             (get_global $tempRet0)
                                                           )
                                                         )
@@ -3848,19 +3859,19 @@
                                             )
                                             (if
                                               (i32.and
-                                                (get_local $11)
+                                                (get_local $12)
                                                 (i32.const 8)
                                               )
                                               (block
-                                                (set_local $6
+                                                (set_local $7
                                                   (get_local $8)
                                                 )
-                                                (set_local $1
-                                                  (get_local $11)
+                                                (set_local $9
+                                                  (get_local $12)
                                                 )
-                                                (set_local $7
+                                                (set_local $6
                                                   (select
-                                                    (tee_local $11
+                                                    (tee_local $12
                                                       (i32.add
                                                         (i32.sub
                                                           (get_local $45)
@@ -3869,50 +3880,50 @@
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.lt_s
-                                                      (get_local $7)
-                                                      (get_local $11)
+                                                      (get_local $6)
+                                                      (get_local $12)
                                                     )
                                                   )
                                                 )
                                                 (set_local $8
                                                   (i32.const 0)
                                                 )
-                                                (set_local $9
+                                                (set_local $10
                                                   (i32.const 4091)
                                                 )
                                                 (br $jumpthreading$inner$7)
                                               )
                                               (block
-                                                (set_local $6
+                                                (set_local $7
                                                   (get_local $8)
                                                 )
-                                                (set_local $1
-                                                  (get_local $11)
+                                                (set_local $9
+                                                  (get_local $12)
                                                 )
                                                 (set_local $8
                                                   (i32.const 0)
                                                 )
-                                                (set_local $9
+                                                (set_local $10
                                                   (i32.const 4091)
                                                 )
                                                 (br $jumpthreading$inner$7)
                                               )
                                             )
                                           )
-                                          (set_local $1
+                                          (set_local $9
                                             (i32.load
-                                              (tee_local $6
-                                                (get_local $17)
+                                              (tee_local $7
+                                                (get_local $18)
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_s
-                                              (tee_local $6
+                                              (tee_local $7
                                                 (i32.load offset=4
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                               (i32.const 0)
@@ -3920,27 +3931,27 @@
                                             (block
                                               (i32.store
                                                 (tee_local $8
-                                                  (get_local $17)
+                                                  (get_local $18)
                                                 )
-                                                (tee_local $1
+                                                (tee_local $9
                                                   (call $_i64Subtract
                                                     (i32.const 0)
                                                     (i32.const 0)
-                                                    (get_local $1)
-                                                    (get_local $6)
+                                                    (get_local $9)
+                                                    (get_local $7)
                                                   )
                                                 )
                                               )
                                               (i32.store offset=4
                                                 (get_local $8)
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (get_global $tempRet0)
                                                 )
                                               )
                                               (set_local $8
                                                 (i32.const 1)
                                               )
-                                              (set_local $9
+                                              (set_local $10
                                                 (i32.const 4091)
                                               )
                                               (br $jumpthreading$inner$3)
@@ -3948,88 +3959,88 @@
                                           )
                                           (if
                                             (i32.and
-                                              (get_local $11)
+                                              (get_local $12)
                                               (i32.const 2048)
                                             )
                                             (block
                                               (set_local $8
                                                 (i32.const 1)
                                               )
-                                              (set_local $9
+                                              (set_local $10
                                                 (i32.const 4092)
                                               )
                                               (br $jumpthreading$inner$3)
                                             )
                                             (block
                                               (set_local $8
-                                                (tee_local $9
+                                                (tee_local $10
                                                   (i32.and
-                                                    (get_local $11)
+                                                    (get_local $12)
                                                     (i32.const 1)
                                                   )
                                                 )
                                               )
-                                              (set_local $9
+                                              (set_local $10
                                                 (select
                                                   (i32.const 4093)
                                                   (i32.const 4091)
-                                                  (get_local $9)
+                                                  (get_local $10)
                                                 )
                                               )
                                               (br $jumpthreading$inner$3)
                                             )
                                           )
                                         )
-                                        (set_local $1
+                                        (set_local $9
                                           (i32.load
-                                            (tee_local $6
-                                              (get_local $17)
+                                            (tee_local $7
+                                              (get_local $18)
                                             )
                                           )
                                         )
-                                        (set_local $6
+                                        (set_local $7
                                           (i32.load offset=4
-                                            (get_local $6)
+                                            (get_local $7)
                                           )
                                         )
                                         (set_local $8
                                           (i32.const 0)
                                         )
-                                        (set_local $9
+                                        (set_local $10
                                           (i32.const 4091)
                                         )
                                         (br $jumpthreading$inner$3)
                                       )
-                                      (set_local $1
-                                        (get_local $17)
+                                      (set_local $9
+                                        (get_local $18)
                                       )
                                       (i32.store8
                                         (get_local $46)
                                         (i32.load
-                                          (get_local $1)
+                                          (get_local $9)
                                         )
                                       )
-                                      (set_local $6
+                                      (set_local $7
                                         (get_local $46)
                                       )
-                                      (set_local $11
+                                      (set_local $12
                                         (get_local $8)
                                       )
-                                      (set_local $10
+                                      (set_local $11
                                         (i32.const 1)
                                       )
                                       (set_local $8
                                         (i32.const 0)
                                       )
-                                      (set_local $9
+                                      (set_local $10
                                         (i32.const 4091)
                                       )
-                                      (set_local $1
+                                      (set_local $9
                                         (get_local $23)
                                       )
                                       (br $jumpthreading$outer$7)
                                     )
-                                    (set_local $1
+                                    (set_local $9
                                       (call $_strerror
                                         (i32.load
                                           (call $___errno_location)
@@ -4038,29 +4049,29 @@
                                     )
                                     (br $jumpthreading$inner$4)
                                   )
-                                  (set_local $1
+                                  (set_local $9
                                     (select
-                                      (tee_local $1
+                                      (tee_local $9
                                         (i32.load
-                                          (get_local $17)
+                                          (get_local $18)
                                         )
                                       )
                                       (i32.const 4101)
                                       (i32.ne
-                                        (get_local $1)
+                                        (get_local $9)
                                         (i32.const 0)
                                       )
                                     )
                                   )
                                   (br $jumpthreading$inner$4)
                                 )
-                                (set_local $1
-                                  (get_local $17)
+                                (set_local $9
+                                  (get_local $18)
                                 )
                                 (i32.store
                                   (get_local $47)
                                   (i32.load
-                                    (get_local $1)
+                                    (get_local $9)
                                   )
                                 )
                                 (i32.store
@@ -4068,34 +4079,40 @@
                                   (i32.const 0)
                                 )
                                 (i32.store
-                                  (get_local $17)
+                                  (get_local $18)
                                   (get_local $47)
                                 )
-                                (set_local $7
+                                (set_local $8
                                   (i32.const -1)
                                 )
                                 (br $jumpthreading$inner$5)
                               )
-                              (br_if $jumpthreading$inner$5
-                                (get_local $7)
-                              )
-                              (block
-                                (call $_pad
-                                  (get_local $0)
-                                  (i32.const 32)
-                                  (get_local $13)
-                                  (i32.const 0)
-                                  (get_local $11)
+                              (if
+                                (get_local $6)
+                                (block
+                                  (set_local $8
+                                    (get_local $6)
+                                  )
+                                  (br $jumpthreading$inner$5)
                                 )
-                                (set_local $6
-                                  (i32.const 0)
+                                (block
+                                  (call $_pad
+                                    (get_local $0)
+                                    (i32.const 32)
+                                    (get_local $14)
+                                    (i32.const 0)
+                                    (get_local $12)
+                                  )
+                                  (set_local $7
+                                    (i32.const 0)
+                                  )
+                                  (br $jumpthreading$inner$6)
                                 )
-                                (br $jumpthreading$inner$6)
                               )
                             )
-                            (set_local $14
+                            (set_local $15
                               (f64.load
-                                (get_local $17)
+                                (get_local $18)
                               )
                             )
                             (i32.store
@@ -4104,7 +4121,7 @@
                             )
                             (f64.store
                               (get_global $tempDoublePtr)
-                              (get_local $14)
+                              (get_local $15)
                             )
                             (set_local $35
                               (if i32
@@ -4118,16 +4135,16 @@
                                   (set_local $28
                                     (i32.const 1)
                                   )
-                                  (set_local $14
+                                  (set_local $15
                                     (f64.neg
-                                      (get_local $14)
+                                      (get_local $15)
                                     )
                                   )
                                   (i32.const 4108)
                                 )
                                 (if i32
                                   (i32.and
-                                    (get_local $11)
+                                    (get_local $12)
                                     (i32.const 2048)
                                   )
                                   (block i32
@@ -4138,9 +4155,9 @@
                                   )
                                   (block i32
                                     (set_local $28
-                                      (tee_local $1
+                                      (tee_local $9
                                         (i32.and
-                                          (get_local $11)
+                                          (get_local $12)
                                           (i32.const 1)
                                         )
                                       )
@@ -4148,7 +4165,7 @@
                                     (select
                                       (i32.const 4114)
                                       (i32.const 4109)
-                                      (get_local $1)
+                                      (get_local $9)
                                     )
                                   )
                                 )
@@ -4156,9 +4173,9 @@
                             )
                             (f64.store
                               (get_global $tempDoublePtr)
-                              (get_local $14)
+                              (get_local $15)
                             )
-                            (set_local $1
+                            (set_local $9
                               (get_local $5)
                             )
                             (set_local $5
@@ -4191,7 +4208,7 @@
                                           (tee_local $21
                                             (f64.mul
                                               (call $_frexpl
-                                                (get_local $14)
+                                                (get_local $15)
                                                 (get_local $20)
                                               )
                                               (f64.const 2)
@@ -4212,61 +4229,61 @@
                                     )
                                     (if
                                       (i32.eq
-                                        (tee_local $16
+                                        (tee_local $13
                                           (i32.or
-                                            (get_local $12)
+                                            (get_local $17)
                                             (i32.const 32)
                                           )
                                         )
                                         (i32.const 97)
                                       )
                                       (block
-                                        (set_local $9
+                                        (set_local $10
                                           (select
                                             (i32.add
                                               (get_local $35)
                                               (i32.const 9)
                                             )
                                             (get_local $35)
-                                            (tee_local $16
+                                            (tee_local $13
                                               (i32.and
-                                                (get_local $12)
+                                                (get_local $17)
                                                 (i32.const 32)
                                               )
                                             )
                                           )
                                         )
-                                        (set_local $10
+                                        (set_local $11
                                           (i32.or
                                             (get_local $28)
                                             (i32.const 2)
                                           )
                                         )
-                                        (set_local $14
+                                        (set_local $15
                                           (if f64
                                             (i32.or
                                               (i32.gt_u
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (i32.const 11)
                                               )
                                               (i32.eqz
                                                 (tee_local $5
                                                   (i32.sub
                                                     (i32.const 12)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                 )
                                               )
                                             )
                                             (get_local $21)
                                             (block f64
-                                              (set_local $14
+                                              (set_local $15
                                                 (f64.const 8)
                                               )
                                               (loop $while-in54
-                                                (set_local $14
+                                                (set_local $15
                                                   (f64.mul
-                                                    (get_local $14)
+                                                    (get_local $15)
                                                     (f64.const 16)
                                                   )
                                                 )
@@ -4282,25 +4299,25 @@
                                               (select
                                                 (f64.neg
                                                   (f64.add
-                                                    (get_local $14)
+                                                    (get_local $15)
                                                     (f64.sub
                                                       (f64.neg
                                                         (get_local $21)
                                                       )
-                                                      (get_local $14)
+                                                      (get_local $15)
                                                     )
                                                   )
                                                 )
                                                 (f64.sub
                                                   (f64.add
                                                     (get_local $21)
-                                                    (get_local $14)
+                                                    (get_local $15)
                                                   )
-                                                  (get_local $14)
+                                                  (get_local $15)
                                                 )
                                                 (i32.eq
                                                   (i32.load8_s
-                                                    (get_local $9)
+                                                    (get_local $10)
                                                   )
                                                   (i32.const 45)
                                                 )
@@ -4310,12 +4327,12 @@
                                         )
                                         (i32.store8
                                           (i32.add
-                                            (tee_local $6
+                                            (tee_local $7
                                               (if i32
                                                 (i32.eq
-                                                  (tee_local $6
+                                                  (tee_local $7
                                                     (call $_fmt_u
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (select
                                                           (i32.sub
                                                             (i32.const 0)
@@ -4335,17 +4352,17 @@
                                                       (i32.shr_s
                                                         (i32.shl
                                                           (i32.lt_s
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                             (i32.const 0)
                                                           )
                                                           (i32.const 31)
                                                         )
                                                         (i32.const 31)
                                                       )
-                                                      (get_local $37)
+                                                      (get_local $38)
                                                     )
                                                   )
-                                                  (get_local $37)
+                                                  (get_local $38)
                                                 )
                                                 (block i32
                                                   (i32.store8
@@ -4354,7 +4371,7 @@
                                                   )
                                                   (get_local $48)
                                                 )
-                                                (get_local $6)
+                                                (get_local $7)
                                               )
                                             )
                                             (i32.const -1)
@@ -4371,27 +4388,27 @@
                                           )
                                         )
                                         (i32.store8
-                                          (tee_local $6
+                                          (tee_local $7
                                             (i32.add
-                                              (get_local $6)
+                                              (get_local $7)
                                               (i32.const -2)
                                             )
                                           )
                                           (i32.add
-                                            (get_local $12)
+                                            (get_local $17)
                                             (i32.const 15)
                                           )
                                         )
-                                        (set_local $12
+                                        (set_local $17
                                           (i32.lt_s
-                                            (get_local $7)
+                                            (get_local $6)
                                             (i32.const 1)
                                           )
                                         )
-                                        (set_local $18
+                                        (set_local $19
                                           (i32.eqz
                                             (i32.and
-                                              (get_local $11)
+                                              (get_local $12)
                                               (i32.const 8)
                                             )
                                           )
@@ -4407,19 +4424,19 @@
                                                 (i32.add
                                                   (tee_local $8
                                                     (call $f64-to-int
-                                                      (get_local $14)
+                                                      (get_local $15)
                                                     )
                                                   )
                                                   (i32.const 4075)
                                                 )
                                               )
-                                              (get_local $16)
+                                              (get_local $13)
                                             )
                                           )
-                                          (set_local $14
+                                          (set_local $15
                                             (f64.mul
                                               (f64.sub
-                                                (get_local $14)
+                                                (get_local $15)
                                                 (f64.convert_s/i32
                                                   (get_local $8)
                                                 )
@@ -4438,7 +4455,7 @@
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (get_local $41)
+                                                    (get_local $42)
                                                   )
                                                   (i32.const 1)
                                                 )
@@ -4447,11 +4464,11 @@
                                                     (br_if $do-once57
                                                       (get_local $8)
                                                       (i32.and
-                                                        (get_local $18)
+                                                        (get_local $19)
                                                         (i32.and
-                                                          (get_local $12)
+                                                          (get_local $17)
                                                           (f64.eq
-                                                            (get_local $14)
+                                                            (get_local $15)
                                                             (f64.const 0)
                                                           )
                                                         )
@@ -4473,7 +4490,7 @@
                                           )
                                           (br_if $while-in56
                                             (f64.ne
-                                              (get_local $14)
+                                              (get_local $15)
                                               (f64.const 0)
                                             )
                                           )
@@ -4481,28 +4498,28 @@
                                         (call $_pad
                                           (get_local $0)
                                           (i32.const 32)
-                                          (get_local $13)
-                                          (tee_local $7
+                                          (get_local $14)
+                                          (tee_local $6
                                             (i32.add
                                               (tee_local $8
                                                 (select
                                                   (i32.sub
                                                     (i32.add
                                                       (get_local $53)
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                     )
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (i32.add
                                                     (i32.sub
                                                       (get_local $51)
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                     )
                                                     (get_local $5)
                                                   )
                                                   (i32.and
                                                     (i32.ne
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 0)
                                                     )
                                                     (i32.lt_s
@@ -4510,15 +4527,15 @@
                                                         (get_local $52)
                                                         (get_local $5)
                                                       )
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                     )
                                                   )
                                                 )
                                               )
-                                              (get_local $10)
+                                              (get_local $11)
                                             )
                                           )
-                                          (get_local $11)
+                                          (get_local $12)
                                         )
                                         (if
                                           (i32.eqz
@@ -4531,8 +4548,8 @@
                                           )
                                           (drop
                                             (call $___fwritex
-                                              (get_local $9)
                                               (get_local $10)
+                                              (get_local $11)
                                               (get_local $0)
                                             )
                                           )
@@ -4540,17 +4557,17 @@
                                         (call $_pad
                                           (get_local $0)
                                           (i32.const 48)
-                                          (get_local $13)
-                                          (get_local $7)
+                                          (get_local $14)
+                                          (get_local $6)
                                           (i32.xor
-                                            (get_local $11)
+                                            (get_local $12)
                                             (i32.const 65536)
                                           )
                                         )
                                         (set_local $5
                                           (i32.sub
                                             (get_local $5)
-                                            (get_local $41)
+                                            (get_local $42)
                                           )
                                         )
                                         (if
@@ -4580,7 +4597,7 @@
                                               (tee_local $5
                                                 (i32.sub
                                                   (get_local $30)
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                             )
@@ -4599,7 +4616,7 @@
                                           )
                                           (drop
                                             (call $___fwritex
-                                              (get_local $6)
+                                              (get_local $7)
                                               (get_local $5)
                                               (get_local $0)
                                             )
@@ -4608,31 +4625,31 @@
                                         (call $_pad
                                           (get_local $0)
                                           (i32.const 32)
-                                          (get_local $13)
-                                          (get_local $7)
+                                          (get_local $14)
+                                          (get_local $6)
                                           (i32.xor
-                                            (get_local $11)
+                                            (get_local $12)
                                             (i32.const 8192)
                                           )
                                         )
                                         (br $do-once49
                                           (select
-                                            (get_local $13)
-                                            (get_local $7)
+                                            (get_local $14)
+                                            (get_local $6)
                                             (i32.lt_s
-                                              (get_local $7)
-                                              (get_local $13)
+                                              (get_local $6)
+                                              (get_local $14)
                                             )
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $18
+                                    (set_local $19
                                       (select
                                         (i32.const 6)
-                                        (get_local $7)
+                                        (get_local $6)
                                         (i32.lt_s
-                                          (get_local $7)
+                                          (get_local $6)
                                           (i32.const 0)
                                         )
                                       )
@@ -4657,7 +4674,7 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $14
+                                                (set_local $15
                                                   (f64.mul
                                                     (get_local $21)
                                                     (f64.const 268435456)
@@ -4666,7 +4683,7 @@
                                                 (get_local $5)
                                               )
                                               (block i32
-                                                (set_local $14
+                                                (set_local $15
                                                   (get_local $21)
                                                 )
                                                 (i32.load
@@ -4685,9 +4702,9 @@
                                     (loop $while-in60
                                       (i32.store
                                         (get_local $5)
-                                        (tee_local $6
+                                        (tee_local $7
                                           (call $f64-to-int
-                                            (get_local $14)
+                                            (get_local $15)
                                           )
                                         )
                                       )
@@ -4699,12 +4716,12 @@
                                       )
                                       (br_if $while-in60
                                         (f64.ne
-                                          (tee_local $14
+                                          (tee_local $15
                                             (f64.mul
                                               (f64.sub
-                                                (get_local $14)
+                                                (get_local $15)
                                                 (f64.convert_u/i32
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                               (f64.const 1e9)
@@ -4716,7 +4733,7 @@
                                     )
                                     (if
                                       (i32.gt_s
-                                        (tee_local $7
+                                        (tee_local $6
                                           (i32.load
                                             (get_local $20)
                                           )
@@ -4724,51 +4741,51 @@
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $6
+                                        (set_local $7
                                           (get_local $8)
                                         )
                                         (loop $while-in62
-                                          (set_local $10
+                                          (set_local $11
                                             (select
                                               (i32.const 29)
-                                              (get_local $7)
+                                              (get_local $6)
                                               (i32.gt_s
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (i32.const 29)
                                               )
                                             )
                                           )
-                                          (set_local $6
+                                          (set_local $7
                                             (block $do-once63 i32
                                               (if i32
                                                 (i32.lt_u
-                                                  (tee_local $7
+                                                  (tee_local $6
                                                     (i32.add
                                                       (get_local $5)
                                                       (i32.const -4)
                                                     )
                                                   )
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (block i32
-                                                  (set_local $9
+                                                  (set_local $10
                                                     (i32.const 0)
                                                   )
                                                   (loop $while-in66
                                                     (set_local $29
                                                       (call $___uremdi3
-                                                        (tee_local $9
+                                                        (tee_local $10
                                                           (call $_i64Add
                                                             (call $_bitshift64Shl
                                                               (i32.load
-                                                                (get_local $7)
+                                                                (get_local $6)
                                                               )
                                                               (i32.const 0)
-                                                              (get_local $10)
+                                                              (get_local $11)
                                                             )
                                                             (get_global $tempRet0)
-                                                            (get_local $9)
+                                                            (get_local $10)
                                                             (i32.const 0)
                                                           )
                                                         )
@@ -4780,12 +4797,12 @@
                                                       )
                                                     )
                                                     (i32.store
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (get_local $29)
                                                     )
-                                                    (set_local $9
+                                                    (set_local $10
                                                       (call $___udivdi3
-                                                        (get_local $9)
+                                                        (get_local $10)
                                                         (get_local $22)
                                                         (i32.const 1000000000)
                                                         (i32.const 0)
@@ -4793,34 +4810,34 @@
                                                     )
                                                     (br_if $while-in66
                                                       (i32.ge_u
-                                                        (tee_local $7
+                                                        (tee_local $6
                                                           (i32.add
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                             (i32.const -4)
                                                           )
                                                         )
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                       )
                                                     )
                                                   )
                                                   (drop
                                                     (br_if $do-once63
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.eqz
-                                                        (get_local $9)
+                                                        (get_local $10)
                                                       )
                                                     )
                                                   )
                                                   (i32.store
-                                                    (tee_local $6
+                                                    (tee_local $7
                                                       (i32.add
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const -4)
                                                       )
                                                     )
-                                                    (get_local $9)
+                                                    (get_local $10)
                                                   )
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                             )
@@ -4830,13 +4847,13 @@
                                               (br_if $while-out67
                                                 (i32.le_u
                                                   (get_local $5)
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                               (if
                                                 (i32.eqz
                                                   (i32.load
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.add
                                                         (get_local $5)
                                                         (i32.const -4)
@@ -4846,7 +4863,7 @@
                                                 )
                                                 (block
                                                   (set_local $5
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (br $while-in68)
                                                 )
@@ -4855,46 +4872,46 @@
                                           )
                                           (i32.store
                                             (get_local $20)
-                                            (tee_local $7
+                                            (tee_local $6
                                               (i32.sub
                                                 (i32.load
                                                   (get_local $20)
                                                 )
-                                                (get_local $10)
+                                                (get_local $11)
                                               )
                                             )
                                           )
                                           (br_if $while-in62
                                             (i32.gt_s
-                                              (get_local $7)
+                                              (get_local $6)
                                               (i32.const 0)
                                             )
                                           )
                                           (block
-                                            (set_local $9
-                                              (get_local $7)
+                                            (set_local $10
+                                              (get_local $6)
                                             )
-                                            (set_local $7
+                                            (set_local $6
                                               (get_local $5)
                                             )
                                           )
                                         )
                                       )
                                       (block
-                                        (set_local $9
-                                          (get_local $7)
-                                        )
-                                        (set_local $6
-                                          (get_local $8)
+                                        (set_local $10
+                                          (get_local $6)
                                         )
                                         (set_local $7
+                                          (get_local $8)
+                                        )
+                                        (set_local $6
                                           (get_local $5)
                                         )
                                       )
                                     )
                                     (if
                                       (i32.lt_s
-                                        (get_local $9)
+                                        (get_local $10)
                                         (i32.const 0)
                                       )
                                       (block
@@ -4902,7 +4919,7 @@
                                           (i32.add
                                             (call $i32s-div
                                               (i32.add
-                                                (get_local $18)
+                                                (get_local $19)
                                                 (i32.const 25)
                                               )
                                               (i32.const 9)
@@ -4912,93 +4929,93 @@
                                         )
                                         (set_local $29
                                           (i32.eq
-                                            (get_local $16)
+                                            (get_local $13)
                                             (i32.const 102)
                                           )
                                         )
                                         (set_local $5
-                                          (get_local $7)
+                                          (get_local $6)
                                         )
                                         (loop $while-in70
-                                          (set_local $10
+                                          (set_local $11
                                             (select
                                               (i32.const 9)
-                                              (tee_local $7
+                                              (tee_local $6
                                                 (i32.sub
                                                   (i32.const 0)
-                                                  (get_local $9)
+                                                  (get_local $10)
                                                 )
                                               )
                                               (i32.gt_s
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (i32.const 9)
                                               )
                                             )
                                           )
-                                          (set_local $7
+                                          (set_local $6
                                             (select
                                               (i32.add
-                                                (tee_local $7
+                                                (tee_local $6
                                                   (select
                                                     (get_local $8)
-                                                    (tee_local $6
+                                                    (tee_local $7
                                                       (block $do-once71 i32
                                                         (if i32
                                                           (i32.lt_u
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                             (get_local $5)
                                                           )
                                                           (block i32
-                                                            (set_local $43
+                                                            (set_local $36
                                                               (i32.add
                                                                 (i32.shl
                                                                   (i32.const 1)
-                                                                  (get_local $10)
+                                                                  (get_local $11)
                                                                 )
                                                                 (i32.const -1)
                                                               )
                                                             )
-                                                            (set_local $36
+                                                            (set_local $37
                                                               (i32.shr_u
                                                                 (i32.const 1000000000)
-                                                                (get_local $10)
+                                                                (get_local $11)
                                                               )
                                                             )
-                                                            (set_local $9
+                                                            (set_local $10
                                                               (i32.const 0)
                                                             )
-                                                            (set_local $7
-                                                              (get_local $6)
+                                                            (set_local $6
+                                                              (get_local $7)
                                                             )
                                                             (loop $while-in74
                                                               (i32.store
-                                                                (get_local $7)
+                                                                (get_local $6)
                                                                 (i32.add
                                                                   (i32.shr_u
                                                                     (tee_local $44
                                                                       (i32.load
-                                                                        (get_local $7)
+                                                                        (get_local $6)
                                                                       )
                                                                     )
-                                                                    (get_local $10)
+                                                                    (get_local $11)
                                                                   )
-                                                                  (get_local $9)
+                                                                  (get_local $10)
                                                                 )
                                                               )
-                                                              (set_local $9
+                                                              (set_local $10
                                                                 (i32.mul
                                                                   (i32.and
                                                                     (get_local $44)
-                                                                    (get_local $43)
+                                                                    (get_local $36)
                                                                   )
-                                                                  (get_local $36)
+                                                                  (get_local $37)
                                                                 )
                                                               )
                                                               (br_if $while-in74
                                                                 (i32.lt_u
-                                                                  (tee_local $7
+                                                                  (tee_local $6
                                                                     (i32.add
-                                                                      (get_local $7)
+                                                                      (get_local $6)
                                                                       (i32.const 4)
                                                                     )
                                                                   )
@@ -5006,29 +5023,29 @@
                                                                 )
                                                               )
                                                             )
-                                                            (set_local $6
+                                                            (set_local $7
                                                               (select
-                                                                (get_local $6)
+                                                                (get_local $7)
                                                                 (i32.add
-                                                                  (get_local $6)
+                                                                  (get_local $7)
                                                                   (i32.const 4)
                                                                 )
                                                                 (i32.load
-                                                                  (get_local $6)
+                                                                  (get_local $7)
                                                                 )
                                                               )
                                                             )
                                                             (drop
                                                               (br_if $do-once71
-                                                                (get_local $6)
+                                                                (get_local $7)
                                                                 (i32.eqz
-                                                                  (get_local $9)
+                                                                  (get_local $10)
                                                                 )
                                                               )
                                                             )
                                                             (i32.store
                                                               (get_local $5)
-                                                              (get_local $9)
+                                                              (get_local $10)
                                                             )
                                                             (set_local $5
                                                               (i32.add
@@ -5036,16 +5053,16 @@
                                                                 (i32.const 4)
                                                               )
                                                             )
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                           )
                                                           (select
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                             (i32.add
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                               (i32.const 4)
                                                             )
                                                             (i32.load
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                             )
                                                           )
                                                         )
@@ -5064,7 +5081,7 @@
                                                 (i32.shr_s
                                                   (i32.sub
                                                     (get_local $5)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (i32.const 2)
                                                 )
@@ -5074,32 +5091,32 @@
                                           )
                                           (i32.store
                                             (get_local $20)
-                                            (tee_local $9
+                                            (tee_local $10
                                               (i32.add
                                                 (i32.load
                                                   (get_local $20)
                                                 )
-                                                (get_local $10)
+                                                (get_local $11)
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_s
-                                              (get_local $9)
+                                              (get_local $10)
                                               (i32.const 0)
-                                            )
-                                            (block
-                                              (set_local $5
-                                                (get_local $7)
-                                              )
-                                              (br $while-in70)
                                             )
                                             (block
                                               (set_local $5
                                                 (get_local $6)
                                               )
-                                              (set_local $9
+                                              (br $while-in70)
+                                            )
+                                            (block
+                                              (set_local $5
                                                 (get_local $7)
+                                              )
+                                              (set_local $10
+                                                (get_local $6)
                                               )
                                             )
                                           )
@@ -5107,10 +5124,10 @@
                                       )
                                       (block
                                         (set_local $5
-                                          (get_local $6)
-                                        )
-                                        (set_local $9
                                           (get_local $7)
+                                        )
+                                        (set_local $10
+                                          (get_local $6)
                                         )
                                       )
                                     )
@@ -5118,10 +5135,10 @@
                                       (if
                                         (i32.lt_u
                                           (get_local $5)
-                                          (get_local $9)
+                                          (get_local $10)
                                         )
                                         (block
-                                          (set_local $6
+                                          (set_local $7
                                             (i32.mul
                                               (i32.shr_s
                                                 (i32.sub
@@ -5135,7 +5152,7 @@
                                           )
                                           (br_if $do-once75
                                             (i32.lt_u
-                                              (tee_local $10
+                                              (tee_local $11
                                                 (i32.load
                                                   (get_local $5)
                                                 )
@@ -5143,22 +5160,22 @@
                                               (i32.const 10)
                                             )
                                           )
-                                          (set_local $7
+                                          (set_local $6
                                             (i32.const 10)
                                           )
                                           (loop $while-in78
-                                            (set_local $6
+                                            (set_local $7
                                               (i32.add
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (i32.const 1)
                                               )
                                             )
                                             (br_if $while-in78
                                               (i32.ge_u
-                                                (get_local $10)
-                                                (tee_local $7
+                                                (get_local $11)
+                                                (tee_local $6
                                                   (i32.mul
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 10)
                                                   )
                                                 )
@@ -5166,23 +5183,23 @@
                                             )
                                           )
                                         )
-                                        (set_local $6
+                                        (set_local $7
                                           (i32.const 0)
                                         )
                                       )
                                     )
-                                    (set_local $16
+                                    (set_local $13
                                       (if i32
                                         (i32.lt_s
-                                          (tee_local $7
+                                          (tee_local $6
                                             (i32.add
                                               (i32.sub
-                                                (get_local $18)
+                                                (get_local $19)
                                                 (select
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (i32.const 0)
                                                   (i32.ne
-                                                    (get_local $16)
+                                                    (get_local $13)
                                                     (i32.const 102)
                                                   )
                                                 )
@@ -5192,13 +5209,13 @@
                                                   (i32.and
                                                     (tee_local $29
                                                       (i32.ne
-                                                        (get_local $18)
+                                                        (get_local $19)
                                                         (i32.const 0)
                                                       )
                                                     )
-                                                    (tee_local $43
+                                                    (tee_local $36
                                                       (i32.eq
-                                                        (get_local $16)
+                                                        (get_local $13)
                                                         (i32.const 103)
                                                       )
                                                     )
@@ -5213,7 +5230,7 @@
                                             (i32.mul
                                               (i32.shr_s
                                                 (i32.sub
-                                                  (get_local $9)
+                                                  (get_local $10)
                                                   (get_local $31)
                                                 )
                                                 (i32.const 2)
@@ -5224,7 +5241,7 @@
                                           )
                                         )
                                         (block i32
-                                          (set_local $7
+                                          (set_local $6
                                             (i32.add
                                               (i32.add
                                                 (get_local $8)
@@ -5233,9 +5250,9 @@
                                               (i32.shl
                                                 (i32.add
                                                   (call $i32s-div
-                                                    (tee_local $10
+                                                    (tee_local $11
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const 9216)
                                                       )
                                                     )
@@ -5249,10 +5266,10 @@
                                           )
                                           (if
                                             (i32.lt_s
-                                              (tee_local $10
+                                              (tee_local $11
                                                 (i32.add
                                                   (call $i32s-rem
-                                                    (get_local $10)
+                                                    (get_local $11)
                                                     (i32.const 9)
                                                   )
                                                   (i32.const 1)
@@ -5261,21 +5278,21 @@
                                               (i32.const 9)
                                             )
                                             (block
-                                              (set_local $16
+                                              (set_local $13
                                                 (i32.const 10)
                                               )
                                               (loop $while-in80
-                                                (set_local $16
+                                                (set_local $13
                                                   (i32.mul
-                                                    (get_local $16)
+                                                    (get_local $13)
                                                     (i32.const 10)
                                                   )
                                                 )
                                                 (br_if $while-in80
                                                   (i32.ne
-                                                    (tee_local $10
+                                                    (tee_local $11
                                                       (i32.add
-                                                        (get_local $10)
+                                                        (get_local $11)
                                                         (i32.const 1)
                                                       )
                                                     )
@@ -5284,7 +5301,7 @@
                                                 )
                                               )
                                             )
-                                            (set_local $16
+                                            (set_local $13
                                               (i32.const 10)
                                             )
                                           )
@@ -5292,24 +5309,24 @@
                                             (if
                                               (i32.eqz
                                                 (i32.and
-                                                  (tee_local $36
+                                                  (tee_local $37
                                                     (i32.eq
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const 4)
                                                       )
-                                                      (get_local $9)
+                                                      (get_local $10)
                                                     )
                                                   )
                                                   (i32.eqz
-                                                    (tee_local $10
+                                                    (tee_local $11
                                                       (call $i32u-rem
                                                         (tee_local $22
                                                           (i32.load
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                           )
                                                         )
-                                                        (get_local $16)
+                                                        (get_local $13)
                                                       )
                                                     )
                                                   )
@@ -5323,19 +5340,19 @@
                                                     (i32.and
                                                       (call $i32u-div
                                                         (get_local $22)
-                                                        (get_local $16)
+                                                        (get_local $13)
                                                       )
                                                       (i32.const 1)
                                                     )
                                                   )
                                                 )
-                                                (set_local $14
+                                                (set_local $15
                                                   (if f64
                                                     (i32.lt_u
-                                                      (get_local $10)
+                                                      (get_local $11)
                                                       (tee_local $44
                                                         (call $i32s-div
-                                                          (get_local $16)
+                                                          (get_local $13)
                                                           (i32.const 2)
                                                         )
                                                       )
@@ -5345,9 +5362,9 @@
                                                       (f64.const 1)
                                                       (f64.const 1.5)
                                                       (i32.and
-                                                        (get_local $36)
+                                                        (get_local $37)
                                                         (i32.eq
-                                                          (get_local $10)
+                                                          (get_local $11)
                                                           (get_local $44)
                                                         )
                                                       )
@@ -5370,9 +5387,9 @@
                                                             )
                                                           )
                                                         )
-                                                        (set_local $14
+                                                        (set_local $15
                                                           (f64.neg
-                                                            (get_local $14)
+                                                            (get_local $15)
                                                           )
                                                         )
                                                         (f64.neg
@@ -5384,11 +5401,11 @@
                                                   )
                                                 )
                                                 (i32.store
-                                                  (get_local $7)
-                                                  (tee_local $10
+                                                  (get_local $6)
+                                                  (tee_local $11
                                                     (i32.sub
                                                       (get_local $22)
-                                                      (get_local $10)
+                                                      (get_local $11)
                                                     )
                                                   )
                                                 )
@@ -5396,36 +5413,36 @@
                                                   (f64.eq
                                                     (f64.add
                                                       (get_local $21)
-                                                      (get_local $14)
+                                                      (get_local $15)
                                                     )
                                                     (get_local $21)
                                                   )
                                                 )
                                                 (i32.store
-                                                  (get_local $7)
-                                                  (tee_local $6
+                                                  (get_local $6)
+                                                  (tee_local $7
                                                     (i32.add
-                                                      (get_local $10)
-                                                      (get_local $16)
+                                                      (get_local $11)
+                                                      (get_local $13)
                                                     )
                                                   )
                                                 )
                                                 (if
                                                   (i32.gt_u
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const 999999999)
                                                   )
                                                   (loop $while-in86
                                                     (i32.store
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 0)
                                                     )
                                                     (set_local $5
                                                       (if i32
                                                         (i32.lt_u
-                                                          (tee_local $7
+                                                          (tee_local $6
                                                             (i32.add
-                                                              (get_local $7)
+                                                              (get_local $6)
                                                               (i32.const -4)
                                                             )
                                                           )
@@ -5447,11 +5464,11 @@
                                                       )
                                                     )
                                                     (i32.store
-                                                      (get_local $7)
-                                                      (tee_local $6
+                                                      (get_local $6)
+                                                      (tee_local $7
                                                         (i32.add
                                                           (i32.load
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                           )
                                                           (i32.const 1)
                                                         )
@@ -5459,13 +5476,13 @@
                                                     )
                                                     (br_if $while-in86
                                                       (i32.gt_u
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const 999999999)
                                                       )
                                                     )
                                                   )
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (i32.mul
                                                     (i32.shr_s
                                                       (i32.sub
@@ -5479,7 +5496,7 @@
                                                 )
                                                 (br_if $do-once81
                                                   (i32.lt_u
-                                                    (tee_local $16
+                                                    (tee_local $13
                                                       (i32.load
                                                         (get_local $5)
                                                       )
@@ -5487,22 +5504,22 @@
                                                     (i32.const 10)
                                                   )
                                                 )
-                                                (set_local $10
+                                                (set_local $11
                                                   (i32.const 10)
                                                 )
                                                 (loop $while-in88
-                                                  (set_local $6
+                                                  (set_local $7
                                                     (i32.add
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.const 1)
                                                     )
                                                   )
                                                   (br_if $while-in88
                                                     (i32.ge_u
-                                                      (get_local $16)
-                                                      (tee_local $10
+                                                      (get_local $13)
+                                                      (tee_local $11
                                                         (i32.mul
-                                                          (get_local $10)
+                                                          (get_local $11)
                                                           (i32.const 10)
                                                         )
                                                       )
@@ -5512,55 +5529,55 @@
                                               )
                                             )
                                           )
-                                          (set_local $10
-                                            (get_local $6)
+                                          (set_local $11
+                                            (get_local $7)
                                           )
-                                          (set_local $9
+                                          (set_local $10
                                             (select
-                                              (tee_local $6
+                                              (tee_local $7
                                                 (i32.add
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (i32.const 4)
                                                 )
                                               )
-                                              (get_local $9)
+                                              (get_local $10)
                                               (i32.gt_u
-                                                (get_local $9)
-                                                (get_local $6)
+                                                (get_local $10)
+                                                (get_local $7)
                                               )
                                             )
                                           )
                                           (get_local $5)
                                         )
                                         (block i32
-                                          (set_local $10
-                                            (get_local $6)
+                                          (set_local $11
+                                            (get_local $7)
                                           )
                                           (get_local $5)
                                         )
                                       )
                                     )
-                                    (set_local $36
+                                    (set_local $37
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $10)
+                                        (get_local $11)
                                       )
                                     )
                                     (set_local $5
-                                      (get_local $9)
+                                      (get_local $10)
                                     )
                                     (loop $while-in90
                                       (block $while-out89
                                         (if
                                           (i32.le_u
                                             (get_local $5)
-                                            (get_local $16)
+                                            (get_local $13)
                                           )
                                           (block
                                             (set_local $22
                                               (i32.const 0)
                                             )
-                                            (set_local $7
+                                            (set_local $10
                                               (get_local $5)
                                             )
                                             (br $while-out89)
@@ -5568,7 +5585,7 @@
                                         )
                                         (if
                                           (i32.load
-                                            (tee_local $6
+                                            (tee_local $7
                                               (i32.add
                                                 (get_local $5)
                                                 (i32.const -4)
@@ -5579,25 +5596,25 @@
                                             (set_local $22
                                               (i32.const 1)
                                             )
-                                            (set_local $7
+                                            (set_local $10
                                               (get_local $5)
                                             )
                                           )
                                           (block
                                             (set_local $5
-                                              (get_local $6)
+                                              (get_local $7)
                                             )
                                             (br $while-in90)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $12
+                                    (set_local $17
                                       (block $do-once91 i32
                                         (if i32
-                                          (get_local $43)
+                                          (get_local $36)
                                           (block i32
-                                            (set_local $9
+                                            (set_local $17
                                               (if i32
                                                 (i32.and
                                                   (i32.gt_s
@@ -5610,20 +5627,20 @@
                                                           )
                                                           (i32.const 1)
                                                         )
-                                                        (get_local $18)
+                                                        (get_local $19)
                                                       )
                                                     )
-                                                    (get_local $10)
+                                                    (get_local $11)
                                                   )
                                                   (i32.gt_s
-                                                    (get_local $10)
+                                                    (get_local $11)
                                                     (i32.const -5)
                                                   )
                                                 )
                                                 (block i32
-                                                  (set_local $6
+                                                  (set_local $7
                                                     (i32.add
-                                                      (get_local $12)
+                                                      (get_local $17)
                                                       (i32.const -1)
                                                     )
                                                   )
@@ -5632,13 +5649,13 @@
                                                       (get_local $5)
                                                       (i32.const -1)
                                                     )
-                                                    (get_local $10)
+                                                    (get_local $11)
                                                   )
                                                 )
                                                 (block i32
-                                                  (set_local $6
+                                                  (set_local $7
                                                     (i32.add
-                                                      (get_local $12)
+                                                      (get_local $17)
                                                       (i32.const -2)
                                                     )
                                                   )
@@ -5650,18 +5667,18 @@
                                               )
                                             )
                                             (if
-                                              (tee_local $12
+                                              (tee_local $6
                                                 (i32.and
-                                                  (get_local $11)
+                                                  (get_local $12)
                                                   (i32.const 8)
                                                 )
                                               )
                                               (block
                                                 (set_local $5
-                                                  (get_local $9)
+                                                  (get_local $17)
                                                 )
                                                 (br $do-once91
-                                                  (get_local $12)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -5671,10 +5688,10 @@
                                                 (block
                                                   (if
                                                     (i32.eqz
-                                                      (tee_local $18
+                                                      (tee_local $19
                                                         (i32.load
                                                           (i32.add
-                                                            (get_local $7)
+                                                            (get_local $10)
                                                             (i32.const -4)
                                                           )
                                                         )
@@ -5689,7 +5706,7 @@
                                                   )
                                                   (if
                                                     (call $i32u-rem
-                                                      (get_local $18)
+                                                      (get_local $19)
                                                       (i32.const 10)
                                                     )
                                                     (block
@@ -5699,7 +5716,7 @@
                                                       (br $do-once93)
                                                     )
                                                     (block
-                                                      (set_local $12
+                                                      (set_local $6
                                                         (i32.const 10)
                                                       )
                                                       (set_local $5
@@ -5717,10 +5734,10 @@
                                                     (br_if $while-in96
                                                       (i32.eqz
                                                         (call $i32u-rem
-                                                          (get_local $18)
-                                                          (tee_local $12
+                                                          (get_local $19)
+                                                          (tee_local $6
                                                             (i32.mul
-                                                              (get_local $12)
+                                                              (get_local $6)
                                                               (i32.const 10)
                                                             )
                                                           )
@@ -5734,12 +5751,12 @@
                                                 )
                                               )
                                             )
-                                            (set_local $12
+                                            (set_local $6
                                               (i32.add
                                                 (i32.mul
                                                   (i32.shr_s
                                                     (i32.sub
-                                                      (get_local $7)
+                                                      (get_local $10)
                                                       (get_local $31)
                                                     )
                                                     (i32.const 2)
@@ -5752,7 +5769,7 @@
                                             (if i32
                                               (i32.eq
                                                 (i32.or
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (i32.const 32)
                                                 )
                                                 (i32.const 102)
@@ -5760,13 +5777,13 @@
                                               (block i32
                                                 (set_local $5
                                                   (select
-                                                    (get_local $9)
+                                                    (get_local $17)
                                                     (tee_local $5
                                                       (select
                                                         (i32.const 0)
                                                         (tee_local $5
                                                           (i32.sub
-                                                            (get_local $12)
+                                                            (get_local $6)
                                                             (get_local $5)
                                                           )
                                                         )
@@ -5777,7 +5794,7 @@
                                                       )
                                                     )
                                                     (i32.lt_s
-                                                      (get_local $9)
+                                                      (get_local $17)
                                                       (get_local $5)
                                                     )
                                                   )
@@ -5787,15 +5804,15 @@
                                               (block i32
                                                 (set_local $5
                                                   (select
-                                                    (get_local $9)
+                                                    (get_local $17)
                                                     (tee_local $5
                                                       (select
                                                         (i32.const 0)
                                                         (tee_local $5
                                                           (i32.sub
                                                             (i32.add
-                                                              (get_local $12)
-                                                              (get_local $10)
+                                                              (get_local $6)
+                                                              (get_local $11)
                                                             )
                                                             (get_local $5)
                                                           )
@@ -5807,7 +5824,7 @@
                                                       )
                                                     )
                                                     (i32.lt_s
-                                                      (get_local $9)
+                                                      (get_local $17)
                                                       (get_local $5)
                                                     )
                                                   )
@@ -5818,26 +5835,26 @@
                                           )
                                           (block i32
                                             (set_local $5
-                                              (get_local $18)
+                                              (get_local $19)
                                             )
-                                            (set_local $6
-                                              (get_local $12)
+                                            (set_local $7
+                                              (get_local $17)
                                             )
                                             (i32.and
-                                              (get_local $11)
+                                              (get_local $12)
                                               (i32.const 8)
                                             )
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $31
+                                    (set_local $29
                                       (i32.and
                                         (i32.ne
-                                          (tee_local $18
+                                          (tee_local $31
                                             (i32.or
                                               (get_local $5)
-                                              (get_local $12)
+                                              (get_local $17)
                                             )
                                           )
                                           (i32.const 0)
@@ -5845,24 +5862,24 @@
                                         (i32.const 1)
                                       )
                                     )
-                                    (set_local $9
+                                    (set_local $19
                                       (if i32
-                                        (tee_local $29
+                                        (tee_local $36
                                           (i32.eq
                                             (i32.or
-                                              (get_local $6)
+                                              (get_local $7)
                                               (i32.const 32)
                                             )
                                             (i32.const 102)
                                           )
                                         )
                                         (block i32
-                                          (set_local $6
+                                          (set_local $7
                                             (select
-                                              (get_local $10)
+                                              (get_local $11)
                                               (i32.const 0)
                                               (i32.gt_s
-                                                (get_local $10)
+                                                (get_local $11)
                                                 (i32.const 0)
                                               )
                                             )
@@ -5874,14 +5891,14 @@
                                             (i32.lt_s
                                               (i32.sub
                                                 (get_local $30)
-                                                (tee_local $9
+                                                (tee_local $6
                                                   (call $_fmt_u
-                                                    (tee_local $9
+                                                    (tee_local $6
                                                       (select
-                                                        (get_local $36)
-                                                        (get_local $10)
+                                                        (get_local $37)
+                                                        (get_local $11)
                                                         (i32.lt_s
-                                                          (get_local $10)
+                                                          (get_local $11)
                                                           (i32.const 0)
                                                         )
                                                       )
@@ -5889,14 +5906,14 @@
                                                     (i32.shr_s
                                                       (i32.shl
                                                         (i32.lt_s
-                                                          (get_local $9)
+                                                          (get_local $6)
                                                           (i32.const 0)
                                                         )
                                                         (i32.const 31)
                                                       )
                                                       (i32.const 31)
                                                     )
-                                                    (get_local $37)
+                                                    (get_local $38)
                                                   )
                                                 )
                                               )
@@ -5904,9 +5921,9 @@
                                             )
                                             (loop $while-in98
                                               (i32.store8
-                                                (tee_local $9
+                                                (tee_local $6
                                                   (i32.add
-                                                    (get_local $9)
+                                                    (get_local $6)
                                                     (i32.const -1)
                                                   )
                                                 )
@@ -5916,7 +5933,7 @@
                                                 (i32.lt_s
                                                   (i32.sub
                                                     (get_local $30)
-                                                    (get_local $9)
+                                                    (get_local $6)
                                                   )
                                                   (i32.const 2)
                                                 )
@@ -5925,13 +5942,13 @@
                                           )
                                           (i32.store8
                                             (i32.add
-                                              (get_local $9)
+                                              (get_local $6)
                                               (i32.const -1)
                                             )
                                             (i32.add
                                               (i32.and
                                                 (i32.shr_s
-                                                  (get_local $10)
+                                                  (get_local $11)
                                                   (i32.const 31)
                                                 )
                                                 (i32.const 2)
@@ -5940,29 +5957,29 @@
                                             )
                                           )
                                           (i32.store8
-                                            (tee_local $9
+                                            (tee_local $6
                                               (i32.add
-                                                (get_local $9)
+                                                (get_local $6)
                                                 (i32.const -2)
                                               )
                                             )
-                                            (get_local $6)
+                                            (get_local $7)
                                           )
-                                          (set_local $6
+                                          (set_local $7
                                             (i32.sub
                                               (get_local $30)
-                                              (get_local $9)
+                                              (get_local $6)
                                             )
                                           )
-                                          (get_local $9)
+                                          (get_local $6)
                                         )
                                       )
                                     )
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $13)
-                                      (tee_local $10
+                                      (get_local $14)
+                                      (tee_local $11
                                         (i32.add
                                           (i32.add
                                             (i32.add
@@ -5972,12 +5989,12 @@
                                               )
                                               (get_local $5)
                                             )
-                                            (get_local $31)
+                                            (get_local $29)
                                           )
-                                          (get_local $6)
+                                          (get_local $7)
                                         )
                                       )
-                                      (get_local $11)
+                                      (get_local $12)
                                     )
                                     (if
                                       (i32.eqz
@@ -5999,34 +6016,34 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 48)
-                                      (get_local $13)
-                                      (get_local $10)
+                                      (get_local $14)
+                                      (get_local $11)
                                       (i32.xor
-                                        (get_local $11)
+                                        (get_local $12)
                                         (i32.const 65536)
                                       )
                                     )
                                     (block $do-once99
                                       (if
-                                        (get_local $29)
+                                        (get_local $36)
                                         (block
-                                          (set_local $9
-                                            (tee_local $12
+                                          (set_local $6
+                                            (tee_local $13
                                               (select
                                                 (get_local $8)
-                                                (get_local $16)
+                                                (get_local $13)
                                                 (i32.gt_u
-                                                  (get_local $16)
+                                                  (get_local $13)
                                                   (get_local $8)
                                                 )
                                               )
                                             )
                                           )
                                           (loop $while-in102
-                                            (set_local $6
+                                            (set_local $7
                                               (call $_fmt_u
                                                 (i32.load
-                                                  (get_local $9)
+                                                  (get_local $6)
                                                 )
                                                 (i32.const 0)
                                                 (get_local $33)
@@ -6035,36 +6052,36 @@
                                             (block $do-once103
                                               (if
                                                 (i32.eq
-                                                  (get_local $9)
-                                                  (get_local $12)
+                                                  (get_local $6)
+                                                  (get_local $13)
                                                 )
                                                 (block
                                                   (br_if $do-once103
                                                     (i32.ne
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (get_local $33)
                                                     )
                                                   )
                                                   (i32.store8
-                                                    (get_local $38)
+                                                    (get_local $39)
                                                     (i32.const 48)
                                                   )
-                                                  (set_local $6
-                                                    (get_local $38)
+                                                  (set_local $7
+                                                    (get_local $39)
                                                   )
                                                 )
                                                 (block
                                                   (br_if $do-once103
                                                     (i32.le_u
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (get_local $24)
                                                     )
                                                   )
                                                   (loop $while-in106
                                                     (i32.store8
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (i32.add
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                           (i32.const -1)
                                                         )
                                                       )
@@ -6072,7 +6089,7 @@
                                                     )
                                                     (br_if $while-in106
                                                       (i32.gt_u
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (get_local $24)
                                                       )
                                                     )
@@ -6091,10 +6108,10 @@
                                               )
                                               (drop
                                                 (call $___fwritex
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (i32.sub
                                                     (get_local $49)
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (get_local $0)
                                                 )
@@ -6102,17 +6119,17 @@
                                             )
                                             (if
                                               (i32.le_u
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (i32.add
-                                                    (get_local $9)
+                                                    (get_local $6)
                                                     (i32.const 4)
                                                   )
                                                 )
                                                 (get_local $8)
                                               )
                                               (block
-                                                (set_local $9
-                                                  (get_local $6)
+                                                (set_local $6
+                                                  (get_local $7)
                                                 )
                                                 (br $while-in102)
                                               )
@@ -6120,7 +6137,7 @@
                                           )
                                           (block $do-once107
                                             (if
-                                              (get_local $18)
+                                              (get_local $31)
                                               (block
                                                 (br_if $do-once107
                                                   (i32.and
@@ -6147,17 +6164,17 @@
                                                 (i32.const 0)
                                               )
                                               (i32.lt_u
-                                                (get_local $6)
                                                 (get_local $7)
+                                                (get_local $10)
                                               )
                                             )
                                             (loop $while-in110
                                               (if
                                                 (i32.gt_u
-                                                  (tee_local $8
+                                                  (tee_local $6
                                                     (call $_fmt_u
                                                       (i32.load
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                       )
                                                       (i32.const 0)
                                                       (get_local $33)
@@ -6167,9 +6184,9 @@
                                                 )
                                                 (loop $while-in112
                                                   (i32.store8
-                                                    (tee_local $8
+                                                    (tee_local $6
                                                       (i32.add
-                                                        (get_local $8)
+                                                        (get_local $6)
                                                         (i32.const -1)
                                                       )
                                                     )
@@ -6177,7 +6194,7 @@
                                                   )
                                                   (br_if $while-in112
                                                     (i32.gt_u
-                                                      (get_local $8)
+                                                      (get_local $6)
                                                       (get_local $24)
                                                     )
                                                   )
@@ -6194,7 +6211,7 @@
                                                 )
                                                 (drop
                                                   (call $___fwritex
-                                                    (get_local $8)
+                                                    (get_local $6)
                                                     (select
                                                       (i32.const 9)
                                                       (get_local $5)
@@ -6207,7 +6224,7 @@
                                                   )
                                                 )
                                               )
-                                              (set_local $8
+                                              (set_local $6
                                                 (i32.add
                                                   (get_local $5)
                                                   (i32.const -9)
@@ -6220,23 +6237,23 @@
                                                     (i32.const 9)
                                                   )
                                                   (i32.lt_u
-                                                    (tee_local $6
+                                                    (tee_local $7
                                                       (i32.add
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $10)
                                                   )
                                                 )
                                                 (block
                                                   (set_local $5
-                                                    (get_local $8)
+                                                    (get_local $6)
                                                   )
                                                   (br $while-in110)
                                                 )
                                                 (set_local $5
-                                                  (get_local $8)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -6253,11 +6270,11 @@
                                           )
                                         )
                                         (block
-                                          (set_local $18
+                                          (set_local $10
                                             (select
-                                              (get_local $7)
+                                              (get_local $10)
                                               (i32.add
-                                                (get_local $16)
+                                                (get_local $13)
                                                 (i32.const 4)
                                               )
                                               (get_local $22)
@@ -6269,25 +6286,25 @@
                                               (i32.const -1)
                                             )
                                             (block
-                                              (set_local $12
+                                              (set_local $17
                                                 (i32.eqz
-                                                  (get_local $12)
+                                                  (get_local $17)
                                                 )
                                               )
-                                              (set_local $8
-                                                (get_local $16)
-                                              )
                                               (set_local $6
+                                                (get_local $13)
+                                              )
+                                              (set_local $7
                                                 (get_local $5)
                                               )
                                               (loop $while-in114
-                                                (set_local $7
+                                                (set_local $8
                                                   (if i32
                                                     (i32.eq
                                                       (tee_local $5
                                                         (call $_fmt_u
                                                           (i32.load
-                                                            (get_local $8)
+                                                            (get_local $6)
                                                           )
                                                           (i32.const 0)
                                                           (get_local $33)
@@ -6297,10 +6314,10 @@
                                                     )
                                                     (block i32
                                                       (i32.store8
-                                                        (get_local $38)
+                                                        (get_local $39)
                                                         (i32.const 48)
                                                       )
-                                                      (get_local $38)
+                                                      (get_local $39)
                                                     )
                                                     (get_local $5)
                                                   )
@@ -6308,13 +6325,13 @@
                                                 (block $do-once115
                                                   (if
                                                     (i32.eq
-                                                      (get_local $8)
-                                                      (get_local $16)
+                                                      (get_local $6)
+                                                      (get_local $13)
                                                     )
                                                     (block
                                                       (set_local $5
                                                         (i32.add
-                                                          (get_local $7)
+                                                          (get_local $8)
                                                           (i32.const 1)
                                                         )
                                                       )
@@ -6329,7 +6346,7 @@
                                                         )
                                                         (drop
                                                           (call $___fwritex
-                                                            (get_local $7)
+                                                            (get_local $8)
                                                             (i32.const 1)
                                                             (get_local $0)
                                                           )
@@ -6337,9 +6354,9 @@
                                                       )
                                                       (br_if $do-once115
                                                         (i32.and
-                                                          (get_local $12)
+                                                          (get_local $17)
                                                           (i32.lt_s
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                             (i32.const 1)
                                                           )
                                                         )
@@ -6363,15 +6380,15 @@
                                                     (block
                                                       (if
                                                         (i32.gt_u
-                                                          (get_local $7)
+                                                          (get_local $8)
                                                           (get_local $24)
                                                         )
                                                         (set_local $5
-                                                          (get_local $7)
+                                                          (get_local $8)
                                                         )
                                                         (block
                                                           (set_local $5
-                                                            (get_local $7)
+                                                            (get_local $8)
                                                           )
                                                           (br $do-once115)
                                                         )
@@ -6396,7 +6413,7 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $7
+                                                (set_local $8
                                                   (i32.sub
                                                     (get_local $49)
                                                     (get_local $5)
@@ -6415,11 +6432,11 @@
                                                     (call $___fwritex
                                                       (get_local $5)
                                                       (select
+                                                        (get_local $8)
                                                         (get_local $7)
-                                                        (get_local $6)
                                                         (i32.gt_s
-                                                          (get_local $6)
                                                           (get_local $7)
+                                                          (get_local $8)
                                                         )
                                                       )
                                                       (get_local $0)
@@ -6429,19 +6446,19 @@
                                                 (br_if $while-in114
                                                   (i32.and
                                                     (i32.lt_u
-                                                      (tee_local $8
+                                                      (tee_local $6
                                                         (i32.add
-                                                          (get_local $8)
+                                                          (get_local $6)
                                                           (i32.const 4)
                                                         )
                                                       )
-                                                      (get_local $18)
+                                                      (get_local $10)
                                                     )
                                                     (i32.gt_s
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (i32.sub
-                                                          (get_local $6)
                                                           (get_local $7)
+                                                          (get_local $8)
                                                         )
                                                       )
                                                       (i32.const -1)
@@ -6449,7 +6466,7 @@
                                                   )
                                                 )
                                                 (set_local $5
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                             )
@@ -6474,10 +6491,10 @@
                                           )
                                           (drop
                                             (call $___fwritex
-                                              (get_local $9)
+                                              (get_local $19)
                                               (i32.sub
                                                 (get_local $30)
-                                                (get_local $9)
+                                                (get_local $19)
                                               )
                                               (get_local $0)
                                             )
@@ -6488,47 +6505,47 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $13)
-                                      (get_local $10)
+                                      (get_local $14)
+                                      (get_local $11)
                                       (i32.xor
-                                        (get_local $11)
+                                        (get_local $12)
                                         (i32.const 8192)
                                       )
                                     )
                                     (select
-                                      (get_local $13)
-                                      (get_local $10)
+                                      (get_local $14)
+                                      (get_local $11)
                                       (i32.lt_s
-                                        (get_local $10)
-                                        (get_local $13)
+                                        (get_local $11)
+                                        (get_local $14)
                                       )
                                     )
                                   )
                                   (block i32
-                                    (set_local $6
+                                    (set_local $7
                                       (select
                                         (i32.const 0)
                                         (get_local $28)
                                         (tee_local $5
                                           (i32.or
                                             (f64.ne
-                                              (get_local $14)
-                                              (get_local $14)
+                                              (get_local $15)
+                                              (get_local $15)
                                             )
                                             (i32.const 0)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $7
+                                    (set_local $6
                                       (select
                                         (select
                                           (i32.const 4135)
                                           (i32.const 4139)
-                                          (tee_local $7
+                                          (tee_local $6
                                             (i32.ne
                                               (i32.and
-                                                (get_local $12)
+                                                (get_local $17)
                                                 (i32.const 32)
                                               )
                                               (i32.const 0)
@@ -6538,7 +6555,7 @@
                                         (select
                                           (i32.const 4127)
                                           (i32.const 4131)
-                                          (get_local $7)
+                                          (get_local $6)
                                         )
                                         (get_local $5)
                                       )
@@ -6546,10 +6563,10 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $13)
+                                      (get_local $14)
                                       (tee_local $5
                                         (i32.add
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.const 3)
                                         )
                                       )
@@ -6572,7 +6589,7 @@
                                               (drop
                                                 (call $___fwritex
                                                   (get_local $35)
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (get_local $0)
                                                 )
                                               )
@@ -6586,7 +6603,7 @@
                                       )
                                       (drop
                                         (call $___fwritex
-                                          (get_local $7)
+                                          (get_local $6)
                                           (i32.const 3)
                                           (get_local $0)
                                         )
@@ -6595,19 +6612,19 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $13)
+                                      (get_local $14)
                                       (get_local $5)
                                       (i32.xor
-                                        (get_local $11)
+                                        (get_local $12)
                                         (i32.const 8192)
                                       )
                                     )
                                     (select
-                                      (get_local $13)
+                                      (get_local $14)
                                       (get_local $5)
                                       (i32.lt_s
                                         (get_local $5)
-                                        (get_local $13)
+                                        (get_local $14)
                                       )
                                     )
                                   )
@@ -6616,26 +6633,26 @@
                             )
                             (br $label$continue$L1)
                           )
-                          (set_local $6
-                            (get_local $1)
+                          (set_local $7
+                            (get_local $9)
                           )
-                          (set_local $10
-                            (get_local $7)
+                          (set_local $11
+                            (get_local $6)
                           )
                           (set_local $8
                             (i32.const 0)
                           )
-                          (set_local $9
+                          (set_local $10
                             (i32.const 4091)
                           )
-                          (set_local $1
+                          (set_local $9
                             (get_local $23)
                           )
                           (br $jumpthreading$outer$7)
                         )
-                        (set_local $9
+                        (set_local $10
                           (i32.and
-                            (get_local $12)
+                            (get_local $17)
                             (i32.const 32)
                           )
                         )
@@ -6644,34 +6661,34 @@
                             (i32.eqz
                               (tee_local $8
                                 (i32.load
-                                  (tee_local $6
-                                    (get_local $17)
+                                  (tee_local $7
+                                    (get_local $18)
                                   )
                                 )
                               )
                             )
                             (i32.eqz
-                              (tee_local $11
+                              (tee_local $12
                                 (i32.load offset=4
-                                  (get_local $6)
+                                  (get_local $7)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $6
+                            (set_local $7
                               (get_local $23)
                             )
                             (set_local $8
                               (i32.const 0)
                             )
-                            (set_local $9
+                            (set_local $10
                               (i32.const 4091)
                             )
                             (br $jumpthreading$inner$7)
                           )
                           (block
-                            (set_local $6
+                            (set_local $7
                               (get_local $8)
                             )
                             (set_local $8
@@ -6689,36 +6706,36 @@
                                   (i32.load8_u
                                     (i32.add
                                       (i32.and
-                                        (get_local $6)
+                                        (get_local $7)
                                         (i32.const 15)
                                       )
                                       (i32.const 4075)
                                     )
                                   )
-                                  (get_local $9)
+                                  (get_local $10)
                                 )
                               )
                               (br_if $while-in123
                                 (i32.eqz
                                   (i32.and
                                     (i32.eqz
-                                      (tee_local $6
+                                      (tee_local $7
                                         (call $_bitshift64Lshr
-                                          (get_local $6)
-                                          (get_local $11)
+                                          (get_local $7)
+                                          (get_local $12)
                                           (i32.const 4)
                                         )
                                       )
                                     )
                                     (i32.eqz
-                                      (tee_local $11
+                                      (tee_local $12
                                         (get_global $tempRet0)
                                       )
                                     )
                                   )
                                 )
                               )
-                              (set_local $6
+                              (set_local $7
                                 (get_local $8)
                               )
                             )
@@ -6726,21 +6743,21 @@
                               (i32.or
                                 (i32.eqz
                                   (i32.and
-                                    (get_local $1)
+                                    (get_local $9)
                                     (i32.const 8)
                                   )
                                 )
                                 (i32.and
                                   (i32.eqz
                                     (i32.load
-                                      (tee_local $11
-                                        (get_local $17)
+                                      (tee_local $12
+                                        (get_local $18)
                                       )
                                     )
                                   )
                                   (i32.eqz
                                     (i32.load offset=4
-                                      (get_local $11)
+                                      (get_local $12)
                                     )
                                   )
                                 )
@@ -6749,7 +6766,7 @@
                                 (set_local $8
                                   (i32.const 0)
                                 )
-                                (set_local $9
+                                (set_local $10
                                   (i32.const 4091)
                                 )
                                 (br $jumpthreading$inner$7)
@@ -6758,11 +6775,11 @@
                                 (set_local $8
                                   (i32.const 2)
                                 )
-                                (set_local $9
+                                (set_local $10
                                   (i32.add
                                     (i32.const 4091)
                                     (i32.shr_s
-                                      (get_local $12)
+                                      (get_local $17)
                                       (i32.const 4)
                                     )
                                   )
@@ -6774,84 +6791,84 @@
                         )
                         (br $jumpthreading$outer$7)
                       )
-                      (set_local $6
+                      (set_local $7
                         (call $_fmt_u
-                          (get_local $1)
-                          (get_local $6)
+                          (get_local $9)
+                          (get_local $7)
                           (get_local $23)
                         )
                       )
-                      (set_local $1
-                        (get_local $11)
+                      (set_local $9
+                        (get_local $12)
                       )
                       (br $jumpthreading$inner$7)
                     )
                     (set_local $26
                       (i32.const 0)
                     )
-                    (set_local $16
+                    (set_local $17
                       (i32.eqz
-                        (tee_local $12
+                        (tee_local $13
                           (call $_memchr
-                            (get_local $1)
+                            (get_local $9)
                             (i32.const 0)
-                            (get_local $7)
+                            (get_local $6)
                           )
                         )
                       )
                     )
-                    (set_local $6
-                      (get_local $1)
+                    (set_local $7
+                      (get_local $9)
                     )
-                    (set_local $11
+                    (set_local $12
                       (get_local $8)
                     )
-                    (set_local $10
+                    (set_local $11
                       (select
-                        (get_local $7)
+                        (get_local $6)
                         (i32.sub
-                          (get_local $12)
-                          (get_local $1)
+                          (get_local $13)
+                          (get_local $9)
                         )
-                        (get_local $16)
+                        (get_local $17)
                       )
                     )
                     (set_local $8
                       (i32.const 0)
                     )
-                    (set_local $9
+                    (set_local $10
                       (i32.const 4091)
                     )
-                    (set_local $1
+                    (set_local $9
                       (select
                         (i32.add
-                          (get_local $1)
-                          (get_local $7)
+                          (get_local $9)
+                          (get_local $6)
                         )
-                        (get_local $12)
-                        (get_local $16)
+                        (get_local $13)
+                        (get_local $17)
                       )
                     )
                     (br $jumpthreading$outer$7)
                   )
-                  (set_local $1
+                  (set_local $9
+                    (i32.const 0)
+                  )
+                  (set_local $7
                     (i32.const 0)
                   )
                   (set_local $6
-                    (i32.const 0)
-                  )
-                  (set_local $8
                     (i32.load
-                      (get_local $17)
+                      (get_local $18)
                     )
                   )
                   (loop $while-in125
                     (block $while-out124
                       (br_if $while-out124
                         (i32.eqz
-                          (tee_local $9
+                          (tee_local $10
                             (i32.load
-                              (get_local $8)
+                              (get_local $6)
                             )
                           )
                         )
@@ -6859,36 +6876,36 @@
                       (br_if $while-out124
                         (i32.or
                           (i32.lt_s
-                            (tee_local $6
+                            (tee_local $7
                               (call $_wctomb
-                                (get_local $40)
-                                (get_local $9)
+                                (get_local $41)
+                                (get_local $10)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.gt_u
-                            (get_local $6)
+                            (get_local $7)
                             (i32.sub
-                              (get_local $7)
-                              (get_local $1)
+                              (get_local $8)
+                              (get_local $9)
                             )
                           )
                         )
                       )
-                      (set_local $8
+                      (set_local $6
                         (i32.add
-                          (get_local $8)
+                          (get_local $6)
                           (i32.const 4)
                         )
                       )
                       (br_if $while-in125
                         (i32.gt_u
-                          (get_local $7)
-                          (tee_local $1
+                          (get_local $8)
+                          (tee_local $9
                             (i32.add
-                              (get_local $6)
-                              (get_local $1)
+                              (get_local $7)
+                              (get_local $9)
                             )
                           )
                         )
@@ -6897,11 +6914,11 @@
                   )
                   (if
                     (i32.lt_s
-                      (get_local $6)
+                      (get_local $7)
                       (i32.const 0)
                     )
                     (block
-                      (set_local $15
+                      (set_local $16
                         (i32.const -1)
                       )
                       (br $label$break$L1)
@@ -6910,19 +6927,19 @@
                   (call $_pad
                     (get_local $0)
                     (i32.const 32)
-                    (get_local $13)
-                    (get_local $1)
-                    (get_local $11)
+                    (get_local $14)
+                    (get_local $9)
+                    (get_local $12)
                   )
                   (if
-                    (get_local $1)
+                    (get_local $9)
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.const 0)
                       )
-                      (set_local $6
+                      (set_local $7
                         (i32.load
-                          (get_local $17)
+                          (get_local $18)
                         )
                       )
                       (loop $while-in127
@@ -6930,41 +6947,41 @@
                           (i32.eqz
                             (tee_local $8
                               (i32.load
-                                (get_local $6)
+                                (get_local $7)
                               )
                             )
                           )
                           (block
-                            (set_local $6
-                              (get_local $1)
+                            (set_local $7
+                              (get_local $9)
                             )
                             (br $jumpthreading$inner$6)
                           )
                         )
-                        (set_local $6
+                        (set_local $7
                           (i32.add
-                            (get_local $6)
+                            (get_local $7)
                             (i32.const 4)
                           )
                         )
                         (if
                           (i32.gt_s
-                            (tee_local $7
+                            (tee_local $6
                               (i32.add
                                 (tee_local $8
                                   (call $_wctomb
-                                    (get_local $40)
+                                    (get_local $41)
                                     (get_local $8)
                                   )
                                 )
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
-                            (get_local $1)
+                            (get_local $9)
                           )
                           (block
-                            (set_local $6
-                              (get_local $1)
+                            (set_local $7
+                              (get_local $9)
                             )
                             (br $jumpthreading$inner$6)
                           )
@@ -6980,7 +6997,7 @@
                           )
                           (drop
                             (call $___fwritex
-                              (get_local $40)
+                              (get_local $41)
                               (get_local $8)
                               (get_local $0)
                             )
@@ -6988,20 +7005,20 @@
                         )
                         (br_if $while-in127
                           (i32.lt_u
-                            (get_local $7)
-                            (get_local $1)
+                            (get_local $6)
+                            (get_local $9)
                           )
                         )
                         (block
-                          (set_local $6
-                            (get_local $1)
+                          (set_local $7
+                            (get_local $9)
                           )
                           (br $jumpthreading$inner$6)
                         )
                       )
                     )
                     (block
-                      (set_local $6
+                      (set_local $7
                         (i32.const 0)
                       )
                       (br $jumpthreading$inner$6)
@@ -7015,23 +7032,23 @@
                 (call $_pad
                   (get_local $0)
                   (i32.const 32)
-                  (get_local $13)
-                  (get_local $6)
+                  (get_local $14)
+                  (get_local $7)
                   (i32.xor
-                    (get_local $11)
+                    (get_local $12)
                     (i32.const 8192)
                   )
                 )
-                (set_local $1
+                (set_local $9
                   (get_local $5)
                 )
                 (set_local $5
                   (select
-                    (get_local $13)
-                    (get_local $6)
+                    (get_local $14)
+                    (get_local $7)
                     (i32.gt_s
-                      (get_local $13)
-                      (get_local $6)
+                      (get_local $14)
+                      (get_local $7)
                     )
                   )
                 )
@@ -7040,39 +7057,39 @@
               (set_local $26
                 (i32.const 0)
               )
-              (set_local $11
+              (set_local $12
                 (select
                   (i32.and
-                    (get_local $1)
+                    (get_local $9)
                     (i32.const -65537)
                   )
-                  (get_local $1)
+                  (get_local $9)
                   (i32.gt_s
-                    (get_local $7)
+                    (get_local $6)
                     (i32.const -1)
                   )
                 )
               )
-              (set_local $6
+              (set_local $7
                 (if i32
                   (i32.or
                     (i32.ne
-                      (get_local $7)
+                      (get_local $6)
                       (i32.const 0)
                     )
-                    (tee_local $1
+                    (tee_local $9
                       (i32.or
                         (i32.ne
                           (i32.load
-                            (tee_local $1
-                              (get_local $17)
+                            (tee_local $9
+                              (get_local $18)
                             )
                           )
                           (i32.const 0)
                         )
                         (i32.ne
                           (i32.load offset=4
-                            (get_local $1)
+                            (get_local $9)
                           )
                           (i32.const 0)
                         )
@@ -7080,40 +7097,40 @@
                     )
                   )
                   (block i32
-                    (set_local $10
+                    (set_local $11
                       (select
-                        (get_local $7)
-                        (tee_local $1
+                        (get_local $6)
+                        (tee_local $9
                           (i32.add
                             (i32.xor
                               (i32.and
-                                (get_local $1)
+                                (get_local $9)
                                 (i32.const 1)
                               )
                               (i32.const 1)
                             )
                             (i32.sub
                               (get_local $45)
-                              (get_local $6)
+                              (get_local $7)
                             )
                           )
                         )
                         (i32.gt_s
-                          (get_local $7)
-                          (get_local $1)
+                          (get_local $6)
+                          (get_local $9)
                         )
                       )
                     )
-                    (set_local $1
+                    (set_local $9
                       (get_local $23)
                     )
-                    (get_local $6)
+                    (get_local $7)
                   )
                   (block i32
-                    (set_local $10
+                    (set_local $11
                       (i32.const 0)
                     )
-                    (set_local $1
+                    (set_local $9
                       (get_local $23)
                     )
                     (get_local $23)
@@ -7124,37 +7141,37 @@
             (call $_pad
               (get_local $0)
               (i32.const 32)
-              (tee_local $7
+              (tee_local $6
                 (select
-                  (tee_local $1
+                  (tee_local $9
                     (i32.add
                       (get_local $8)
-                      (tee_local $10
+                      (tee_local $11
                         (select
-                          (tee_local $12
+                          (tee_local $13
                             (i32.sub
-                              (get_local $1)
-                              (get_local $6)
+                              (get_local $9)
+                              (get_local $7)
                             )
                           )
-                          (get_local $10)
+                          (get_local $11)
                           (i32.lt_s
-                            (get_local $10)
-                            (get_local $12)
+                            (get_local $11)
+                            (get_local $13)
                           )
                         )
                       )
                     )
                   )
-                  (get_local $13)
+                  (get_local $14)
                   (i32.lt_s
-                    (get_local $13)
-                    (get_local $1)
+                    (get_local $14)
+                    (get_local $9)
                   )
                 )
               )
-              (get_local $1)
-              (get_local $11)
+              (get_local $9)
+              (get_local $12)
             )
             (if
               (i32.eqz
@@ -7167,7 +7184,7 @@
               )
               (drop
                 (call $___fwritex
-                  (get_local $9)
+                  (get_local $10)
                   (get_local $8)
                   (get_local $0)
                 )
@@ -7176,18 +7193,18 @@
             (call $_pad
               (get_local $0)
               (i32.const 48)
-              (get_local $7)
-              (get_local $1)
+              (get_local $6)
+              (get_local $9)
               (i32.xor
-                (get_local $11)
+                (get_local $12)
                 (i32.const 65536)
               )
             )
             (call $_pad
               (get_local $0)
               (i32.const 48)
-              (get_local $10)
-              (get_local $12)
+              (get_local $11)
+              (get_local $13)
               (i32.const 0)
             )
             (if
@@ -7201,8 +7218,8 @@
               )
               (drop
                 (call $___fwritex
-                  (get_local $6)
-                  (get_local $12)
+                  (get_local $7)
+                  (get_local $13)
                   (get_local $0)
                 )
               )
@@ -7210,18 +7227,18 @@
             (call $_pad
               (get_local $0)
               (i32.const 32)
-              (get_local $7)
-              (get_local $1)
+              (get_local $6)
+              (get_local $9)
               (i32.xor
-                (get_local $11)
+                (get_local $12)
                 (i32.const 8192)
               )
             )
-            (set_local $1
+            (set_local $9
               (get_local $5)
             )
             (set_local $5
-              (get_local $7)
+              (get_local $6)
             )
             (br $label$continue$L1)
           )
@@ -7233,7 +7250,7 @@
           (get_local $0)
         )
         (if
-          (get_local $19)
+          (get_local $1)
           (block
             (set_local $0
               (i32.const 1)
@@ -7278,7 +7295,7 @@
                   )
                 )
                 (block
-                  (set_local $15
+                  (set_local $16
                     (i32.const 1)
                   )
                   (br $label$break$L343)
@@ -7308,7 +7325,7 @@
                     )
                   )
                   (block
-                    (set_local $15
+                    (set_local $16
                       (i32.const -1)
                     )
                     (br $label$break$L343)
@@ -7325,17 +7342,17 @@
                     )
                     (br $while-in132)
                   )
-                  (set_local $15
+                  (set_local $16
                     (i32.const 1)
                   )
                 )
               )
-              (set_local $15
+              (set_local $16
                 (i32.const 1)
               )
             )
           )
-          (set_local $15
+          (set_local $16
             (i32.const 0)
           )
         )
@@ -7344,7 +7361,7 @@
     (set_global $STACKTOP
       (get_local $25)
     )
-    (get_local $15)
+    (get_local $16)
   )
   (func $_pop_arg_336 (param $0 i32) (param $1 i32) (param $2 i32)
     (local $3 i32)
@@ -7920,23 +7937,23 @@
               (get_local $1)
               (select
                 (i32.const 256)
-                (tee_local $1
+                (tee_local $4
                   (i32.sub
                     (get_local $2)
                     (get_local $3)
                   )
                 )
                 (i32.gt_u
-                  (get_local $1)
+                  (get_local $4)
                   (i32.const 256)
                 )
               )
             )
           )
-          (set_local $4
+          (set_local $7
             (i32.eqz
               (i32.and
-                (tee_local $7
+                (tee_local $1
                   (i32.load
                     (get_local $0)
                   )
@@ -7947,7 +7964,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $1)
+              (get_local $4)
               (i32.const 255)
             )
             (block
@@ -7958,16 +7975,16 @@
                 )
               )
               (set_local $2
-                (get_local $7)
+                (get_local $4)
               )
               (set_local $3
-                (get_local $4)
+                (get_local $7)
               )
               (loop $while-in
                 (set_local $3
                   (i32.eqz
                     (i32.and
-                      (tee_local $2
+                      (tee_local $1
                         (if i32
                           (get_local $3)
                           (block i32
@@ -7982,7 +7999,7 @@
                               (get_local $0)
                             )
                           )
-                          (get_local $2)
+                          (get_local $1)
                         )
                       )
                       (i32.const 32)
@@ -7991,9 +8008,9 @@
                 )
                 (br_if $while-in
                   (i32.gt_u
-                    (tee_local $1
+                    (tee_local $2
                       (i32.add
-                        (get_local $1)
+                        (get_local $2)
                         (i32.const -256)
                       )
                     )
@@ -8001,7 +8018,7 @@
                   )
                 )
               )
-              (set_local $1
+              (set_local $4
                 (i32.and
                   (get_local $8)
                   (i32.const 255)
@@ -8015,14 +8032,14 @@
             )
             (br_if $do-once
               (i32.eqz
-                (get_local $4)
+                (get_local $7)
               )
             )
           )
           (drop
             (call $___fwritex
               (get_local $5)
-              (get_local $1)
+              (get_local $4)
               (get_local $0)
             )
           )
@@ -8067,16 +8084,16 @@
         (block
           (if
             (i32.and
-              (tee_local $2
+              (tee_local $1
                 (i32.shr_u
-                  (tee_local $10
+                  (tee_local $8
                     (i32.load
                       (i32.const 176)
                     )
                   )
-                  (tee_local $7
+                  (tee_local $2
                     (i32.shr_u
-                      (tee_local $4
+                      (tee_local $6
                         (select
                           (i32.const 16)
                           (i32.and
@@ -8104,11 +8121,11 @@
                 (i32.load
                   (tee_local $1
                     (i32.add
-                      (tee_local $7
+                      (tee_local $9
                         (i32.load
-                          (tee_local $3
+                          (tee_local $2
                             (i32.add
-                              (tee_local $2
+                              (tee_local $3
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
@@ -8117,12 +8134,12 @@
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $2)
+                                              (get_local $1)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $7)
+                                          (get_local $2)
                                         )
                                       )
                                       (i32.const 1)
@@ -8143,13 +8160,13 @@
               )
               (if
                 (i32.eq
-                  (get_local $2)
+                  (get_local $3)
                   (get_local $6)
                 )
                 (i32.store
                   (i32.const 176)
                   (i32.and
-                    (get_local $10)
+                    (get_local $8)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
@@ -8179,15 +8196,15 @@
                           )
                         )
                       )
-                      (get_local $7)
+                      (get_local $9)
                     )
                     (block
                       (i32.store
                         (get_local $0)
-                        (get_local $2)
+                        (get_local $3)
                       )
                       (i32.store
-                        (get_local $3)
+                        (get_local $2)
                         (get_local $6)
                       )
                     )
@@ -8196,7 +8213,7 @@
                 )
               )
               (i32.store offset=4
-                (get_local $7)
+                (get_local $9)
                 (i32.or
                   (tee_local $0
                     (i32.shl
@@ -8211,7 +8228,7 @@
                 (tee_local $0
                   (i32.add
                     (i32.add
-                      (get_local $7)
+                      (get_local $9)
                       (get_local $0)
                     )
                     (i32.const 4)
@@ -8231,7 +8248,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $4)
+              (get_local $6)
               (tee_local $0
                 (i32.load
                   (i32.const 184)
@@ -8240,37 +8257,37 @@
             )
             (block
               (if
-                (get_local $2)
+                (get_local $1)
                 (block
-                  (set_local $7
+                  (set_local $3
                     (i32.and
                       (i32.shr_u
-                        (tee_local $3
+                        (tee_local $1
                           (i32.add
                             (i32.and
-                              (tee_local $3
+                              (tee_local $1
                                 (i32.and
                                   (i32.shl
+                                    (get_local $1)
                                     (get_local $2)
-                                    (get_local $7)
                                   )
                                   (i32.or
-                                    (tee_local $3
+                                    (tee_local $1
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $7)
+                                        (get_local $2)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $3)
+                                      (get_local $1)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $3)
+                                (get_local $1)
                               )
                             )
                             (i32.const -1)
@@ -8281,13 +8298,13 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $12
+                  (set_local $11
                     (i32.load
-                      (tee_local $7
+                      (tee_local $3
                         (i32.add
-                          (tee_local $6
+                          (tee_local $4
                             (i32.load
-                              (tee_local $3
+                              (tee_local $1
                                 (i32.add
                                   (tee_local $2
                                     (i32.add
@@ -8300,13 +8317,13 @@
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $3
+                                                      (tee_local $1
                                                         (i32.and
                                                           (i32.shr_u
                                                             (tee_local $2
                                                               (i32.shr_u
+                                                                (get_local $1)
                                                                 (get_local $3)
-                                                                (get_local $7)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -8314,15 +8331,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $7)
+                                                      (get_local $3)
                                                     )
-                                                    (tee_local $3
+                                                    (tee_local $1
                                                       (i32.and
                                                         (i32.shr_u
                                                           (tee_local $2
                                                             (i32.shr_u
                                                               (get_local $2)
-                                                              (get_local $3)
+                                                              (get_local $1)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -8331,13 +8348,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (tee_local $3
+                                                  (tee_local $1
                                                     (i32.and
                                                       (i32.shr_u
                                                         (tee_local $2
                                                           (i32.shr_u
                                                             (get_local $2)
-                                                            (get_local $3)
+                                                            (get_local $1)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -8346,13 +8363,13 @@
                                                     )
                                                   )
                                                 )
-                                                (tee_local $3
+                                                (tee_local $1
                                                   (i32.and
                                                     (i32.shr_u
                                                       (tee_local $2
                                                         (i32.shr_u
                                                           (get_local $2)
-                                                          (get_local $3)
+                                                          (get_local $1)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -8363,7 +8380,7 @@
                                               )
                                               (i32.shr_u
                                                 (get_local $2)
-                                                (get_local $3)
+                                                (get_local $1)
                                               )
                                             )
                                           )
@@ -8386,13 +8403,13 @@
                   (if
                     (i32.eq
                       (get_local $2)
-                      (get_local $12)
+                      (get_local $11)
                     )
                     (block
                       (i32.store
                         (i32.const 176)
                         (i32.and
-                          (get_local $10)
+                          (get_local $8)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
@@ -8409,7 +8426,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $12)
+                          (get_local $11)
                           (i32.load
                             (i32.const 192)
                           )
@@ -8421,12 +8438,12 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $12)
+                                (get_local $11)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $6)
+                          (get_local $4)
                         )
                         (block
                           (i32.store
@@ -8434,8 +8451,8 @@
                             (get_local $2)
                           )
                           (i32.store
-                            (get_local $3)
-                            (get_local $12)
+                            (get_local $1)
+                            (get_local $11)
                           )
                           (set_local $16
                             (i32.load
@@ -8448,27 +8465,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $6)
+                    (get_local $4)
                     (i32.or
-                      (get_local $4)
+                      (get_local $6)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $6
+                    (tee_local $4
                       (i32.add
-                        (get_local $6)
                         (get_local $4)
+                        (get_local $6)
                       )
                     )
                     (i32.or
-                      (tee_local $4
+                      (tee_local $6
                         (i32.sub
                           (i32.shl
                             (get_local $5)
                             (i32.const 3)
                           )
-                          (get_local $4)
+                          (get_local $6)
                         )
                       )
                       (i32.const 1)
@@ -8476,10 +8493,10 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $6)
                       (get_local $4)
+                      (get_local $6)
                     )
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (if
                     (get_local $16)
@@ -8508,7 +8525,7 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $3
+                          (tee_local $1
                             (i32.load
                               (i32.const 176)
                             )
@@ -8524,7 +8541,7 @@
                           (i32.lt_u
                             (tee_local $0
                               (i32.load
-                                (tee_local $3
+                                (tee_local $1
                                   (i32.add
                                     (get_local $2)
                                     (i32.const 8)
@@ -8538,10 +8555,10 @@
                           )
                           (call $_abort)
                           (block
-                            (set_local $15
-                              (get_local $3)
+                            (set_local $7
+                              (get_local $1)
                             )
-                            (set_local $1
+                            (set_local $9
                               (get_local $0)
                             )
                           )
@@ -8550,32 +8567,32 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $3)
+                              (get_local $1)
                               (get_local $0)
                             )
                           )
-                          (set_local $15
+                          (set_local $7
                             (i32.add
                               (get_local $2)
                               (i32.const 8)
                             )
                           )
-                          (set_local $1
+                          (set_local $9
                             (get_local $2)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $15)
+                        (get_local $7)
                         (get_local $5)
                       )
                       (i32.store offset=12
-                        (get_local $1)
+                        (get_local $9)
                         (get_local $5)
                       )
                       (i32.store offset=8
                         (get_local $5)
-                        (get_local $1)
+                        (get_local $9)
                       )
                       (i32.store offset=12
                         (get_local $5)
@@ -8585,14 +8602,14 @@
                   )
                   (i32.store
                     (i32.const 184)
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $6)
+                    (get_local $4)
                   )
                   (return
-                    (get_local $7)
+                    (get_local $3)
                   )
                 )
               )
@@ -8623,7 +8640,7 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $7
+                  (set_local $3
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
@@ -8708,13 +8725,13 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $4)
+                      (get_local $6)
                     )
                   )
-                  (set_local $2
+                  (set_local $1
                     (get_local $0)
                   )
-                  (set_local $1
+                  (set_local $2
                     (get_local $0)
                   )
                   (loop $while-in
@@ -8723,7 +8740,7 @@
                         (i32.eqz
                           (tee_local $0
                             (i32.load offset=16
-                              (get_local $2)
+                              (get_local $1)
                             )
                           )
                         )
@@ -8731,24 +8748,24 @@
                           (i32.eqz
                             (tee_local $0
                               (i32.load offset=20
-                                (get_local $2)
+                                (get_local $1)
                               )
                             )
                           )
                           (block
-                            (set_local $12
-                              (get_local $7)
+                            (set_local $9
+                              (get_local $3)
                             )
-                            (set_local $11
-                              (get_local $1)
+                            (set_local $7
+                              (get_local $2)
                             )
                             (br $while-out)
                           )
                         )
                       )
-                      (set_local $12
+                      (set_local $9
                         (i32.lt_u
-                          (tee_local $2
+                          (tee_local $1
                             (i32.sub
                               (i32.and
                                 (i32.load offset=4
@@ -8756,27 +8773,27 @@
                                 )
                                 (i32.const -8)
                               )
-                              (get_local $4)
+                              (get_local $6)
                             )
                           )
-                          (get_local $7)
+                          (get_local $3)
                         )
                       )
-                      (set_local $7
+                      (set_local $3
                         (select
-                          (get_local $2)
-                          (get_local $7)
-                          (get_local $12)
+                          (get_local $1)
+                          (get_local $3)
+                          (get_local $9)
                         )
-                      )
-                      (set_local $2
-                        (get_local $0)
                       )
                       (set_local $1
+                        (get_local $0)
+                      )
+                      (set_local $2
                         (select
                           (get_local $0)
-                          (get_local $1)
-                          (get_local $12)
+                          (get_local $2)
+                          (get_local $9)
                         )
                       )
                       (br $while-in)
@@ -8784,7 +8801,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $11)
+                      (get_local $7)
                       (tee_local $10
                         (i32.load
                           (i32.const 192)
@@ -8795,11 +8812,11 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $11)
-                      (tee_local $14
+                      (get_local $7)
+                      (tee_local $17
                         (i32.add
-                          (get_local $11)
-                          (get_local $4)
+                          (get_local $7)
+                          (get_local $6)
                         )
                       )
                     )
@@ -8807,7 +8824,7 @@
                   )
                   (set_local $8
                     (i32.load offset=24
-                      (get_local $11)
+                      (get_local $7)
                     )
                   )
                   (block $do-once4
@@ -8815,10 +8832,10 @@
                       (i32.eq
                         (tee_local $0
                           (i32.load offset=12
-                            (get_local $11)
+                            (get_local $7)
                           )
                         )
-                        (get_local $11)
+                        (get_local $7)
                       )
                       (block
                         (if
@@ -8827,7 +8844,7 @@
                               (i32.load
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $11)
+                                    (get_local $7)
                                     (i32.const 20)
                                   )
                                 )
@@ -8840,7 +8857,7 @@
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
-                                      (get_local $11)
+                                      (get_local $7)
                                       (i32.const 16)
                                     )
                                   )
@@ -8848,7 +8865,7 @@
                               )
                             )
                             (block
-                              (set_local $6
+                              (set_local $5
                                 (i32.const 0)
                               )
                               (br $do-once4)
@@ -8859,7 +8876,7 @@
                           (if
                             (tee_local $2
                               (i32.load
-                                (tee_local $7
+                                (tee_local $3
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 20)
@@ -8872,7 +8889,7 @@
                                 (get_local $2)
                               )
                               (set_local $0
-                                (get_local $7)
+                                (get_local $3)
                               )
                               (br $while-in7)
                             )
@@ -8880,7 +8897,7 @@
                           (if
                             (tee_local $2
                               (i32.load
-                                (tee_local $7
+                                (tee_local $3
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 16)
@@ -8893,7 +8910,7 @@
                                 (get_local $2)
                               )
                               (set_local $0
-                                (get_local $7)
+                                (get_local $3)
                               )
                               (br $while-in7)
                             )
@@ -8910,7 +8927,7 @@
                               (get_local $0)
                               (i32.const 0)
                             )
-                            (set_local $6
+                            (set_local $5
                               (get_local $1)
                             )
                           )
@@ -8919,9 +8936,9 @@
                       (block
                         (if
                           (i32.lt_u
-                            (tee_local $7
+                            (tee_local $3
                               (i32.load offset=8
-                                (get_local $11)
+                                (get_local $7)
                               )
                             )
                             (get_local $10)
@@ -8933,12 +8950,12 @@
                             (i32.load
                               (tee_local $2
                                 (i32.add
-                                  (get_local $7)
+                                  (get_local $3)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $11)
+                            (get_local $7)
                           )
                           (call $_abort)
                         )
@@ -8952,7 +8969,7 @@
                                 )
                               )
                             )
-                            (get_local $11)
+                            (get_local $7)
                           )
                           (block
                             (i32.store
@@ -8961,9 +8978,9 @@
                             )
                             (i32.store
                               (get_local $1)
-                              (get_local $7)
+                              (get_local $3)
                             )
-                            (set_local $6
+                            (set_local $5
                               (get_local $0)
                             )
                           )
@@ -8978,7 +8995,7 @@
                       (block
                         (if
                           (i32.eq
-                            (get_local $11)
+                            (get_local $7)
                             (i32.load
                               (tee_local $0
                                 (i32.add
@@ -8986,7 +9003,7 @@
                                   (i32.shl
                                     (tee_local $1
                                       (i32.load offset=28
-                                        (get_local $11)
+                                        (get_local $7)
                                       )
                                     )
                                     (i32.const 2)
@@ -8998,11 +9015,11 @@
                           (block
                             (i32.store
                               (get_local $0)
-                              (get_local $6)
+                              (get_local $5)
                             )
                             (if
                               (i32.eqz
-                                (get_local $6)
+                                (get_local $5)
                               )
                               (block
                                 (i32.store
@@ -9044,27 +9061,27 @@
                                     )
                                   )
                                 )
-                                (get_local $11)
+                                (get_local $7)
                               )
                               (i32.store
                                 (get_local $0)
-                                (get_local $6)
+                                (get_local $5)
                               )
                               (i32.store offset=20
                                 (get_local $8)
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                             (br_if $do-once8
                               (i32.eqz
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $6)
+                            (get_local $5)
                             (tee_local $0
                               (i32.load
                                 (i32.const 192)
@@ -9074,13 +9091,13 @@
                           (call $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $6)
+                          (get_local $5)
                           (get_local $8)
                         )
                         (if
                           (tee_local $1
                             (i32.load offset=16
-                              (get_local $11)
+                              (get_local $7)
                             )
                           )
                           (if
@@ -9091,12 +9108,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $6)
+                                (get_local $5)
                                 (get_local $1)
                               )
                               (i32.store offset=24
                                 (get_local $1)
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                           )
@@ -9104,7 +9121,7 @@
                         (if
                           (tee_local $0
                             (i32.load offset=20
-                              (get_local $11)
+                              (get_local $7)
                             )
                           )
                           (if
@@ -9117,12 +9134,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $6)
+                                (get_local $5)
                                 (get_local $0)
                               )
                               (i32.store offset=24
                                 (get_local $0)
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                           )
@@ -9132,17 +9149,17 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $12)
+                      (get_local $9)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $11)
+                        (get_local $7)
                         (i32.or
                           (tee_local $0
                             (i32.add
-                              (get_local $12)
-                              (get_local $4)
+                              (get_local $9)
+                              (get_local $6)
                             )
                           )
                           (i32.const 3)
@@ -9152,7 +9169,7 @@
                         (tee_local $0
                           (i32.add
                             (i32.add
-                              (get_local $11)
+                              (get_local $7)
                               (get_local $0)
                             )
                             (i32.const 4)
@@ -9168,25 +9185,25 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $11)
+                        (get_local $7)
                         (i32.or
-                          (get_local $4)
+                          (get_local $6)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $14)
+                        (get_local $17)
                         (i32.or
-                          (get_local $12)
+                          (get_local $9)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $14)
-                          (get_local $12)
+                          (get_local $17)
+                          (get_local $9)
                         )
-                        (get_local $12)
+                        (get_local $9)
                       )
                       (if
                         (tee_local $0
@@ -9195,7 +9212,7 @@
                           )
                         )
                         (block
-                          (set_local $4
+                          (set_local $3
                             (i32.load
                               (i32.const 196)
                             )
@@ -9249,10 +9266,10 @@
                               )
                               (call $_abort)
                               (block
-                                (set_local $5
+                                (set_local $11
                                   (get_local $1)
                                 )
-                                (set_local $3
+                                (set_local $4
                                   (get_local $0)
                                 )
                               )
@@ -9265,59 +9282,59 @@
                                   (get_local $0)
                                 )
                               )
-                              (set_local $5
+                              (set_local $11
                                 (i32.add
                                   (get_local $2)
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $3
+                              (set_local $4
                                 (get_local $2)
                               )
                             )
                           )
                           (i32.store
-                            (get_local $5)
-                            (get_local $4)
+                            (get_local $11)
+                            (get_local $3)
                           )
                           (i32.store offset=12
-                            (get_local $3)
                             (get_local $4)
+                            (get_local $3)
                           )
                           (i32.store offset=8
-                            (get_local $4)
                             (get_local $3)
+                            (get_local $4)
                           )
                           (i32.store offset=12
-                            (get_local $4)
+                            (get_local $3)
                             (get_local $2)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $12)
+                        (get_local $9)
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $14)
+                        (get_local $17)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $11)
+                      (get_local $7)
                       (i32.const 8)
                     )
                   )
                 )
                 (set_local $0
-                  (get_local $4)
+                  (get_local $6)
                 )
               )
             )
             (set_local $0
-              (get_local $4)
+              (get_local $6)
             )
           )
         )
@@ -9348,7 +9365,7 @@
                 )
               )
               (block
-                (set_local $3
+                (set_local $9
                   (i32.sub
                     (i32.const 0)
                     (get_local $6)
@@ -9360,7 +9377,7 @@
                       (tee_local $0
                         (i32.load offset=480
                           (i32.shl
-                            (tee_local $17
+                            (tee_local $18
                               (if i32
                                 (tee_local $0
                                   (i32.shr_u
@@ -9389,7 +9406,7 @@
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (tee_local $1
+                                                            (tee_local $4
                                                               (i32.shl
                                                                 (get_local $0)
                                                                 (tee_local $5
@@ -9419,9 +9436,9 @@
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $1
+                                                          (tee_local $4
                                                             (i32.shl
-                                                              (get_local $1)
+                                                              (get_local $4)
                                                               (get_local $0)
                                                             )
                                                           )
@@ -9436,7 +9453,7 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $1)
+                                                  (get_local $4)
                                                   (get_local $0)
                                                 )
                                                 (i32.const 15)
@@ -9462,10 +9479,10 @@
                         )
                       )
                       (block
-                        (set_local $16
+                        (set_local $7
                           (i32.const 0)
                         )
-                        (set_local $18
+                        (set_local $16
                           (i32.shl
                             (get_local $6)
                             (select
@@ -9473,26 +9490,26 @@
                               (i32.sub
                                 (i32.const 25)
                                 (i32.shr_u
-                                  (get_local $17)
+                                  (get_local $18)
                                   (i32.const 1)
                                 )
                               )
                               (i32.eq
-                                (get_local $17)
+                                (get_local $18)
                                 (i32.const 31)
                               )
                             )
                           )
                         )
-                        (set_local $5
+                        (set_local $4
                           (i32.const 0)
                         )
                         (loop $while-in14
                           (if
                             (i32.lt_u
-                              (tee_local $1
+                              (tee_local $5
                                 (i32.sub
-                                  (tee_local $15
+                                  (tee_local $11
                                     (i32.and
                                       (i32.load offset=4
                                         (get_local $0)
@@ -9503,21 +9520,21 @@
                                   (get_local $6)
                                 )
                               )
-                              (get_local $3)
+                              (get_local $9)
                             )
                             (if
                               (i32.eq
-                                (get_local $15)
+                                (get_local $11)
                                 (get_local $6)
                               )
                               (block
-                                (set_local $4
-                                  (get_local $1)
+                                (set_local $2
+                                  (get_local $5)
                                 )
-                                (set_local $7
+                                (set_local $3
                                   (get_local $0)
                                 )
-                                (set_local $2
+                                (set_local $1
                                   (get_local $0)
                                 )
                                 (set_local $19
@@ -9526,21 +9543,18 @@
                                 (br $jumpthreading$outer$2)
                               )
                               (block
-                                (set_local $3
-                                  (get_local $1)
+                                (set_local $9
+                                  (get_local $5)
                                 )
-                                (set_local $1
+                                (set_local $4
                                   (get_local $0)
                                 )
                               )
                             )
-                            (set_local $1
-                              (get_local $5)
-                            )
                           )
                           (set_local $0
                             (select
-                              (get_local $16)
+                              (get_local $7)
                               (tee_local $5
                                 (i32.load offset=20
                                   (get_local $0)
@@ -9552,7 +9566,7 @@
                                 )
                                 (i32.eq
                                   (get_local $5)
-                                  (tee_local $15
+                                  (tee_local $11
                                     (i32.load
                                       (i32.add
                                         (i32.add
@@ -9561,7 +9575,7 @@
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $18)
+                                            (get_local $16)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -9575,12 +9589,12 @@
                           )
                           (set_local $5
                             (i32.shl
-                              (get_local $18)
+                              (get_local $16)
                               (i32.xor
                                 (i32.and
-                                  (tee_local $16
+                                  (tee_local $7
                                     (i32.eqz
-                                      (get_local $15)
+                                      (get_local $11)
                                     )
                                   )
                                   (i32.const 1)
@@ -9590,20 +9604,17 @@
                             )
                           )
                           (br_if $jumpthreading$inner$2
-                            (get_local $16)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $16
+                            (set_local $7
                               (get_local $0)
                             )
-                            (set_local $18
+                            (set_local $16
                               (get_local $5)
                             )
                             (set_local $0
-                              (get_local $15)
-                            )
-                            (set_local $5
-                              (get_local $1)
+                              (get_local $11)
                             )
                             (br $while-in14)
                           )
@@ -9613,7 +9624,7 @@
                         (set_local $0
                           (i32.const 0)
                         )
-                        (set_local $1
+                        (set_local $4
                           (i32.const 0)
                         )
                         (br $jumpthreading$inner$2)
@@ -9629,7 +9640,7 @@
                             (get_local $0)
                           )
                           (i32.eqz
-                            (get_local $1)
+                            (get_local $4)
                           )
                         )
                         (block i32
@@ -9642,7 +9653,7 @@
                                     (tee_local $0
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $17)
+                                        (get_local $18)
                                       )
                                     )
                                     (i32.sub
@@ -9660,7 +9671,7 @@
                               (br $do-once)
                             )
                           )
-                          (set_local $15
+                          (set_local $11
                             (i32.and
                               (i32.shr_u
                                 (tee_local $0
@@ -9693,7 +9704,7 @@
                                               (tee_local $5
                                                 (i32.shr_u
                                                   (get_local $0)
-                                                  (get_local $15)
+                                                  (get_local $11)
                                                 )
                                               )
                                               (i32.const 5)
@@ -9701,7 +9712,7 @@
                                             (i32.const 8)
                                           )
                                         )
-                                        (get_local $15)
+                                        (get_local $11)
                                       )
                                       (tee_local $0
                                         (i32.and
@@ -9761,25 +9772,25 @@
                       )
                     )
                     (block
-                      (set_local $4
-                        (get_local $3)
+                      (set_local $2
+                        (get_local $9)
                       )
-                      (set_local $7
+                      (set_local $3
                         (get_local $0)
                       )
-                      (set_local $2
-                        (get_local $1)
+                      (set_local $1
+                        (get_local $4)
                       )
                       (set_local $19
                         (i32.const 90)
                       )
                     )
                     (block
-                      (set_local $9
-                        (get_local $3)
-                      )
                       (set_local $13
-                        (get_local $1)
+                        (get_local $9)
+                      )
+                      (set_local $12
+                        (get_local $4)
                       )
                     )
                   )
@@ -9790,71 +9801,71 @@
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $1
+                    (set_local $4
                       (i32.lt_u
                         (tee_local $0
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $7)
+                                (get_local $3)
                               )
                               (i32.const -8)
                             )
                             (get_local $6)
                           )
                         )
-                        (get_local $4)
-                      )
-                    )
-                    (set_local $4
-                      (select
-                        (get_local $0)
-                        (get_local $4)
-                        (get_local $1)
+                        (get_local $2)
                       )
                     )
                     (set_local $2
                       (select
-                        (get_local $7)
+                        (get_local $0)
                         (get_local $2)
+                        (get_local $4)
+                      )
+                    )
+                    (set_local $1
+                      (select
+                        (get_local $3)
                         (get_local $1)
+                        (get_local $4)
                       )
                     )
                     (if
                       (tee_local $0
                         (i32.load offset=16
-                          (get_local $7)
+                          (get_local $3)
                         )
                       )
                       (block
-                        (set_local $7
+                        (set_local $3
                           (get_local $0)
                         )
                         (br $while-in16)
                       )
                     )
                     (br_if $while-in16
-                      (tee_local $7
+                      (tee_local $3
                         (i32.load offset=20
-                          (get_local $7)
+                          (get_local $3)
                         )
                       )
                     )
                     (block
-                      (set_local $9
-                        (get_local $4)
-                      )
                       (set_local $13
                         (get_local $2)
+                      )
+                      (set_local $12
+                        (get_local $1)
                       )
                     )
                   )
                 )
                 (if
-                  (get_local $13)
+                  (get_local $12)
                   (if
                     (i32.lt_u
-                      (get_local $9)
+                      (get_local $13)
                       (i32.sub
                         (i32.load
                           (i32.const 184)
@@ -9865,7 +9876,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $13)
+                          (get_local $12)
                           (tee_local $4
                             (i32.load
                               (i32.const 192)
@@ -9876,19 +9887,19 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $13)
+                          (get_local $12)
                           (tee_local $5
                             (i32.add
-                              (get_local $13)
+                              (get_local $12)
                               (get_local $6)
                             )
                           )
                         )
                         (call $_abort)
                       )
-                      (set_local $7
+                      (set_local $9
                         (i32.load offset=24
-                          (get_local $13)
+                          (get_local $12)
                         )
                       )
                       (block $do-once17
@@ -9896,10 +9907,10 @@
                           (i32.eq
                             (tee_local $0
                               (i32.load offset=12
-                                (get_local $13)
+                                (get_local $12)
                               )
                             )
-                            (get_local $13)
+                            (get_local $12)
                           )
                           (block
                             (if
@@ -9908,7 +9919,7 @@
                                   (i32.load
                                     (tee_local $0
                                       (i32.add
-                                        (get_local $13)
+                                        (get_local $12)
                                         (i32.const 20)
                                       )
                                     )
@@ -9921,7 +9932,7 @@
                                     (i32.load
                                       (tee_local $0
                                         (i32.add
-                                          (get_local $13)
+                                          (get_local $12)
                                           (i32.const 16)
                                         )
                                       )
@@ -9929,7 +9940,7 @@
                                   )
                                 )
                                 (block
-                                  (set_local $8
+                                  (set_local $14
                                     (i32.const 0)
                                   )
                                   (br $do-once17)
@@ -9938,9 +9949,9 @@
                             )
                             (loop $while-in20
                               (if
-                                (tee_local $3
+                                (tee_local $2
                                   (i32.load
-                                    (tee_local $2
+                                    (tee_local $3
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 20)
@@ -9950,18 +9961,18 @@
                                 )
                                 (block
                                   (set_local $1
-                                    (get_local $3)
+                                    (get_local $2)
                                   )
                                   (set_local $0
-                                    (get_local $2)
+                                    (get_local $3)
                                   )
                                   (br $while-in20)
                                 )
                               )
                               (if
-                                (tee_local $3
+                                (tee_local $2
                                   (i32.load
-                                    (tee_local $2
+                                    (tee_local $3
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 16)
@@ -9971,10 +9982,10 @@
                                 )
                                 (block
                                   (set_local $1
-                                    (get_local $3)
+                                    (get_local $2)
                                   )
                                   (set_local $0
-                                    (get_local $2)
+                                    (get_local $3)
                                   )
                                   (br $while-in20)
                                 )
@@ -9991,7 +10002,7 @@
                                   (get_local $0)
                                   (i32.const 0)
                                 )
-                                (set_local $8
+                                (set_local $14
                                   (get_local $1)
                                 )
                               )
@@ -10000,9 +10011,9 @@
                           (block
                             (if
                               (i32.lt_u
-                                (tee_local $2
+                                (tee_local $3
                                   (i32.load offset=8
-                                    (get_local $13)
+                                    (get_local $12)
                                   )
                                 )
                                 (get_local $4)
@@ -10012,14 +10023,14 @@
                             (if
                               (i32.ne
                                 (i32.load
-                                  (tee_local $3
+                                  (tee_local $2
                                     (i32.add
-                                      (get_local $2)
+                                      (get_local $3)
                                       (i32.const 12)
                                     )
                                   )
                                 )
-                                (get_local $13)
+                                (get_local $12)
                               )
                               (call $_abort)
                             )
@@ -10033,18 +10044,18 @@
                                     )
                                   )
                                 )
-                                (get_local $13)
+                                (get_local $12)
                               )
                               (block
                                 (i32.store
-                                  (get_local $3)
+                                  (get_local $2)
                                   (get_local $0)
                                 )
                                 (i32.store
                                   (get_local $1)
-                                  (get_local $2)
+                                  (get_local $3)
                                 )
-                                (set_local $8
+                                (set_local $14
                                   (get_local $0)
                                 )
                               )
@@ -10055,11 +10066,11 @@
                       )
                       (block $do-once21
                         (if
-                          (get_local $7)
+                          (get_local $9)
                           (block
                             (if
                               (i32.eq
-                                (get_local $13)
+                                (get_local $12)
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
@@ -10067,7 +10078,7 @@
                                       (i32.shl
                                         (tee_local $1
                                           (i32.load offset=28
-                                            (get_local $13)
+                                            (get_local $12)
                                           )
                                         )
                                         (i32.const 2)
@@ -10079,11 +10090,11 @@
                               (block
                                 (i32.store
                                   (get_local $0)
-                                  (get_local $8)
+                                  (get_local $14)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $8)
+                                    (get_local $14)
                                   )
                                   (block
                                     (i32.store
@@ -10108,7 +10119,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $7)
+                                    (get_local $9)
                                     (i32.load
                                       (i32.const 192)
                                     )
@@ -10120,32 +10131,32 @@
                                     (i32.load
                                       (tee_local $0
                                         (i32.add
-                                          (get_local $7)
+                                          (get_local $9)
                                           (i32.const 16)
                                         )
                                       )
                                     )
-                                    (get_local $13)
+                                    (get_local $12)
                                   )
                                   (i32.store
                                     (get_local $0)
-                                    (get_local $8)
+                                    (get_local $14)
                                   )
                                   (i32.store offset=20
-                                    (get_local $7)
-                                    (get_local $8)
+                                    (get_local $9)
+                                    (get_local $14)
                                   )
                                 )
                                 (br_if $do-once21
                                   (i32.eqz
-                                    (get_local $8)
+                                    (get_local $14)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $8)
+                                (get_local $14)
                                 (tee_local $0
                                   (i32.load
                                     (i32.const 192)
@@ -10155,13 +10166,13 @@
                               (call $_abort)
                             )
                             (i32.store offset=24
-                              (get_local $8)
-                              (get_local $7)
+                              (get_local $14)
+                              (get_local $9)
                             )
                             (if
                               (tee_local $1
                                 (i32.load offset=16
-                                  (get_local $13)
+                                  (get_local $12)
                                 )
                               )
                               (if
@@ -10172,12 +10183,12 @@
                                 (call $_abort)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $8)
+                                    (get_local $14)
                                     (get_local $1)
                                   )
                                   (i32.store offset=24
                                     (get_local $1)
-                                    (get_local $8)
+                                    (get_local $14)
                                   )
                                 )
                               )
@@ -10185,7 +10196,7 @@
                             (if
                               (tee_local $0
                                 (i32.load offset=20
-                                  (get_local $13)
+                                  (get_local $12)
                                 )
                               )
                               (if
@@ -10198,12 +10209,12 @@
                                 (call $_abort)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $8)
+                                    (get_local $14)
                                     (get_local $0)
                                   )
                                   (i32.store offset=24
                                     (get_local $0)
-                                    (get_local $8)
+                                    (get_local $14)
                                   )
                                 )
                               )
@@ -10214,16 +10225,16 @@
                       (block $do-once25
                         (if
                           (i32.lt_u
-                            (get_local $9)
+                            (get_local $13)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $13)
+                              (get_local $12)
                               (i32.or
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $9)
+                                    (get_local $13)
                                     (get_local $6)
                                   )
                                 )
@@ -10234,7 +10245,7 @@
                               (tee_local $0
                                 (i32.add
                                   (i32.add
-                                    (get_local $13)
+                                    (get_local $12)
                                     (get_local $0)
                                   )
                                   (i32.const 4)
@@ -10250,7 +10261,7 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $13)
+                              (get_local $12)
                               (i32.or
                                 (get_local $6)
                                 (i32.const 3)
@@ -10259,30 +10270,30 @@
                             (i32.store offset=4
                               (get_local $5)
                               (i32.or
-                                (get_local $9)
+                                (get_local $13)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
                                 (get_local $5)
-                                (get_local $9)
+                                (get_local $13)
                               )
-                              (get_local $9)
+                              (get_local $13)
                             )
                             (set_local $0
                               (i32.shr_u
-                                (get_local $9)
+                                (get_local $13)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $9)
+                                (get_local $13)
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $3
+                                (set_local $2
                                   (i32.add
                                     (i32.const 216)
                                     (i32.shl
@@ -10314,7 +10325,7 @@
                                         (i32.load
                                           (tee_local $1
                                             (i32.add
-                                              (get_local $3)
+                                              (get_local $2)
                                               (i32.const 8)
                                             )
                                           )
@@ -10329,7 +10340,7 @@
                                       (set_local $20
                                         (get_local $1)
                                       )
-                                      (set_local $10
+                                      (set_local $8
                                         (get_local $0)
                                       )
                                     )
@@ -10344,12 +10355,12 @@
                                     )
                                     (set_local $20
                                       (i32.add
-                                        (get_local $3)
+                                        (get_local $2)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $10
-                                      (get_local $3)
+                                    (set_local $8
+                                      (get_local $2)
                                     )
                                   )
                                 )
@@ -10358,16 +10369,16 @@
                                   (get_local $5)
                                 )
                                 (i32.store offset=12
-                                  (get_local $10)
+                                  (get_local $8)
                                   (get_local $5)
                                 )
                                 (i32.store offset=8
                                   (get_local $5)
-                                  (get_local $10)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=12
                                   (get_local $5)
-                                  (get_local $3)
+                                  (get_local $2)
                                 )
                                 (br $do-once25)
                               )
@@ -10380,20 +10391,20 @@
                                     (if i32
                                       (tee_local $0
                                         (i32.shr_u
-                                          (get_local $9)
+                                          (get_local $13)
                                           (i32.const 8)
                                         )
                                       )
                                       (if i32
                                         (i32.gt_u
-                                          (get_local $9)
+                                          (get_local $13)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $9)
+                                              (get_local $13)
                                               (i32.add
                                                 (tee_local $0
                                                   (i32.add
@@ -10408,7 +10419,7 @@
                                                                   (tee_local $1
                                                                     (i32.shl
                                                                       (get_local $0)
-                                                                      (tee_local $3
+                                                                      (tee_local $2
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
@@ -10429,7 +10440,7 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $3)
+                                                          (get_local $2)
                                                         )
                                                         (tee_local $0
                                                           (i32.and
@@ -10539,7 +10550,7 @@
                             )
                             (set_local $3
                               (i32.shl
-                                (get_local $9)
+                                (get_local $13)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
@@ -10573,7 +10584,7 @@
                                           )
                                           (i32.const -8)
                                         )
-                                        (get_local $9)
+                                        (get_local $13)
                                       )
                                     )
                                     (set_local $2
@@ -10649,9 +10660,9 @@
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (tee_local $2
+                                    (tee_local $3
                                       (i32.load
-                                        (tee_local $3
+                                        (tee_local $2
                                           (i32.add
                                             (get_local $0)
                                             (i32.const 8)
@@ -10672,16 +10683,16 @@
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $2)
+                                    (get_local $3)
                                     (get_local $5)
                                   )
                                   (i32.store
-                                    (get_local $3)
+                                    (get_local $2)
                                     (get_local $5)
                                   )
                                   (i32.store offset=8
                                     (get_local $5)
-                                    (get_local $2)
+                                    (get_local $3)
                                   )
                                   (i32.store offset=12
                                     (get_local $5)
@@ -10700,7 +10711,7 @@
                       )
                       (return
                         (i32.add
-                          (get_local $13)
+                          (get_local $12)
                           (i32.const 8)
                         )
                       )
@@ -10732,14 +10743,14 @@
         (get_local $0)
       )
       (block
-        (set_local $2
+        (set_local $3
           (i32.load
             (i32.const 196)
           )
         )
         (if
           (i32.gt_u
-            (tee_local $3
+            (tee_local $2
               (i32.sub
                 (get_local $1)
                 (get_local $0)
@@ -10752,31 +10763,31 @@
               (i32.const 196)
               (tee_local $1
                 (i32.add
-                  (get_local $2)
+                  (get_local $3)
                   (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 184)
-              (get_local $3)
+              (get_local $2)
             )
             (i32.store offset=4
               (get_local $1)
               (i32.or
-                (get_local $3)
+                (get_local $2)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $1)
-                (get_local $3)
+                (get_local $2)
               )
-              (get_local $3)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $2)
+              (get_local $3)
               (i32.or
                 (get_local $0)
                 (i32.const 3)
@@ -10793,7 +10804,7 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $2)
+              (get_local $3)
               (i32.or
                 (get_local $1)
                 (i32.const 3)
@@ -10803,7 +10814,7 @@
               (tee_local $0
                 (i32.add
                   (i32.add
-                    (get_local $2)
+                    (get_local $3)
                     (get_local $1)
                   )
                   (i32.const 4)
@@ -10820,7 +10831,7 @@
         )
         (return
           (i32.add
-            (get_local $2)
+            (get_local $3)
             (i32.const 8)
           )
         )
@@ -10838,7 +10849,7 @@
       (block
         (i32.store
           (i32.const 188)
-          (tee_local $3
+          (tee_local $2
             (i32.sub
               (get_local $1)
               (get_local $0)
@@ -10849,7 +10860,7 @@
           (i32.const 200)
           (tee_local $1
             (i32.add
-              (tee_local $2
+              (tee_local $3
                 (i32.load
                   (i32.const 200)
                 )
@@ -10861,12 +10872,12 @@
         (i32.store offset=4
           (get_local $1)
           (i32.or
-            (get_local $3)
+            (get_local $2)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $2)
+          (get_local $3)
           (i32.or
             (get_local $0)
             (i32.const 3)
@@ -10874,7 +10885,7 @@
         )
         (return
           (i32.add
-            (get_local $2)
+            (get_local $3)
             (i32.const 8)
           )
         )
@@ -10939,7 +10950,7 @@
         )
       )
     )
-    (set_local $10
+    (set_local $11
       (i32.add
         (get_local $0)
         (i32.const 48)
@@ -10947,7 +10958,7 @@
     )
     (if
       (i32.le_u
-        (tee_local $8
+        (tee_local $7
           (i32.and
             (tee_local $6
               (i32.add
@@ -10964,7 +10975,7 @@
                 )
               )
             )
-            (tee_local $7
+            (tee_local $9
               (i32.sub
                 (i32.const 0)
                 (get_local $1)
@@ -10979,7 +10990,7 @@
       )
     )
     (if
-      (tee_local $2
+      (tee_local $3
         (i32.load
           (i32.const 616)
         )
@@ -10989,19 +11000,19 @@
           (i32.le_u
             (tee_local $1
               (i32.add
-                (tee_local $3
+                (tee_local $2
                   (i32.load
                     (i32.const 608)
                   )
                 )
-                (get_local $8)
+                (get_local $7)
               )
             )
-            (get_local $3)
+            (get_local $2)
           )
           (i32.gt_u
             (get_local $1)
-            (get_local $2)
+            (get_local $3)
           )
         )
         (return
@@ -11026,7 +11037,7 @@
                 (block $jumpthreading$inner$3
                   (br_if $jumpthreading$inner$3
                     (i32.eqz
-                      (tee_local $4
+                      (tee_local $3
                         (i32.load
                           (i32.const 200)
                         )
@@ -11040,17 +11051,17 @@
                     (block $while-out33
                       (if
                         (i32.le_u
-                          (tee_local $3
+                          (tee_local $2
                             (i32.load
                               (get_local $1)
                             )
                           )
-                          (get_local $4)
+                          (get_local $3)
                         )
                         (if
                           (i32.gt_u
                             (i32.add
-                              (get_local $3)
+                              (get_local $2)
                               (i32.load
                                 (tee_local $2
                                   (i32.add
@@ -11060,7 +11071,7 @@
                                 )
                               )
                             )
-                            (get_local $4)
+                            (get_local $3)
                           )
                           (block
                             (set_local $4
@@ -11090,7 +11101,7 @@
                               (i32.const 188)
                             )
                           )
-                          (get_local $7)
+                          (get_local $9)
                         )
                       )
                       (i32.const 2147483647)
@@ -11111,10 +11122,16 @@
                           )
                         )
                       )
-                      (br_if $jumpthreading$inner$12
+                      (if
                         (i32.ne
                           (get_local $3)
                           (i32.const -1)
+                        )
+                        (block
+                          (set_local $2
+                            (get_local $1)
+                          )
+                          (br $jumpthreading$inner$12)
                         )
                       )
                       (br $jumpthreading$inner$4)
@@ -11134,7 +11151,7 @@
                   (block
                     (set_local $4
                       (i32.add
-                        (tee_local $7
+                        (tee_local $9
                           (i32.load
                             (i32.const 608)
                           )
@@ -11158,7 +11175,7 @@
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $8)
+                                (get_local $7)
                                 (get_local $1)
                               )
                               (i32.and
@@ -11172,7 +11189,7 @@
                                 )
                               )
                             )
-                            (get_local $8)
+                            (get_local $7)
                           )
                         )
                       )
@@ -11199,7 +11216,7 @@
                             (i32.or
                               (i32.le_u
                                 (get_local $4)
-                                (get_local $7)
+                                (get_local $9)
                               )
                               (i32.gt_u
                                 (get_local $4)
@@ -11208,7 +11225,7 @@
                             )
                           )
                         )
-                        (br_if $jumpthreading$inner$12
+                        (if
                           (i32.eq
                             (tee_local $2
                               (call $_sbrk
@@ -11217,12 +11234,18 @@
                             )
                             (get_local $3)
                           )
-                        )
-                        (block
-                          (set_local $3
-                            (get_local $2)
+                          (block
+                            (set_local $2
+                              (get_local $1)
+                            )
+                            (br $jumpthreading$inner$12)
                           )
-                          (br $jumpthreading$inner$4)
+                          (block
+                            (set_local $3
+                              (get_local $2)
+                            )
+                            (br $jumpthreading$inner$4)
+                          )
                         )
                       )
                     )
@@ -11239,7 +11262,7 @@
               (if
                 (i32.and
                   (i32.gt_u
-                    (get_local $10)
+                    (get_local $11)
                     (get_local $1)
                   )
                   (i32.and
@@ -11300,10 +11323,16 @@
                   )
                 )
               )
-              (br_if $jumpthreading$inner$12
+              (if
                 (i32.ne
                   (get_local $3)
                   (i32.const -1)
+                )
+                (block
+                  (set_local $2
+                    (get_local $1)
+                  )
+                  (br $jumpthreading$inner$12)
                 )
               )
             )
@@ -11320,7 +11349,7 @@
         )
         (if
           (i32.lt_u
-            (get_local $8)
+            (get_local $7)
             (i32.const 2147483647)
           )
           (if
@@ -11328,7 +11357,7 @@
               (i32.lt_u
                 (tee_local $3
                   (call $_sbrk
-                    (get_local $8)
+                    (get_local $7)
                   )
                 )
                 (tee_local $1
@@ -11350,7 +11379,7 @@
             )
             (br_if $jumpthreading$inner$12
               (i32.gt_u
-                (tee_local $1
+                (tee_local $2
                   (i32.sub
                     (get_local $1)
                     (get_local $3)
@@ -11368,36 +11397,36 @@
       )
       (i32.store
         (i32.const 608)
-        (tee_local $2
+        (tee_local $1
           (i32.add
             (i32.load
               (i32.const 608)
             )
-            (get_local $1)
+            (get_local $2)
           )
         )
       )
       (if
         (i32.gt_u
-          (get_local $2)
+          (get_local $1)
           (i32.load
             (i32.const 612)
           )
         )
         (i32.store
           (i32.const 612)
-          (get_local $2)
+          (get_local $1)
         )
       )
       (block $do-once40
         (if
-          (tee_local $9
+          (tee_local $8
             (i32.load
               (i32.const 200)
             )
           )
           (block
-            (set_local $2
+            (set_local $1
               (i32.const 624)
             )
             (block $jumpthreading$outer$9
@@ -11409,14 +11438,14 @@
                       (i32.add
                         (tee_local $6
                           (i32.load
-                            (get_local $2)
+                            (get_local $1)
                           )
                         )
-                        (tee_local $7
+                        (tee_local $9
                           (i32.load
                             (tee_local $4
                               (i32.add
-                                (get_local $2)
+                                (get_local $1)
                                 (i32.const 4)
                               )
                             )
@@ -11426,9 +11455,9 @@
                     )
                   )
                   (br_if $while-in45
-                    (tee_local $2
+                    (tee_local $1
                       (i32.load offset=8
-                        (get_local $2)
+                        (get_local $1)
                       )
                     )
                   )
@@ -11439,7 +11468,7 @@
                 (i32.eqz
                   (i32.and
                     (i32.load offset=12
-                      (get_local $2)
+                      (get_local $1)
                     )
                     (i32.const 8)
                   )
@@ -11447,11 +11476,11 @@
                 (if
                   (i32.and
                     (i32.lt_u
-                      (get_local $9)
+                      (get_local $8)
                       (get_local $3)
                     )
                     (i32.ge_u
-                      (get_local $9)
+                      (get_local $8)
                       (get_local $6)
                     )
                   )
@@ -11459,21 +11488,21 @@
                     (i32.store
                       (get_local $4)
                       (i32.add
-                        (get_local $7)
-                        (get_local $1)
+                        (get_local $9)
+                        (get_local $2)
                       )
                     )
-                    (set_local $2
+                    (set_local $3
                       (i32.add
-                        (get_local $9)
-                        (tee_local $3
+                        (get_local $8)
+                        (tee_local $1
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (tee_local $3
+                                (tee_local $1
                                   (i32.add
-                                    (get_local $9)
+                                    (get_local $8)
                                     (i32.const 8)
                                   )
                                 )
@@ -11482,7 +11511,7 @@
                             )
                             (i32.const 0)
                             (i32.and
-                              (get_local $3)
+                              (get_local $1)
                               (i32.const 7)
                             )
                           )
@@ -11492,8 +11521,8 @@
                     (set_local $1
                       (i32.add
                         (i32.sub
+                          (get_local $2)
                           (get_local $1)
-                          (get_local $3)
                         )
                         (i32.load
                           (i32.const 188)
@@ -11502,14 +11531,14 @@
                     )
                     (i32.store
                       (i32.const 200)
-                      (get_local $2)
+                      (get_local $3)
                     )
                     (i32.store
                       (i32.const 188)
                       (get_local $1)
                     )
                     (i32.store offset=4
-                      (get_local $2)
+                      (get_local $3)
                       (i32.or
                         (get_local $1)
                         (i32.const 1)
@@ -11517,7 +11546,7 @@
                     )
                     (i32.store offset=4
                       (i32.add
-                        (get_local $2)
+                        (get_local $3)
                         (get_local $1)
                       )
                       (i32.const 40)
@@ -11537,7 +11566,7 @@
               (if i32
                 (i32.lt_u
                   (get_local $3)
-                  (tee_local $2
+                  (tee_local $1
                     (i32.load
                       (i32.const 192)
                     )
@@ -11550,16 +11579,16 @@
                   )
                   (get_local $3)
                 )
-                (get_local $2)
-              )
-            )
-            (set_local $7
-              (i32.add
-                (get_local $3)
                 (get_local $1)
               )
             )
-            (set_local $2
+            (set_local $9
+              (i32.add
+                (get_local $3)
+                (get_local $2)
+              )
+            )
+            (set_local $1
               (i32.const 624)
             )
             (block $jumpthreading$outer$10
@@ -11568,21 +11597,21 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $2)
+                        (get_local $1)
                       )
-                      (get_local $7)
+                      (get_local $9)
                     )
                     (block
                       (set_local $4
-                        (get_local $2)
+                        (get_local $1)
                       )
                       (br $jumpthreading$inner$10)
                     )
                   )
                   (br_if $while-in47
-                    (tee_local $2
+                    (tee_local $1
                       (i32.load offset=8
-                        (get_local $2)
+                        (get_local $1)
                       )
                     )
                   )
@@ -11595,7 +11624,7 @@
               (if
                 (i32.and
                   (i32.load offset=12
-                    (get_local $2)
+                    (get_local $1)
                   )
                   (i32.const 8)
                 )
@@ -11608,20 +11637,20 @@
                     (get_local $3)
                   )
                   (i32.store
-                    (tee_local $2
+                    (tee_local $1
                       (i32.add
-                        (get_local $2)
+                        (get_local $1)
                         (i32.const 4)
                       )
                     )
                     (i32.add
                       (i32.load
-                        (get_local $2)
+                        (get_local $1)
                       )
-                      (get_local $1)
+                      (get_local $2)
                     )
                   )
-                  (set_local $8
+                  (set_local $10
                     (i32.add
                       (tee_local $6
                         (i32.add
@@ -11653,16 +11682,16 @@
                   (set_local $4
                     (i32.sub
                       (i32.sub
-                        (tee_local $10
+                        (tee_local $7
                           (i32.add
-                            (get_local $7)
+                            (get_local $9)
                             (select
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
                                   (tee_local $1
                                     (i32.add
-                                      (get_local $7)
+                                      (get_local $9)
                                       (i32.const 8)
                                     )
                                   )
@@ -11692,8 +11721,8 @@
                   (block $do-once48
                     (if
                       (i32.eq
-                        (get_local $10)
-                        (get_local $9)
+                        (get_local $7)
+                        (get_local $8)
                       )
                       (block
                         (i32.store
@@ -11709,10 +11738,10 @@
                         )
                         (i32.store
                           (i32.const 200)
-                          (get_local $8)
+                          (get_local $10)
                         )
                         (i32.store offset=4
-                          (get_local $8)
+                          (get_local $10)
                           (i32.or
                             (get_local $0)
                             (i32.const 1)
@@ -11722,7 +11751,7 @@
                       (block
                         (if
                           (i32.eq
-                            (get_local $10)
+                            (get_local $7)
                             (i32.load
                               (i32.const 196)
                             )
@@ -11741,10 +11770,10 @@
                             )
                             (i32.store
                               (i32.const 196)
-                              (get_local $8)
+                              (get_local $10)
                             )
                             (i32.store offset=4
-                              (get_local $8)
+                              (get_local $10)
                               (i32.or
                                 (get_local $0)
                                 (i32.const 1)
@@ -11752,7 +11781,7 @@
                             )
                             (i32.store
                               (i32.add
-                                (get_local $8)
+                                (get_local $10)
                                 (get_local $0)
                               )
                               (get_local $0)
@@ -11768,7 +11797,7 @@
                                   (i32.and
                                     (tee_local $0
                                       (i32.load offset=4
-                                        (get_local $10)
+                                        (get_local $7)
                                       )
                                     )
                                     (i32.const 3)
@@ -11776,7 +11805,7 @@
                                   (i32.const 1)
                                 )
                                 (block i32
-                                  (set_local $7
+                                  (set_local $9
                                     (i32.and
                                       (get_local $0)
                                       (i32.const -8)
@@ -11795,17 +11824,17 @@
                                         (i32.const 256)
                                       )
                                       (block
-                                        (set_local $2
+                                        (set_local $3
                                           (i32.load offset=12
-                                            (get_local $10)
+                                            (get_local $7)
                                           )
                                         )
                                         (block $do-once51
                                           (if
                                             (i32.ne
-                                              (tee_local $3
+                                              (tee_local $2
                                                 (i32.load offset=8
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                 )
                                               )
                                               (tee_local $0
@@ -11824,7 +11853,7 @@
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $3)
+                                                  (get_local $2)
                                                   (get_local $5)
                                                 )
                                                 (call $_abort)
@@ -11832,9 +11861,9 @@
                                               (br_if $do-once51
                                                 (i32.eq
                                                   (i32.load offset=12
-                                                    (get_local $3)
+                                                    (get_local $2)
                                                   )
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                 )
                                               )
                                               (call $_abort)
@@ -11843,8 +11872,8 @@
                                         )
                                         (if
                                           (i32.eq
-                                            (get_local $2)
                                             (get_local $3)
+                                            (get_local $2)
                                           )
                                           (block
                                             (i32.store
@@ -11868,19 +11897,19 @@
                                         (block $do-once53
                                           (if
                                             (i32.eq
-                                              (get_local $2)
+                                              (get_local $3)
                                               (get_local $0)
                                             )
                                             (set_local $21
                                               (i32.add
-                                                (get_local $2)
+                                                (get_local $3)
                                                 (i32.const 8)
                                               )
                                             )
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $2)
+                                                  (get_local $3)
                                                   (get_local $5)
                                                 )
                                                 (call $_abort)
@@ -11890,12 +11919,12 @@
                                                   (i32.load
                                                     (tee_local $0
                                                       (i32.add
-                                                        (get_local $2)
+                                                        (get_local $3)
                                                         (i32.const 8)
                                                       )
                                                     )
                                                   )
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                 )
                                                 (block
                                                   (set_local $21
@@ -11909,18 +11938,18 @@
                                           )
                                         )
                                         (i32.store offset=12
-                                          (get_local $3)
                                           (get_local $2)
+                                          (get_local $3)
                                         )
                                         (i32.store
                                           (get_local $21)
-                                          (get_local $3)
+                                          (get_local $2)
                                         )
                                       )
                                       (block
-                                        (set_local $12
+                                        (set_local $11
                                           (i32.load offset=24
-                                            (get_local $10)
+                                            (get_local $7)
                                           )
                                         )
                                         (block $do-once55
@@ -11928,10 +11957,10 @@
                                             (i32.eq
                                               (tee_local $0
                                                 (i32.load offset=12
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                 )
                                               )
-                                              (get_local $10)
+                                              (get_local $7)
                                             )
                                             (block
                                               (if
@@ -11940,9 +11969,9 @@
                                                     (i32.load
                                                       (tee_local $0
                                                         (i32.add
-                                                          (tee_local $3
+                                                          (tee_local $2
                                                             (i32.add
-                                                              (get_local $10)
+                                                              (get_local $7)
                                                               (i32.const 16)
                                                             )
                                                           )
@@ -11955,14 +11984,14 @@
                                                 (if
                                                   (tee_local $1
                                                     (i32.load
-                                                      (get_local $3)
+                                                      (get_local $2)
                                                     )
                                                   )
                                                   (set_local $0
-                                                    (get_local $3)
+                                                    (get_local $2)
                                                   )
                                                   (block
-                                                    (set_local $14
+                                                    (set_local $15
                                                       (i32.const 0)
                                                     )
                                                     (br $do-once55)
@@ -11971,9 +12000,9 @@
                                               )
                                               (loop $while-in58
                                                 (if
-                                                  (tee_local $3
+                                                  (tee_local $2
                                                     (i32.load
-                                                      (tee_local $2
+                                                      (tee_local $3
                                                         (i32.add
                                                           (get_local $1)
                                                           (i32.const 20)
@@ -11983,18 +12012,18 @@
                                                   )
                                                   (block
                                                     (set_local $1
-                                                      (get_local $3)
+                                                      (get_local $2)
                                                     )
                                                     (set_local $0
-                                                      (get_local $2)
+                                                      (get_local $3)
                                                     )
                                                     (br $while-in58)
                                                   )
                                                 )
                                                 (if
-                                                  (tee_local $3
+                                                  (tee_local $2
                                                     (i32.load
-                                                      (tee_local $2
+                                                      (tee_local $3
                                                         (i32.add
                                                           (get_local $1)
                                                           (i32.const 16)
@@ -12004,10 +12033,10 @@
                                                   )
                                                   (block
                                                     (set_local $1
-                                                      (get_local $3)
+                                                      (get_local $2)
                                                     )
                                                     (set_local $0
-                                                      (get_local $2)
+                                                      (get_local $3)
                                                     )
                                                     (br $while-in58)
                                                   )
@@ -12024,7 +12053,7 @@
                                                     (get_local $0)
                                                     (i32.const 0)
                                                   )
-                                                  (set_local $14
+                                                  (set_local $15
                                                     (get_local $1)
                                                   )
                                                 )
@@ -12033,9 +12062,9 @@
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (tee_local $2
+                                                  (tee_local $3
                                                     (i32.load offset=8
-                                                      (get_local $10)
+                                                      (get_local $7)
                                                     )
                                                   )
                                                   (get_local $5)
@@ -12045,14 +12074,14 @@
                                               (if
                                                 (i32.ne
                                                   (i32.load
-                                                    (tee_local $3
+                                                    (tee_local $2
                                                       (i32.add
-                                                        (get_local $2)
+                                                        (get_local $3)
                                                         (i32.const 12)
                                                       )
                                                     )
                                                   )
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                 )
                                                 (call $_abort)
                                               )
@@ -12066,18 +12095,18 @@
                                                       )
                                                     )
                                                   )
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                 )
                                                 (block
                                                   (i32.store
-                                                    (get_local $3)
+                                                    (get_local $2)
                                                     (get_local $0)
                                                   )
                                                   (i32.store
                                                     (get_local $1)
-                                                    (get_local $2)
+                                                    (get_local $3)
                                                   )
-                                                  (set_local $14
+                                                  (set_local $15
                                                     (get_local $0)
                                                   )
                                                 )
@@ -12088,13 +12117,13 @@
                                         )
                                         (br_if $label$break$L331
                                           (i32.eqz
-                                            (get_local $12)
+                                            (get_local $11)
                                           )
                                         )
                                         (block $do-once59
                                           (if
                                             (i32.eq
-                                              (get_local $10)
+                                              (get_local $7)
                                               (i32.load
                                                 (tee_local $0
                                                   (i32.add
@@ -12102,7 +12131,7 @@
                                                     (i32.shl
                                                       (tee_local $1
                                                         (i32.load offset=28
-                                                          (get_local $10)
+                                                          (get_local $7)
                                                         )
                                                       )
                                                       (i32.const 2)
@@ -12114,10 +12143,10 @@
                                             (block
                                               (i32.store
                                                 (get_local $0)
-                                                (get_local $14)
+                                                (get_local $15)
                                               )
                                               (br_if $do-once59
-                                                (get_local $14)
+                                                (get_local $15)
                                               )
                                               (i32.store
                                                 (i32.const 180)
@@ -12139,7 +12168,7 @@
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $12)
+                                                  (get_local $11)
                                                   (i32.load
                                                     (i32.const 192)
                                                   )
@@ -12151,25 +12180,25 @@
                                                   (i32.load
                                                     (tee_local $0
                                                       (i32.add
-                                                        (get_local $12)
+                                                        (get_local $11)
                                                         (i32.const 16)
                                                       )
                                                     )
                                                   )
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                 )
                                                 (i32.store
                                                   (get_local $0)
-                                                  (get_local $14)
+                                                  (get_local $15)
                                                 )
                                                 (i32.store offset=20
-                                                  (get_local $12)
-                                                  (get_local $14)
+                                                  (get_local $11)
+                                                  (get_local $15)
                                                 )
                                               )
                                               (br_if $label$break$L331
                                                 (i32.eqz
-                                                  (get_local $14)
+                                                  (get_local $15)
                                                 )
                                               )
                                             )
@@ -12177,7 +12206,7 @@
                                         )
                                         (if
                                           (i32.lt_u
-                                            (get_local $14)
+                                            (get_local $15)
                                             (tee_local $1
                                               (i32.load
                                                 (i32.const 192)
@@ -12187,15 +12216,15 @@
                                           (call $_abort)
                                         )
                                         (i32.store offset=24
-                                          (get_local $14)
-                                          (get_local $12)
+                                          (get_local $15)
+                                          (get_local $11)
                                         )
                                         (if
-                                          (tee_local $3
+                                          (tee_local $2
                                             (i32.load
                                               (tee_local $0
                                                 (i32.add
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                   (i32.const 16)
                                                 )
                                               )
@@ -12203,18 +12232,18 @@
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $3)
+                                              (get_local $2)
                                               (get_local $1)
                                             )
                                             (call $_abort)
                                             (block
                                               (i32.store offset=16
-                                                (get_local $14)
-                                                (get_local $3)
+                                                (get_local $15)
+                                                (get_local $2)
                                               )
                                               (i32.store offset=24
-                                                (get_local $3)
-                                                (get_local $14)
+                                                (get_local $2)
+                                                (get_local $15)
                                               )
                                             )
                                           )
@@ -12238,12 +12267,12 @@
                                           (call $_abort)
                                           (block
                                             (i32.store offset=20
-                                              (get_local $14)
+                                              (get_local $15)
                                               (get_local $0)
                                             )
                                             (i32.store offset=24
                                               (get_local $0)
-                                              (get_local $14)
+                                              (get_local $15)
                                             )
                                           )
                                         )
@@ -12252,16 +12281,16 @@
                                   )
                                   (set_local $4
                                     (i32.add
-                                      (get_local $7)
+                                      (get_local $9)
                                       (get_local $4)
                                     )
                                   )
                                   (i32.add
-                                    (get_local $10)
                                     (get_local $7)
+                                    (get_local $9)
                                   )
                                 )
-                                (get_local $10)
+                                (get_local $7)
                               )
                               (i32.const 4)
                             )
@@ -12274,7 +12303,7 @@
                           )
                         )
                         (i32.store offset=4
-                          (get_local $8)
+                          (get_local $10)
                           (i32.or
                             (get_local $4)
                             (i32.const 1)
@@ -12282,7 +12311,7 @@
                         )
                         (i32.store
                           (i32.add
-                            (get_local $8)
+                            (get_local $10)
                             (get_local $4)
                           )
                           (get_local $4)
@@ -12299,7 +12328,7 @@
                             (i32.const 256)
                           )
                           (block
-                            (set_local $3
+                            (set_local $2
                               (i32.add
                                 (i32.const 216)
                                 (i32.shl
@@ -12333,7 +12362,7 @@
                                         (i32.load
                                           (tee_local $1
                                             (i32.add
-                                              (get_local $3)
+                                              (get_local $2)
                                               (i32.const 8)
                                             )
                                           )
@@ -12347,7 +12376,7 @@
                                       (set_local $22
                                         (get_local $1)
                                       )
-                                      (set_local $11
+                                      (set_local $17
                                         (get_local $0)
                                       )
                                       (br $do-once63)
@@ -12365,31 +12394,31 @@
                                   )
                                   (set_local $22
                                     (i32.add
-                                      (get_local $3)
+                                      (get_local $2)
                                       (i32.const 8)
                                     )
                                   )
-                                  (set_local $11
-                                    (get_local $3)
+                                  (set_local $17
+                                    (get_local $2)
                                   )
                                 )
                               )
                             )
                             (i32.store
                               (get_local $22)
-                              (get_local $8)
+                              (get_local $10)
                             )
                             (i32.store offset=12
-                              (get_local $11)
-                              (get_local $8)
+                              (get_local $17)
+                              (get_local $10)
                             )
                             (i32.store offset=8
-                              (get_local $8)
-                              (get_local $11)
+                              (get_local $10)
+                              (get_local $17)
                             )
                             (i32.store offset=12
-                              (get_local $8)
-                              (get_local $3)
+                              (get_local $10)
+                              (get_local $2)
                             )
                             (br $do-once48)
                           )
@@ -12435,7 +12464,7 @@
                                                                 (tee_local $1
                                                                   (i32.shl
                                                                     (get_local $0)
-                                                                    (tee_local $3
+                                                                    (tee_local $2
                                                                       (i32.and
                                                                         (i32.shr_u
                                                                           (i32.add
@@ -12456,7 +12485,7 @@
                                                             (i32.const 4)
                                                           )
                                                         )
-                                                        (get_local $3)
+                                                        (get_local $2)
                                                       )
                                                       (tee_local $0
                                                         (i32.and
@@ -12506,13 +12535,13 @@
                           )
                         )
                         (i32.store offset=28
-                          (get_local $8)
+                          (get_local $10)
                           (get_local $3)
                         )
                         (i32.store offset=4
                           (tee_local $0
                             (i32.add
-                              (get_local $8)
+                              (get_local $10)
                               (i32.const 16)
                             )
                           )
@@ -12548,19 +12577,19 @@
                             )
                             (i32.store
                               (get_local $2)
-                              (get_local $8)
+                              (get_local $10)
                             )
                             (i32.store offset=24
-                              (get_local $8)
+                              (get_local $10)
                               (get_local $2)
                             )
                             (i32.store offset=12
-                              (get_local $8)
-                              (get_local $8)
+                              (get_local $10)
+                              (get_local $10)
                             )
                             (i32.store offset=8
-                              (get_local $8)
-                              (get_local $8)
+                              (get_local $10)
+                              (get_local $10)
                             )
                             (br $do-once48)
                           )
@@ -12655,19 +12684,19 @@
                               (block
                                 (i32.store
                                   (get_local $3)
-                                  (get_local $8)
+                                  (get_local $10)
                                 )
                                 (i32.store offset=24
-                                  (get_local $8)
+                                  (get_local $10)
                                   (get_local $0)
                                 )
                                 (i32.store offset=12
-                                  (get_local $8)
-                                  (get_local $8)
+                                  (get_local $10)
+                                  (get_local $10)
                                 )
                                 (i32.store offset=8
-                                  (get_local $8)
-                                  (get_local $8)
+                                  (get_local $10)
+                                  (get_local $10)
                                 )
                                 (br $do-once48)
                               )
@@ -12677,9 +12706,9 @@
                           (if
                             (i32.and
                               (i32.ge_u
-                                (tee_local $2
+                                (tee_local $3
                                   (i32.load
-                                    (tee_local $3
+                                    (tee_local $2
                                       (i32.add
                                         (get_local $0)
                                         (i32.const 8)
@@ -12700,23 +12729,23 @@
                             )
                             (block
                               (i32.store offset=12
-                                (get_local $2)
-                                (get_local $8)
+                                (get_local $3)
+                                (get_local $10)
                               )
                               (i32.store
-                                (get_local $3)
-                                (get_local $8)
+                                (get_local $2)
+                                (get_local $10)
                               )
                               (i32.store offset=8
-                                (get_local $8)
-                                (get_local $2)
+                                (get_local $10)
+                                (get_local $3)
                               )
                               (i32.store offset=12
-                                (get_local $8)
+                                (get_local $10)
                                 (get_local $0)
                               )
                               (i32.store offset=24
-                                (get_local $8)
+                                (get_local $10)
                                 (i32.const 0)
                               )
                             )
@@ -12739,24 +12768,30 @@
               (block $while-out69
                 (if
                   (i32.le_u
-                    (tee_local $2
+                    (tee_local $1
                       (i32.load
                         (get_local $4)
                       )
                     )
-                    (get_local $9)
+                    (get_local $8)
                   )
-                  (br_if $while-out69
+                  (if
                     (i32.gt_u
-                      (tee_local $2
+                      (tee_local $1
                         (i32.add
-                          (get_local $2)
+                          (get_local $1)
                           (i32.load offset=4
                             (get_local $4)
                           )
                         )
                       )
-                      (get_local $9)
+                      (get_local $8)
+                    )
+                    (block
+                      (set_local $4
+                        (get_local $1)
+                      )
+                      (br $while-out69)
                     )
                   )
                 )
@@ -12768,11 +12803,11 @@
                 (br $while-in70)
               )
             )
-            (set_local $7
+            (set_local $9
               (i32.add
-                (tee_local $4
+                (tee_local $1
                   (i32.add
-                    (get_local $2)
+                    (get_local $4)
                     (i32.const -47)
                   )
                 )
@@ -12783,31 +12818,31 @@
               (i32.add
                 (tee_local $11
                   (select
-                    (get_local $9)
-                    (tee_local $4
+                    (get_local $8)
+                    (tee_local $1
                       (i32.add
-                        (get_local $4)
+                        (get_local $1)
                         (select
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (get_local $7)
+                              (get_local $9)
                             )
                             (i32.const 7)
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $7)
+                            (get_local $9)
                             (i32.const 7)
                           )
                         )
                       )
                     )
                     (i32.lt_u
-                      (get_local $4)
-                      (tee_local $7
+                      (get_local $1)
+                      (tee_local $9
                         (i32.add
-                          (get_local $9)
+                          (get_local $8)
                           (i32.const 16)
                         )
                       )
@@ -12822,12 +12857,12 @@
               (tee_local $6
                 (i32.add
                   (get_local $3)
-                  (tee_local $4
+                  (tee_local $1
                     (select
                       (i32.and
                         (i32.sub
                           (i32.const 0)
-                          (tee_local $4
+                          (tee_local $1
                             (i32.add
                               (get_local $3)
                               (i32.const 8)
@@ -12838,7 +12873,7 @@
                       )
                       (i32.const 0)
                       (i32.and
-                        (get_local $4)
+                        (get_local $1)
                         (i32.const 7)
                       )
                     )
@@ -12848,27 +12883,27 @@
             )
             (i32.store
               (i32.const 188)
-              (tee_local $4
+              (tee_local $1
                 (i32.sub
                   (i32.add
-                    (get_local $1)
+                    (get_local $2)
                     (i32.const -40)
                   )
-                  (get_local $4)
+                  (get_local $1)
                 )
               )
             )
             (i32.store offset=4
               (get_local $6)
               (i32.or
-                (get_local $4)
+                (get_local $1)
                 (i32.const 1)
               )
             )
             (i32.store offset=4
               (i32.add
                 (get_local $6)
-                (get_local $4)
+                (get_local $1)
               )
               (i32.const 40)
             )
@@ -12879,7 +12914,7 @@
               )
             )
             (i32.store
-              (tee_local $4
+              (tee_local $6
                 (i32.add
                   (get_local $11)
                   (i32.const 4)
@@ -12917,7 +12952,7 @@
             )
             (i32.store
               (i32.const 628)
-              (get_local $1)
+              (get_local $2)
             )
             (i32.store
               (i32.const 636)
@@ -12949,32 +12984,32 @@
                     (get_local $1)
                     (i32.const 4)
                   )
-                  (get_local $2)
+                  (get_local $4)
                 )
               )
             )
             (if
               (i32.ne
                 (get_local $11)
-                (get_local $9)
+                (get_local $8)
               )
               (block
                 (i32.store
-                  (get_local $4)
+                  (get_local $6)
                   (i32.and
                     (i32.load
-                      (get_local $4)
+                      (get_local $6)
                     )
                     (i32.const -2)
                   )
                 )
                 (i32.store offset=4
-                  (get_local $9)
+                  (get_local $8)
                   (i32.or
                     (tee_local $6
                       (i32.sub
                         (get_local $11)
-                        (get_local $9)
+                        (get_local $8)
                       )
                     )
                     (i32.const 1)
@@ -12996,7 +13031,7 @@
                     (i32.const 256)
                   )
                   (block
-                    (set_local $2
+                    (set_local $3
                       (i32.add
                         (i32.const 216)
                         (i32.shl
@@ -13010,7 +13045,7 @@
                     )
                     (if
                       (i32.and
-                        (tee_local $3
+                        (tee_local $2
                           (i32.load
                             (i32.const 176)
                           )
@@ -13026,9 +13061,9 @@
                         (i32.lt_u
                           (tee_local $1
                             (i32.load
-                              (tee_local $3
+                              (tee_local $2
                                 (i32.add
-                                  (get_local $2)
+                                  (get_local $3)
                                   (i32.const 8)
                                 )
                               )
@@ -13041,9 +13076,9 @@
                         (call $_abort)
                         (block
                           (set_local $23
-                            (get_local $3)
+                            (get_local $2)
                           )
-                          (set_local $12
+                          (set_local $10
                             (get_local $1)
                           )
                         )
@@ -13052,45 +13087,45 @@
                         (i32.store
                           (i32.const 176)
                           (i32.or
-                            (get_local $3)
+                            (get_local $2)
                             (get_local $1)
                           )
                         )
                         (set_local $23
                           (i32.add
-                            (get_local $2)
+                            (get_local $3)
                             (i32.const 8)
                           )
                         )
-                        (set_local $12
-                          (get_local $2)
+                        (set_local $10
+                          (get_local $3)
                         )
                       )
                     )
                     (i32.store
                       (get_local $23)
-                      (get_local $9)
+                      (get_local $8)
                     )
                     (i32.store offset=12
-                      (get_local $12)
-                      (get_local $9)
+                      (get_local $10)
+                      (get_local $8)
                     )
                     (i32.store offset=8
-                      (get_local $9)
-                      (get_local $12)
+                      (get_local $8)
+                      (get_local $10)
                     )
                     (i32.store offset=12
-                      (get_local $9)
-                      (get_local $2)
+                      (get_local $8)
+                      (get_local $3)
                     )
                     (br $do-once40)
                   )
                 )
-                (set_local $4
+                (set_local $3
                   (i32.add
                     (i32.const 480)
                     (i32.shl
-                      (tee_local $2
+                      (tee_local $4
                         (if i32
                           (tee_local $1
                             (i32.shr_u
@@ -13119,10 +13154,10 @@
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (tee_local $3
+                                                      (tee_local $2
                                                         (i32.shl
                                                           (get_local $1)
-                                                          (tee_local $2
+                                                          (tee_local $3
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
@@ -13143,15 +13178,15 @@
                                                   (i32.const 4)
                                                 )
                                               )
-                                              (get_local $2)
+                                              (get_local $3)
                                             )
                                             (tee_local $1
                                               (i32.and
                                                 (i32.shr_u
                                                   (i32.add
-                                                    (tee_local $3
+                                                    (tee_local $2
                                                       (i32.shl
-                                                        (get_local $3)
+                                                        (get_local $2)
                                                         (get_local $1)
                                                       )
                                                     )
@@ -13166,7 +13201,7 @@
                                         )
                                         (i32.shr_u
                                           (i32.shl
-                                            (get_local $3)
+                                            (get_local $2)
                                             (get_local $1)
                                           )
                                           (i32.const 15)
@@ -13192,21 +13227,21 @@
                   )
                 )
                 (i32.store offset=28
-                  (get_local $9)
-                  (get_local $2)
+                  (get_local $8)
+                  (get_local $4)
                 )
                 (i32.store offset=20
-                  (get_local $9)
+                  (get_local $8)
                   (i32.const 0)
                 )
                 (i32.store
-                  (get_local $7)
+                  (get_local $9)
                   (i32.const 0)
                 )
                 (if
                   (i32.eqz
                     (i32.and
-                      (tee_local $3
+                      (tee_local $2
                         (i32.load
                           (i32.const 180)
                         )
@@ -13214,7 +13249,7 @@
                       (tee_local $1
                         (i32.shl
                           (i32.const 1)
-                          (get_local $2)
+                          (get_local $4)
                         )
                       )
                     )
@@ -13223,30 +13258,30 @@
                     (i32.store
                       (i32.const 180)
                       (i32.or
-                        (get_local $3)
+                        (get_local $2)
                         (get_local $1)
                       )
                     )
                     (i32.store
-                      (get_local $4)
-                      (get_local $9)
+                      (get_local $3)
+                      (get_local $8)
                     )
                     (i32.store offset=24
-                      (get_local $9)
-                      (get_local $4)
+                      (get_local $8)
+                      (get_local $3)
                     )
                     (i32.store offset=12
-                      (get_local $9)
-                      (get_local $9)
+                      (get_local $8)
+                      (get_local $8)
                     )
                     (i32.store offset=8
-                      (get_local $9)
-                      (get_local $9)
+                      (get_local $8)
+                      (get_local $8)
                     )
                     (br $do-once40)
                   )
                 )
-                (set_local $2
+                (set_local $4
                   (i32.shl
                     (get_local $6)
                     (select
@@ -13254,12 +13289,12 @@
                       (i32.sub
                         (i32.const 25)
                         (i32.shr_u
-                          (get_local $2)
+                          (get_local $4)
                           (i32.const 1)
                         )
                       )
                       (i32.eq
-                        (get_local $2)
+                        (get_local $4)
                         (i32.const 31)
                       )
                     )
@@ -13267,7 +13302,7 @@
                 )
                 (set_local $1
                   (i32.load
-                    (get_local $4)
+                    (get_local $3)
                   )
                 )
                 (block $jumpthreading$outer$8
@@ -13285,17 +13320,17 @@
                             (get_local $6)
                           )
                         )
-                        (set_local $4
+                        (set_local $3
                           (i32.shl
-                            (get_local $2)
+                            (get_local $4)
                             (i32.const 1)
                           )
                         )
                         (br_if $jumpthreading$inner$7
                           (i32.eqz
-                            (tee_local $3
+                            (tee_local $2
                               (i32.load
-                                (tee_local $2
+                                (tee_local $4
                                   (i32.add
                                     (i32.add
                                       (get_local $1)
@@ -13303,7 +13338,7 @@
                                     )
                                     (i32.shl
                                       (i32.shr_u
-                                        (get_local $2)
+                                        (get_local $4)
                                         (i32.const 31)
                                       )
                                       (i32.const 2)
@@ -13315,11 +13350,11 @@
                           )
                         )
                         (block
-                          (set_local $2
-                            (get_local $4)
+                          (set_local $4
+                            (get_local $3)
                           )
                           (set_local $1
-                            (get_local $3)
+                            (get_local $2)
                           )
                           (br $while-in74)
                         )
@@ -13327,7 +13362,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $2)
+                        (get_local $4)
                         (i32.load
                           (i32.const 192)
                         )
@@ -13335,20 +13370,20 @@
                       (call $_abort)
                       (block
                         (i32.store
-                          (get_local $2)
-                          (get_local $9)
+                          (get_local $4)
+                          (get_local $8)
                         )
                         (i32.store offset=24
-                          (get_local $9)
+                          (get_local $8)
                           (get_local $1)
                         )
                         (i32.store offset=12
-                          (get_local $9)
-                          (get_local $9)
+                          (get_local $8)
+                          (get_local $8)
                         )
                         (i32.store offset=8
-                          (get_local $9)
-                          (get_local $9)
+                          (get_local $8)
+                          (get_local $8)
                         )
                         (br $do-once40)
                       )
@@ -13360,7 +13395,7 @@
                       (i32.ge_u
                         (tee_local $4
                           (i32.load
-                            (tee_local $2
+                            (tee_local $3
                               (i32.add
                                 (get_local $1)
                                 (i32.const 8)
@@ -13368,7 +13403,7 @@
                             )
                           )
                         )
-                        (tee_local $3
+                        (tee_local $2
                           (i32.load
                             (i32.const 192)
                           )
@@ -13376,28 +13411,28 @@
                       )
                       (i32.ge_u
                         (get_local $1)
-                        (get_local $3)
+                        (get_local $2)
                       )
                     )
                     (block
                       (i32.store offset=12
                         (get_local $4)
-                        (get_local $9)
+                        (get_local $8)
                       )
                       (i32.store
-                        (get_local $2)
-                        (get_local $9)
+                        (get_local $3)
+                        (get_local $8)
                       )
                       (i32.store offset=8
-                        (get_local $9)
+                        (get_local $8)
                         (get_local $4)
                       )
                       (i32.store offset=12
-                        (get_local $9)
+                        (get_local $8)
                         (get_local $1)
                       )
                       (i32.store offset=24
-                        (get_local $9)
+                        (get_local $8)
                         (i32.const 0)
                       )
                     )
@@ -13411,7 +13446,7 @@
             (if
               (i32.or
                 (i32.eqz
-                  (tee_local $2
+                  (tee_local $1
                     (i32.load
                       (i32.const 192)
                     )
@@ -13419,7 +13454,7 @@
                 )
                 (i32.lt_u
                   (get_local $3)
-                  (get_local $2)
+                  (get_local $1)
                 )
               )
               (i32.store
@@ -13433,7 +13468,7 @@
             )
             (i32.store
               (i32.const 628)
-              (get_local $1)
+              (get_local $2)
             )
             (i32.store
               (i32.const 636)
@@ -13449,7 +13484,7 @@
               (i32.const 208)
               (i32.const -1)
             )
-            (set_local $2
+            (set_local $1
               (i32.const 0)
             )
             (loop $while-in43
@@ -13459,7 +13494,7 @@
                     (i32.const 216)
                     (i32.shl
                       (i32.shl
-                        (get_local $2)
+                        (get_local $1)
                         (i32.const 1)
                       )
                       (i32.const 2)
@@ -13474,9 +13509,9 @@
               )
               (br_if $while-in43
                 (i32.ne
-                  (tee_local $2
+                  (tee_local $1
                     (i32.add
-                      (get_local $2)
+                      (get_local $1)
                       (i32.const 1)
                     )
                   )
@@ -13486,15 +13521,15 @@
             )
             (i32.store
               (i32.const 200)
-              (tee_local $2
+              (tee_local $3
                 (i32.add
                   (get_local $3)
-                  (tee_local $3
+                  (tee_local $1
                     (select
                       (i32.and
                         (i32.sub
                           (i32.const 0)
-                          (tee_local $3
+                          (tee_local $1
                             (i32.add
                               (get_local $3)
                               (i32.const 8)
@@ -13505,7 +13540,7 @@
                       )
                       (i32.const 0)
                       (i32.and
-                        (get_local $3)
+                        (get_local $1)
                         (i32.const 7)
                       )
                     )
@@ -13518,15 +13553,15 @@
               (tee_local $1
                 (i32.sub
                   (i32.add
-                    (get_local $1)
+                    (get_local $2)
                     (i32.const -40)
                   )
-                  (get_local $3)
+                  (get_local $1)
                 )
               )
             )
             (i32.store offset=4
-              (get_local $2)
+              (get_local $3)
               (i32.or
                 (get_local $1)
                 (i32.const 1)
@@ -13534,7 +13569,7 @@
             )
             (i32.store offset=4
               (i32.add
-                (get_local $2)
+                (get_local $3)
                 (get_local $1)
               )
               (i32.const 40)
@@ -13560,7 +13595,7 @@
         (block
           (i32.store
             (i32.const 188)
-            (tee_local $3
+            (tee_local $2
               (i32.sub
                 (get_local $1)
                 (get_local $0)
@@ -13571,7 +13606,7 @@
             (i32.const 200)
             (tee_local $1
               (i32.add
-                (tee_local $2
+                (tee_local $3
                   (i32.load
                     (i32.const 200)
                   )
@@ -13583,12 +13618,12 @@
           (i32.store offset=4
             (get_local $1)
             (i32.or
-              (get_local $3)
+              (get_local $2)
               (i32.const 1)
             )
           )
           (i32.store offset=4
-            (get_local $2)
+            (get_local $3)
             (i32.or
               (get_local $0)
               (i32.const 3)
@@ -13596,7 +13631,7 @@
           )
           (return
             (i32.add
-              (get_local $2)
+              (get_local $3)
               (i32.const 8)
             )
           )
@@ -13633,7 +13668,7 @@
     )
     (if
       (i32.lt_u
-        (tee_local $1
+        (tee_local $4
           (i32.add
             (get_local $0)
             (i32.const -8)
@@ -13649,9 +13684,9 @@
     )
     (if
       (i32.eq
-        (tee_local $5
+        (tee_local $10
           (i32.and
-            (tee_local $7
+            (tee_local $2
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -13666,12 +13701,12 @@
       )
       (call $_abort)
     )
-    (set_local $8
+    (set_local $6
       (i32.add
-        (get_local $1)
+        (get_local $4)
         (tee_local $0
           (i32.and
-            (get_local $7)
+            (get_local $2)
             (i32.const -8)
           )
         )
@@ -13680,43 +13715,43 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $7)
+          (get_local $2)
           (i32.const 1)
         )
         (block
           (set_local $3
-            (get_local $1)
+            (get_local $4)
           )
-          (set_local $4
+          (set_local $1
             (get_local $0)
           )
         )
         (block
-          (set_local $7
+          (set_local $8
             (i32.load
-              (get_local $1)
+              (get_local $4)
             )
           )
           (if
             (i32.eqz
-              (get_local $5)
+              (get_local $10)
             )
             (return)
           )
-          (set_local $0
+          (set_local $2
             (i32.add
-              (get_local $7)
+              (get_local $8)
               (get_local $0)
             )
           )
           (if
             (i32.lt_u
-              (tee_local $1
+              (tee_local $0
                 (i32.add
-                  (get_local $1)
+                  (get_local $4)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $7)
+                    (get_local $8)
                   )
                 )
               )
@@ -13726,7 +13761,7 @@
           )
           (if
             (i32.eq
-              (get_local $1)
+              (get_local $0)
               (i32.load
                 (i32.const 196)
               )
@@ -13735,11 +13770,11 @@
               (if
                 (i32.ne
                   (i32.and
-                    (tee_local $4
+                    (tee_local $3
                       (i32.load
-                        (tee_local $3
+                        (tee_local $1
                           (i32.add
-                            (get_local $8)
+                            (get_local $6)
                             (i32.const 4)
                           )
                         )
@@ -13751,72 +13786,72 @@
                 )
                 (block
                   (set_local $3
-                    (get_local $1)
-                  )
-                  (set_local $4
                     (get_local $0)
+                  )
+                  (set_local $1
+                    (get_local $2)
                   )
                   (br $do-once)
                 )
               )
               (i32.store
                 (i32.const 184)
-                (get_local $0)
+                (get_local $2)
               )
               (i32.store
-                (get_local $3)
+                (get_local $1)
                 (i32.and
-                  (get_local $4)
+                  (get_local $3)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $1)
+                (get_local $0)
                 (i32.or
-                  (get_local $0)
+                  (get_local $2)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
-                  (get_local $1)
                   (get_local $0)
+                  (get_local $2)
                 )
-                (get_local $0)
+                (get_local $2)
               )
               (return)
             )
           )
-          (set_local $5
+          (set_local $10
             (i32.shr_u
-              (get_local $7)
+              (get_local $8)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $7)
+              (get_local $8)
               (i32.const 256)
             )
             (block
-              (set_local $6
+              (set_local $3
                 (i32.load offset=12
-                  (get_local $1)
+                  (get_local $0)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $3
+                  (tee_local $4
                     (i32.load offset=8
-                      (get_local $1)
+                      (get_local $0)
                     )
                   )
-                  (tee_local $4
+                  (tee_local $1
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $5)
+                          (get_local $10)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -13827,7 +13862,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $3)
+                      (get_local $4)
                       (get_local $11)
                     )
                     (call $_abort)
@@ -13835,9 +13870,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $3)
+                        (get_local $4)
                       )
-                      (get_local $1)
+                      (get_local $0)
                     )
                     (call $_abort)
                   )
@@ -13845,8 +13880,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $6)
                   (get_local $3)
+                  (get_local $4)
                 )
                 (block
                   (i32.store
@@ -13858,36 +13893,36 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $5)
+                          (get_local $10)
                         )
                         (i32.const -1)
                       )
                     )
                   )
                   (set_local $3
-                    (get_local $1)
-                  )
-                  (set_local $4
                     (get_local $0)
+                  )
+                  (set_local $1
+                    (get_local $2)
                   )
                   (br $do-once)
                 )
               )
               (if
                 (i32.eq
-                  (get_local $6)
-                  (get_local $4)
+                  (get_local $3)
+                  (get_local $1)
                 )
-                (set_local $2
+                (set_local $5
                   (i32.add
-                    (get_local $6)
+                    (get_local $3)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $6)
+                      (get_local $3)
                       (get_local $11)
                     )
                     (call $_abort)
@@ -13895,84 +13930,84 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $4
+                        (tee_local $1
                           (i32.add
-                            (get_local $6)
+                            (get_local $3)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $1)
+                      (get_local $0)
                     )
-                    (set_local $2
-                      (get_local $4)
+                    (set_local $5
+                      (get_local $1)
                     )
                     (call $_abort)
                   )
                 )
               )
               (i32.store offset=12
+                (get_local $4)
                 (get_local $3)
-                (get_local $6)
               )
               (i32.store
-                (get_local $2)
-                (get_local $3)
+                (get_local $5)
+                (get_local $4)
               )
               (set_local $3
-                (get_local $1)
-              )
-              (set_local $4
                 (get_local $0)
+              )
+              (set_local $1
+                (get_local $2)
               )
               (br $do-once)
             )
           )
           (set_local $12
             (i32.load offset=24
-              (get_local $1)
+              (get_local $0)
             )
           )
           (block $do-once0
             (if
               (i32.eq
-                (tee_local $2
+                (tee_local $4
                   (i32.load offset=12
-                    (get_local $1)
+                    (get_local $0)
                   )
                 )
-                (get_local $1)
+                (get_local $0)
               )
               (block
                 (if
-                  (i32.eqz
-                    (tee_local $5
-                      (i32.load
-                        (tee_local $2
-                          (i32.add
-                            (tee_local $7
-                              (i32.add
-                                (get_local $1)
-                                (i32.const 16)
-                              )
+                  (tee_local $4
+                    (i32.load
+                      (tee_local $8
+                        (i32.add
+                          (tee_local $5
+                            (i32.add
+                              (get_local $0)
+                              (i32.const 16)
                             )
-                            (i32.const 4)
                           )
+                          (i32.const 4)
                         )
                       )
                     )
                   )
+                  (set_local $5
+                    (get_local $8)
+                  )
                   (if
-                    (tee_local $5
-                      (i32.load
-                        (get_local $7)
+                    (i32.eqz
+                      (tee_local $4
+                        (i32.load
+                          (get_local $5)
+                        )
                       )
                     )
-                    (set_local $2
-                      (get_local $7)
-                    )
                     (block
-                      (set_local $6
+                      (set_local $7
                         (i32.const 0)
                       )
                       (br $do-once0)
@@ -13981,43 +14016,43 @@
                 )
                 (loop $while-in
                   (if
-                    (tee_local $7
+                    (tee_local $10
                       (i32.load
-                        (tee_local $10
+                        (tee_local $8
                           (i32.add
-                            (get_local $5)
+                            (get_local $4)
                             (i32.const 20)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $5
-                        (get_local $7)
-                      )
-                      (set_local $2
+                      (set_local $4
                         (get_local $10)
+                      )
+                      (set_local $5
+                        (get_local $8)
                       )
                       (br $while-in)
                     )
                   )
                   (if
-                    (tee_local $7
+                    (tee_local $10
                       (i32.load
-                        (tee_local $10
+                        (tee_local $8
                           (i32.add
-                            (get_local $5)
+                            (get_local $4)
                             (i32.const 16)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $5
-                        (get_local $7)
-                      )
-                      (set_local $2
+                      (set_local $4
                         (get_local $10)
+                      )
+                      (set_local $5
+                        (get_local $8)
                       )
                       (br $while-in)
                     )
@@ -14025,17 +14060,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $2)
+                    (get_local $5)
                     (get_local $11)
                   )
                   (call $_abort)
                   (block
                     (i32.store
-                      (get_local $2)
+                      (get_local $5)
                       (i32.const 0)
                     )
-                    (set_local $6
-                      (get_local $5)
+                    (set_local $7
+                      (get_local $4)
                     )
                   )
                 )
@@ -14043,9 +14078,9 @@
               (block
                 (if
                   (i32.lt_u
-                    (tee_local $10
+                    (tee_local $5
                       (i32.load offset=8
-                        (get_local $1)
+                        (get_local $0)
                       )
                     )
                     (get_local $11)
@@ -14055,40 +14090,40 @@
                 (if
                   (i32.ne
                     (i32.load
-                      (tee_local $7
+                      (tee_local $8
                         (i32.add
-                          (get_local $10)
+                          (get_local $5)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $1)
+                    (get_local $0)
                   )
                   (call $_abort)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $5
+                      (tee_local $10
                         (i32.add
-                          (get_local $2)
+                          (get_local $4)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $1)
+                    (get_local $0)
                   )
                   (block
                     (i32.store
-                      (get_local $7)
-                      (get_local $2)
+                      (get_local $8)
+                      (get_local $4)
                     )
                     (i32.store
-                      (get_local $5)
                       (get_local $10)
+                      (get_local $5)
                     )
-                    (set_local $6
-                      (get_local $2)
+                    (set_local $7
+                      (get_local $4)
                     )
                   )
                   (call $_abort)
@@ -14101,15 +14136,15 @@
             (block
               (if
                 (i32.eq
-                  (get_local $1)
+                  (get_local $0)
                   (i32.load
-                    (tee_local $2
+                    (tee_local $5
                       (i32.add
                         (i32.const 480)
                         (i32.shl
-                          (tee_local $5
+                          (tee_local $4
                             (i32.load offset=28
-                              (get_local $1)
+                              (get_local $0)
                             )
                           )
                           (i32.const 2)
@@ -14120,12 +14155,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $2)
-                    (get_local $6)
+                    (get_local $5)
+                    (get_local $7)
                   )
                   (if
                     (i32.eqz
-                      (get_local $6)
+                      (get_local $7)
                     )
                     (block
                       (i32.store
@@ -14137,17 +14172,17 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $5)
+                              (get_local $4)
                             )
                             (i32.const -1)
                           )
                         )
                       )
                       (set_local $3
-                        (get_local $1)
-                      )
-                      (set_local $4
                         (get_local $0)
+                      )
+                      (set_local $1
+                        (get_local $2)
                       )
                       (br $do-once)
                     )
@@ -14166,34 +14201,34 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $2
+                        (tee_local $4
                           (i32.add
                             (get_local $12)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $1)
+                      (get_local $0)
                     )
                     (i32.store
-                      (get_local $2)
-                      (get_local $6)
+                      (get_local $4)
+                      (get_local $7)
                     )
                     (i32.store offset=20
                       (get_local $12)
-                      (get_local $6)
+                      (get_local $7)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $6)
+                      (get_local $7)
                     )
                     (block
                       (set_local $3
-                        (get_local $1)
-                      )
-                      (set_local $4
                         (get_local $0)
+                      )
+                      (set_local $1
+                        (get_local $2)
                       )
                       (br $do-once)
                     )
@@ -14202,7 +14237,7 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $6)
+                  (get_local $7)
                   (tee_local $5
                     (i32.load
                       (i32.const 192)
@@ -14212,15 +14247,15 @@
                 (call $_abort)
               )
               (i32.store offset=24
-                (get_local $6)
+                (get_local $7)
                 (get_local $12)
               )
               (if
-                (tee_local $7
+                (tee_local $4
                   (i32.load
-                    (tee_local $2
+                    (tee_local $8
                       (i32.add
-                        (get_local $1)
+                        (get_local $0)
                         (i32.const 16)
                       )
                     )
@@ -14228,31 +14263,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $7)
+                    (get_local $4)
                     (get_local $5)
                   )
                   (call $_abort)
                   (block
                     (i32.store offset=16
-                      (get_local $6)
                       (get_local $7)
+                      (get_local $4)
                     )
                     (i32.store offset=24
+                      (get_local $4)
                       (get_local $7)
-                      (get_local $6)
                     )
                   )
                 )
               )
               (if
-                (tee_local $2
+                (tee_local $4
                   (i32.load offset=4
-                    (get_local $2)
+                    (get_local $8)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $2)
+                    (get_local $4)
                     (i32.load
                       (i32.const 192)
                     )
@@ -14260,37 +14295,37 @@
                   (call $_abort)
                   (block
                     (i32.store offset=20
-                      (get_local $6)
-                      (get_local $2)
+                      (get_local $7)
+                      (get_local $4)
                     )
                     (i32.store offset=24
-                      (get_local $2)
-                      (get_local $6)
+                      (get_local $4)
+                      (get_local $7)
                     )
                     (set_local $3
-                      (get_local $1)
-                    )
-                    (set_local $4
                       (get_local $0)
+                    )
+                    (set_local $1
+                      (get_local $2)
                     )
                   )
                 )
                 (block
                   (set_local $3
-                    (get_local $1)
-                  )
-                  (set_local $4
                     (get_local $0)
+                  )
+                  (set_local $1
+                    (get_local $2)
                   )
                 )
               )
             )
             (block
               (set_local $3
-                (get_local $1)
-              )
-              (set_local $4
                 (get_local $0)
+              )
+              (set_local $1
+                (get_local $2)
               )
             )
           )
@@ -14300,18 +14335,18 @@
     (if
       (i32.ge_u
         (get_local $3)
-        (get_local $8)
+        (get_local $6)
       )
       (call $_abort)
     )
     (if
       (i32.eqz
         (i32.and
-          (tee_local $1
+          (tee_local $0
             (i32.load
-              (tee_local $0
+              (tee_local $2
                 (i32.add
-                  (get_local $8)
+                  (get_local $6)
                   (i32.const 4)
                 )
               )
@@ -14324,36 +14359,36 @@
     )
     (if
       (i32.and
-        (get_local $1)
+        (get_local $0)
         (i32.const 2)
       )
       (block
         (i32.store
-          (get_local $0)
+          (get_local $2)
           (i32.and
-            (get_local $1)
+            (get_local $0)
             (i32.const -2)
           )
         )
         (i32.store offset=4
           (get_local $3)
           (i32.or
-            (get_local $4)
+            (get_local $1)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $3)
-            (get_local $4)
+            (get_local $1)
           )
-          (get_local $4)
+          (get_local $1)
         )
       )
       (block
         (if
           (i32.eq
-            (get_local $8)
+            (get_local $6)
             (i32.load
               (i32.const 200)
             )
@@ -14366,7 +14401,7 @@
                   (i32.load
                     (i32.const 188)
                   )
-                  (get_local $4)
+                  (get_local $1)
                 )
               )
             )
@@ -14403,7 +14438,7 @@
         )
         (if
           (i32.eq
-            (get_local $8)
+            (get_local $6)
             (i32.load
               (i32.const 196)
             )
@@ -14416,7 +14451,7 @@
                   (i32.load
                     (i32.const 184)
                   )
-                  (get_local $4)
+                  (get_local $1)
                 )
               )
             )
@@ -14444,35 +14479,35 @@
         (set_local $5
           (i32.add
             (i32.and
-              (get_local $1)
+              (get_local $0)
               (i32.const -8)
             )
-            (get_local $4)
+            (get_local $1)
           )
         )
         (set_local $4
           (i32.shr_u
-            (get_local $1)
+            (get_local $0)
             (i32.const 3)
           )
         )
         (block $do-once4
           (if
             (i32.lt_u
-              (get_local $1)
+              (get_local $0)
               (i32.const 256)
             )
             (block
-              (set_local $2
+              (set_local $1
                 (i32.load offset=12
-                  (get_local $8)
+                  (get_local $6)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $1
+                  (tee_local $2
                     (i32.load offset=8
-                      (get_local $8)
+                      (get_local $6)
                     )
                   )
                   (tee_local $0
@@ -14491,7 +14526,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $2)
                       (i32.load
                         (i32.const 192)
                       )
@@ -14501,9 +14536,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $1)
+                        (get_local $2)
                       )
-                      (get_local $8)
+                      (get_local $6)
                     )
                     (call $_abort)
                   )
@@ -14511,8 +14546,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $2)
                   (get_local $1)
+                  (get_local $2)
                 )
                 (block
                   (i32.store
@@ -14535,19 +14570,19 @@
               )
               (if
                 (i32.eq
-                  (get_local $2)
+                  (get_local $1)
                   (get_local $0)
                 )
                 (set_local $14
                   (i32.add
-                    (get_local $2)
+                    (get_local $1)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $2)
+                      (get_local $1)
                       (i32.load
                         (i32.const 192)
                       )
@@ -14559,12 +14594,12 @@
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $2)
+                            (get_local $1)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $8)
+                      (get_local $6)
                     )
                     (set_local $14
                       (get_local $0)
@@ -14574,18 +14609,18 @@
                 )
               )
               (i32.store offset=12
-                (get_local $1)
                 (get_local $2)
+                (get_local $1)
               )
               (i32.store
                 (get_local $14)
-                (get_local $1)
+                (get_local $2)
               )
             )
             (block
-              (set_local $6
+              (set_local $7
                 (i32.load offset=24
-                  (get_local $8)
+                  (get_local $6)
                 )
               )
               (block $do-once6
@@ -14593,38 +14628,38 @@
                   (i32.eq
                     (tee_local $0
                       (i32.load offset=12
-                        (get_local $8)
+                        (get_local $6)
                       )
                     )
-                    (get_local $8)
+                    (get_local $6)
                   )
                   (block
                     (if
-                      (i32.eqz
-                        (tee_local $4
-                          (i32.load
-                            (tee_local $0
-                              (i32.add
-                                (tee_local $1
-                                  (i32.add
-                                    (get_local $8)
-                                    (i32.const 16)
-                                  )
+                      (tee_local $0
+                        (i32.load
+                          (tee_local $2
+                            (i32.add
+                              (tee_local $1
+                                (i32.add
+                                  (get_local $6)
+                                  (i32.const 16)
                                 )
-                                (i32.const 4)
                               )
+                              (i32.const 4)
                             )
                           )
                         )
                       )
+                      (set_local $1
+                        (get_local $2)
+                      )
                       (if
-                        (tee_local $4
-                          (i32.load
-                            (get_local $1)
+                        (i32.eqz
+                          (tee_local $0
+                            (i32.load
+                              (get_local $1)
+                            )
                           )
-                        )
-                        (set_local $0
-                          (get_local $1)
                         )
                         (block
                           (set_local $9
@@ -14636,42 +14671,42 @@
                     )
                     (loop $while-in9
                       (if
-                        (tee_local $1
+                        (tee_local $4
                           (i32.load
                             (tee_local $2
                               (i32.add
-                                (get_local $4)
+                                (get_local $0)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $4
-                            (get_local $1)
-                          )
                           (set_local $0
+                            (get_local $4)
+                          )
+                          (set_local $1
                             (get_local $2)
                           )
                           (br $while-in9)
                         )
                       )
                       (if
-                        (tee_local $1
+                        (tee_local $4
                           (i32.load
                             (tee_local $2
                               (i32.add
-                                (get_local $4)
+                                (get_local $0)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $4
-                            (get_local $1)
-                          )
                           (set_local $0
+                            (get_local $4)
+                          )
+                          (set_local $1
                             (get_local $2)
                           )
                           (br $while-in9)
@@ -14680,7 +14715,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $0)
+                        (get_local $1)
                         (i32.load
                           (i32.const 192)
                         )
@@ -14688,11 +14723,11 @@
                       (call $_abort)
                       (block
                         (i32.store
-                          (get_local $0)
+                          (get_local $1)
                           (i32.const 0)
                         )
                         (set_local $9
-                          (get_local $4)
+                          (get_local $0)
                         )
                       )
                     )
@@ -14700,9 +14735,9 @@
                   (block
                     (if
                       (i32.lt_u
-                        (tee_local $2
+                        (tee_local $1
                           (i32.load offset=8
-                            (get_local $8)
+                            (get_local $6)
                           )
                         )
                         (i32.load
@@ -14714,14 +14749,14 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (tee_local $1
+                          (tee_local $2
                             (i32.add
-                              (get_local $2)
+                              (get_local $1)
                               (i32.const 12)
                             )
                           )
                         )
-                        (get_local $8)
+                        (get_local $6)
                       )
                       (call $_abort)
                     )
@@ -14735,16 +14770,16 @@
                             )
                           )
                         )
-                        (get_local $8)
+                        (get_local $6)
                       )
                       (block
                         (i32.store
-                          (get_local $1)
+                          (get_local $2)
                           (get_local $0)
                         )
                         (i32.store
                           (get_local $4)
-                          (get_local $2)
+                          (get_local $1)
                         )
                         (set_local $9
                           (get_local $0)
@@ -14756,19 +14791,19 @@
                 )
               )
               (if
-                (get_local $6)
+                (get_local $7)
                 (block
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $6)
                       (i32.load
-                        (tee_local $0
+                        (tee_local $1
                           (i32.add
                             (i32.const 480)
                             (i32.shl
-                              (tee_local $4
+                              (tee_local $0
                                 (i32.load offset=28
-                                  (get_local $8)
+                                  (get_local $6)
                                 )
                               )
                               (i32.const 2)
@@ -14779,7 +14814,7 @@
                     )
                     (block
                       (i32.store
-                        (get_local $0)
+                        (get_local $1)
                         (get_local $9)
                       )
                       (if
@@ -14796,7 +14831,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $4)
+                                  (get_local $0)
                                 )
                                 (i32.const -1)
                               )
@@ -14809,7 +14844,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $6)
+                          (get_local $7)
                           (i32.load
                             (i32.const 192)
                           )
@@ -14821,19 +14856,19 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $6)
+                                (get_local $7)
                                 (i32.const 16)
                               )
                             )
                           )
-                          (get_local $8)
+                          (get_local $6)
                         )
                         (i32.store
                           (get_local $0)
                           (get_local $9)
                         )
                         (i32.store offset=20
-                          (get_local $6)
+                          (get_local $7)
                           (get_local $9)
                         )
                       )
@@ -14847,7 +14882,7 @@
                   (if
                     (i32.lt_u
                       (get_local $9)
-                      (tee_local $4
+                      (tee_local $1
                         (i32.load
                           (i32.const 192)
                         )
@@ -14857,14 +14892,14 @@
                   )
                   (i32.store offset=24
                     (get_local $9)
-                    (get_local $6)
+                    (get_local $7)
                   )
                   (if
-                    (tee_local $1
+                    (tee_local $0
                       (i32.load
-                        (tee_local $0
+                        (tee_local $2
                           (i32.add
-                            (get_local $8)
+                            (get_local $6)
                             (i32.const 16)
                           )
                         )
@@ -14872,17 +14907,17 @@
                     )
                     (if
                       (i32.lt_u
+                        (get_local $0)
                         (get_local $1)
-                        (get_local $4)
                       )
                       (call $_abort)
                       (block
                         (i32.store offset=16
                           (get_local $9)
-                          (get_local $1)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $1)
+                          (get_local $0)
                           (get_local $9)
                         )
                       )
@@ -14891,7 +14926,7 @@
                   (if
                     (tee_local $0
                       (i32.load offset=4
-                        (get_local $0)
+                        (get_local $2)
                       )
                     )
                     (if
@@ -14947,30 +14982,30 @@
             )
             (return)
           )
-          (set_local $4
+          (set_local $1
             (get_local $5)
           )
         )
       )
     )
-    (set_local $0
+    (set_local $2
       (i32.shr_u
-        (get_local $4)
+        (get_local $1)
         (i32.const 3)
       )
     )
     (if
       (i32.lt_u
-        (get_local $4)
+        (get_local $1)
         (i32.const 256)
       )
       (block
-        (set_local $1
+        (set_local $0
           (i32.add
             (i32.const 216)
             (i32.shl
               (i32.shl
-                (get_local $0)
+                (get_local $2)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -14979,25 +15014,25 @@
         )
         (if
           (i32.and
-            (tee_local $4
+            (tee_local $1
               (i32.load
                 (i32.const 176)
               )
             )
-            (tee_local $0
+            (tee_local $2
               (i32.shl
                 (i32.const 1)
-                (get_local $0)
+                (get_local $2)
               )
             )
           )
           (if
             (i32.lt_u
-              (tee_local $0
+              (tee_local $2
                 (i32.load
-                  (tee_local $4
+                  (tee_local $1
                     (i32.add
-                      (get_local $1)
+                      (get_local $0)
                       (i32.const 8)
                     )
                   )
@@ -15010,10 +15045,10 @@
             (call $_abort)
             (block
               (set_local $15
-                (get_local $4)
+                (get_local $1)
               )
               (set_local $13
-                (get_local $0)
+                (get_local $2)
               )
             )
           )
@@ -15021,18 +15056,18 @@
             (i32.store
               (i32.const 176)
               (i32.or
-                (get_local $4)
-                (get_local $0)
+                (get_local $1)
+                (get_local $2)
               )
             )
             (set_local $15
               (i32.add
-                (get_local $1)
+                (get_local $0)
                 (i32.const 8)
               )
             )
             (set_local $13
-              (get_local $1)
+              (get_local $0)
             )
           )
         )
@@ -15050,33 +15085,33 @@
         )
         (i32.store offset=12
           (get_local $3)
-          (get_local $1)
+          (get_local $0)
         )
         (return)
       )
     )
-    (set_local $5
+    (set_local $4
       (i32.add
         (i32.const 480)
         (i32.shl
-          (tee_local $2
+          (tee_local $0
             (if i32
               (tee_local $0
                 (i32.shr_u
-                  (get_local $4)
+                  (get_local $1)
                   (i32.const 8)
                 )
               )
               (if i32
                 (i32.gt_u
-                  (get_local $4)
+                  (get_local $1)
                   (i32.const 16777215)
                 )
                 (i32.const 31)
                 (i32.or
                   (i32.and
                     (i32.shr_u
-                      (get_local $4)
+                      (get_local $1)
                       (i32.add
                         (tee_local $0
                           (i32.add
@@ -15084,14 +15119,14 @@
                               (i32.const 14)
                               (i32.or
                                 (i32.or
-                                  (tee_local $0
+                                  (tee_local $4
                                     (i32.and
                                       (i32.shr_u
                                         (i32.add
-                                          (tee_local $1
+                                          (tee_local $2
                                             (i32.shl
                                               (get_local $0)
-                                              (tee_local $2
+                                              (tee_local $0
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
@@ -15112,16 +15147,16 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $2)
+                                  (get_local $0)
                                 )
-                                (tee_local $0
+                                (tee_local $2
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (tee_local $1
+                                        (tee_local $0
                                           (i32.shl
-                                            (get_local $1)
-                                            (get_local $0)
+                                            (get_local $2)
+                                            (get_local $4)
                                           )
                                         )
                                         (i32.const 245760)
@@ -15135,8 +15170,8 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $1)
                                 (get_local $0)
+                                (get_local $2)
                               )
                               (i32.const 15)
                             )
@@ -15162,7 +15197,7 @@
     )
     (i32.store offset=28
       (get_local $3)
-      (get_local $2)
+      (get_local $0)
     )
     (i32.store offset=20
       (get_local $3)
@@ -15175,33 +15210,33 @@
     (block $do-once12
       (if
         (i32.and
-          (tee_local $1
+          (tee_local $2
             (i32.load
               (i32.const 180)
             )
           )
-          (tee_local $0
+          (tee_local $5
             (i32.shl
               (i32.const 1)
-              (get_local $2)
+              (get_local $0)
             )
           )
         )
         (block
           (set_local $2
             (i32.shl
-              (get_local $4)
+              (get_local $1)
               (select
                 (i32.const 0)
                 (i32.sub
                   (i32.const 25)
                   (i32.shr_u
-                    (get_local $2)
+                    (get_local $0)
                     (i32.const 1)
                   )
                 )
                 (i32.eq
-                  (get_local $2)
+                  (get_local $0)
                   (i32.const 31)
                 )
               )
@@ -15209,7 +15244,7 @@
           )
           (set_local $0
             (i32.load
-              (get_local $5)
+              (get_local $4)
             )
           )
           (block $jumpthreading$outer$1
@@ -15224,52 +15259,59 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $4)
+                      (get_local $1)
                     )
                   )
-                  (set_local $5
+                  (set_local $4
                     (i32.shl
                       (get_local $2)
                       (i32.const 1)
                     )
                   )
-                  (br_if $jumpthreading$inner$0
-                    (i32.eqz
-                      (tee_local $1
-                        (i32.load
-                          (tee_local $2
+                  (if
+                    (tee_local $5
+                      (i32.load
+                        (tee_local $2
+                          (i32.add
                             (i32.add
-                              (i32.add
-                                (get_local $0)
-                                (i32.const 16)
+                              (get_local $0)
+                              (i32.const 16)
+                            )
+                            (i32.shl
+                              (i32.shr_u
+                                (get_local $2)
+                                (i32.const 31)
                               )
-                              (i32.shl
-                                (i32.shr_u
-                                  (get_local $2)
-                                  (i32.const 31)
-                                )
-                                (i32.const 2)
-                              )
+                              (i32.const 2)
                             )
                           )
                         )
                       )
                     )
-                  )
-                  (block
-                    (set_local $2
-                      (get_local $5)
+                    (block
+                      (set_local $2
+                        (get_local $4)
+                      )
+                      (set_local $0
+                        (get_local $5)
+                      )
+                      (br $while-in15)
                     )
-                    (set_local $0
-                      (get_local $1)
+                    (block
+                      (set_local $1
+                        (get_local $0)
+                      )
+                      (set_local $0
+                        (get_local $2)
+                      )
+                      (br $jumpthreading$inner$0)
                     )
-                    (br $while-in15)
                   )
                 )
               )
               (if
                 (i32.lt_u
-                  (get_local $2)
+                  (get_local $0)
                   (i32.load
                     (i32.const 192)
                   )
@@ -15277,12 +15319,12 @@
                 (call $_abort)
                 (block
                   (i32.store
-                    (get_local $2)
+                    (get_local $0)
                     (get_local $3)
                   )
                   (i32.store offset=24
                     (get_local $3)
-                    (get_local $0)
+                    (get_local $1)
                   )
                   (i32.store offset=12
                     (get_local $3)
@@ -15300,9 +15342,9 @@
             (if
               (i32.and
                 (i32.ge_u
-                  (tee_local $2
+                  (tee_local $1
                     (i32.load
-                      (tee_local $1
+                      (tee_local $2
                         (i32.add
                           (get_local $0)
                           (i32.const 8)
@@ -15323,16 +15365,16 @@
               )
               (block
                 (i32.store offset=12
-                  (get_local $2)
+                  (get_local $1)
                   (get_local $3)
                 )
                 (i32.store
-                  (get_local $1)
+                  (get_local $2)
                   (get_local $3)
                 )
                 (i32.store offset=8
                   (get_local $3)
-                  (get_local $2)
+                  (get_local $1)
                 )
                 (i32.store offset=12
                   (get_local $3)
@@ -15351,17 +15393,17 @@
           (i32.store
             (i32.const 180)
             (i32.or
-              (get_local $1)
-              (get_local $0)
+              (get_local $2)
+              (get_local $5)
             )
           )
           (i32.store
-            (get_local $5)
+            (get_local $4)
             (get_local $3)
           )
           (i32.store offset=24
             (get_local $3)
-            (get_local $5)
+            (get_local $4)
           )
           (i32.store offset=12
             (get_local $3)
@@ -15395,7 +15437,7 @@
     (loop $while-in17
       (set_local $0
         (i32.add
-          (tee_local $4
+          (tee_local $1
             (i32.load
               (get_local $0)
             )
@@ -15404,7 +15446,7 @@
         )
       )
       (br_if $while-in17
-        (get_local $4)
+        (get_local $1)
       )
     )
     (i32.store

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -798,7 +798,7 @@
     (local $12 i32)
     (local $13 i32)
     (local $14 i32)
-    (set_local $8
+    (set_local $7
       (get_global $STACKTOP)
     )
     (set_global $STACKTOP
@@ -814,23 +814,23 @@
       )
       (call $abort)
     )
-    (set_local $9
+    (set_local $8
       (i32.add
-        (get_local $8)
+        (get_local $7)
         (i32.const 16)
       )
     )
-    (set_local $10
-      (get_local $8)
+    (set_local $9
+      (get_local $7)
     )
     (i32.store
       (tee_local $3
         (i32.add
-          (get_local $8)
+          (get_local $7)
           (i32.const 32)
         )
       )
-      (tee_local $4
+      (tee_local $5
         (i32.load
           (tee_local $6
             (i32.add
@@ -843,17 +843,17 @@
     )
     (i32.store offset=4
       (get_local $3)
-      (tee_local $7
+      (tee_local $4
         (i32.sub
           (i32.load
-            (tee_local $11
+            (tee_local $10
               (i32.add
                 (get_local $0)
                 (i32.const 20)
               )
             )
           )
-          (get_local $4)
+          (get_local $5)
         )
       )
     )
@@ -880,12 +880,12 @@
     (set_local $1
       (get_local $3)
     )
-    (set_local $4
+    (set_local $5
       (i32.const 2)
     )
-    (set_local $7
+    (set_local $11
       (i32.add
-        (get_local $7)
+        (get_local $4)
         (get_local $2)
       )
     )
@@ -896,8 +896,8 @@
             (loop $while-in
               (br_if $jumpthreading$inner$0
                 (i32.eq
-                  (get_local $7)
-                  (tee_local $5
+                  (get_local $11)
+                  (tee_local $4
                     (if i32
                       (i32.load
                         (i32.const 16)
@@ -908,24 +908,24 @@
                           (get_local $0)
                         )
                         (i32.store
-                          (get_local $10)
+                          (get_local $9)
                           (i32.load
                             (get_local $13)
                           )
                         )
                         (i32.store offset=4
-                          (get_local $10)
+                          (get_local $9)
                           (get_local $1)
                         )
                         (i32.store offset=8
-                          (get_local $10)
-                          (get_local $4)
+                          (get_local $9)
+                          (get_local $5)
                         )
                         (set_local $3
                           (call $___syscall_ret
                             (call $___syscall146
                               (i32.const 146)
-                              (get_local $10)
+                              (get_local $9)
                             )
                           )
                         )
@@ -936,23 +936,23 @@
                       )
                       (block i32
                         (i32.store
-                          (get_local $9)
+                          (get_local $8)
                           (i32.load
                             (get_local $13)
                           )
                         )
                         (i32.store offset=4
-                          (get_local $9)
+                          (get_local $8)
                           (get_local $1)
                         )
                         (i32.store offset=8
-                          (get_local $9)
-                          (get_local $4)
+                          (get_local $8)
+                          (get_local $5)
                         )
                         (call $___syscall_ret
                           (call $___syscall146
                             (i32.const 146)
-                            (get_local $9)
+                            (get_local $8)
                           )
                         )
                       )
@@ -962,21 +962,21 @@
               )
               (br_if $jumpthreading$inner$1
                 (i32.lt_s
-                  (get_local $5)
+                  (get_local $4)
                   (i32.const 0)
                 )
               )
               (block
-                (set_local $7
+                (set_local $11
                   (i32.sub
-                    (get_local $7)
-                    (get_local $5)
+                    (get_local $11)
+                    (get_local $4)
                   )
                 )
                 (set_local $1
                   (if i32
                     (i32.gt_u
-                      (get_local $5)
+                      (get_local $4)
                       (tee_local $12
                         (i32.load offset=4
                           (get_local $1)
@@ -993,12 +993,12 @@
                         )
                       )
                       (i32.store
-                        (get_local $11)
+                        (get_local $10)
                         (get_local $3)
                       )
-                      (set_local $5
+                      (set_local $4
                         (i32.sub
-                          (get_local $5)
+                          (get_local $4)
                           (get_local $12)
                         )
                       )
@@ -1008,9 +1008,9 @@
                           (i32.const 8)
                         )
                       )
-                      (set_local $4
+                      (set_local $5
                         (i32.add
-                          (get_local $4)
+                          (get_local $5)
                           (i32.const -1)
                         )
                       )
@@ -1020,7 +1020,7 @@
                     )
                     (if i32
                       (i32.eq
-                        (get_local $4)
+                        (get_local $5)
                         (i32.const 2)
                       )
                       (block i32
@@ -1030,13 +1030,13 @@
                             (i32.load
                               (get_local $6)
                             )
-                            (get_local $5)
+                            (get_local $4)
                           )
                         )
                         (set_local $3
                           (get_local $1)
                         )
-                        (set_local $4
+                        (set_local $5
                           (i32.const 2)
                         )
                         (get_local $12)
@@ -1056,14 +1056,14 @@
                     (i32.load
                       (get_local $3)
                     )
-                    (get_local $5)
+                    (get_local $4)
                   )
                 )
                 (i32.store offset=4
                   (get_local $3)
                   (i32.sub
                     (get_local $1)
-                    (get_local $5)
+                    (get_local $4)
                   )
                 )
                 (set_local $1
@@ -1093,7 +1093,7 @@
             )
           )
           (i32.store
-            (get_local $11)
+            (get_local $10)
             (get_local $0)
           )
           (br $jumpthreading$outer$1
@@ -1109,7 +1109,7 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $11)
+          (get_local $10)
           (i32.const 0)
         )
         (i32.store
@@ -1130,14 +1130,14 @@
             )
           )
           (i32.eq
-            (get_local $4)
+            (get_local $5)
             (i32.const 2)
           )
         )
       )
     )
     (set_global $STACKTOP
-      (get_local $8)
+      (get_local $7)
     )
     (get_local $0)
   )
@@ -8086,14 +8086,14 @@
             (i32.and
               (tee_local $1
                 (i32.shr_u
-                  (tee_local $8
+                  (tee_local $10
                     (i32.load
                       (i32.const 176)
                     )
                   )
                   (tee_local $2
                     (i32.shr_u
-                      (tee_local $6
+                      (tee_local $3
                         (select
                           (i32.const 16)
                           (i32.and
@@ -8166,7 +8166,7 @@
                 (i32.store
                   (i32.const 176)
                   (i32.and
-                    (get_local $8)
+                    (get_local $10)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
@@ -8248,7 +8248,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $6)
+              (get_local $3)
               (tee_local $0
                 (i32.load
                   (i32.const 184)
@@ -8259,7 +8259,7 @@
               (if
                 (get_local $1)
                 (block
-                  (set_local $3
+                  (set_local $4
                     (i32.and
                       (i32.shr_u
                         (tee_local $1
@@ -8298,11 +8298,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $11
+                  (set_local $12
                     (i32.load
-                      (tee_local $3
+                      (tee_local $4
                         (i32.add
-                          (tee_local $4
+                          (tee_local $6
                             (i32.load
                               (tee_local $1
                                 (i32.add
@@ -8323,7 +8323,7 @@
                                                             (tee_local $2
                                                               (i32.shr_u
                                                                 (get_local $1)
-                                                                (get_local $3)
+                                                                (get_local $4)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -8331,7 +8331,7 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $3)
+                                                      (get_local $4)
                                                     )
                                                     (tee_local $1
                                                       (i32.and
@@ -8403,13 +8403,13 @@
                   (if
                     (i32.eq
                       (get_local $2)
-                      (get_local $11)
+                      (get_local $12)
                     )
                     (block
                       (i32.store
                         (i32.const 176)
                         (i32.and
-                          (get_local $8)
+                          (get_local $10)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
@@ -8426,7 +8426,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $11)
+                          (get_local $12)
                           (i32.load
                             (i32.const 192)
                           )
@@ -8438,12 +8438,12 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $11)
+                                (get_local $12)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $4)
+                          (get_local $6)
                         )
                         (block
                           (i32.store
@@ -8452,7 +8452,7 @@
                           )
                           (i32.store
                             (get_local $1)
-                            (get_local $11)
+                            (get_local $12)
                           )
                           (set_local $16
                             (i32.load
@@ -8465,27 +8465,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $4)
+                    (get_local $6)
                     (i32.or
-                      (get_local $6)
+                      (get_local $3)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $4
+                    (tee_local $6
                       (i32.add
-                        (get_local $4)
                         (get_local $6)
+                        (get_local $3)
                       )
                     )
                     (i32.or
-                      (tee_local $6
+                      (tee_local $3
                         (i32.sub
                           (i32.shl
                             (get_local $5)
                             (i32.const 3)
                           )
-                          (get_local $6)
+                          (get_local $3)
                         )
                       )
                       (i32.const 1)
@@ -8493,10 +8493,10 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $4)
                       (get_local $6)
+                      (get_local $3)
                     )
-                    (get_local $6)
+                    (get_local $3)
                   )
                   (if
                     (get_local $16)
@@ -8555,7 +8555,7 @@
                           )
                           (call $_abort)
                           (block
-                            (set_local $7
+                            (set_local $15
                               (get_local $1)
                             )
                             (set_local $9
@@ -8571,7 +8571,7 @@
                               (get_local $0)
                             )
                           )
-                          (set_local $7
+                          (set_local $15
                             (i32.add
                               (get_local $2)
                               (i32.const 8)
@@ -8583,7 +8583,7 @@
                         )
                       )
                       (i32.store
-                        (get_local $7)
+                        (get_local $15)
                         (get_local $5)
                       )
                       (i32.store offset=12
@@ -8602,14 +8602,14 @@
                   )
                   (i32.store
                     (i32.const 184)
-                    (get_local $6)
+                    (get_local $3)
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (return
-                    (get_local $3)
+                    (get_local $4)
                   )
                 )
               )
@@ -8640,7 +8640,7 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $3
+                  (set_local $9
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
@@ -8725,7 +8725,7 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $6)
+                      (get_local $3)
                     )
                   )
                   (set_local $1
@@ -8753,17 +8753,17 @@
                             )
                           )
                           (block
-                            (set_local $9
-                              (get_local $3)
+                            (set_local $12
+                              (get_local $9)
                             )
-                            (set_local $7
+                            (set_local $11
                               (get_local $2)
                             )
                             (br $while-out)
                           )
                         )
                       )
-                      (set_local $9
+                      (set_local $12
                         (i32.lt_u
                           (tee_local $1
                             (i32.sub
@@ -8773,17 +8773,17 @@
                                 )
                                 (i32.const -8)
                               )
-                              (get_local $6)
+                              (get_local $3)
                             )
                           )
-                          (get_local $3)
+                          (get_local $9)
                         )
                       )
-                      (set_local $3
+                      (set_local $9
                         (select
                           (get_local $1)
-                          (get_local $3)
                           (get_local $9)
+                          (get_local $12)
                         )
                       )
                       (set_local $1
@@ -8793,7 +8793,7 @@
                         (select
                           (get_local $0)
                           (get_local $2)
-                          (get_local $9)
+                          (get_local $12)
                         )
                       )
                       (br $while-in)
@@ -8801,7 +8801,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $11)
                       (tee_local $10
                         (i32.load
                           (i32.const 192)
@@ -8812,19 +8812,19 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $7)
-                      (tee_local $17
+                      (get_local $11)
+                      (tee_local $14
                         (i32.add
-                          (get_local $7)
-                          (get_local $6)
+                          (get_local $11)
+                          (get_local $3)
                         )
                       )
                     )
                     (call $_abort)
                   )
-                  (set_local $8
+                  (set_local $7
                     (i32.load offset=24
-                      (get_local $7)
+                      (get_local $11)
                     )
                   )
                   (block $do-once4
@@ -8832,10 +8832,10 @@
                       (i32.eq
                         (tee_local $0
                           (i32.load offset=12
-                            (get_local $7)
+                            (get_local $11)
                           )
                         )
-                        (get_local $7)
+                        (get_local $11)
                       )
                       (block
                         (if
@@ -8844,7 +8844,7 @@
                               (i32.load
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $7)
+                                    (get_local $11)
                                     (i32.const 20)
                                   )
                                 )
@@ -8857,7 +8857,7 @@
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
-                                      (get_local $7)
+                                      (get_local $11)
                                       (i32.const 16)
                                     )
                                   )
@@ -8865,7 +8865,7 @@
                               )
                             )
                             (block
-                              (set_local $5
+                              (set_local $6
                                 (i32.const 0)
                               )
                               (br $do-once4)
@@ -8876,7 +8876,7 @@
                           (if
                             (tee_local $2
                               (i32.load
-                                (tee_local $3
+                                (tee_local $9
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 20)
@@ -8889,7 +8889,7 @@
                                 (get_local $2)
                               )
                               (set_local $0
-                                (get_local $3)
+                                (get_local $9)
                               )
                               (br $while-in7)
                             )
@@ -8897,7 +8897,7 @@
                           (if
                             (tee_local $2
                               (i32.load
-                                (tee_local $3
+                                (tee_local $9
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 16)
@@ -8910,7 +8910,7 @@
                                 (get_local $2)
                               )
                               (set_local $0
-                                (get_local $3)
+                                (get_local $9)
                               )
                               (br $while-in7)
                             )
@@ -8927,7 +8927,7 @@
                               (get_local $0)
                               (i32.const 0)
                             )
-                            (set_local $5
+                            (set_local $6
                               (get_local $1)
                             )
                           )
@@ -8936,9 +8936,9 @@
                       (block
                         (if
                           (i32.lt_u
-                            (tee_local $3
+                            (tee_local $9
                               (i32.load offset=8
-                                (get_local $7)
+                                (get_local $11)
                               )
                             )
                             (get_local $10)
@@ -8950,12 +8950,12 @@
                             (i32.load
                               (tee_local $2
                                 (i32.add
-                                  (get_local $3)
+                                  (get_local $9)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $7)
+                            (get_local $11)
                           )
                           (call $_abort)
                         )
@@ -8969,7 +8969,7 @@
                                 )
                               )
                             )
-                            (get_local $7)
+                            (get_local $11)
                           )
                           (block
                             (i32.store
@@ -8978,9 +8978,9 @@
                             )
                             (i32.store
                               (get_local $1)
-                              (get_local $3)
+                              (get_local $9)
                             )
-                            (set_local $5
+                            (set_local $6
                               (get_local $0)
                             )
                           )
@@ -8991,11 +8991,11 @@
                   )
                   (block $do-once8
                     (if
-                      (get_local $8)
+                      (get_local $7)
                       (block
                         (if
                           (i32.eq
-                            (get_local $7)
+                            (get_local $11)
                             (i32.load
                               (tee_local $0
                                 (i32.add
@@ -9003,7 +9003,7 @@
                                   (i32.shl
                                     (tee_local $1
                                       (i32.load offset=28
-                                        (get_local $7)
+                                        (get_local $11)
                                       )
                                     )
                                     (i32.const 2)
@@ -9015,11 +9015,11 @@
                           (block
                             (i32.store
                               (get_local $0)
-                              (get_local $5)
+                              (get_local $6)
                             )
                             (if
                               (i32.eqz
-                                (get_local $5)
+                                (get_local $6)
                               )
                               (block
                                 (i32.store
@@ -9044,7 +9044,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -9056,32 +9056,32 @@
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
-                                      (get_local $8)
+                                      (get_local $7)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $7)
+                                (get_local $11)
                               )
                               (i32.store
                                 (get_local $0)
-                                (get_local $5)
+                                (get_local $6)
                               )
                               (i32.store offset=20
-                                (get_local $8)
-                                (get_local $5)
+                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                             (br_if $do-once8
                               (i32.eqz
-                                (get_local $5)
+                                (get_local $6)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $5)
+                            (get_local $6)
                             (tee_local $0
                               (i32.load
                                 (i32.const 192)
@@ -9091,13 +9091,13 @@
                           (call $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $5)
-                          (get_local $8)
+                          (get_local $6)
+                          (get_local $7)
                         )
                         (if
                           (tee_local $1
                             (i32.load offset=16
-                              (get_local $7)
+                              (get_local $11)
                             )
                           )
                           (if
@@ -9108,12 +9108,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $5)
+                                (get_local $6)
                                 (get_local $1)
                               )
                               (i32.store offset=24
                                 (get_local $1)
-                                (get_local $5)
+                                (get_local $6)
                               )
                             )
                           )
@@ -9121,7 +9121,7 @@
                         (if
                           (tee_local $0
                             (i32.load offset=20
-                              (get_local $7)
+                              (get_local $11)
                             )
                           )
                           (if
@@ -9134,12 +9134,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $5)
+                                (get_local $6)
                                 (get_local $0)
                               )
                               (i32.store offset=24
                                 (get_local $0)
-                                (get_local $5)
+                                (get_local $6)
                               )
                             )
                           )
@@ -9149,17 +9149,17 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $9)
+                      (get_local $12)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $7)
+                        (get_local $11)
                         (i32.or
                           (tee_local $0
                             (i32.add
-                              (get_local $9)
-                              (get_local $6)
+                              (get_local $12)
+                              (get_local $3)
                             )
                           )
                           (i32.const 3)
@@ -9169,7 +9169,7 @@
                         (tee_local $0
                           (i32.add
                             (i32.add
-                              (get_local $7)
+                              (get_local $11)
                               (get_local $0)
                             )
                             (i32.const 4)
@@ -9185,25 +9185,25 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $7)
+                        (get_local $11)
                         (i32.or
-                          (get_local $6)
+                          (get_local $3)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $17)
+                        (get_local $14)
                         (i32.or
-                          (get_local $9)
+                          (get_local $12)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $17)
-                          (get_local $9)
+                          (get_local $14)
+                          (get_local $12)
                         )
-                        (get_local $9)
+                        (get_local $12)
                       )
                       (if
                         (tee_local $0
@@ -9266,7 +9266,7 @@
                               )
                               (call $_abort)
                               (block
-                                (set_local $11
+                                (set_local $5
                                   (get_local $1)
                                 )
                                 (set_local $4
@@ -9282,7 +9282,7 @@
                                   (get_local $0)
                                 )
                               )
-                              (set_local $11
+                              (set_local $5
                                 (i32.add
                                   (get_local $2)
                                   (i32.const 8)
@@ -9294,7 +9294,7 @@
                             )
                           )
                           (i32.store
-                            (get_local $11)
+                            (get_local $5)
                             (get_local $3)
                           )
                           (i32.store offset=12
@@ -9313,28 +9313,28 @@
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $9)
+                        (get_local $12)
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $17)
+                        (get_local $14)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $7)
+                      (get_local $11)
                       (i32.const 8)
                     )
                   )
                 )
                 (set_local $0
-                  (get_local $6)
+                  (get_local $3)
                 )
               )
             )
             (set_local $0
-              (get_local $6)
+              (get_local $3)
             )
           )
         )
@@ -9377,7 +9377,7 @@
                       (tee_local $0
                         (i32.load offset=480
                           (i32.shl
-                            (tee_local $18
+                            (tee_local $17
                               (if i32
                                 (tee_local $0
                                   (i32.shr_u
@@ -9479,10 +9479,10 @@
                         )
                       )
                       (block
-                        (set_local $7
+                        (set_local $16
                           (i32.const 0)
                         )
-                        (set_local $16
+                        (set_local $18
                           (i32.shl
                             (get_local $6)
                             (select
@@ -9490,12 +9490,12 @@
                               (i32.sub
                                 (i32.const 25)
                                 (i32.shr_u
-                                  (get_local $18)
+                                  (get_local $17)
                                   (i32.const 1)
                                 )
                               )
                               (i32.eq
-                                (get_local $18)
+                                (get_local $17)
                                 (i32.const 31)
                               )
                             )
@@ -9509,7 +9509,7 @@
                             (i32.lt_u
                               (tee_local $5
                                 (i32.sub
-                                  (tee_local $11
+                                  (tee_local $15
                                     (i32.and
                                       (i32.load offset=4
                                         (get_local $0)
@@ -9524,7 +9524,7 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $11)
+                                (get_local $15)
                                 (get_local $6)
                               )
                               (block
@@ -9554,7 +9554,7 @@
                           )
                           (set_local $0
                             (select
-                              (get_local $7)
+                              (get_local $16)
                               (tee_local $5
                                 (i32.load offset=20
                                   (get_local $0)
@@ -9566,7 +9566,7 @@
                                 )
                                 (i32.eq
                                   (get_local $5)
-                                  (tee_local $11
+                                  (tee_local $15
                                     (i32.load
                                       (i32.add
                                         (i32.add
@@ -9575,7 +9575,7 @@
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $16)
+                                            (get_local $18)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -9589,12 +9589,12 @@
                           )
                           (set_local $5
                             (i32.shl
-                              (get_local $16)
+                              (get_local $18)
                               (i32.xor
                                 (i32.and
-                                  (tee_local $7
+                                  (tee_local $16
                                     (i32.eqz
-                                      (get_local $11)
+                                      (get_local $15)
                                     )
                                   )
                                   (i32.const 1)
@@ -9604,17 +9604,17 @@
                             )
                           )
                           (br_if $jumpthreading$inner$2
-                            (get_local $7)
+                            (get_local $16)
                           )
                           (block
-                            (set_local $7
+                            (set_local $16
                               (get_local $0)
                             )
-                            (set_local $16
+                            (set_local $18
                               (get_local $5)
                             )
                             (set_local $0
-                              (get_local $11)
+                              (get_local $15)
                             )
                             (br $while-in14)
                           )
@@ -9653,7 +9653,7 @@
                                     (tee_local $0
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $18)
+                                        (get_local $17)
                                       )
                                     )
                                     (i32.sub
@@ -9671,7 +9671,7 @@
                               (br $do-once)
                             )
                           )
-                          (set_local $11
+                          (set_local $15
                             (i32.and
                               (i32.shr_u
                                 (tee_local $0
@@ -9704,7 +9704,7 @@
                                               (tee_local $5
                                                 (i32.shr_u
                                                   (get_local $0)
-                                                  (get_local $11)
+                                                  (get_local $15)
                                                 )
                                               )
                                               (i32.const 5)
@@ -9712,7 +9712,7 @@
                                             (i32.const 8)
                                           )
                                         )
-                                        (get_local $11)
+                                        (get_local $15)
                                       )
                                       (tee_local $0
                                         (i32.and
@@ -9786,10 +9786,10 @@
                       )
                     )
                     (block
-                      (set_local $13
+                      (set_local $8
                         (get_local $9)
                       )
-                      (set_local $12
+                      (set_local $13
                         (get_local $4)
                       )
                     )
@@ -9852,20 +9852,20 @@
                       )
                     )
                     (block
-                      (set_local $13
+                      (set_local $8
                         (get_local $2)
                       )
-                      (set_local $12
+                      (set_local $13
                         (get_local $1)
                       )
                     )
                   )
                 )
                 (if
-                  (get_local $12)
+                  (get_local $13)
                   (if
                     (i32.lt_u
-                      (get_local $13)
+                      (get_local $8)
                       (i32.sub
                         (i32.load
                           (i32.const 184)
@@ -9876,7 +9876,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $12)
+                          (get_local $13)
                           (tee_local $4
                             (i32.load
                               (i32.const 192)
@@ -9887,10 +9887,10 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $12)
+                          (get_local $13)
                           (tee_local $5
                             (i32.add
-                              (get_local $12)
+                              (get_local $13)
                               (get_local $6)
                             )
                           )
@@ -9899,7 +9899,7 @@
                       )
                       (set_local $9
                         (i32.load offset=24
-                          (get_local $12)
+                          (get_local $13)
                         )
                       )
                       (block $do-once17
@@ -9907,10 +9907,10 @@
                           (i32.eq
                             (tee_local $0
                               (i32.load offset=12
-                                (get_local $12)
+                                (get_local $13)
                               )
                             )
-                            (get_local $12)
+                            (get_local $13)
                           )
                           (block
                             (if
@@ -9919,7 +9919,7 @@
                                   (i32.load
                                     (tee_local $0
                                       (i32.add
-                                        (get_local $12)
+                                        (get_local $13)
                                         (i32.const 20)
                                       )
                                     )
@@ -9932,7 +9932,7 @@
                                     (i32.load
                                       (tee_local $0
                                         (i32.add
-                                          (get_local $12)
+                                          (get_local $13)
                                           (i32.const 16)
                                         )
                                       )
@@ -9940,7 +9940,7 @@
                                   )
                                 )
                                 (block
-                                  (set_local $14
+                                  (set_local $7
                                     (i32.const 0)
                                   )
                                   (br $do-once17)
@@ -10002,7 +10002,7 @@
                                   (get_local $0)
                                   (i32.const 0)
                                 )
-                                (set_local $14
+                                (set_local $7
                                   (get_local $1)
                                 )
                               )
@@ -10013,7 +10013,7 @@
                               (i32.lt_u
                                 (tee_local $3
                                   (i32.load offset=8
-                                    (get_local $12)
+                                    (get_local $13)
                                   )
                                 )
                                 (get_local $4)
@@ -10030,7 +10030,7 @@
                                     )
                                   )
                                 )
-                                (get_local $12)
+                                (get_local $13)
                               )
                               (call $_abort)
                             )
@@ -10044,7 +10044,7 @@
                                     )
                                   )
                                 )
-                                (get_local $12)
+                                (get_local $13)
                               )
                               (block
                                 (i32.store
@@ -10055,7 +10055,7 @@
                                   (get_local $1)
                                   (get_local $3)
                                 )
-                                (set_local $14
+                                (set_local $7
                                   (get_local $0)
                                 )
                               )
@@ -10070,7 +10070,7 @@
                           (block
                             (if
                               (i32.eq
-                                (get_local $12)
+                                (get_local $13)
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
@@ -10078,7 +10078,7 @@
                                       (i32.shl
                                         (tee_local $1
                                           (i32.load offset=28
-                                            (get_local $12)
+                                            (get_local $13)
                                           )
                                         )
                                         (i32.const 2)
@@ -10090,11 +10090,11 @@
                               (block
                                 (i32.store
                                   (get_local $0)
-                                  (get_local $14)
+                                  (get_local $7)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $14)
+                                    (get_local $7)
                                   )
                                   (block
                                     (i32.store
@@ -10136,27 +10136,27 @@
                                         )
                                       )
                                     )
-                                    (get_local $12)
+                                    (get_local $13)
                                   )
                                   (i32.store
                                     (get_local $0)
-                                    (get_local $14)
+                                    (get_local $7)
                                   )
                                   (i32.store offset=20
                                     (get_local $9)
-                                    (get_local $14)
+                                    (get_local $7)
                                   )
                                 )
                                 (br_if $do-once21
                                   (i32.eqz
-                                    (get_local $14)
+                                    (get_local $7)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $14)
+                                (get_local $7)
                                 (tee_local $0
                                   (i32.load
                                     (i32.const 192)
@@ -10166,13 +10166,13 @@
                               (call $_abort)
                             )
                             (i32.store offset=24
-                              (get_local $14)
+                              (get_local $7)
                               (get_local $9)
                             )
                             (if
                               (tee_local $1
                                 (i32.load offset=16
-                                  (get_local $12)
+                                  (get_local $13)
                                 )
                               )
                               (if
@@ -10183,12 +10183,12 @@
                                 (call $_abort)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $14)
+                                    (get_local $7)
                                     (get_local $1)
                                   )
                                   (i32.store offset=24
                                     (get_local $1)
-                                    (get_local $14)
+                                    (get_local $7)
                                   )
                                 )
                               )
@@ -10196,7 +10196,7 @@
                             (if
                               (tee_local $0
                                 (i32.load offset=20
-                                  (get_local $12)
+                                  (get_local $13)
                                 )
                               )
                               (if
@@ -10209,12 +10209,12 @@
                                 (call $_abort)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $14)
+                                    (get_local $7)
                                     (get_local $0)
                                   )
                                   (i32.store offset=24
                                     (get_local $0)
-                                    (get_local $14)
+                                    (get_local $7)
                                   )
                                 )
                               )
@@ -10225,16 +10225,16 @@
                       (block $do-once25
                         (if
                           (i32.lt_u
-                            (get_local $13)
+                            (get_local $8)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $12)
+                              (get_local $13)
                               (i32.or
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $13)
+                                    (get_local $8)
                                     (get_local $6)
                                   )
                                 )
@@ -10245,7 +10245,7 @@
                               (tee_local $0
                                 (i32.add
                                   (i32.add
-                                    (get_local $12)
+                                    (get_local $13)
                                     (get_local $0)
                                   )
                                   (i32.const 4)
@@ -10261,7 +10261,7 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $12)
+                              (get_local $13)
                               (i32.or
                                 (get_local $6)
                                 (i32.const 3)
@@ -10270,26 +10270,26 @@
                             (i32.store offset=4
                               (get_local $5)
                               (i32.or
-                                (get_local $13)
+                                (get_local $8)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
                                 (get_local $5)
-                                (get_local $13)
+                                (get_local $8)
                               )
-                              (get_local $13)
+                              (get_local $8)
                             )
                             (set_local $0
                               (i32.shr_u
-                                (get_local $13)
+                                (get_local $8)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $13)
+                                (get_local $8)
                                 (i32.const 256)
                               )
                               (block
@@ -10340,7 +10340,7 @@
                                       (set_local $20
                                         (get_local $1)
                                       )
-                                      (set_local $8
+                                      (set_local $10
                                         (get_local $0)
                                       )
                                     )
@@ -10359,7 +10359,7 @@
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $8
+                                    (set_local $10
                                       (get_local $2)
                                     )
                                   )
@@ -10369,12 +10369,12 @@
                                   (get_local $5)
                                 )
                                 (i32.store offset=12
-                                  (get_local $8)
+                                  (get_local $10)
                                   (get_local $5)
                                 )
                                 (i32.store offset=8
                                   (get_local $5)
-                                  (get_local $8)
+                                  (get_local $10)
                                 )
                                 (i32.store offset=12
                                   (get_local $5)
@@ -10391,20 +10391,20 @@
                                     (if i32
                                       (tee_local $0
                                         (i32.shr_u
-                                          (get_local $13)
+                                          (get_local $8)
                                           (i32.const 8)
                                         )
                                       )
                                       (if i32
                                         (i32.gt_u
-                                          (get_local $13)
+                                          (get_local $8)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $13)
+                                              (get_local $8)
                                               (i32.add
                                                 (tee_local $0
                                                   (i32.add
@@ -10550,7 +10550,7 @@
                             )
                             (set_local $3
                               (i32.shl
-                                (get_local $13)
+                                (get_local $8)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
@@ -10584,7 +10584,7 @@
                                           )
                                           (i32.const -8)
                                         )
-                                        (get_local $13)
+                                        (get_local $8)
                                       )
                                     )
                                     (set_local $2
@@ -10711,7 +10711,7 @@
                       )
                       (return
                         (i32.add
-                          (get_local $12)
+                          (get_local $13)
                           (i32.const 8)
                         )
                       )
@@ -10950,7 +10950,7 @@
         )
       )
     )
-    (set_local $11
+    (set_local $10
       (i32.add
         (get_local $0)
         (i32.const 48)
@@ -11037,7 +11037,7 @@
                 (block $jumpthreading$inner$3
                   (br_if $jumpthreading$inner$3
                     (i32.eqz
-                      (tee_local $3
+                      (tee_local $4
                         (i32.load
                           (i32.const 200)
                         )
@@ -11056,14 +11056,14 @@
                               (get_local $1)
                             )
                           )
-                          (get_local $3)
+                          (get_local $4)
                         )
                         (if
                           (i32.gt_u
                             (i32.add
                               (get_local $2)
                               (i32.load
-                                (tee_local $2
+                                (tee_local $3
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 4)
@@ -11071,7 +11071,7 @@
                                 )
                               )
                             )
-                            (get_local $3)
+                            (get_local $4)
                           )
                           (block
                             (set_local $4
@@ -11108,7 +11108,7 @@
                     )
                     (if
                       (i32.eq
-                        (tee_local $3
+                        (tee_local $2
                           (call $_sbrk
                             (get_local $1)
                           )
@@ -11118,20 +11118,14 @@
                             (get_local $4)
                           )
                           (i32.load
-                            (get_local $2)
+                            (get_local $3)
                           )
                         )
                       )
-                      (if
+                      (br_if $jumpthreading$inner$12
                         (i32.ne
-                          (get_local $3)
+                          (get_local $2)
                           (i32.const -1)
-                        )
-                        (block
-                          (set_local $2
-                            (get_local $1)
-                          )
-                          (br $jumpthreading$inner$12)
                         )
                       )
                       (br $jumpthreading$inner$4)
@@ -11141,7 +11135,7 @@
                 )
                 (if
                   (i32.ne
-                    (tee_local $3
+                    (tee_local $2
                       (call $_sbrk
                         (i32.const 0)
                       )
@@ -11159,7 +11153,7 @@
                         (tee_local $1
                           (if i32
                             (i32.and
-                              (tee_local $2
+                              (tee_local $3
                                 (i32.add
                                   (tee_local $4
                                     (i32.load
@@ -11170,7 +11164,7 @@
                                 )
                               )
                               (tee_local $1
-                                (get_local $3)
+                                (get_local $2)
                               )
                             )
                             (i32.add
@@ -11180,7 +11174,7 @@
                               )
                               (i32.and
                                 (i32.add
-                                  (get_local $2)
+                                  (get_local $3)
                                   (get_local $1)
                                 )
                                 (i32.sub
@@ -11207,7 +11201,7 @@
                       )
                       (block
                         (if
-                          (tee_local $2
+                          (tee_local $3
                             (i32.load
                               (i32.const 616)
                             )
@@ -11220,32 +11214,26 @@
                               )
                               (i32.gt_u
                                 (get_local $4)
-                                (get_local $2)
+                                (get_local $3)
                               )
                             )
                           )
                         )
-                        (if
+                        (br_if $jumpthreading$inner$12
                           (i32.eq
-                            (tee_local $2
+                            (tee_local $3
                               (call $_sbrk
                                 (get_local $1)
                               )
                             )
+                            (get_local $2)
+                          )
+                        )
+                        (block
+                          (set_local $2
                             (get_local $3)
                           )
-                          (block
-                            (set_local $2
-                              (get_local $1)
-                            )
-                            (br $jumpthreading$inner$12)
-                          )
-                          (block
-                            (set_local $3
-                              (get_local $2)
-                            )
-                            (br $jumpthreading$inner$4)
-                          )
+                          (br $jumpthreading$inner$4)
                         )
                       )
                     )
@@ -11262,7 +11250,7 @@
               (if
                 (i32.and
                   (i32.gt_u
-                    (get_local $11)
+                    (get_local $10)
                     (get_local $1)
                   )
                   (i32.and
@@ -11271,21 +11259,21 @@
                       (i32.const 2147483647)
                     )
                     (i32.ne
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const -1)
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (tee_local $2
+                    (tee_local $3
                       (i32.and
                         (i32.add
                           (i32.sub
                             (get_local $5)
                             (get_local $1)
                           )
-                          (tee_local $2
+                          (tee_local $3
                             (i32.load
                               (i32.const 656)
                             )
@@ -11293,7 +11281,7 @@
                         )
                         (i32.sub
                           (i32.const 0)
-                          (get_local $2)
+                          (get_local $3)
                         )
                       )
                     )
@@ -11302,7 +11290,7 @@
                   (if
                     (i32.eq
                       (call $_sbrk
-                        (get_local $2)
+                        (get_local $3)
                       )
                       (i32.const -1)
                     )
@@ -11316,23 +11304,17 @@
                     )
                     (set_local $1
                       (i32.add
-                        (get_local $2)
+                        (get_local $3)
                         (get_local $1)
                       )
                     )
                   )
                 )
               )
-              (if
+              (br_if $jumpthreading$inner$12
                 (i32.ne
-                  (get_local $3)
+                  (get_local $2)
                   (i32.const -1)
-                )
-                (block
-                  (set_local $2
-                    (get_local $1)
-                  )
-                  (br $jumpthreading$inner$12)
                 )
               )
             )
@@ -11355,7 +11337,7 @@
           (if
             (i32.and
               (i32.lt_u
-                (tee_local $3
+                (tee_local $2
                   (call $_sbrk
                     (get_local $7)
                   )
@@ -11368,7 +11350,7 @@
               )
               (i32.and
                 (i32.ne
-                  (get_local $3)
+                  (get_local $2)
                   (i32.const -1)
                 )
                 (i32.ne
@@ -11379,10 +11361,10 @@
             )
             (br_if $jumpthreading$inner$12
               (i32.gt_u
-                (tee_local $2
+                (tee_local $1
                   (i32.sub
                     (get_local $1)
-                    (get_local $3)
+                    (get_local $2)
                   )
                 )
                 (i32.add
@@ -11397,25 +11379,25 @@
       )
       (i32.store
         (i32.const 608)
-        (tee_local $1
+        (tee_local $3
           (i32.add
             (i32.load
               (i32.const 608)
             )
-            (get_local $2)
+            (get_local $1)
           )
         )
       )
       (if
         (i32.gt_u
-          (get_local $1)
+          (get_local $3)
           (i32.load
             (i32.const 612)
           )
         )
         (i32.store
           (i32.const 612)
-          (get_local $1)
+          (get_local $3)
         )
       )
       (block $do-once40
@@ -11426,7 +11408,7 @@
             )
           )
           (block
-            (set_local $1
+            (set_local $3
               (i32.const 624)
             )
             (block $jumpthreading$outer$9
@@ -11434,18 +11416,18 @@
                 (loop $while-in45
                   (br_if $jumpthreading$inner$9
                     (i32.eq
-                      (get_local $3)
+                      (get_local $2)
                       (i32.add
                         (tee_local $6
                           (i32.load
-                            (get_local $1)
+                            (get_local $3)
                           )
                         )
                         (tee_local $9
                           (i32.load
                             (tee_local $4
                               (i32.add
-                                (get_local $1)
+                                (get_local $3)
                                 (i32.const 4)
                               )
                             )
@@ -11455,9 +11437,9 @@
                     )
                   )
                   (br_if $while-in45
-                    (tee_local $1
+                    (tee_local $3
                       (i32.load offset=8
-                        (get_local $1)
+                        (get_local $3)
                       )
                     )
                   )
@@ -11468,7 +11450,7 @@
                 (i32.eqz
                   (i32.and
                     (i32.load offset=12
-                      (get_local $1)
+                      (get_local $3)
                     )
                     (i32.const 8)
                   )
@@ -11477,7 +11459,7 @@
                   (i32.and
                     (i32.lt_u
                       (get_local $8)
-                      (get_local $3)
+                      (get_local $2)
                     )
                     (i32.ge_u
                       (get_local $8)
@@ -11489,18 +11471,18 @@
                       (get_local $4)
                       (i32.add
                         (get_local $9)
-                        (get_local $2)
+                        (get_local $1)
                       )
                     )
                     (set_local $3
                       (i32.add
                         (get_local $8)
-                        (tee_local $1
+                        (tee_local $2
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (tee_local $1
+                                (tee_local $2
                                   (i32.add
                                     (get_local $8)
                                     (i32.const 8)
@@ -11511,7 +11493,7 @@
                             )
                             (i32.const 0)
                             (i32.and
-                              (get_local $1)
+                              (get_local $2)
                               (i32.const 7)
                             )
                           )
@@ -11521,8 +11503,8 @@
                     (set_local $1
                       (i32.add
                         (i32.sub
-                          (get_local $2)
                           (get_local $1)
+                          (get_local $2)
                         )
                         (i32.load
                           (i32.const 188)
@@ -11565,8 +11547,8 @@
             (set_local $5
               (if i32
                 (i32.lt_u
-                  (get_local $3)
-                  (tee_local $1
+                  (get_local $2)
+                  (tee_local $3
                     (i32.load
                       (i32.const 192)
                     )
@@ -11575,20 +11557,20 @@
                 (block i32
                   (i32.store
                     (i32.const 192)
-                    (get_local $3)
+                    (get_local $2)
                   )
-                  (get_local $3)
+                  (get_local $2)
                 )
-                (get_local $1)
+                (get_local $3)
               )
             )
             (set_local $9
               (i32.add
-                (get_local $3)
                 (get_local $2)
+                (get_local $1)
               )
             )
-            (set_local $1
+            (set_local $3
               (i32.const 624)
             )
             (block $jumpthreading$outer$10
@@ -11597,21 +11579,21 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $1)
+                        (get_local $3)
                       )
                       (get_local $9)
                     )
                     (block
                       (set_local $4
-                        (get_local $1)
+                        (get_local $3)
                       )
                       (br $jumpthreading$inner$10)
                     )
                   )
                   (br_if $while-in47
-                    (tee_local $1
+                    (tee_local $3
                       (i32.load offset=8
-                        (get_local $1)
+                        (get_local $3)
                       )
                     )
                   )
@@ -11624,7 +11606,7 @@
               (if
                 (i32.and
                   (i32.load offset=12
-                    (get_local $1)
+                    (get_local $3)
                   )
                   (i32.const 8)
                 )
@@ -11634,34 +11616,34 @@
                 (block
                   (i32.store
                     (get_local $4)
-                    (get_local $3)
+                    (get_local $2)
                   )
                   (i32.store
-                    (tee_local $1
+                    (tee_local $3
                       (i32.add
-                        (get_local $1)
+                        (get_local $3)
                         (i32.const 4)
                       )
                     )
                     (i32.add
                       (i32.load
-                        (get_local $1)
+                        (get_local $3)
                       )
-                      (get_local $2)
+                      (get_local $1)
                     )
                   )
-                  (set_local $10
+                  (set_local $7
                     (i32.add
                       (tee_local $6
                         (i32.add
-                          (get_local $3)
+                          (get_local $2)
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
                                 (tee_local $1
                                   (i32.add
-                                    (get_local $3)
+                                    (get_local $2)
                                     (i32.const 8)
                                   )
                                 )
@@ -11682,7 +11664,7 @@
                   (set_local $4
                     (i32.sub
                       (i32.sub
-                        (tee_local $7
+                        (tee_local $10
                           (i32.add
                             (get_local $9)
                             (select
@@ -11721,7 +11703,7 @@
                   (block $do-once48
                     (if
                       (i32.eq
-                        (get_local $7)
+                        (get_local $10)
                         (get_local $8)
                       )
                       (block
@@ -11738,10 +11720,10 @@
                         )
                         (i32.store
                           (i32.const 200)
-                          (get_local $10)
+                          (get_local $7)
                         )
                         (i32.store offset=4
-                          (get_local $10)
+                          (get_local $7)
                           (i32.or
                             (get_local $0)
                             (i32.const 1)
@@ -11751,7 +11733,7 @@
                       (block
                         (if
                           (i32.eq
-                            (get_local $7)
+                            (get_local $10)
                             (i32.load
                               (i32.const 196)
                             )
@@ -11770,10 +11752,10 @@
                             )
                             (i32.store
                               (i32.const 196)
-                              (get_local $10)
+                              (get_local $7)
                             )
                             (i32.store offset=4
-                              (get_local $10)
+                              (get_local $7)
                               (i32.or
                                 (get_local $0)
                                 (i32.const 1)
@@ -11781,7 +11763,7 @@
                             )
                             (i32.store
                               (i32.add
-                                (get_local $10)
+                                (get_local $7)
                                 (get_local $0)
                               )
                               (get_local $0)
@@ -11797,7 +11779,7 @@
                                   (i32.and
                                     (tee_local $0
                                       (i32.load offset=4
-                                        (get_local $7)
+                                        (get_local $10)
                                       )
                                     )
                                     (i32.const 3)
@@ -11826,7 +11808,7 @@
                                       (block
                                         (set_local $3
                                           (i32.load offset=12
-                                            (get_local $7)
+                                            (get_local $10)
                                           )
                                         )
                                         (block $do-once51
@@ -11834,7 +11816,7 @@
                                             (i32.ne
                                               (tee_local $2
                                                 (i32.load offset=8
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                 )
                                               )
                                               (tee_local $0
@@ -11863,7 +11845,7 @@
                                                   (i32.load offset=12
                                                     (get_local $2)
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                 )
                                               )
                                               (call $_abort)
@@ -11924,7 +11906,7 @@
                                                       )
                                                     )
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                 )
                                                 (block
                                                   (set_local $21
@@ -11947,9 +11929,9 @@
                                         )
                                       )
                                       (block
-                                        (set_local $11
+                                        (set_local $12
                                           (i32.load offset=24
-                                            (get_local $7)
+                                            (get_local $10)
                                           )
                                         )
                                         (block $do-once55
@@ -11957,10 +11939,10 @@
                                             (i32.eq
                                               (tee_local $0
                                                 (i32.load offset=12
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                 )
                                               )
-                                              (get_local $7)
+                                              (get_local $10)
                                             )
                                             (block
                                               (if
@@ -11971,7 +11953,7 @@
                                                         (i32.add
                                                           (tee_local $2
                                                             (i32.add
-                                                              (get_local $7)
+                                                              (get_local $10)
                                                               (i32.const 16)
                                                             )
                                                           )
@@ -11991,7 +11973,7 @@
                                                     (get_local $2)
                                                   )
                                                   (block
-                                                    (set_local $15
+                                                    (set_local $14
                                                       (i32.const 0)
                                                     )
                                                     (br $do-once55)
@@ -12053,7 +12035,7 @@
                                                     (get_local $0)
                                                     (i32.const 0)
                                                   )
-                                                  (set_local $15
+                                                  (set_local $14
                                                     (get_local $1)
                                                   )
                                                 )
@@ -12064,7 +12046,7 @@
                                                 (i32.lt_u
                                                   (tee_local $3
                                                     (i32.load offset=8
-                                                      (get_local $7)
+                                                      (get_local $10)
                                                     )
                                                   )
                                                   (get_local $5)
@@ -12081,7 +12063,7 @@
                                                       )
                                                     )
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                 )
                                                 (call $_abort)
                                               )
@@ -12095,7 +12077,7 @@
                                                       )
                                                     )
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                 )
                                                 (block
                                                   (i32.store
@@ -12106,7 +12088,7 @@
                                                     (get_local $1)
                                                     (get_local $3)
                                                   )
-                                                  (set_local $15
+                                                  (set_local $14
                                                     (get_local $0)
                                                   )
                                                 )
@@ -12117,13 +12099,13 @@
                                         )
                                         (br_if $label$break$L331
                                           (i32.eqz
-                                            (get_local $11)
+                                            (get_local $12)
                                           )
                                         )
                                         (block $do-once59
                                           (if
                                             (i32.eq
-                                              (get_local $7)
+                                              (get_local $10)
                                               (i32.load
                                                 (tee_local $0
                                                   (i32.add
@@ -12131,7 +12113,7 @@
                                                     (i32.shl
                                                       (tee_local $1
                                                         (i32.load offset=28
-                                                          (get_local $7)
+                                                          (get_local $10)
                                                         )
                                                       )
                                                       (i32.const 2)
@@ -12143,10 +12125,10 @@
                                             (block
                                               (i32.store
                                                 (get_local $0)
-                                                (get_local $15)
+                                                (get_local $14)
                                               )
                                               (br_if $do-once59
-                                                (get_local $15)
+                                                (get_local $14)
                                               )
                                               (i32.store
                                                 (i32.const 180)
@@ -12168,7 +12150,7 @@
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $11)
+                                                  (get_local $12)
                                                   (i32.load
                                                     (i32.const 192)
                                                   )
@@ -12180,25 +12162,25 @@
                                                   (i32.load
                                                     (tee_local $0
                                                       (i32.add
-                                                        (get_local $11)
+                                                        (get_local $12)
                                                         (i32.const 16)
                                                       )
                                                     )
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                 )
                                                 (i32.store
                                                   (get_local $0)
-                                                  (get_local $15)
+                                                  (get_local $14)
                                                 )
                                                 (i32.store offset=20
-                                                  (get_local $11)
-                                                  (get_local $15)
+                                                  (get_local $12)
+                                                  (get_local $14)
                                                 )
                                               )
                                               (br_if $label$break$L331
                                                 (i32.eqz
-                                                  (get_local $15)
+                                                  (get_local $14)
                                                 )
                                               )
                                             )
@@ -12206,7 +12188,7 @@
                                         )
                                         (if
                                           (i32.lt_u
-                                            (get_local $15)
+                                            (get_local $14)
                                             (tee_local $1
                                               (i32.load
                                                 (i32.const 192)
@@ -12216,15 +12198,15 @@
                                           (call $_abort)
                                         )
                                         (i32.store offset=24
-                                          (get_local $15)
-                                          (get_local $11)
+                                          (get_local $14)
+                                          (get_local $12)
                                         )
                                         (if
                                           (tee_local $2
                                             (i32.load
                                               (tee_local $0
                                                 (i32.add
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                   (i32.const 16)
                                                 )
                                               )
@@ -12238,12 +12220,12 @@
                                             (call $_abort)
                                             (block
                                               (i32.store offset=16
-                                                (get_local $15)
+                                                (get_local $14)
                                                 (get_local $2)
                                               )
                                               (i32.store offset=24
                                                 (get_local $2)
-                                                (get_local $15)
+                                                (get_local $14)
                                               )
                                             )
                                           )
@@ -12267,12 +12249,12 @@
                                           (call $_abort)
                                           (block
                                             (i32.store offset=20
-                                              (get_local $15)
+                                              (get_local $14)
                                               (get_local $0)
                                             )
                                             (i32.store offset=24
                                               (get_local $0)
-                                              (get_local $15)
+                                              (get_local $14)
                                             )
                                           )
                                         )
@@ -12286,11 +12268,11 @@
                                     )
                                   )
                                   (i32.add
-                                    (get_local $7)
+                                    (get_local $10)
                                     (get_local $9)
                                   )
                                 )
-                                (get_local $7)
+                                (get_local $10)
                               )
                               (i32.const 4)
                             )
@@ -12303,7 +12285,7 @@
                           )
                         )
                         (i32.store offset=4
-                          (get_local $10)
+                          (get_local $7)
                           (i32.or
                             (get_local $4)
                             (i32.const 1)
@@ -12311,7 +12293,7 @@
                         )
                         (i32.store
                           (i32.add
-                            (get_local $10)
+                            (get_local $7)
                             (get_local $4)
                           )
                           (get_local $4)
@@ -12376,7 +12358,7 @@
                                       (set_local $22
                                         (get_local $1)
                                       )
-                                      (set_local $17
+                                      (set_local $11
                                         (get_local $0)
                                       )
                                       (br $do-once63)
@@ -12398,7 +12380,7 @@
                                       (i32.const 8)
                                     )
                                   )
-                                  (set_local $17
+                                  (set_local $11
                                     (get_local $2)
                                   )
                                 )
@@ -12406,18 +12388,18 @@
                             )
                             (i32.store
                               (get_local $22)
-                              (get_local $10)
+                              (get_local $7)
                             )
                             (i32.store offset=12
-                              (get_local $17)
-                              (get_local $10)
+                              (get_local $11)
+                              (get_local $7)
                             )
                             (i32.store offset=8
-                              (get_local $10)
-                              (get_local $17)
+                              (get_local $7)
+                              (get_local $11)
                             )
                             (i32.store offset=12
-                              (get_local $10)
+                              (get_local $7)
                               (get_local $2)
                             )
                             (br $do-once48)
@@ -12535,13 +12517,13 @@
                           )
                         )
                         (i32.store offset=28
-                          (get_local $10)
+                          (get_local $7)
                           (get_local $3)
                         )
                         (i32.store offset=4
                           (tee_local $0
                             (i32.add
-                              (get_local $10)
+                              (get_local $7)
                               (i32.const 16)
                             )
                           )
@@ -12577,19 +12559,19 @@
                             )
                             (i32.store
                               (get_local $2)
-                              (get_local $10)
+                              (get_local $7)
                             )
                             (i32.store offset=24
-                              (get_local $10)
+                              (get_local $7)
                               (get_local $2)
                             )
                             (i32.store offset=12
-                              (get_local $10)
-                              (get_local $10)
+                              (get_local $7)
+                              (get_local $7)
                             )
                             (i32.store offset=8
-                              (get_local $10)
-                              (get_local $10)
+                              (get_local $7)
+                              (get_local $7)
                             )
                             (br $do-once48)
                           )
@@ -12684,19 +12666,19 @@
                               (block
                                 (i32.store
                                   (get_local $3)
-                                  (get_local $10)
+                                  (get_local $7)
                                 )
                                 (i32.store offset=24
-                                  (get_local $10)
+                                  (get_local $7)
                                   (get_local $0)
                                 )
                                 (i32.store offset=12
-                                  (get_local $10)
-                                  (get_local $10)
+                                  (get_local $7)
+                                  (get_local $7)
                                 )
                                 (i32.store offset=8
-                                  (get_local $10)
-                                  (get_local $10)
+                                  (get_local $7)
+                                  (get_local $7)
                                 )
                                 (br $do-once48)
                               )
@@ -12730,22 +12712,22 @@
                             (block
                               (i32.store offset=12
                                 (get_local $3)
-                                (get_local $10)
+                                (get_local $7)
                               )
                               (i32.store
                                 (get_local $2)
-                                (get_local $10)
+                                (get_local $7)
                               )
                               (i32.store offset=8
-                                (get_local $10)
+                                (get_local $7)
                                 (get_local $3)
                               )
                               (i32.store offset=12
-                                (get_local $10)
+                                (get_local $7)
                                 (get_local $0)
                               )
                               (i32.store offset=24
-                                (get_local $10)
+                                (get_local $7)
                                 (i32.const 0)
                               )
                             )
@@ -12768,30 +12750,24 @@
               (block $while-out69
                 (if
                   (i32.le_u
-                    (tee_local $1
+                    (tee_local $3
                       (i32.load
                         (get_local $4)
                       )
                     )
                     (get_local $8)
                   )
-                  (if
+                  (br_if $while-out69
                     (i32.gt_u
-                      (tee_local $1
+                      (tee_local $3
                         (i32.add
-                          (get_local $1)
+                          (get_local $3)
                           (i32.load offset=4
                             (get_local $4)
                           )
                         )
                       )
                       (get_local $8)
-                    )
-                    (block
-                      (set_local $4
-                        (get_local $1)
-                      )
-                      (br $while-out69)
                     )
                   )
                 )
@@ -12805,9 +12781,9 @@
             )
             (set_local $9
               (i32.add
-                (tee_local $1
+                (tee_local $4
                   (i32.add
-                    (get_local $4)
+                    (get_local $3)
                     (i32.const -47)
                   )
                 )
@@ -12819,9 +12795,9 @@
                 (tee_local $11
                   (select
                     (get_local $8)
-                    (tee_local $1
+                    (tee_local $4
                       (i32.add
-                        (get_local $1)
+                        (get_local $4)
                         (select
                           (i32.and
                             (i32.sub
@@ -12839,7 +12815,7 @@
                       )
                     )
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $4)
                       (tee_local $9
                         (i32.add
                           (get_local $8)
@@ -12856,15 +12832,15 @@
               (i32.const 200)
               (tee_local $6
                 (i32.add
-                  (get_local $3)
-                  (tee_local $1
+                  (get_local $2)
+                  (tee_local $4
                     (select
                       (i32.and
                         (i32.sub
                           (i32.const 0)
-                          (tee_local $1
+                          (tee_local $4
                             (i32.add
-                              (get_local $3)
+                              (get_local $2)
                               (i32.const 8)
                             )
                           )
@@ -12873,7 +12849,7 @@
                       )
                       (i32.const 0)
                       (i32.and
-                        (get_local $1)
+                        (get_local $4)
                         (i32.const 7)
                       )
                     )
@@ -12883,27 +12859,27 @@
             )
             (i32.store
               (i32.const 188)
-              (tee_local $1
+              (tee_local $4
                 (i32.sub
                   (i32.add
-                    (get_local $2)
+                    (get_local $1)
                     (i32.const -40)
                   )
-                  (get_local $1)
+                  (get_local $4)
                 )
               )
             )
             (i32.store offset=4
               (get_local $6)
               (i32.or
-                (get_local $1)
+                (get_local $4)
                 (i32.const 1)
               )
             )
             (i32.store offset=4
               (i32.add
                 (get_local $6)
-                (get_local $1)
+                (get_local $4)
               )
               (i32.const 40)
             )
@@ -12914,7 +12890,7 @@
               )
             )
             (i32.store
-              (tee_local $6
+              (tee_local $4
                 (i32.add
                   (get_local $11)
                   (i32.const 4)
@@ -12948,11 +12924,11 @@
             )
             (i32.store
               (i32.const 624)
-              (get_local $3)
+              (get_local $2)
             )
             (i32.store
               (i32.const 628)
-              (get_local $2)
+              (get_local $1)
             )
             (i32.store
               (i32.const 636)
@@ -12984,7 +12960,7 @@
                     (get_local $1)
                     (i32.const 4)
                   )
-                  (get_local $4)
+                  (get_local $3)
                 )
               )
             )
@@ -12995,10 +12971,10 @@
               )
               (block
                 (i32.store
-                  (get_local $6)
+                  (get_local $4)
                   (i32.and
                     (i32.load
-                      (get_local $6)
+                      (get_local $4)
                     )
                     (i32.const -2)
                   )
@@ -13078,7 +13054,7 @@
                           (set_local $23
                             (get_local $2)
                           )
-                          (set_local $10
+                          (set_local $12
                             (get_local $1)
                           )
                         )
@@ -13097,7 +13073,7 @@
                             (i32.const 8)
                           )
                         )
-                        (set_local $10
+                        (set_local $12
                           (get_local $3)
                         )
                       )
@@ -13107,12 +13083,12 @@
                       (get_local $8)
                     )
                     (i32.store offset=12
-                      (get_local $10)
+                      (get_local $12)
                       (get_local $8)
                     )
                     (i32.store offset=8
                       (get_local $8)
-                      (get_local $10)
+                      (get_local $12)
                     )
                     (i32.store offset=12
                       (get_local $8)
@@ -13446,29 +13422,29 @@
             (if
               (i32.or
                 (i32.eqz
-                  (tee_local $1
+                  (tee_local $3
                     (i32.load
                       (i32.const 192)
                     )
                   )
                 )
                 (i32.lt_u
+                  (get_local $2)
                   (get_local $3)
-                  (get_local $1)
                 )
               )
               (i32.store
                 (i32.const 192)
-                (get_local $3)
+                (get_local $2)
               )
             )
             (i32.store
               (i32.const 624)
-              (get_local $3)
+              (get_local $2)
             )
             (i32.store
               (i32.const 628)
-              (get_local $2)
+              (get_local $1)
             )
             (i32.store
               (i32.const 636)
@@ -13484,7 +13460,7 @@
               (i32.const 208)
               (i32.const -1)
             )
-            (set_local $1
+            (set_local $3
               (i32.const 0)
             )
             (loop $while-in43
@@ -13494,7 +13470,7 @@
                     (i32.const 216)
                     (i32.shl
                       (i32.shl
-                        (get_local $1)
+                        (get_local $3)
                         (i32.const 1)
                       )
                       (i32.const 2)
@@ -13509,9 +13485,9 @@
               )
               (br_if $while-in43
                 (i32.ne
-                  (tee_local $1
+                  (tee_local $3
                     (i32.add
-                      (get_local $1)
+                      (get_local $3)
                       (i32.const 1)
                     )
                   )
@@ -13523,15 +13499,15 @@
               (i32.const 200)
               (tee_local $3
                 (i32.add
-                  (get_local $3)
-                  (tee_local $1
+                  (get_local $2)
+                  (tee_local $2
                     (select
                       (i32.and
                         (i32.sub
                           (i32.const 0)
-                          (tee_local $1
+                          (tee_local $2
                             (i32.add
-                              (get_local $3)
+                              (get_local $2)
                               (i32.const 8)
                             )
                           )
@@ -13540,7 +13516,7 @@
                       )
                       (i32.const 0)
                       (i32.and
-                        (get_local $1)
+                        (get_local $2)
                         (i32.const 7)
                       )
                     )
@@ -13553,10 +13529,10 @@
               (tee_local $1
                 (i32.sub
                   (i32.add
-                    (get_local $2)
+                    (get_local $1)
                     (i32.const -40)
                   )
-                  (get_local $1)
+                  (get_local $2)
                 )
               )
             )
@@ -13668,7 +13644,7 @@
     )
     (if
       (i32.lt_u
-        (tee_local $4
+        (tee_local $1
           (i32.add
             (get_local $0)
             (i32.const -8)
@@ -13684,9 +13660,9 @@
     )
     (if
       (i32.eq
-        (tee_local $10
+        (tee_local $5
           (i32.and
-            (tee_local $2
+            (tee_local $7
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -13701,12 +13677,12 @@
       )
       (call $_abort)
     )
-    (set_local $6
+    (set_local $8
       (i32.add
-        (get_local $4)
+        (get_local $1)
         (tee_local $0
           (i32.and
-            (get_local $2)
+            (get_local $7)
             (i32.const -8)
           )
         )
@@ -13715,43 +13691,43 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $2)
+          (get_local $7)
           (i32.const 1)
         )
         (block
-          (set_local $3
-            (get_local $4)
+          (set_local $2
+            (get_local $1)
           )
-          (set_local $1
+          (set_local $3
             (get_local $0)
           )
         )
         (block
-          (set_local $8
+          (set_local $7
             (i32.load
-              (get_local $4)
+              (get_local $1)
             )
           )
           (if
             (i32.eqz
-              (get_local $10)
+              (get_local $5)
             )
             (return)
           )
-          (set_local $2
+          (set_local $0
             (i32.add
-              (get_local $8)
+              (get_local $7)
               (get_local $0)
             )
           )
           (if
             (i32.lt_u
-              (tee_local $0
+              (tee_local $1
                 (i32.add
-                  (get_local $4)
+                  (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $8)
+                    (get_local $7)
                   )
                 )
               )
@@ -13761,7 +13737,7 @@
           )
           (if
             (i32.eq
-              (get_local $0)
+              (get_local $1)
               (i32.load
                 (i32.const 196)
               )
@@ -13772,9 +13748,9 @@
                   (i32.and
                     (tee_local $3
                       (i32.load
-                        (tee_local $1
+                        (tee_local $2
                           (i32.add
-                            (get_local $6)
+                            (get_local $8)
                             (i32.const 4)
                           )
                         )
@@ -13785,73 +13761,73 @@
                   (i32.const 3)
                 )
                 (block
+                  (set_local $2
+                    (get_local $1)
+                  )
                   (set_local $3
                     (get_local $0)
-                  )
-                  (set_local $1
-                    (get_local $2)
                   )
                   (br $do-once)
                 )
               )
               (i32.store
                 (i32.const 184)
-                (get_local $2)
+                (get_local $0)
               )
               (i32.store
-                (get_local $1)
+                (get_local $2)
                 (i32.and
                   (get_local $3)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $0)
+                (get_local $1)
                 (i32.or
-                  (get_local $2)
+                  (get_local $0)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
+                  (get_local $1)
                   (get_local $0)
-                  (get_local $2)
                 )
-                (get_local $2)
+                (get_local $0)
               )
               (return)
             )
           )
-          (set_local $10
+          (set_local $5
             (i32.shr_u
-              (get_local $8)
+              (get_local $7)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $8)
+              (get_local $7)
               (i32.const 256)
             )
             (block
-              (set_local $3
+              (set_local $6
                 (i32.load offset=12
-                  (get_local $0)
+                  (get_local $1)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $4
+                  (tee_local $2
                     (i32.load offset=8
-                      (get_local $0)
+                      (get_local $1)
                     )
                   )
-                  (tee_local $1
+                  (tee_local $3
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $10)
+                          (get_local $5)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -13862,7 +13838,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $4)
+                      (get_local $2)
                       (get_local $11)
                     )
                     (call $_abort)
@@ -13870,9 +13846,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $4)
+                        (get_local $2)
                       )
-                      (get_local $0)
+                      (get_local $1)
                     )
                     (call $_abort)
                   )
@@ -13880,8 +13856,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $3)
-                  (get_local $4)
+                  (get_local $6)
+                  (get_local $2)
                 )
                 (block
                   (i32.store
@@ -13893,36 +13869,36 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $10)
+                          (get_local $5)
                         )
                         (i32.const -1)
                       )
                     )
                   )
+                  (set_local $2
+                    (get_local $1)
+                  )
                   (set_local $3
                     (get_local $0)
-                  )
-                  (set_local $1
-                    (get_local $2)
                   )
                   (br $do-once)
                 )
               )
               (if
                 (i32.eq
+                  (get_local $6)
                   (get_local $3)
-                  (get_local $1)
                 )
-                (set_local $5
+                (set_local $4
                   (i32.add
-                    (get_local $3)
+                    (get_local $6)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $3)
+                      (get_local $6)
                       (get_local $11)
                     )
                     (call $_abort)
@@ -13930,42 +13906,42 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $1
+                        (tee_local $3
                           (i32.add
-                            (get_local $3)
+                            (get_local $6)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $0)
-                    )
-                    (set_local $5
                       (get_local $1)
+                    )
+                    (set_local $4
+                      (get_local $3)
                     )
                     (call $_abort)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $4)
-                (get_local $3)
+                (get_local $2)
+                (get_local $6)
               )
               (i32.store
-                (get_local $5)
                 (get_local $4)
+                (get_local $2)
+              )
+              (set_local $2
+                (get_local $1)
               )
               (set_local $3
                 (get_local $0)
-              )
-              (set_local $1
-                (get_local $2)
               )
               (br $do-once)
             )
           )
           (set_local $12
             (i32.load offset=24
-              (get_local $0)
+              (get_local $1)
             )
           )
           (block $do-once0
@@ -13973,41 +13949,41 @@
               (i32.eq
                 (tee_local $4
                   (i32.load offset=12
-                    (get_local $0)
+                    (get_local $1)
                   )
                 )
-                (get_local $0)
+                (get_local $1)
               )
               (block
                 (if
-                  (tee_local $4
-                    (i32.load
-                      (tee_local $8
-                        (i32.add
-                          (tee_local $5
-                            (i32.add
-                              (get_local $0)
-                              (i32.const 16)
+                  (i32.eqz
+                    (tee_local $5
+                      (i32.load
+                        (tee_local $4
+                          (i32.add
+                            (tee_local $7
+                              (i32.add
+                                (get_local $1)
+                                (i32.const 16)
+                              )
                             )
+                            (i32.const 4)
                           )
-                          (i32.const 4)
                         )
                       )
                     )
-                  )
-                  (set_local $5
-                    (get_local $8)
                   )
                   (if
-                    (i32.eqz
-                      (tee_local $4
-                        (i32.load
-                          (get_local $5)
-                        )
+                    (tee_local $5
+                      (i32.load
+                        (get_local $7)
                       )
                     )
+                    (set_local $4
+                      (get_local $7)
+                    )
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.const 0)
                       )
                       (br $do-once0)
@@ -14016,43 +13992,43 @@
                 )
                 (loop $while-in
                   (if
-                    (tee_local $10
+                    (tee_local $7
                       (i32.load
-                        (tee_local $8
+                        (tee_local $10
                           (i32.add
-                            (get_local $4)
+                            (get_local $5)
                             (i32.const 20)
                           )
                         )
                       )
                     )
                     (block
+                      (set_local $5
+                        (get_local $7)
+                      )
                       (set_local $4
                         (get_local $10)
-                      )
-                      (set_local $5
-                        (get_local $8)
                       )
                       (br $while-in)
                     )
                   )
                   (if
-                    (tee_local $10
+                    (tee_local $7
                       (i32.load
-                        (tee_local $8
+                        (tee_local $10
                           (i32.add
-                            (get_local $4)
+                            (get_local $5)
                             (i32.const 16)
                           )
                         )
                       )
                     )
                     (block
+                      (set_local $5
+                        (get_local $7)
+                      )
                       (set_local $4
                         (get_local $10)
-                      )
-                      (set_local $5
-                        (get_local $8)
                       )
                       (br $while-in)
                     )
@@ -14060,17 +14036,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $5)
+                    (get_local $4)
                     (get_local $11)
                   )
                   (call $_abort)
                   (block
                     (i32.store
-                      (get_local $5)
+                      (get_local $4)
                       (i32.const 0)
                     )
-                    (set_local $7
-                      (get_local $4)
+                    (set_local $6
+                      (get_local $5)
                     )
                   )
                 )
@@ -14078,9 +14054,9 @@
               (block
                 (if
                   (i32.lt_u
-                    (tee_local $5
+                    (tee_local $10
                       (i32.load offset=8
-                        (get_local $0)
+                        (get_local $1)
                       )
                     )
                     (get_local $11)
@@ -14090,39 +14066,39 @@
                 (if
                   (i32.ne
                     (i32.load
-                      (tee_local $8
+                      (tee_local $7
                         (i32.add
-                          (get_local $5)
+                          (get_local $10)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $1)
                   )
                   (call $_abort)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $10
+                      (tee_local $5
                         (i32.add
                           (get_local $4)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $1)
                   )
                   (block
                     (i32.store
-                      (get_local $8)
+                      (get_local $7)
                       (get_local $4)
                     )
                     (i32.store
-                      (get_local $10)
                       (get_local $5)
+                      (get_local $10)
                     )
-                    (set_local $7
+                    (set_local $6
                       (get_local $4)
                     )
                   )
@@ -14136,15 +14112,15 @@
             (block
               (if
                 (i32.eq
-                  (get_local $0)
+                  (get_local $1)
                   (i32.load
-                    (tee_local $5
+                    (tee_local $4
                       (i32.add
                         (i32.const 480)
                         (i32.shl
-                          (tee_local $4
+                          (tee_local $5
                             (i32.load offset=28
-                              (get_local $0)
+                              (get_local $1)
                             )
                           )
                           (i32.const 2)
@@ -14155,12 +14131,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $5)
-                    (get_local $7)
+                    (get_local $4)
+                    (get_local $6)
                   )
                   (if
                     (i32.eqz
-                      (get_local $7)
+                      (get_local $6)
                     )
                     (block
                       (i32.store
@@ -14172,17 +14148,17 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $4)
+                              (get_local $5)
                             )
                             (i32.const -1)
                           )
                         )
                       )
+                      (set_local $2
+                        (get_local $1)
+                      )
                       (set_local $3
                         (get_local $0)
-                      )
-                      (set_local $1
-                        (get_local $2)
                       )
                       (br $do-once)
                     )
@@ -14208,27 +14184,27 @@
                           )
                         )
                       )
-                      (get_local $0)
+                      (get_local $1)
                     )
                     (i32.store
                       (get_local $4)
-                      (get_local $7)
+                      (get_local $6)
                     )
                     (i32.store offset=20
                       (get_local $12)
-                      (get_local $7)
+                      (get_local $6)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $7)
+                      (get_local $6)
                     )
                     (block
+                      (set_local $2
+                        (get_local $1)
+                      )
                       (set_local $3
                         (get_local $0)
-                      )
-                      (set_local $1
-                        (get_local $2)
                       )
                       (br $do-once)
                     )
@@ -14237,7 +14213,7 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $7)
+                  (get_local $6)
                   (tee_local $5
                     (i32.load
                       (i32.const 192)
@@ -14247,15 +14223,15 @@
                 (call $_abort)
               )
               (i32.store offset=24
-                (get_local $7)
+                (get_local $6)
                 (get_local $12)
               )
               (if
-                (tee_local $4
+                (tee_local $7
                   (i32.load
-                    (tee_local $8
+                    (tee_local $4
                       (i32.add
-                        (get_local $0)
+                        (get_local $1)
                         (i32.const 16)
                       )
                     )
@@ -14263,18 +14239,18 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $4)
+                    (get_local $7)
                     (get_local $5)
                   )
                   (call $_abort)
                   (block
                     (i32.store offset=16
+                      (get_local $6)
                       (get_local $7)
-                      (get_local $4)
                     )
                     (i32.store offset=24
-                      (get_local $4)
                       (get_local $7)
+                      (get_local $6)
                     )
                   )
                 )
@@ -14282,7 +14258,7 @@
               (if
                 (tee_local $4
                   (i32.load offset=4
-                    (get_local $8)
+                    (get_local $4)
                   )
                 )
                 (if
@@ -14295,37 +14271,37 @@
                   (call $_abort)
                   (block
                     (i32.store offset=20
-                      (get_local $7)
+                      (get_local $6)
                       (get_local $4)
                     )
                     (i32.store offset=24
                       (get_local $4)
-                      (get_local $7)
+                      (get_local $6)
+                    )
+                    (set_local $2
+                      (get_local $1)
                     )
                     (set_local $3
                       (get_local $0)
                     )
-                    (set_local $1
-                      (get_local $2)
-                    )
                   )
                 )
                 (block
+                  (set_local $2
+                    (get_local $1)
+                  )
                   (set_local $3
                     (get_local $0)
-                  )
-                  (set_local $1
-                    (get_local $2)
                   )
                 )
               )
             )
             (block
+              (set_local $2
+                (get_local $1)
+              )
               (set_local $3
                 (get_local $0)
-              )
-              (set_local $1
-                (get_local $2)
               )
             )
           )
@@ -14334,19 +14310,19 @@
     )
     (if
       (i32.ge_u
-        (get_local $3)
-        (get_local $6)
+        (get_local $2)
+        (get_local $8)
       )
       (call $_abort)
     )
     (if
       (i32.eqz
         (i32.and
-          (tee_local $0
+          (tee_local $1
             (i32.load
-              (tee_local $2
+              (tee_local $0
                 (i32.add
-                  (get_local $6)
+                  (get_local $8)
                   (i32.const 4)
                 )
               )
@@ -14359,36 +14335,36 @@
     )
     (if
       (i32.and
-        (get_local $0)
+        (get_local $1)
         (i32.const 2)
       )
       (block
         (i32.store
-          (get_local $2)
+          (get_local $0)
           (i32.and
-            (get_local $0)
+            (get_local $1)
             (i32.const -2)
           )
         )
         (i32.store offset=4
-          (get_local $3)
+          (get_local $2)
           (i32.or
-            (get_local $1)
+            (get_local $3)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
+            (get_local $2)
             (get_local $3)
-            (get_local $1)
           )
-          (get_local $1)
+          (get_local $3)
         )
       )
       (block
         (if
           (i32.eq
-            (get_local $6)
+            (get_local $8)
             (i32.load
               (i32.const 200)
             )
@@ -14401,16 +14377,16 @@
                   (i32.load
                     (i32.const 188)
                   )
-                  (get_local $1)
+                  (get_local $3)
                 )
               )
             )
             (i32.store
               (i32.const 200)
-              (get_local $3)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
                 (get_local $0)
                 (i32.const 1)
@@ -14418,7 +14394,7 @@
             )
             (if
               (i32.ne
-                (get_local $3)
+                (get_local $2)
                 (i32.load
                   (i32.const 196)
                 )
@@ -14438,7 +14414,7 @@
         )
         (if
           (i32.eq
-            (get_local $6)
+            (get_local $8)
             (i32.load
               (i32.const 196)
             )
@@ -14451,16 +14427,16 @@
                   (i32.load
                     (i32.const 184)
                   )
-                  (get_local $1)
+                  (get_local $3)
                 )
               )
             )
             (i32.store
               (i32.const 196)
-              (get_local $3)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
                 (get_local $0)
                 (i32.const 1)
@@ -14468,7 +14444,7 @@
             )
             (i32.store
               (i32.add
-                (get_local $3)
+                (get_local $2)
                 (get_local $0)
               )
               (get_local $0)
@@ -14479,35 +14455,35 @@
         (set_local $5
           (i32.add
             (i32.and
-              (get_local $0)
+              (get_local $1)
               (i32.const -8)
             )
-            (get_local $1)
+            (get_local $3)
           )
         )
-        (set_local $4
+        (set_local $3
           (i32.shr_u
-            (get_local $0)
+            (get_local $1)
             (i32.const 3)
           )
         )
         (block $do-once4
           (if
             (i32.lt_u
-              (get_local $0)
+              (get_local $1)
               (i32.const 256)
             )
             (block
-              (set_local $1
+              (set_local $4
                 (i32.load offset=12
-                  (get_local $6)
+                  (get_local $8)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $2
+                  (tee_local $1
                     (i32.load offset=8
-                      (get_local $6)
+                      (get_local $8)
                     )
                   )
                   (tee_local $0
@@ -14515,68 +14491,12 @@
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $4)
+                          (get_local $3)
                           (i32.const 1)
                         )
                         (i32.const 2)
                       )
                     )
-                  )
-                )
-                (block
-                  (if
-                    (i32.lt_u
-                      (get_local $2)
-                      (i32.load
-                        (i32.const 192)
-                      )
-                    )
-                    (call $_abort)
-                  )
-                  (if
-                    (i32.ne
-                      (i32.load offset=12
-                        (get_local $2)
-                      )
-                      (get_local $6)
-                    )
-                    (call $_abort)
-                  )
-                )
-              )
-              (if
-                (i32.eq
-                  (get_local $1)
-                  (get_local $2)
-                )
-                (block
-                  (i32.store
-                    (i32.const 176)
-                    (i32.and
-                      (i32.load
-                        (i32.const 176)
-                      )
-                      (i32.xor
-                        (i32.shl
-                          (i32.const 1)
-                          (get_local $4)
-                        )
-                        (i32.const -1)
-                      )
-                    )
-                  )
-                  (br $do-once4)
-                )
-              )
-              (if
-                (i32.eq
-                  (get_local $1)
-                  (get_local $0)
-                )
-                (set_local $14
-                  (i32.add
-                    (get_local $1)
-                    (i32.const 8)
                   )
                 )
                 (block
@@ -14590,16 +14510,72 @@
                     (call $_abort)
                   )
                   (if
+                    (i32.ne
+                      (i32.load offset=12
+                        (get_local $1)
+                      )
+                      (get_local $8)
+                    )
+                    (call $_abort)
+                  )
+                )
+              )
+              (if
+                (i32.eq
+                  (get_local $4)
+                  (get_local $1)
+                )
+                (block
+                  (i32.store
+                    (i32.const 176)
+                    (i32.and
+                      (i32.load
+                        (i32.const 176)
+                      )
+                      (i32.xor
+                        (i32.shl
+                          (i32.const 1)
+                          (get_local $3)
+                        )
+                        (i32.const -1)
+                      )
+                    )
+                  )
+                  (br $do-once4)
+                )
+              )
+              (if
+                (i32.eq
+                  (get_local $4)
+                  (get_local $0)
+                )
+                (set_local $14
+                  (i32.add
+                    (get_local $4)
+                    (i32.const 8)
+                  )
+                )
+                (block
+                  (if
+                    (i32.lt_u
+                      (get_local $4)
+                      (i32.load
+                        (i32.const 192)
+                      )
+                    )
+                    (call $_abort)
+                  )
+                  (if
                     (i32.eq
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $1)
+                            (get_local $4)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $6)
+                      (get_local $8)
                     )
                     (set_local $14
                       (get_local $0)
@@ -14609,18 +14585,18 @@
                 )
               )
               (i32.store offset=12
-                (get_local $2)
                 (get_local $1)
+                (get_local $4)
               )
               (i32.store
                 (get_local $14)
-                (get_local $2)
+                (get_local $1)
               )
             )
             (block
-              (set_local $7
+              (set_local $6
                 (i32.load offset=24
-                  (get_local $6)
+                  (get_local $8)
                 )
               )
               (block $do-once6
@@ -14628,38 +14604,38 @@
                   (i32.eq
                     (tee_local $0
                       (i32.load offset=12
-                        (get_local $6)
+                        (get_local $8)
                       )
                     )
-                    (get_local $6)
+                    (get_local $8)
                   )
                   (block
                     (if
-                      (tee_local $0
-                        (i32.load
-                          (tee_local $2
-                            (i32.add
-                              (tee_local $1
-                                (i32.add
-                                  (get_local $6)
-                                  (i32.const 16)
+                      (i32.eqz
+                        (tee_local $3
+                          (i32.load
+                            (tee_local $0
+                              (i32.add
+                                (tee_local $1
+                                  (i32.add
+                                    (get_local $8)
+                                    (i32.const 16)
+                                  )
                                 )
+                                (i32.const 4)
                               )
-                              (i32.const 4)
                             )
                           )
                         )
                       )
-                      (set_local $1
-                        (get_local $2)
-                      )
                       (if
-                        (i32.eqz
-                          (tee_local $0
-                            (i32.load
-                              (get_local $1)
-                            )
+                        (tee_local $3
+                          (i32.load
+                            (get_local $1)
                           )
+                        )
+                        (set_local $0
+                          (get_local $1)
                         )
                         (block
                           (set_local $9
@@ -14671,43 +14647,43 @@
                     )
                     (loop $while-in9
                       (if
-                        (tee_local $4
+                        (tee_local $1
                           (i32.load
-                            (tee_local $2
+                            (tee_local $4
                               (i32.add
-                                (get_local $0)
+                                (get_local $3)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
+                          (set_local $3
+                            (get_local $1)
+                          )
                           (set_local $0
                             (get_local $4)
-                          )
-                          (set_local $1
-                            (get_local $2)
                           )
                           (br $while-in9)
                         )
                       )
                       (if
-                        (tee_local $4
+                        (tee_local $1
                           (i32.load
-                            (tee_local $2
+                            (tee_local $4
                               (i32.add
-                                (get_local $0)
+                                (get_local $3)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
+                          (set_local $3
+                            (get_local $1)
+                          )
                           (set_local $0
                             (get_local $4)
-                          )
-                          (set_local $1
-                            (get_local $2)
                           )
                           (br $while-in9)
                         )
@@ -14715,7 +14691,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $0)
                         (i32.load
                           (i32.const 192)
                         )
@@ -14723,11 +14699,11 @@
                       (call $_abort)
                       (block
                         (i32.store
-                          (get_local $1)
+                          (get_local $0)
                           (i32.const 0)
                         )
                         (set_local $9
-                          (get_local $0)
+                          (get_local $3)
                         )
                       )
                     )
@@ -14735,9 +14711,9 @@
                   (block
                     (if
                       (i32.lt_u
-                        (tee_local $1
+                        (tee_local $4
                           (i32.load offset=8
-                            (get_local $6)
+                            (get_local $8)
                           )
                         )
                         (i32.load
@@ -14749,37 +14725,37 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (tee_local $2
+                          (tee_local $1
                             (i32.add
-                              (get_local $1)
+                              (get_local $4)
                               (i32.const 12)
                             )
                           )
                         )
-                        (get_local $6)
+                        (get_local $8)
                       )
                       (call $_abort)
                     )
                     (if
                       (i32.eq
                         (i32.load
-                          (tee_local $4
+                          (tee_local $3
                             (i32.add
                               (get_local $0)
                               (i32.const 8)
                             )
                           )
                         )
-                        (get_local $6)
+                        (get_local $8)
                       )
                       (block
                         (i32.store
-                          (get_local $2)
+                          (get_local $1)
                           (get_local $0)
                         )
                         (i32.store
+                          (get_local $3)
                           (get_local $4)
-                          (get_local $1)
                         )
                         (set_local $9
                           (get_local $0)
@@ -14791,19 +14767,19 @@
                 )
               )
               (if
-                (get_local $7)
+                (get_local $6)
                 (block
                   (if
                     (i32.eq
-                      (get_local $6)
+                      (get_local $8)
                       (i32.load
-                        (tee_local $1
+                        (tee_local $0
                           (i32.add
                             (i32.const 480)
                             (i32.shl
-                              (tee_local $0
+                              (tee_local $3
                                 (i32.load offset=28
-                                  (get_local $6)
+                                  (get_local $8)
                                 )
                               )
                               (i32.const 2)
@@ -14814,7 +14790,7 @@
                     )
                     (block
                       (i32.store
-                        (get_local $1)
+                        (get_local $0)
                         (get_local $9)
                       )
                       (if
@@ -14831,7 +14807,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $0)
+                                  (get_local $3)
                                 )
                                 (i32.const -1)
                               )
@@ -14844,7 +14820,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $7)
+                          (get_local $6)
                           (i32.load
                             (i32.const 192)
                           )
@@ -14856,19 +14832,19 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $7)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                             )
                           )
-                          (get_local $6)
+                          (get_local $8)
                         )
                         (i32.store
                           (get_local $0)
                           (get_local $9)
                         )
                         (i32.store offset=20
-                          (get_local $7)
+                          (get_local $6)
                           (get_local $9)
                         )
                       )
@@ -14882,7 +14858,7 @@
                   (if
                     (i32.lt_u
                       (get_local $9)
-                      (tee_local $1
+                      (tee_local $3
                         (i32.load
                           (i32.const 192)
                         )
@@ -14892,14 +14868,14 @@
                   )
                   (i32.store offset=24
                     (get_local $9)
-                    (get_local $7)
+                    (get_local $6)
                   )
                   (if
-                    (tee_local $0
+                    (tee_local $1
                       (i32.load
-                        (tee_local $2
+                        (tee_local $0
                           (i32.add
-                            (get_local $6)
+                            (get_local $8)
                             (i32.const 16)
                           )
                         )
@@ -14907,17 +14883,17 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $0)
                         (get_local $1)
+                        (get_local $3)
                       )
                       (call $_abort)
                       (block
                         (i32.store offset=16
                           (get_local $9)
-                          (get_local $0)
+                          (get_local $1)
                         )
                         (i32.store offset=24
-                          (get_local $0)
+                          (get_local $1)
                           (get_local $9)
                         )
                       )
@@ -14926,7 +14902,7 @@
                   (if
                     (tee_local $0
                       (i32.load offset=4
-                        (get_local $2)
+                        (get_local $0)
                       )
                     )
                     (if
@@ -14955,7 +14931,7 @@
           )
         )
         (i32.store offset=4
-          (get_local $3)
+          (get_local $2)
           (i32.or
             (get_local $5)
             (i32.const 1)
@@ -14963,14 +14939,14 @@
         )
         (i32.store
           (i32.add
-            (get_local $3)
+            (get_local $2)
             (get_local $5)
           )
           (get_local $5)
         )
         (if
           (i32.eq
-            (get_local $3)
+            (get_local $2)
             (i32.load
               (i32.const 196)
             )
@@ -14982,30 +14958,30 @@
             )
             (return)
           )
-          (set_local $1
+          (set_local $3
             (get_local $5)
           )
         )
       )
     )
-    (set_local $2
+    (set_local $0
       (i32.shr_u
-        (get_local $1)
+        (get_local $3)
         (i32.const 3)
       )
     )
     (if
       (i32.lt_u
-        (get_local $1)
+        (get_local $3)
         (i32.const 256)
       )
       (block
-        (set_local $0
+        (set_local $1
           (i32.add
             (i32.const 216)
             (i32.shl
               (i32.shl
-                (get_local $2)
+                (get_local $0)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -15014,25 +14990,25 @@
         )
         (if
           (i32.and
-            (tee_local $1
+            (tee_local $3
               (i32.load
                 (i32.const 176)
               )
             )
-            (tee_local $2
+            (tee_local $0
               (i32.shl
                 (i32.const 1)
-                (get_local $2)
+                (get_local $0)
               )
             )
           )
           (if
             (i32.lt_u
-              (tee_local $2
+              (tee_local $0
                 (i32.load
-                  (tee_local $1
+                  (tee_local $3
                     (i32.add
-                      (get_local $0)
+                      (get_local $1)
                       (i32.const 8)
                     )
                   )
@@ -15045,10 +15021,10 @@
             (call $_abort)
             (block
               (set_local $15
-                (get_local $1)
+                (get_local $3)
               )
               (set_local $13
-                (get_local $2)
+                (get_local $0)
               )
             )
           )
@@ -15056,36 +15032,36 @@
             (i32.store
               (i32.const 176)
               (i32.or
-                (get_local $1)
-                (get_local $2)
+                (get_local $3)
+                (get_local $0)
               )
             )
             (set_local $15
               (i32.add
-                (get_local $0)
+                (get_local $1)
                 (i32.const 8)
               )
             )
             (set_local $13
-              (get_local $0)
+              (get_local $1)
             )
           )
         )
         (i32.store
           (get_local $15)
-          (get_local $3)
+          (get_local $2)
         )
         (i32.store offset=12
           (get_local $13)
-          (get_local $3)
+          (get_local $2)
         )
         (i32.store offset=8
-          (get_local $3)
+          (get_local $2)
           (get_local $13)
         )
         (i32.store offset=12
-          (get_local $3)
-          (get_local $0)
+          (get_local $2)
+          (get_local $1)
         )
         (return)
       )
@@ -15094,24 +15070,24 @@
       (i32.add
         (i32.const 480)
         (i32.shl
-          (tee_local $0
+          (tee_local $5
             (if i32
               (tee_local $0
                 (i32.shr_u
-                  (get_local $1)
+                  (get_local $3)
                   (i32.const 8)
                 )
               )
               (if i32
                 (i32.gt_u
-                  (get_local $1)
+                  (get_local $3)
                   (i32.const 16777215)
                 )
                 (i32.const 31)
                 (i32.or
                   (i32.and
                     (i32.shr_u
-                      (get_local $1)
+                      (get_local $3)
                       (i32.add
                         (tee_local $0
                           (i32.add
@@ -15119,14 +15095,14 @@
                               (i32.const 14)
                               (i32.or
                                 (i32.or
-                                  (tee_local $4
+                                  (tee_local $0
                                     (i32.and
                                       (i32.shr_u
                                         (i32.add
-                                          (tee_local $2
+                                          (tee_local $1
                                             (i32.shl
                                               (get_local $0)
-                                              (tee_local $0
+                                              (tee_local $4
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
@@ -15147,16 +15123,16 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $0)
+                                  (get_local $4)
                                 )
-                                (tee_local $2
+                                (tee_local $0
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (tee_local $0
+                                        (tee_local $1
                                           (i32.shl
-                                            (get_local $2)
-                                            (get_local $4)
+                                            (get_local $1)
+                                            (get_local $0)
                                           )
                                         )
                                         (i32.const 245760)
@@ -15170,8 +15146,8 @@
                             )
                             (i32.shr_u
                               (i32.shl
+                                (get_local $1)
                                 (get_local $0)
-                                (get_local $2)
                               )
                               (i32.const 15)
                             )
@@ -15196,47 +15172,47 @@
       )
     )
     (i32.store offset=28
-      (get_local $3)
-      (get_local $0)
+      (get_local $2)
+      (get_local $5)
     )
     (i32.store offset=20
-      (get_local $3)
+      (get_local $2)
       (i32.const 0)
     )
     (i32.store offset=16
-      (get_local $3)
+      (get_local $2)
       (i32.const 0)
     )
     (block $do-once12
       (if
         (i32.and
-          (tee_local $2
+          (tee_local $1
             (i32.load
               (i32.const 180)
             )
           )
-          (tee_local $5
+          (tee_local $0
             (i32.shl
               (i32.const 1)
-              (get_local $0)
+              (get_local $5)
             )
           )
         )
         (block
-          (set_local $2
+          (set_local $5
             (i32.shl
-              (get_local $1)
+              (get_local $3)
               (select
                 (i32.const 0)
                 (i32.sub
                   (i32.const 25)
                   (i32.shr_u
-                    (get_local $0)
+                    (get_local $5)
                     (i32.const 1)
                   )
                 )
                 (i32.eq
-                  (get_local $0)
+                  (get_local $5)
                   (i32.const 31)
                 )
               )
@@ -15259,59 +15235,52 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $1)
+                      (get_local $3)
                     )
                   )
                   (set_local $4
                     (i32.shl
-                      (get_local $2)
+                      (get_local $5)
                       (i32.const 1)
                     )
                   )
-                  (if
-                    (tee_local $5
-                      (i32.load
-                        (tee_local $2
-                          (i32.add
+                  (br_if $jumpthreading$inner$0
+                    (i32.eqz
+                      (tee_local $1
+                        (i32.load
+                          (tee_local $5
                             (i32.add
-                              (get_local $0)
-                              (i32.const 16)
-                            )
-                            (i32.shl
-                              (i32.shr_u
-                                (get_local $2)
-                                (i32.const 31)
+                              (i32.add
+                                (get_local $0)
+                                (i32.const 16)
                               )
-                              (i32.const 2)
+                              (i32.shl
+                                (i32.shr_u
+                                  (get_local $5)
+                                  (i32.const 31)
+                                )
+                                (i32.const 2)
+                              )
                             )
                           )
                         )
                       )
                     )
-                    (block
-                      (set_local $2
-                        (get_local $4)
-                      )
-                      (set_local $0
-                        (get_local $5)
-                      )
-                      (br $while-in15)
+                  )
+                  (block
+                    (set_local $5
+                      (get_local $4)
                     )
-                    (block
-                      (set_local $1
-                        (get_local $0)
-                      )
-                      (set_local $0
-                        (get_local $2)
-                      )
-                      (br $jumpthreading$inner$0)
+                    (set_local $0
+                      (get_local $1)
                     )
+                    (br $while-in15)
                   )
                 )
               )
               (if
                 (i32.lt_u
-                  (get_local $0)
+                  (get_local $5)
                   (i32.load
                     (i32.const 192)
                   )
@@ -15319,20 +15288,20 @@
                 (call $_abort)
                 (block
                   (i32.store
-                    (get_local $0)
-                    (get_local $3)
+                    (get_local $5)
+                    (get_local $2)
                   )
                   (i32.store offset=24
-                    (get_local $3)
-                    (get_local $1)
+                    (get_local $2)
+                    (get_local $0)
                   )
                   (i32.store offset=12
-                    (get_local $3)
-                    (get_local $3)
+                    (get_local $2)
+                    (get_local $2)
                   )
                   (i32.store offset=8
-                    (get_local $3)
-                    (get_local $3)
+                    (get_local $2)
+                    (get_local $2)
                   )
                   (br $do-once12)
                 )
@@ -15342,9 +15311,9 @@
             (if
               (i32.and
                 (i32.ge_u
-                  (tee_local $1
+                  (tee_local $4
                     (i32.load
-                      (tee_local $2
+                      (tee_local $1
                         (i32.add
                           (get_local $0)
                           (i32.const 8)
@@ -15352,7 +15321,7 @@
                       )
                     )
                   )
-                  (tee_local $4
+                  (tee_local $3
                     (i32.load
                       (i32.const 192)
                     )
@@ -15360,28 +15329,28 @@
                 )
                 (i32.ge_u
                   (get_local $0)
-                  (get_local $4)
+                  (get_local $3)
                 )
               )
               (block
                 (i32.store offset=12
-                  (get_local $1)
-                  (get_local $3)
+                  (get_local $4)
+                  (get_local $2)
                 )
                 (i32.store
+                  (get_local $1)
                   (get_local $2)
-                  (get_local $3)
                 )
                 (i32.store offset=8
-                  (get_local $3)
-                  (get_local $1)
+                  (get_local $2)
+                  (get_local $4)
                 )
                 (i32.store offset=12
-                  (get_local $3)
+                  (get_local $2)
                   (get_local $0)
                 )
                 (i32.store offset=24
-                  (get_local $3)
+                  (get_local $2)
                   (i32.const 0)
                 )
               )
@@ -15393,25 +15362,25 @@
           (i32.store
             (i32.const 180)
             (i32.or
-              (get_local $2)
-              (get_local $5)
+              (get_local $1)
+              (get_local $0)
             )
           )
           (i32.store
             (get_local $4)
-            (get_local $3)
+            (get_local $2)
           )
           (i32.store offset=24
-            (get_local $3)
+            (get_local $2)
             (get_local $4)
           )
           (i32.store offset=12
-            (get_local $3)
-            (get_local $3)
+            (get_local $2)
+            (get_local $2)
           )
           (i32.store offset=8
-            (get_local $3)
-            (get_local $3)
+            (get_local $2)
+            (get_local $2)
           )
         )
       )
@@ -15437,7 +15406,7 @@
     (loop $while-in17
       (set_local $0
         (i32.add
-          (tee_local $1
+          (tee_local $3
             (i32.load
               (get_local $0)
             )
@@ -15446,7 +15415,7 @@
         )
       )
       (br_if $while-in17
-        (get_local $1)
+        (get_local $3)
       )
     )
     (i32.store

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -791,7 +791,7 @@
     (local $12 i32)
     (local $13 i32)
     (local $14 i32)
-    (set_local $7
+    (set_local $8
       (get_global $STACKTOP)
     )
     (set_global $STACKTOP
@@ -807,23 +807,23 @@
       )
       (call $abort)
     )
-    (set_local $8
+    (set_local $9
       (i32.add
-        (get_local $7)
+        (get_local $8)
         (i32.const 16)
       )
     )
-    (set_local $9
-      (get_local $7)
+    (set_local $10
+      (get_local $8)
     )
     (i32.store
       (tee_local $3
         (i32.add
-          (get_local $7)
+          (get_local $8)
           (i32.const 32)
         )
       )
-      (tee_local $5
+      (tee_local $4
         (i32.load
           (tee_local $6
             (i32.add
@@ -836,17 +836,17 @@
     )
     (i32.store offset=4
       (get_local $3)
-      (tee_local $4
+      (tee_local $7
         (i32.sub
           (i32.load
-            (tee_local $10
+            (tee_local $11
               (i32.add
                 (get_local $0)
                 (i32.const 20)
               )
             )
           )
-          (get_local $5)
+          (get_local $4)
         )
       )
     )
@@ -873,12 +873,12 @@
     (set_local $1
       (get_local $3)
     )
-    (set_local $5
+    (set_local $4
       (i32.const 2)
     )
-    (set_local $11
+    (set_local $7
       (i32.add
-        (get_local $4)
+        (get_local $7)
         (get_local $2)
       )
     )
@@ -889,8 +889,8 @@
             (loop $while-in
               (br_if $jumpthreading$inner$0
                 (i32.eq
-                  (get_local $11)
-                  (tee_local $4
+                  (get_local $7)
+                  (tee_local $5
                     (if i32
                       (i32.load
                         (i32.const 16)
@@ -901,24 +901,24 @@
                           (get_local $0)
                         )
                         (i32.store
-                          (get_local $9)
+                          (get_local $10)
                           (i32.load
                             (get_local $13)
                           )
                         )
                         (i32.store offset=4
-                          (get_local $9)
+                          (get_local $10)
                           (get_local $1)
                         )
                         (i32.store offset=8
-                          (get_local $9)
-                          (get_local $5)
+                          (get_local $10)
+                          (get_local $4)
                         )
                         (set_local $3
                           (call $___syscall_ret
                             (call $___syscall146
                               (i32.const 146)
-                              (get_local $9)
+                              (get_local $10)
                             )
                           )
                         )
@@ -929,23 +929,23 @@
                       )
                       (block i32
                         (i32.store
-                          (get_local $8)
+                          (get_local $9)
                           (i32.load
                             (get_local $13)
                           )
                         )
                         (i32.store offset=4
-                          (get_local $8)
+                          (get_local $9)
                           (get_local $1)
                         )
                         (i32.store offset=8
-                          (get_local $8)
-                          (get_local $5)
+                          (get_local $9)
+                          (get_local $4)
                         )
                         (call $___syscall_ret
                           (call $___syscall146
                             (i32.const 146)
-                            (get_local $8)
+                            (get_local $9)
                           )
                         )
                       )
@@ -955,21 +955,21 @@
               )
               (br_if $jumpthreading$inner$1
                 (i32.lt_s
-                  (get_local $4)
+                  (get_local $5)
                   (i32.const 0)
                 )
               )
               (block
-                (set_local $11
+                (set_local $7
                   (i32.sub
-                    (get_local $11)
-                    (get_local $4)
+                    (get_local $7)
+                    (get_local $5)
                   )
                 )
                 (set_local $1
                   (if i32
                     (i32.gt_u
-                      (get_local $4)
+                      (get_local $5)
                       (tee_local $12
                         (i32.load offset=4
                           (get_local $1)
@@ -986,12 +986,12 @@
                         )
                       )
                       (i32.store
-                        (get_local $10)
+                        (get_local $11)
                         (get_local $3)
                       )
-                      (set_local $4
+                      (set_local $5
                         (i32.sub
-                          (get_local $4)
+                          (get_local $5)
                           (get_local $12)
                         )
                       )
@@ -1001,9 +1001,9 @@
                           (i32.const 8)
                         )
                       )
-                      (set_local $5
+                      (set_local $4
                         (i32.add
-                          (get_local $5)
+                          (get_local $4)
                           (i32.const -1)
                         )
                       )
@@ -1013,7 +1013,7 @@
                     )
                     (if i32
                       (i32.eq
-                        (get_local $5)
+                        (get_local $4)
                         (i32.const 2)
                       )
                       (block i32
@@ -1023,13 +1023,13 @@
                             (i32.load
                               (get_local $6)
                             )
-                            (get_local $4)
+                            (get_local $5)
                           )
                         )
                         (set_local $3
                           (get_local $1)
                         )
-                        (set_local $5
+                        (set_local $4
                           (i32.const 2)
                         )
                         (get_local $12)
@@ -1049,14 +1049,14 @@
                     (i32.load
                       (get_local $3)
                     )
-                    (get_local $4)
+                    (get_local $5)
                   )
                 )
                 (i32.store offset=4
                   (get_local $3)
                   (i32.sub
                     (get_local $1)
-                    (get_local $4)
+                    (get_local $5)
                   )
                 )
                 (set_local $1
@@ -1086,7 +1086,7 @@
             )
           )
           (i32.store
-            (get_local $10)
+            (get_local $11)
             (get_local $0)
           )
           (br $jumpthreading$outer$1
@@ -1102,7 +1102,7 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $10)
+          (get_local $11)
           (i32.const 0)
         )
         (i32.store
@@ -1123,14 +1123,14 @@
             )
           )
           (i32.eq
-            (get_local $5)
+            (get_local $4)
             (i32.const 2)
           )
         )
       )
     )
     (set_global $STACKTOP
-      (get_local $7)
+      (get_local $8)
     )
     (get_local $0)
   )
@@ -1902,7 +1902,7 @@
         (block $jumpthreading$inner$1
           (if
             (i32.and
-              (tee_local $3
+              (tee_local $4
                 (i32.ne
                   (get_local $2)
                   (i32.const 0)
@@ -1923,11 +1923,17 @@
                   (i32.const 255)
                 )
               )
+              (set_local $3
+                (get_local $2)
+              )
+              (set_local $2
+                (get_local $0)
+              )
               (loop $while-in
-                (br_if $jumpthreading$inner$2
+                (if
                   (i32.eq
                     (i32.load8_s
-                      (get_local $0)
+                      (get_local $2)
                     )
                     (i32.shr_s
                       (i32.shl
@@ -1937,14 +1943,20 @@
                       (i32.const 24)
                     )
                   )
+                  (block
+                    (set_local $0
+                      (get_local $3)
+                    )
+                    (br $jumpthreading$inner$2)
+                  )
                 )
                 (br_if $while-in
                   (i32.and
-                    (tee_local $3
+                    (tee_local $0
                       (i32.ne
-                        (tee_local $2
+                        (tee_local $3
                           (i32.add
-                            (get_local $2)
+                            (get_local $3)
                             (i32.const -1)
                           )
                         )
@@ -1953,9 +1965,9 @@
                     )
                     (i32.ne
                       (i32.and
-                        (tee_local $0
+                        (tee_local $2
                           (i32.add
-                            (get_local $0)
+                            (get_local $2)
                             (i32.const 1)
                           )
                         )
@@ -1968,24 +1980,41 @@
                 (br $jumpthreading$inner$1)
               )
             )
+            (block
+              (set_local $3
+                (get_local $2)
+              )
+              (set_local $2
+                (get_local $0)
+              )
+              (set_local $0
+                (get_local $4)
+              )
+            )
           )
         )
-        (br_if $jumpthreading$inner$2
-          (get_local $3)
-        )
-        (set_local $1
-          (i32.const 0)
+        (if
+          (get_local $0)
+          (block
+            (set_local $0
+              (get_local $3)
+            )
+            (br $jumpthreading$inner$2)
+          )
+          (set_local $0
+            (i32.const 0)
+          )
         )
         (br $label$break$L8)
       )
       (if
-        (i32.eq
+        (i32.ne
           (i32.load8_s
-            (get_local $0)
+            (get_local $2)
           )
           (i32.shr_s
             (i32.shl
-              (tee_local $4
+              (tee_local $1
                 (i32.and
                   (get_local $1)
                   (i32.const 255)
@@ -1996,9 +2025,6 @@
             (i32.const 24)
           )
         )
-        (set_local $1
-          (get_local $2)
-        )
         (block
           (set_local $3
             (i32.mul
@@ -2008,69 +2034,52 @@
           )
           (block $jumpthreading$outer$0
             (block $jumpthreading$inner$0
-              (if
-                (i32.gt_u
-                  (get_local $2)
+              (br_if $jumpthreading$inner$0
+                (i32.le_u
+                  (get_local $0)
                   (i32.const 3)
                 )
-                (loop $while-in3
-                  (block $while-out2
-                    (if
-                      (i32.and
-                        (i32.xor
-                          (i32.and
-                            (tee_local $1
-                              (i32.xor
-                                (i32.load
-                                  (get_local $0)
-                                )
-                                (get_local $3)
+              )
+              (loop $while-in3
+                (block $while-out2
+                  (br_if $while-out2
+                    (i32.and
+                      (i32.xor
+                        (i32.and
+                          (tee_local $4
+                            (i32.xor
+                              (i32.load
+                                (get_local $2)
                               )
+                              (get_local $3)
                             )
-                            (i32.const -2139062144)
                           )
                           (i32.const -2139062144)
                         )
-                        (i32.add
-                          (get_local $1)
-                          (i32.const -16843009)
-                        )
+                        (i32.const -2139062144)
                       )
-                      (block
-                        (set_local $1
-                          (get_local $2)
-                        )
-                        (br $while-out2)
-                      )
-                    )
-                    (set_local $0
                       (i32.add
-                        (get_local $0)
-                        (i32.const 4)
+                        (get_local $4)
+                        (i32.const -16843009)
                       )
-                    )
-                    (br_if $jumpthreading$inner$0
-                      (i32.le_u
-                        (tee_local $1
-                          (i32.add
-                            (get_local $2)
-                            (i32.const -4)
-                          )
-                        )
-                        (i32.const 3)
-                      )
-                    )
-                    (block
-                      (set_local $2
-                        (get_local $1)
-                      )
-                      (br $while-in3)
                     )
                   )
-                )
-                (block
-                  (set_local $1
-                    (get_local $2)
+                  (set_local $2
+                    (i32.add
+                      (get_local $2)
+                      (i32.const 4)
+                    )
+                  )
+                  (br_if $while-in3
+                    (i32.gt_u
+                      (tee_local $0
+                        (i32.add
+                          (get_local $0)
+                          (i32.const -4)
+                        )
+                      )
+                      (i32.const 3)
+                    )
                   )
                   (br $jumpthreading$inner$0)
                 )
@@ -2079,10 +2088,10 @@
             )
             (if
               (i32.eqz
-                (get_local $1)
+                (get_local $0)
               )
               (block
-                (set_local $1
+                (set_local $0
                   (i32.const 0)
                 )
                 (br $label$break$L8)
@@ -2093,32 +2102,32 @@
             (br_if $label$break$L8
               (i32.eq
                 (i32.load8_s
-                  (get_local $0)
+                  (get_local $2)
                 )
                 (i32.shr_s
                   (i32.shl
-                    (get_local $4)
+                    (get_local $1)
                     (i32.const 24)
                   )
                   (i32.const 24)
                 )
               )
             )
-            (set_local $0
+            (set_local $2
               (i32.add
-                (get_local $0)
+                (get_local $2)
                 (i32.const 1)
               )
             )
             (br_if $while-in5
-              (tee_local $1
+              (tee_local $0
                 (i32.add
-                  (get_local $1)
+                  (get_local $0)
                   (i32.const -1)
                 )
               )
             )
-            (set_local $1
+            (set_local $0
               (i32.const 0)
             )
           )
@@ -2126,10 +2135,10 @@
       )
     )
     (select
-      (get_local $0)
+      (get_local $2)
       (i32.const 0)
       (i32.ne
-        (get_local $1)
+        (get_local $0)
         (i32.const 0)
       )
     )
@@ -2295,8 +2304,8 @@
     (local $11 i32)
     (local $12 i32)
     (local $13 i32)
-    (local $14 f64)
-    (local $15 i32)
+    (local $14 i32)
+    (local $15 f64)
     (local $16 i32)
     (local $17 i32)
     (local $18 i32)
@@ -2359,10 +2368,10 @@
         (i32.const 16)
       )
     )
-    (set_local $17
+    (set_local $18
       (get_local $25)
     )
-    (set_local $40
+    (set_local $41
       (i32.add
         (get_local $25)
         (i32.const 528)
@@ -2377,7 +2386,7 @@
     (set_local $45
       (tee_local $23
         (i32.add
-          (tee_local $19
+          (tee_local $9
             (i32.add
               (get_local $25)
               (i32.const 536)
@@ -2389,7 +2398,7 @@
     )
     (set_local $46
       (i32.add
-        (get_local $19)
+        (get_local $9)
         (i32.const 39)
       )
     )
@@ -2404,9 +2413,9 @@
         (i32.const 4)
       )
     )
-    (set_local $37
+    (set_local $38
       (i32.add
-        (tee_local $19
+        (tee_local $9
           (i32.add
             (get_local $25)
             (i32.const 576)
@@ -2417,16 +2426,16 @@
     )
     (set_local $48
       (i32.add
-        (get_local $19)
+        (get_local $9)
         (i32.const 11)
       )
     )
     (set_local $51
       (i32.sub
         (tee_local $30
-          (get_local $37)
+          (get_local $38)
         )
-        (tee_local $41
+        (tee_local $42
           (tee_local $24
             (i32.add
               (get_local $25)
@@ -2439,7 +2448,7 @@
     (set_local $52
       (i32.sub
         (i32.const -2)
-        (get_local $41)
+        (get_local $42)
       )
     )
     (set_local $53
@@ -2467,29 +2476,32 @@
         )
       )
     )
-    (set_local $38
+    (set_local $39
       (i32.add
         (get_local $24)
         (i32.const 8)
       )
     )
-    (set_local $15
+    (set_local $16
       (i32.const 0)
+    )
+    (set_local $9
+      (get_local $1)
     )
     (set_local $5
       (i32.const 0)
     )
-    (set_local $19
+    (set_local $1
       (i32.const 0)
     )
     (block $label$break$L343
       (block $jumpthreading$inner$8
         (loop $label$continue$L1
           (block $label$break$L1
-            (set_local $15
+            (set_local $16
               (if i32
                 (i32.gt_s
-                  (get_local $15)
+                  (get_local $16)
                   (i32.const -1)
                 )
                 (if i32
@@ -2497,7 +2509,7 @@
                     (get_local $5)
                     (i32.sub
                       (i32.const 2147483647)
-                      (get_local $15)
+                      (get_local $16)
                     )
                   )
                   (block i32
@@ -2509,19 +2521,19 @@
                   )
                   (i32.add
                     (get_local $5)
-                    (get_local $15)
+                    (get_local $16)
                   )
                 )
-                (get_local $15)
+                (get_local $16)
               )
             )
             (br_if $jumpthreading$inner$8
               (i32.eqz
                 (i32.shr_s
                   (i32.shl
-                    (tee_local $6
+                    (tee_local $7
                       (i32.load8_s
-                        (get_local $1)
+                        (get_local $9)
                       )
                     )
                     (i32.const 24)
@@ -2531,7 +2543,7 @@
               )
             )
             (set_local $5
-              (get_local $1)
+              (get_local $9)
             )
             (loop $label$continue$L9
               (block $label$break$L9
@@ -2542,7 +2554,7 @@
                         (i32.sub
                           (i32.shr_s
                             (i32.shl
-                              (get_local $6)
+                              (get_local $7)
                               (i32.const 24)
                             )
                             (i32.const 24)
@@ -2551,10 +2563,10 @@
                         )
                       )
                     )
-                    (set_local $39
+                    (set_local $40
                       (get_local $5)
                     )
-                    (set_local $42
+                    (set_local $43
                       (get_local $5)
                     )
                     (set_local $26
@@ -2570,7 +2582,7 @@
                   )
                   (br $label$break$L9)
                 )
-                (set_local $6
+                (set_local $7
                   (i32.load8_s
                     (tee_local $5
                       (i32.add
@@ -2596,23 +2608,23 @@
                   (if
                     (i32.ne
                       (i32.load8_s offset=1
-                        (get_local $39)
+                        (get_local $40)
                       )
                       (i32.const 37)
                     )
                     (block
                       (set_local $27
-                        (get_local $39)
+                        (get_local $40)
                       )
                       (set_local $34
-                        (get_local $42)
+                        (get_local $43)
                       )
                       (br $label$break$L12)
                     )
                   )
                   (set_local $34
                     (i32.add
-                      (get_local $42)
+                      (get_local $43)
                       (i32.const 1)
                     )
                   )
@@ -2621,7 +2633,7 @@
                       (i32.load8_s
                         (tee_local $27
                           (i32.add
-                            (get_local $39)
+                            (get_local $40)
                             (i32.const 2)
                           )
                         )
@@ -2629,10 +2641,10 @@
                       (i32.const 37)
                     )
                     (block
-                      (set_local $39
+                      (set_local $40
                         (get_local $27)
                       )
-                      (set_local $42
+                      (set_local $43
                         (get_local $34)
                       )
                       (br $while-in)
@@ -2641,10 +2653,10 @@
                 )
               )
             )
-            (set_local $6
+            (set_local $7
               (i32.sub
                 (get_local $34)
-                (get_local $1)
+                (get_local $9)
               )
             )
             (if
@@ -2660,8 +2672,8 @@
                 )
                 (drop
                   (call $___fwritex
-                    (get_local $1)
-                    (get_local $6)
+                    (get_local $9)
+                    (get_local $7)
                     (get_local $0)
                   )
                 )
@@ -2670,26 +2682,26 @@
             (if
               (i32.ne
                 (get_local $34)
-                (get_local $1)
+                (get_local $9)
               )
               (block
-                (set_local $1
+                (set_local $9
                   (get_local $27)
                 )
                 (set_local $5
-                  (get_local $6)
+                  (get_local $7)
                 )
                 (br $label$continue$L1)
               )
             )
-            (set_local $18
+            (set_local $19
               (if i32
                 (i32.lt_u
-                  (tee_local $8
+                  (tee_local $10
                     (i32.add
                       (i32.shr_s
                         (i32.shl
-                          (tee_local $7
+                          (tee_local $6
                             (i32.load8_s
                               (tee_local $5
                                 (i32.add
@@ -2709,7 +2721,7 @@
                   (i32.const 10)
                 )
                 (block i32
-                  (set_local $7
+                  (set_local $6
                     (i32.load8_s
                       (tee_local $5
                         (select
@@ -2718,7 +2730,7 @@
                             (i32.const 3)
                           )
                           (get_local $5)
-                          (tee_local $11
+                          (tee_local $12
                             (i32.eq
                               (i32.load8_s offset=2
                                 (get_local $27)
@@ -2730,30 +2742,35 @@
                       )
                     )
                   )
-                  (set_local $19
+                  (set_local $8
                     (select
                       (i32.const 1)
-                      (get_local $19)
-                      (get_local $11)
+                      (get_local $1)
+                      (get_local $12)
                     )
                   )
                   (select
-                    (get_local $8)
+                    (get_local $10)
                     (i32.const -1)
-                    (get_local $11)
+                    (get_local $12)
                   )
                 )
-                (i32.const -1)
+                (block i32
+                  (set_local $8
+                    (get_local $1)
+                  )
+                  (i32.const -1)
+                )
               )
             )
             (block $label$break$L25
               (if
                 (i32.eq
                   (i32.and
-                    (tee_local $11
+                    (tee_local $12
                       (i32.shr_s
                         (i32.shl
-                          (get_local $7)
+                          (get_local $6)
                           (i32.const 24)
                         )
                         (i32.const 24)
@@ -2764,41 +2781,35 @@
                   (i32.const 32)
                 )
                 (block
-                  (set_local $8
+                  (set_local $1
+                    (get_local $6)
+                  )
+                  (set_local $6
                     (i32.const 0)
                   )
                   (loop $while-in4
-                    (if
+                    (br_if $label$break$L25
                       (i32.eqz
                         (i32.and
                           (i32.shl
                             (i32.const 1)
                             (i32.add
-                              (get_local $11)
+                              (get_local $12)
                               (i32.const -32)
                             )
                           )
                           (i32.const 75913)
                         )
                       )
-                      (block
-                        (set_local $11
-                          (get_local $7)
-                        )
-                        (set_local $7
-                          (get_local $8)
-                        )
-                        (br $label$break$L25)
-                      )
                     )
-                    (set_local $8
+                    (set_local $6
                       (i32.or
                         (i32.shl
                           (i32.const 1)
                           (i32.add
                             (i32.shr_s
                               (i32.shl
-                                (get_local $7)
+                                (get_local $1)
                                 (i32.const 24)
                               )
                               (i32.const 24)
@@ -2806,16 +2817,16 @@
                             (i32.const -32)
                           )
                         )
-                        (get_local $8)
+                        (get_local $6)
                       )
                     )
                     (br_if $while-in4
                       (i32.eq
                         (i32.and
-                          (tee_local $11
+                          (tee_local $12
                             (i32.shr_s
                               (i32.shl
-                                (tee_local $7
+                                (tee_local $1
                                   (i32.load8_s
                                     (tee_local $5
                                       (i32.add
@@ -2835,21 +2846,13 @@
                         (i32.const 32)
                       )
                     )
-                    (block
-                      (set_local $11
-                        (get_local $7)
-                      )
-                      (set_local $7
-                        (get_local $8)
-                      )
-                    )
                   )
                 )
                 (block
-                  (set_local $11
-                    (get_local $7)
+                  (set_local $1
+                    (get_local $6)
                   )
-                  (set_local $7
+                  (set_local $6
                     (i32.const 0)
                   )
                 )
@@ -2860,7 +2863,7 @@
                 (i32.eq
                   (i32.shr_s
                     (i32.shl
-                      (get_local $11)
+                      (get_local $1)
                       (i32.const 24)
                     )
                     (i32.const 24)
@@ -2868,15 +2871,15 @@
                   (i32.const 42)
                 )
                 (block
-                  (set_local $19
+                  (set_local $1
                     (block $jumpthreading$outer$0 i32
                       (block $jumpthreading$inner$0
                         (br_if $jumpthreading$inner$0
                           (i32.ge_u
-                            (tee_local $11
+                            (tee_local $12
                               (i32.add
                                 (i32.load8_s
-                                  (tee_local $8
+                                  (tee_local $1
                                     (i32.add
                                       (get_local $5)
                                       (i32.const 1)
@@ -2901,19 +2904,19 @@
                           (i32.add
                             (get_local $4)
                             (i32.shl
-                              (get_local $11)
+                              (get_local $12)
                               (i32.const 2)
                             )
                           )
                           (i32.const 10)
                         )
-                        (set_local $19
+                        (set_local $1
                           (i32.add
                             (get_local $3)
                             (i32.shl
                               (i32.add
                                 (i32.load8_s
-                                  (get_local $8)
+                                  (get_local $1)
                                 )
                                 (i32.const -48)
                               )
@@ -2927,9 +2930,9 @@
                             (i32.const 3)
                           )
                         )
-                        (set_local $13
+                        (set_local $14
                           (i32.load
-                            (get_local $19)
+                            (get_local $1)
                           )
                         )
                         (br $jumpthreading$outer$0
@@ -2940,9 +2943,9 @@
                         (i32.const 0)
                       )
                       (if
-                        (get_local $19)
+                        (get_local $8)
                         (block
-                          (set_local $15
+                          (set_local $16
                             (i32.const -1)
                           )
                           (br $label$break$L1)
@@ -2953,24 +2956,24 @@
                           (get_local $32)
                         )
                         (block
-                          (set_local $11
-                            (get_local $7)
+                          (set_local $12
+                            (get_local $6)
                           )
                           (set_local $5
-                            (get_local $8)
+                            (get_local $1)
                           )
-                          (set_local $19
+                          (set_local $1
                             (i32.const 0)
                           )
-                          (set_local $13
+                          (set_local $14
                             (i32.const 0)
                           )
                           (br $do-once5)
                         )
                       )
-                      (set_local $13
+                      (set_local $14
                         (i32.load
-                          (tee_local $19
+                          (tee_local $5
                             (i32.and
                               (i32.add
                                 (i32.load
@@ -2986,45 +2989,45 @@
                       (i32.store
                         (get_local $2)
                         (i32.add
-                          (get_local $19)
+                          (get_local $5)
                           (i32.const 4)
                         )
                       )
                       (set_local $5
-                        (get_local $8)
+                        (get_local $1)
                       )
                       (i32.const 0)
                     )
                   )
-                  (set_local $11
+                  (set_local $12
                     (if i32
                       (i32.lt_s
-                        (get_local $13)
+                        (get_local $14)
                         (i32.const 0)
                       )
                       (block i32
-                        (set_local $13
+                        (set_local $14
                           (i32.sub
                             (i32.const 0)
-                            (get_local $13)
+                            (get_local $14)
                           )
                         )
                         (i32.or
-                          (get_local $7)
+                          (get_local $6)
                           (i32.const 8192)
                         )
                       )
-                      (get_local $7)
+                      (get_local $6)
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (tee_local $11
+                    (tee_local $1
                       (i32.add
                         (i32.shr_s
                           (i32.shl
-                            (get_local $11)
+                            (get_local $1)
                             (i32.const 24)
                           )
                           (i32.const 24)
@@ -3035,22 +3038,22 @@
                     (i32.const 10)
                   )
                   (block
-                    (set_local $8
+                    (set_local $12
                       (i32.const 0)
                     )
                     (loop $while-in8
-                      (set_local $11
+                      (set_local $1
                         (i32.add
                           (i32.mul
-                            (get_local $8)
+                            (get_local $12)
                             (i32.const 10)
                           )
-                          (get_local $11)
+                          (get_local $1)
                         )
                       )
                       (if
                         (i32.lt_u
-                          (tee_local $9
+                          (tee_local $10
                             (i32.add
                               (i32.load8_s
                                 (tee_local $5
@@ -3066,40 +3069,48 @@
                           (i32.const 10)
                         )
                         (block
-                          (set_local $8
-                            (get_local $11)
+                          (set_local $12
+                            (get_local $1)
                           )
-                          (set_local $11
-                            (get_local $9)
+                          (set_local $1
+                            (get_local $10)
                           )
                           (br $while-in8)
                         )
-                        (set_local $13
-                          (get_local $11)
+                        (set_local $14
+                          (get_local $1)
                         )
                       )
                     )
                     (if
                       (i32.lt_s
-                        (get_local $13)
+                        (get_local $14)
                         (i32.const 0)
                       )
                       (block
-                        (set_local $15
+                        (set_local $16
                           (i32.const -1)
                         )
                         (br $label$break$L1)
                       )
-                      (set_local $11
-                        (get_local $7)
+                      (block
+                        (set_local $12
+                          (get_local $6)
+                        )
+                        (set_local $1
+                          (get_local $8)
+                        )
                       )
                     )
                   )
                   (block
-                    (set_local $11
-                      (get_local $7)
+                    (set_local $12
+                      (get_local $6)
                     )
-                    (set_local $13
+                    (set_local $1
+                      (get_local $8)
+                    )
+                    (set_local $14
                       (i32.const 0)
                     )
                   )
@@ -3120,7 +3131,7 @@
                       (i32.ne
                         (i32.shr_s
                           (i32.shl
-                            (tee_local $7
+                            (tee_local $6
                               (i32.load8_s
                                 (tee_local $8
                                   (i32.add
@@ -3139,11 +3150,11 @@
                       (block
                         (if
                           (i32.lt_u
-                            (tee_local $7
+                            (tee_local $6
                               (i32.add
                                 (i32.shr_s
                                   (i32.shl
-                                    (get_local $7)
+                                    (get_local $6)
                                     (i32.const 24)
                                   )
                                   (i32.const 24)
@@ -3162,7 +3173,7 @@
                             )
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (i32.const 0)
                             )
                             (br $label$break$L46
@@ -3171,18 +3182,18 @@
                           )
                         )
                         (loop $while-in11
-                          (set_local $7
+                          (set_local $6
                             (i32.add
                               (i32.mul
                                 (get_local $8)
                                 (i32.const 10)
                               )
-                              (get_local $7)
+                              (get_local $6)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (tee_local $9
+                              (tee_local $10
                                 (i32.add
                                   (i32.load8_s
                                     (tee_local $5
@@ -3199,10 +3210,10 @@
                             )
                             (block
                               (set_local $8
-                                (get_local $7)
+                                (get_local $6)
                               )
-                              (set_local $7
-                                (get_local $9)
+                              (set_local $6
+                                (get_local $10)
                               )
                               (br $while-in11)
                             )
@@ -3215,7 +3226,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (tee_local $7
+                        (tee_local $6
                           (i32.add
                             (i32.load8_s
                               (tee_local $8
@@ -3242,13 +3253,13 @@
                             (i32.add
                               (get_local $4)
                               (i32.shl
-                                (get_local $7)
+                                (get_local $6)
                                 (i32.const 2)
                               )
                             )
                             (i32.const 10)
                           )
-                          (set_local $7
+                          (set_local $6
                             (i32.add
                               (get_local $3)
                               (i32.shl
@@ -3262,9 +3273,9 @@
                               )
                             )
                           )
-                          (set_local $7
+                          (set_local $6
                             (i32.load
-                              (get_local $7)
+                              (get_local $6)
                             )
                           )
                           (br $label$break$L46
@@ -3277,9 +3288,9 @@
                       )
                     )
                     (if
-                      (get_local $19)
+                      (get_local $1)
                       (block
-                        (set_local $15
+                        (set_local $16
                           (i32.const -1)
                         )
                         (br $label$break$L1)
@@ -3288,7 +3299,7 @@
                     (if i32
                       (get_local $32)
                       (block i32
-                        (set_local $7
+                        (set_local $6
                           (i32.load
                             (tee_local $5
                               (i32.and
@@ -3313,7 +3324,7 @@
                         (get_local $8)
                       )
                       (block i32
-                        (set_local $7
+                        (set_local $6
                           (i32.const 0)
                         )
                         (get_local $8)
@@ -3321,7 +3332,7 @@
                     )
                   )
                   (block i32
-                    (set_local $7
+                    (set_local $6
                       (i32.const -1)
                     )
                     (get_local $5)
@@ -3329,13 +3340,13 @@
                 )
               )
             )
-            (set_local $9
+            (set_local $10
               (i32.const 0)
             )
             (loop $while-in13
               (if
                 (i32.gt_u
-                  (tee_local $10
+                  (tee_local $11
                     (i32.add
                       (i32.load8_s
                         (get_local $8)
@@ -3346,7 +3357,7 @@
                   (i32.const 57)
                 )
                 (block
-                  (set_local $15
+                  (set_local $16
                     (i32.const -1)
                   )
                   (br $label$break$L1)
@@ -3361,19 +3372,19 @@
               (if
                 (i32.lt_u
                   (i32.add
-                    (tee_local $10
+                    (tee_local $11
                       (i32.and
-                        (tee_local $12
+                        (tee_local $13
                           (i32.load8_s
                             (i32.add
                               (i32.add
                                 (i32.const 3611)
                                 (i32.mul
-                                  (get_local $9)
+                                  (get_local $10)
                                   (i32.const 58)
                                 )
                               )
-                              (get_local $10)
+                              (get_local $11)
                             )
                           )
                         )
@@ -3388,12 +3399,12 @@
                   (set_local $8
                     (get_local $5)
                   )
-                  (set_local $9
-                    (get_local $10)
+                  (set_local $10
+                    (get_local $11)
                   )
                   (br $while-in13)
                 )
-                (set_local $16
+                (set_local $17
                   (get_local $8)
                 )
               )
@@ -3402,14 +3413,14 @@
               (i32.eqz
                 (i32.shr_s
                   (i32.shl
-                    (get_local $12)
+                    (get_local $13)
                     (i32.const 24)
                   )
                   (i32.const 24)
                 )
               )
               (block
-                (set_local $15
+                (set_local $16
                   (i32.const -1)
                 )
                 (br $label$break$L1)
@@ -3417,7 +3428,7 @@
             )
             (set_local $8
               (i32.gt_s
-                (get_local $18)
+                (get_local $19)
                 (i32.const -1)
               )
             )
@@ -3427,7 +3438,7 @@
                   (i32.eq
                     (i32.shr_s
                       (i32.shl
-                        (get_local $12)
+                        (get_local $13)
                         (i32.const 24)
                       )
                       (i32.const 24)
@@ -3437,7 +3448,7 @@
                   (if
                     (get_local $8)
                     (block
-                      (set_local $15
+                      (set_local $16
                         (i32.const -1)
                       )
                       (br $label$break$L1)
@@ -3452,19 +3463,19 @@
                           (i32.add
                             (get_local $4)
                             (i32.shl
-                              (get_local $18)
+                              (get_local $19)
                               (i32.const 2)
                             )
                           )
-                          (get_local $10)
+                          (get_local $11)
                         )
-                        (set_local $12
+                        (set_local $13
                           (i32.load offset=4
-                            (tee_local $10
+                            (tee_local $11
                               (i32.add
                                 (get_local $3)
                                 (i32.shl
-                                  (get_local $18)
+                                  (get_local $19)
                                   (i32.const 3)
                                 )
                               )
@@ -3473,15 +3484,15 @@
                         )
                         (i32.store
                           (tee_local $8
-                            (get_local $17)
+                            (get_local $18)
                           )
                           (i32.load
-                            (get_local $10)
+                            (get_local $11)
                           )
                         )
                         (i32.store offset=4
                           (get_local $8)
-                          (get_local $12)
+                          (get_local $13)
                         )
                         (br $jumpthreading$inner$1)
                       )
@@ -3491,15 +3502,15 @@
                         (get_local $32)
                       )
                       (block
-                        (set_local $15
+                        (set_local $16
                           (i32.const 0)
                         )
                         (br $label$break$L1)
                       )
                     )
                     (call $_pop_arg_336
-                      (get_local $17)
-                      (get_local $10)
+                      (get_local $18)
+                      (get_local $11)
                       (get_local $2)
                     )
                   )
@@ -3514,27 +3525,27 @@
                   (get_local $32)
                 )
                 (block
-                  (set_local $1
+                  (set_local $9
                     (get_local $5)
                   )
                   (set_local $5
-                    (get_local $6)
+                    (get_local $7)
                   )
                   (br $label$continue$L1)
                 )
               )
             )
-            (set_local $11
+            (set_local $12
               (select
                 (tee_local $8
                   (i32.and
-                    (get_local $11)
+                    (get_local $12)
                     (i32.const -65537)
                   )
                 )
-                (get_local $11)
+                (get_local $12)
                 (i32.and
-                  (get_local $11)
+                  (get_local $12)
                   (i32.const 8192)
                 )
               )
@@ -3561,25 +3572,25 @@
                                                   (block $switch-case27
                                                     (br_table $switch-case42 $switch-default120 $switch-case40 $switch-default120 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case29 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case42 $switch-default120 $switch-case37 $switch-case34 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-case34 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case29 $switch-default120
                                                       (i32.sub
-                                                        (tee_local $12
+                                                        (tee_local $17
                                                           (select
                                                             (i32.and
-                                                              (tee_local $10
+                                                              (tee_local $11
                                                                 (i32.load8_s
-                                                                  (get_local $16)
+                                                                  (get_local $17)
                                                                 )
                                                               )
                                                               (i32.const -33)
                                                             )
-                                                            (get_local $10)
+                                                            (get_local $11)
                                                             (i32.and
                                                               (i32.ne
-                                                                (get_local $9)
+                                                                (get_local $10)
                                                                 (i32.const 0)
                                                               )
                                                               (i32.eq
                                                                 (i32.and
-                                                                  (get_local $10)
+                                                                  (get_local $11)
                                                                   (i32.const 15)
                                                                 )
                                                                 (i32.const 3)
@@ -3601,53 +3612,53 @@
                                                                 (block $switch-case19
                                                                   (br_table $switch-case19 $switch-case20 $switch-case21 $switch-case22 $switch-case23 $switch-default26 $switch-case24 $switch-case25 $switch-default26
                                                                     (i32.sub
-                                                                      (get_local $9)
+                                                                      (get_local $10)
                                                                       (i32.const 0)
                                                                     )
                                                                   )
                                                                 )
                                                                 (i32.store
                                                                   (i32.load
-                                                                    (get_local $17)
+                                                                    (get_local $18)
                                                                   )
-                                                                  (get_local $15)
+                                                                  (get_local $16)
                                                                 )
-                                                                (set_local $1
+                                                                (set_local $9
                                                                   (get_local $5)
                                                                 )
                                                                 (set_local $5
-                                                                  (get_local $6)
+                                                                  (get_local $7)
                                                                 )
                                                                 (br $label$continue$L1)
                                                               )
                                                               (i32.store
                                                                 (i32.load
-                                                                  (get_local $17)
+                                                                  (get_local $18)
                                                                 )
-                                                                (get_local $15)
+                                                                (get_local $16)
                                                               )
-                                                              (set_local $1
+                                                              (set_local $9
                                                                 (get_local $5)
                                                               )
                                                               (set_local $5
-                                                                (get_local $6)
+                                                                (get_local $7)
                                                               )
                                                               (br $label$continue$L1)
                                                             )
                                                             (i32.store
-                                                              (tee_local $1
+                                                              (tee_local $9
                                                                 (i32.load
-                                                                  (get_local $17)
+                                                                  (get_local $18)
                                                                 )
                                                               )
-                                                              (get_local $15)
+                                                              (get_local $16)
                                                             )
                                                             (i32.store offset=4
-                                                              (get_local $1)
+                                                              (get_local $9)
                                                               (i32.shr_s
                                                                 (i32.shl
                                                                   (i32.lt_s
-                                                                    (get_local $15)
+                                                                    (get_local $16)
                                                                     (i32.const 0)
                                                                   )
                                                                   (i32.const 31)
@@ -3655,70 +3666,70 @@
                                                                 (i32.const 31)
                                                               )
                                                             )
-                                                            (set_local $1
+                                                            (set_local $9
                                                               (get_local $5)
                                                             )
                                                             (set_local $5
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                             )
                                                             (br $label$continue$L1)
                                                           )
                                                           (i32.store16
                                                             (i32.load
-                                                              (get_local $17)
+                                                              (get_local $18)
                                                             )
-                                                            (get_local $15)
+                                                            (get_local $16)
                                                           )
-                                                          (set_local $1
+                                                          (set_local $9
                                                             (get_local $5)
                                                           )
                                                           (set_local $5
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                           )
                                                           (br $label$continue$L1)
                                                         )
                                                         (i32.store8
                                                           (i32.load
-                                                            (get_local $17)
+                                                            (get_local $18)
                                                           )
-                                                          (get_local $15)
+                                                          (get_local $16)
                                                         )
-                                                        (set_local $1
+                                                        (set_local $9
                                                           (get_local $5)
                                                         )
                                                         (set_local $5
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                         )
                                                         (br $label$continue$L1)
                                                       )
                                                       (i32.store
                                                         (i32.load
-                                                          (get_local $17)
+                                                          (get_local $18)
                                                         )
-                                                        (get_local $15)
+                                                        (get_local $16)
                                                       )
-                                                      (set_local $1
+                                                      (set_local $9
                                                         (get_local $5)
                                                       )
                                                       (set_local $5
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                       )
                                                       (br $label$continue$L1)
                                                     )
                                                     (i32.store
-                                                      (tee_local $1
+                                                      (tee_local $9
                                                         (i32.load
-                                                          (get_local $17)
+                                                          (get_local $18)
                                                         )
                                                       )
-                                                      (get_local $15)
+                                                      (get_local $16)
                                                     )
                                                     (i32.store offset=4
-                                                      (get_local $1)
+                                                      (get_local $9)
                                                       (i32.shr_s
                                                         (i32.shl
                                                           (i32.lt_s
-                                                            (get_local $15)
+                                                            (get_local $16)
                                                             (i32.const 0)
                                                           )
                                                           (i32.const 31)
@@ -3726,55 +3737,55 @@
                                                         (i32.const 31)
                                                       )
                                                     )
-                                                    (set_local $1
+                                                    (set_local $9
                                                       (get_local $5)
                                                     )
                                                     (set_local $5
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                     )
                                                     (br $label$continue$L1)
                                                   )
-                                                  (set_local $1
+                                                  (set_local $9
                                                     (get_local $5)
                                                   )
                                                   (set_local $5
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (br $label$continue$L1)
                                                 )
-                                                (set_local $1
+                                                (set_local $9
                                                   (i32.or
-                                                    (get_local $11)
+                                                    (get_local $12)
                                                     (i32.const 8)
                                                   )
                                                 )
-                                                (set_local $7
+                                                (set_local $6
                                                   (select
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 8)
                                                     (i32.gt_u
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 8)
                                                     )
                                                   )
                                                 )
-                                                (set_local $12
+                                                (set_local $17
                                                   (i32.const 120)
                                                 )
                                                 (br $jumpthreading$inner$2)
                                               )
-                                              (set_local $1
-                                                (get_local $11)
+                                              (set_local $9
+                                                (get_local $12)
                                               )
                                               (br $jumpthreading$inner$2)
                                             )
                                             (if
                                               (i32.and
                                                 (i32.eqz
-                                                  (tee_local $6
+                                                  (tee_local $7
                                                     (i32.load
-                                                      (tee_local $1
-                                                        (get_local $17)
+                                                      (tee_local $9
+                                                        (get_local $18)
                                                       )
                                                     )
                                                   )
@@ -3782,7 +3793,7 @@
                                                 (i32.eqz
                                                   (tee_local $8
                                                     (i32.load offset=4
-                                                      (get_local $1)
+                                                      (get_local $9)
                                                     )
                                                   )
                                                 )
@@ -3791,10 +3802,10 @@
                                                 (get_local $23)
                                               )
                                               (block
-                                                (set_local $1
-                                                  (get_local $6)
+                                                (set_local $9
+                                                  (get_local $7)
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (get_local $8)
                                                 )
                                                 (set_local $8
@@ -3810,7 +3821,7 @@
                                                     )
                                                     (i32.or
                                                       (i32.and
-                                                        (get_local $1)
+                                                        (get_local $9)
                                                         (i32.const 7)
                                                       )
                                                       (i32.const 48)
@@ -3820,16 +3831,16 @@
                                                     (i32.eqz
                                                       (i32.and
                                                         (i32.eqz
-                                                          (tee_local $1
+                                                          (tee_local $9
                                                             (call $_bitshift64Lshr
-                                                              (get_local $1)
-                                                              (get_local $6)
+                                                              (get_local $9)
+                                                              (get_local $7)
                                                               (i32.const 3)
                                                             )
                                                           )
                                                         )
                                                         (i32.eqz
-                                                          (tee_local $6
+                                                          (tee_local $7
                                                             (get_global $tempRet0)
                                                           )
                                                         )
@@ -3841,19 +3852,19 @@
                                             )
                                             (if
                                               (i32.and
-                                                (get_local $11)
+                                                (get_local $12)
                                                 (i32.const 8)
                                               )
                                               (block
-                                                (set_local $6
+                                                (set_local $7
                                                   (get_local $8)
                                                 )
-                                                (set_local $1
-                                                  (get_local $11)
+                                                (set_local $9
+                                                  (get_local $12)
                                                 )
-                                                (set_local $7
+                                                (set_local $6
                                                   (select
-                                                    (tee_local $11
+                                                    (tee_local $12
                                                       (i32.add
                                                         (i32.sub
                                                           (get_local $45)
@@ -3862,50 +3873,50 @@
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.lt_s
-                                                      (get_local $7)
-                                                      (get_local $11)
+                                                      (get_local $6)
+                                                      (get_local $12)
                                                     )
                                                   )
                                                 )
                                                 (set_local $8
                                                   (i32.const 0)
                                                 )
-                                                (set_local $9
+                                                (set_local $10
                                                   (i32.const 4091)
                                                 )
                                                 (br $jumpthreading$inner$7)
                                               )
                                               (block
-                                                (set_local $6
+                                                (set_local $7
                                                   (get_local $8)
                                                 )
-                                                (set_local $1
-                                                  (get_local $11)
+                                                (set_local $9
+                                                  (get_local $12)
                                                 )
                                                 (set_local $8
                                                   (i32.const 0)
                                                 )
-                                                (set_local $9
+                                                (set_local $10
                                                   (i32.const 4091)
                                                 )
                                                 (br $jumpthreading$inner$7)
                                               )
                                             )
                                           )
-                                          (set_local $1
+                                          (set_local $9
                                             (i32.load
-                                              (tee_local $6
-                                                (get_local $17)
+                                              (tee_local $7
+                                                (get_local $18)
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_s
-                                              (tee_local $6
+                                              (tee_local $7
                                                 (i32.load offset=4
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                               (i32.const 0)
@@ -3913,27 +3924,27 @@
                                             (block
                                               (i32.store
                                                 (tee_local $8
-                                                  (get_local $17)
+                                                  (get_local $18)
                                                 )
-                                                (tee_local $1
+                                                (tee_local $9
                                                   (call $_i64Subtract
                                                     (i32.const 0)
                                                     (i32.const 0)
-                                                    (get_local $1)
-                                                    (get_local $6)
+                                                    (get_local $9)
+                                                    (get_local $7)
                                                   )
                                                 )
                                               )
                                               (i32.store offset=4
                                                 (get_local $8)
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (get_global $tempRet0)
                                                 )
                                               )
                                               (set_local $8
                                                 (i32.const 1)
                                               )
-                                              (set_local $9
+                                              (set_local $10
                                                 (i32.const 4091)
                                               )
                                               (br $jumpthreading$inner$3)
@@ -3941,88 +3952,88 @@
                                           )
                                           (if
                                             (i32.and
-                                              (get_local $11)
+                                              (get_local $12)
                                               (i32.const 2048)
                                             )
                                             (block
                                               (set_local $8
                                                 (i32.const 1)
                                               )
-                                              (set_local $9
+                                              (set_local $10
                                                 (i32.const 4092)
                                               )
                                               (br $jumpthreading$inner$3)
                                             )
                                             (block
                                               (set_local $8
-                                                (tee_local $9
+                                                (tee_local $10
                                                   (i32.and
-                                                    (get_local $11)
+                                                    (get_local $12)
                                                     (i32.const 1)
                                                   )
                                                 )
                                               )
-                                              (set_local $9
+                                              (set_local $10
                                                 (select
                                                   (i32.const 4093)
                                                   (i32.const 4091)
-                                                  (get_local $9)
+                                                  (get_local $10)
                                                 )
                                               )
                                               (br $jumpthreading$inner$3)
                                             )
                                           )
                                         )
-                                        (set_local $1
+                                        (set_local $9
                                           (i32.load
-                                            (tee_local $6
-                                              (get_local $17)
+                                            (tee_local $7
+                                              (get_local $18)
                                             )
                                           )
                                         )
-                                        (set_local $6
+                                        (set_local $7
                                           (i32.load offset=4
-                                            (get_local $6)
+                                            (get_local $7)
                                           )
                                         )
                                         (set_local $8
                                           (i32.const 0)
                                         )
-                                        (set_local $9
+                                        (set_local $10
                                           (i32.const 4091)
                                         )
                                         (br $jumpthreading$inner$3)
                                       )
-                                      (set_local $1
-                                        (get_local $17)
+                                      (set_local $9
+                                        (get_local $18)
                                       )
                                       (i32.store8
                                         (get_local $46)
                                         (i32.load
-                                          (get_local $1)
+                                          (get_local $9)
                                         )
                                       )
-                                      (set_local $6
+                                      (set_local $7
                                         (get_local $46)
                                       )
-                                      (set_local $11
+                                      (set_local $12
                                         (get_local $8)
                                       )
-                                      (set_local $10
+                                      (set_local $11
                                         (i32.const 1)
                                       )
                                       (set_local $8
                                         (i32.const 0)
                                       )
-                                      (set_local $9
+                                      (set_local $10
                                         (i32.const 4091)
                                       )
-                                      (set_local $1
+                                      (set_local $9
                                         (get_local $23)
                                       )
                                       (br $jumpthreading$outer$7)
                                     )
-                                    (set_local $1
+                                    (set_local $9
                                       (call $_strerror
                                         (i32.load
                                           (call $___errno_location)
@@ -4031,29 +4042,29 @@
                                     )
                                     (br $jumpthreading$inner$4)
                                   )
-                                  (set_local $1
+                                  (set_local $9
                                     (select
-                                      (tee_local $1
+                                      (tee_local $9
                                         (i32.load
-                                          (get_local $17)
+                                          (get_local $18)
                                         )
                                       )
                                       (i32.const 4101)
                                       (i32.ne
-                                        (get_local $1)
+                                        (get_local $9)
                                         (i32.const 0)
                                       )
                                     )
                                   )
                                   (br $jumpthreading$inner$4)
                                 )
-                                (set_local $1
-                                  (get_local $17)
+                                (set_local $9
+                                  (get_local $18)
                                 )
                                 (i32.store
                                   (get_local $47)
                                   (i32.load
-                                    (get_local $1)
+                                    (get_local $9)
                                   )
                                 )
                                 (i32.store
@@ -4061,34 +4072,40 @@
                                   (i32.const 0)
                                 )
                                 (i32.store
-                                  (get_local $17)
+                                  (get_local $18)
                                   (get_local $47)
                                 )
-                                (set_local $7
+                                (set_local $8
                                   (i32.const -1)
                                 )
                                 (br $jumpthreading$inner$5)
                               )
-                              (br_if $jumpthreading$inner$5
-                                (get_local $7)
-                              )
-                              (block
-                                (call $_pad
-                                  (get_local $0)
-                                  (i32.const 32)
-                                  (get_local $13)
-                                  (i32.const 0)
-                                  (get_local $11)
+                              (if
+                                (get_local $6)
+                                (block
+                                  (set_local $8
+                                    (get_local $6)
+                                  )
+                                  (br $jumpthreading$inner$5)
                                 )
-                                (set_local $6
-                                  (i32.const 0)
+                                (block
+                                  (call $_pad
+                                    (get_local $0)
+                                    (i32.const 32)
+                                    (get_local $14)
+                                    (i32.const 0)
+                                    (get_local $12)
+                                  )
+                                  (set_local $7
+                                    (i32.const 0)
+                                  )
+                                  (br $jumpthreading$inner$6)
                                 )
-                                (br $jumpthreading$inner$6)
                               )
                             )
-                            (set_local $14
+                            (set_local $15
                               (f64.load
-                                (get_local $17)
+                                (get_local $18)
                               )
                             )
                             (i32.store
@@ -4097,7 +4114,7 @@
                             )
                             (f64.store
                               (get_global $tempDoublePtr)
-                              (get_local $14)
+                              (get_local $15)
                             )
                             (set_local $35
                               (if i32
@@ -4111,16 +4128,16 @@
                                   (set_local $28
                                     (i32.const 1)
                                   )
-                                  (set_local $14
+                                  (set_local $15
                                     (f64.neg
-                                      (get_local $14)
+                                      (get_local $15)
                                     )
                                   )
                                   (i32.const 4108)
                                 )
                                 (if i32
                                   (i32.and
-                                    (get_local $11)
+                                    (get_local $12)
                                     (i32.const 2048)
                                   )
                                   (block i32
@@ -4131,9 +4148,9 @@
                                   )
                                   (block i32
                                     (set_local $28
-                                      (tee_local $1
+                                      (tee_local $9
                                         (i32.and
-                                          (get_local $11)
+                                          (get_local $12)
                                           (i32.const 1)
                                         )
                                       )
@@ -4141,7 +4158,7 @@
                                     (select
                                       (i32.const 4114)
                                       (i32.const 4109)
-                                      (get_local $1)
+                                      (get_local $9)
                                     )
                                   )
                                 )
@@ -4149,9 +4166,9 @@
                             )
                             (f64.store
                               (get_global $tempDoublePtr)
-                              (get_local $14)
+                              (get_local $15)
                             )
-                            (set_local $1
+                            (set_local $9
                               (get_local $5)
                             )
                             (set_local $5
@@ -4184,7 +4201,7 @@
                                           (tee_local $21
                                             (f64.mul
                                               (call $_frexpl
-                                                (get_local $14)
+                                                (get_local $15)
                                                 (get_local $20)
                                               )
                                               (f64.const 2)
@@ -4205,61 +4222,61 @@
                                     )
                                     (if
                                       (i32.eq
-                                        (tee_local $16
+                                        (tee_local $13
                                           (i32.or
-                                            (get_local $12)
+                                            (get_local $17)
                                             (i32.const 32)
                                           )
                                         )
                                         (i32.const 97)
                                       )
                                       (block
-                                        (set_local $9
+                                        (set_local $10
                                           (select
                                             (i32.add
                                               (get_local $35)
                                               (i32.const 9)
                                             )
                                             (get_local $35)
-                                            (tee_local $16
+                                            (tee_local $13
                                               (i32.and
-                                                (get_local $12)
+                                                (get_local $17)
                                                 (i32.const 32)
                                               )
                                             )
                                           )
                                         )
-                                        (set_local $10
+                                        (set_local $11
                                           (i32.or
                                             (get_local $28)
                                             (i32.const 2)
                                           )
                                         )
-                                        (set_local $14
+                                        (set_local $15
                                           (if f64
                                             (i32.or
                                               (i32.gt_u
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (i32.const 11)
                                               )
                                               (i32.eqz
                                                 (tee_local $5
                                                   (i32.sub
                                                     (i32.const 12)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                 )
                                               )
                                             )
                                             (get_local $21)
                                             (block f64
-                                              (set_local $14
+                                              (set_local $15
                                                 (f64.const 8)
                                               )
                                               (loop $while-in54
-                                                (set_local $14
+                                                (set_local $15
                                                   (f64.mul
-                                                    (get_local $14)
+                                                    (get_local $15)
                                                     (f64.const 16)
                                                   )
                                                 )
@@ -4275,25 +4292,25 @@
                                               (select
                                                 (f64.neg
                                                   (f64.add
-                                                    (get_local $14)
+                                                    (get_local $15)
                                                     (f64.sub
                                                       (f64.neg
                                                         (get_local $21)
                                                       )
-                                                      (get_local $14)
+                                                      (get_local $15)
                                                     )
                                                   )
                                                 )
                                                 (f64.sub
                                                   (f64.add
                                                     (get_local $21)
-                                                    (get_local $14)
+                                                    (get_local $15)
                                                   )
-                                                  (get_local $14)
+                                                  (get_local $15)
                                                 )
                                                 (i32.eq
                                                   (i32.load8_s
-                                                    (get_local $9)
+                                                    (get_local $10)
                                                   )
                                                   (i32.const 45)
                                                 )
@@ -4303,12 +4320,12 @@
                                         )
                                         (i32.store8
                                           (i32.add
-                                            (tee_local $6
+                                            (tee_local $7
                                               (if i32
                                                 (i32.eq
-                                                  (tee_local $6
+                                                  (tee_local $7
                                                     (call $_fmt_u
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (select
                                                           (i32.sub
                                                             (i32.const 0)
@@ -4328,17 +4345,17 @@
                                                       (i32.shr_s
                                                         (i32.shl
                                                           (i32.lt_s
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                             (i32.const 0)
                                                           )
                                                           (i32.const 31)
                                                         )
                                                         (i32.const 31)
                                                       )
-                                                      (get_local $37)
+                                                      (get_local $38)
                                                     )
                                                   )
-                                                  (get_local $37)
+                                                  (get_local $38)
                                                 )
                                                 (block i32
                                                   (i32.store8
@@ -4347,7 +4364,7 @@
                                                   )
                                                   (get_local $48)
                                                 )
-                                                (get_local $6)
+                                                (get_local $7)
                                               )
                                             )
                                             (i32.const -1)
@@ -4364,27 +4381,27 @@
                                           )
                                         )
                                         (i32.store8
-                                          (tee_local $6
+                                          (tee_local $7
                                             (i32.add
-                                              (get_local $6)
+                                              (get_local $7)
                                               (i32.const -2)
                                             )
                                           )
                                           (i32.add
-                                            (get_local $12)
+                                            (get_local $17)
                                             (i32.const 15)
                                           )
                                         )
-                                        (set_local $12
+                                        (set_local $17
                                           (i32.lt_s
-                                            (get_local $7)
+                                            (get_local $6)
                                             (i32.const 1)
                                           )
                                         )
-                                        (set_local $18
+                                        (set_local $19
                                           (i32.eqz
                                             (i32.and
-                                              (get_local $11)
+                                              (get_local $12)
                                               (i32.const 8)
                                             )
                                           )
@@ -4400,19 +4417,19 @@
                                                 (i32.add
                                                   (tee_local $8
                                                     (i32.trunc_s/f64
-                                                      (get_local $14)
+                                                      (get_local $15)
                                                     )
                                                   )
                                                   (i32.const 4075)
                                                 )
                                               )
-                                              (get_local $16)
+                                              (get_local $13)
                                             )
                                           )
-                                          (set_local $14
+                                          (set_local $15
                                             (f64.mul
                                               (f64.sub
-                                                (get_local $14)
+                                                (get_local $15)
                                                 (f64.convert_s/i32
                                                   (get_local $8)
                                                 )
@@ -4431,7 +4448,7 @@
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (get_local $41)
+                                                    (get_local $42)
                                                   )
                                                   (i32.const 1)
                                                 )
@@ -4440,11 +4457,11 @@
                                                     (br_if $do-once57
                                                       (get_local $8)
                                                       (i32.and
-                                                        (get_local $18)
+                                                        (get_local $19)
                                                         (i32.and
-                                                          (get_local $12)
+                                                          (get_local $17)
                                                           (f64.eq
-                                                            (get_local $14)
+                                                            (get_local $15)
                                                             (f64.const 0)
                                                           )
                                                         )
@@ -4466,7 +4483,7 @@
                                           )
                                           (br_if $while-in56
                                             (f64.ne
-                                              (get_local $14)
+                                              (get_local $15)
                                               (f64.const 0)
                                             )
                                           )
@@ -4474,28 +4491,28 @@
                                         (call $_pad
                                           (get_local $0)
                                           (i32.const 32)
-                                          (get_local $13)
-                                          (tee_local $7
+                                          (get_local $14)
+                                          (tee_local $6
                                             (i32.add
                                               (tee_local $8
                                                 (select
                                                   (i32.sub
                                                     (i32.add
                                                       (get_local $53)
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                     )
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (i32.add
                                                     (i32.sub
                                                       (get_local $51)
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                     )
                                                     (get_local $5)
                                                   )
                                                   (i32.and
                                                     (i32.ne
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 0)
                                                     )
                                                     (i32.lt_s
@@ -4503,15 +4520,15 @@
                                                         (get_local $52)
                                                         (get_local $5)
                                                       )
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                     )
                                                   )
                                                 )
                                               )
-                                              (get_local $10)
+                                              (get_local $11)
                                             )
                                           )
-                                          (get_local $11)
+                                          (get_local $12)
                                         )
                                         (if
                                           (i32.eqz
@@ -4524,8 +4541,8 @@
                                           )
                                           (drop
                                             (call $___fwritex
-                                              (get_local $9)
                                               (get_local $10)
+                                              (get_local $11)
                                               (get_local $0)
                                             )
                                           )
@@ -4533,17 +4550,17 @@
                                         (call $_pad
                                           (get_local $0)
                                           (i32.const 48)
-                                          (get_local $13)
-                                          (get_local $7)
+                                          (get_local $14)
+                                          (get_local $6)
                                           (i32.xor
-                                            (get_local $11)
+                                            (get_local $12)
                                             (i32.const 65536)
                                           )
                                         )
                                         (set_local $5
                                           (i32.sub
                                             (get_local $5)
-                                            (get_local $41)
+                                            (get_local $42)
                                           )
                                         )
                                         (if
@@ -4573,7 +4590,7 @@
                                               (tee_local $5
                                                 (i32.sub
                                                   (get_local $30)
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                             )
@@ -4592,7 +4609,7 @@
                                           )
                                           (drop
                                             (call $___fwritex
-                                              (get_local $6)
+                                              (get_local $7)
                                               (get_local $5)
                                               (get_local $0)
                                             )
@@ -4601,31 +4618,31 @@
                                         (call $_pad
                                           (get_local $0)
                                           (i32.const 32)
-                                          (get_local $13)
-                                          (get_local $7)
+                                          (get_local $14)
+                                          (get_local $6)
                                           (i32.xor
-                                            (get_local $11)
+                                            (get_local $12)
                                             (i32.const 8192)
                                           )
                                         )
                                         (br $do-once49
                                           (select
-                                            (get_local $13)
-                                            (get_local $7)
+                                            (get_local $14)
+                                            (get_local $6)
                                             (i32.lt_s
-                                              (get_local $7)
-                                              (get_local $13)
+                                              (get_local $6)
+                                              (get_local $14)
                                             )
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $18
+                                    (set_local $19
                                       (select
                                         (i32.const 6)
-                                        (get_local $7)
+                                        (get_local $6)
                                         (i32.lt_s
-                                          (get_local $7)
+                                          (get_local $6)
                                           (i32.const 0)
                                         )
                                       )
@@ -4650,7 +4667,7 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $14
+                                                (set_local $15
                                                   (f64.mul
                                                     (get_local $21)
                                                     (f64.const 268435456)
@@ -4659,7 +4676,7 @@
                                                 (get_local $5)
                                               )
                                               (block i32
-                                                (set_local $14
+                                                (set_local $15
                                                   (get_local $21)
                                                 )
                                                 (i32.load
@@ -4678,9 +4695,9 @@
                                     (loop $while-in60
                                       (i32.store
                                         (get_local $5)
-                                        (tee_local $6
+                                        (tee_local $7
                                           (i32.trunc_s/f64
-                                            (get_local $14)
+                                            (get_local $15)
                                           )
                                         )
                                       )
@@ -4692,12 +4709,12 @@
                                       )
                                       (br_if $while-in60
                                         (f64.ne
-                                          (tee_local $14
+                                          (tee_local $15
                                             (f64.mul
                                               (f64.sub
-                                                (get_local $14)
+                                                (get_local $15)
                                                 (f64.convert_u/i32
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                               (f64.const 1e9)
@@ -4709,7 +4726,7 @@
                                     )
                                     (if
                                       (i32.gt_s
-                                        (tee_local $7
+                                        (tee_local $6
                                           (i32.load
                                             (get_local $20)
                                           )
@@ -4717,51 +4734,51 @@
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $6
+                                        (set_local $7
                                           (get_local $8)
                                         )
                                         (loop $while-in62
-                                          (set_local $10
+                                          (set_local $11
                                             (select
                                               (i32.const 29)
-                                              (get_local $7)
+                                              (get_local $6)
                                               (i32.gt_s
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (i32.const 29)
                                               )
                                             )
                                           )
-                                          (set_local $6
+                                          (set_local $7
                                             (block $do-once63 i32
                                               (if i32
                                                 (i32.lt_u
-                                                  (tee_local $7
+                                                  (tee_local $6
                                                     (i32.add
                                                       (get_local $5)
                                                       (i32.const -4)
                                                     )
                                                   )
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (block i32
-                                                  (set_local $9
+                                                  (set_local $10
                                                     (i32.const 0)
                                                   )
                                                   (loop $while-in66
                                                     (set_local $29
                                                       (call $___uremdi3
-                                                        (tee_local $9
+                                                        (tee_local $10
                                                           (call $_i64Add
                                                             (call $_bitshift64Shl
                                                               (i32.load
-                                                                (get_local $7)
+                                                                (get_local $6)
                                                               )
                                                               (i32.const 0)
-                                                              (get_local $10)
+                                                              (get_local $11)
                                                             )
                                                             (get_global $tempRet0)
-                                                            (get_local $9)
+                                                            (get_local $10)
                                                             (i32.const 0)
                                                           )
                                                         )
@@ -4773,12 +4790,12 @@
                                                       )
                                                     )
                                                     (i32.store
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (get_local $29)
                                                     )
-                                                    (set_local $9
+                                                    (set_local $10
                                                       (call $___udivdi3
-                                                        (get_local $9)
+                                                        (get_local $10)
                                                         (get_local $22)
                                                         (i32.const 1000000000)
                                                         (i32.const 0)
@@ -4786,34 +4803,34 @@
                                                     )
                                                     (br_if $while-in66
                                                       (i32.ge_u
-                                                        (tee_local $7
+                                                        (tee_local $6
                                                           (i32.add
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                             (i32.const -4)
                                                           )
                                                         )
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                       )
                                                     )
                                                   )
                                                   (drop
                                                     (br_if $do-once63
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.eqz
-                                                        (get_local $9)
+                                                        (get_local $10)
                                                       )
                                                     )
                                                   )
                                                   (i32.store
-                                                    (tee_local $6
+                                                    (tee_local $7
                                                       (i32.add
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const -4)
                                                       )
                                                     )
-                                                    (get_local $9)
+                                                    (get_local $10)
                                                   )
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                             )
@@ -4823,13 +4840,13 @@
                                               (br_if $while-out67
                                                 (i32.le_u
                                                   (get_local $5)
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                               (if
                                                 (i32.eqz
                                                   (i32.load
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.add
                                                         (get_local $5)
                                                         (i32.const -4)
@@ -4839,7 +4856,7 @@
                                                 )
                                                 (block
                                                   (set_local $5
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (br $while-in68)
                                                 )
@@ -4848,46 +4865,46 @@
                                           )
                                           (i32.store
                                             (get_local $20)
-                                            (tee_local $7
+                                            (tee_local $6
                                               (i32.sub
                                                 (i32.load
                                                   (get_local $20)
                                                 )
-                                                (get_local $10)
+                                                (get_local $11)
                                               )
                                             )
                                           )
                                           (br_if $while-in62
                                             (i32.gt_s
-                                              (get_local $7)
+                                              (get_local $6)
                                               (i32.const 0)
                                             )
                                           )
                                           (block
-                                            (set_local $9
-                                              (get_local $7)
+                                            (set_local $10
+                                              (get_local $6)
                                             )
-                                            (set_local $7
+                                            (set_local $6
                                               (get_local $5)
                                             )
                                           )
                                         )
                                       )
                                       (block
-                                        (set_local $9
-                                          (get_local $7)
-                                        )
-                                        (set_local $6
-                                          (get_local $8)
+                                        (set_local $10
+                                          (get_local $6)
                                         )
                                         (set_local $7
+                                          (get_local $8)
+                                        )
+                                        (set_local $6
                                           (get_local $5)
                                         )
                                       )
                                     )
                                     (if
                                       (i32.lt_s
-                                        (get_local $9)
+                                        (get_local $10)
                                         (i32.const 0)
                                       )
                                       (block
@@ -4895,7 +4912,7 @@
                                           (i32.add
                                             (i32.div_s
                                               (i32.add
-                                                (get_local $18)
+                                                (get_local $19)
                                                 (i32.const 25)
                                               )
                                               (i32.const 9)
@@ -4905,93 +4922,93 @@
                                         )
                                         (set_local $29
                                           (i32.eq
-                                            (get_local $16)
+                                            (get_local $13)
                                             (i32.const 102)
                                           )
                                         )
                                         (set_local $5
-                                          (get_local $7)
+                                          (get_local $6)
                                         )
                                         (loop $while-in70
-                                          (set_local $10
+                                          (set_local $11
                                             (select
                                               (i32.const 9)
-                                              (tee_local $7
+                                              (tee_local $6
                                                 (i32.sub
                                                   (i32.const 0)
-                                                  (get_local $9)
+                                                  (get_local $10)
                                                 )
                                               )
                                               (i32.gt_s
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (i32.const 9)
                                               )
                                             )
                                           )
-                                          (set_local $7
+                                          (set_local $6
                                             (select
                                               (i32.add
-                                                (tee_local $7
+                                                (tee_local $6
                                                   (select
                                                     (get_local $8)
-                                                    (tee_local $6
+                                                    (tee_local $7
                                                       (block $do-once71 i32
                                                         (if i32
                                                           (i32.lt_u
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                             (get_local $5)
                                                           )
                                                           (block i32
-                                                            (set_local $43
+                                                            (set_local $36
                                                               (i32.add
                                                                 (i32.shl
                                                                   (i32.const 1)
-                                                                  (get_local $10)
+                                                                  (get_local $11)
                                                                 )
                                                                 (i32.const -1)
                                                               )
                                                             )
-                                                            (set_local $36
+                                                            (set_local $37
                                                               (i32.shr_u
                                                                 (i32.const 1000000000)
-                                                                (get_local $10)
+                                                                (get_local $11)
                                                               )
                                                             )
-                                                            (set_local $9
+                                                            (set_local $10
                                                               (i32.const 0)
                                                             )
-                                                            (set_local $7
-                                                              (get_local $6)
+                                                            (set_local $6
+                                                              (get_local $7)
                                                             )
                                                             (loop $while-in74
                                                               (i32.store
-                                                                (get_local $7)
+                                                                (get_local $6)
                                                                 (i32.add
                                                                   (i32.shr_u
                                                                     (tee_local $44
                                                                       (i32.load
-                                                                        (get_local $7)
+                                                                        (get_local $6)
                                                                       )
                                                                     )
-                                                                    (get_local $10)
+                                                                    (get_local $11)
                                                                   )
-                                                                  (get_local $9)
+                                                                  (get_local $10)
                                                                 )
                                                               )
-                                                              (set_local $9
+                                                              (set_local $10
                                                                 (i32.mul
                                                                   (i32.and
                                                                     (get_local $44)
-                                                                    (get_local $43)
+                                                                    (get_local $36)
                                                                   )
-                                                                  (get_local $36)
+                                                                  (get_local $37)
                                                                 )
                                                               )
                                                               (br_if $while-in74
                                                                 (i32.lt_u
-                                                                  (tee_local $7
+                                                                  (tee_local $6
                                                                     (i32.add
-                                                                      (get_local $7)
+                                                                      (get_local $6)
                                                                       (i32.const 4)
                                                                     )
                                                                   )
@@ -4999,29 +5016,29 @@
                                                                 )
                                                               )
                                                             )
-                                                            (set_local $6
+                                                            (set_local $7
                                                               (select
-                                                                (get_local $6)
+                                                                (get_local $7)
                                                                 (i32.add
-                                                                  (get_local $6)
+                                                                  (get_local $7)
                                                                   (i32.const 4)
                                                                 )
                                                                 (i32.load
-                                                                  (get_local $6)
+                                                                  (get_local $7)
                                                                 )
                                                               )
                                                             )
                                                             (drop
                                                               (br_if $do-once71
-                                                                (get_local $6)
+                                                                (get_local $7)
                                                                 (i32.eqz
-                                                                  (get_local $9)
+                                                                  (get_local $10)
                                                                 )
                                                               )
                                                             )
                                                             (i32.store
                                                               (get_local $5)
-                                                              (get_local $9)
+                                                              (get_local $10)
                                                             )
                                                             (set_local $5
                                                               (i32.add
@@ -5029,16 +5046,16 @@
                                                                 (i32.const 4)
                                                               )
                                                             )
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                           )
                                                           (select
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                             (i32.add
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                               (i32.const 4)
                                                             )
                                                             (i32.load
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                             )
                                                           )
                                                         )
@@ -5057,7 +5074,7 @@
                                                 (i32.shr_s
                                                   (i32.sub
                                                     (get_local $5)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (i32.const 2)
                                                 )
@@ -5067,32 +5084,32 @@
                                           )
                                           (i32.store
                                             (get_local $20)
-                                            (tee_local $9
+                                            (tee_local $10
                                               (i32.add
                                                 (i32.load
                                                   (get_local $20)
                                                 )
-                                                (get_local $10)
+                                                (get_local $11)
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_s
-                                              (get_local $9)
+                                              (get_local $10)
                                               (i32.const 0)
-                                            )
-                                            (block
-                                              (set_local $5
-                                                (get_local $7)
-                                              )
-                                              (br $while-in70)
                                             )
                                             (block
                                               (set_local $5
                                                 (get_local $6)
                                               )
-                                              (set_local $9
+                                              (br $while-in70)
+                                            )
+                                            (block
+                                              (set_local $5
                                                 (get_local $7)
+                                              )
+                                              (set_local $10
+                                                (get_local $6)
                                               )
                                             )
                                           )
@@ -5100,10 +5117,10 @@
                                       )
                                       (block
                                         (set_local $5
-                                          (get_local $6)
-                                        )
-                                        (set_local $9
                                           (get_local $7)
+                                        )
+                                        (set_local $10
+                                          (get_local $6)
                                         )
                                       )
                                     )
@@ -5111,10 +5128,10 @@
                                       (if
                                         (i32.lt_u
                                           (get_local $5)
-                                          (get_local $9)
+                                          (get_local $10)
                                         )
                                         (block
-                                          (set_local $6
+                                          (set_local $7
                                             (i32.mul
                                               (i32.shr_s
                                                 (i32.sub
@@ -5128,7 +5145,7 @@
                                           )
                                           (br_if $do-once75
                                             (i32.lt_u
-                                              (tee_local $10
+                                              (tee_local $11
                                                 (i32.load
                                                   (get_local $5)
                                                 )
@@ -5136,22 +5153,22 @@
                                               (i32.const 10)
                                             )
                                           )
-                                          (set_local $7
+                                          (set_local $6
                                             (i32.const 10)
                                           )
                                           (loop $while-in78
-                                            (set_local $6
+                                            (set_local $7
                                               (i32.add
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (i32.const 1)
                                               )
                                             )
                                             (br_if $while-in78
                                               (i32.ge_u
-                                                (get_local $10)
-                                                (tee_local $7
+                                                (get_local $11)
+                                                (tee_local $6
                                                   (i32.mul
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 10)
                                                   )
                                                 )
@@ -5159,23 +5176,23 @@
                                             )
                                           )
                                         )
-                                        (set_local $6
+                                        (set_local $7
                                           (i32.const 0)
                                         )
                                       )
                                     )
-                                    (set_local $16
+                                    (set_local $13
                                       (if i32
                                         (i32.lt_s
-                                          (tee_local $7
+                                          (tee_local $6
                                             (i32.add
                                               (i32.sub
-                                                (get_local $18)
+                                                (get_local $19)
                                                 (select
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (i32.const 0)
                                                   (i32.ne
-                                                    (get_local $16)
+                                                    (get_local $13)
                                                     (i32.const 102)
                                                   )
                                                 )
@@ -5185,13 +5202,13 @@
                                                   (i32.and
                                                     (tee_local $29
                                                       (i32.ne
-                                                        (get_local $18)
+                                                        (get_local $19)
                                                         (i32.const 0)
                                                       )
                                                     )
-                                                    (tee_local $43
+                                                    (tee_local $36
                                                       (i32.eq
-                                                        (get_local $16)
+                                                        (get_local $13)
                                                         (i32.const 103)
                                                       )
                                                     )
@@ -5206,7 +5223,7 @@
                                             (i32.mul
                                               (i32.shr_s
                                                 (i32.sub
-                                                  (get_local $9)
+                                                  (get_local $10)
                                                   (get_local $31)
                                                 )
                                                 (i32.const 2)
@@ -5217,7 +5234,7 @@
                                           )
                                         )
                                         (block i32
-                                          (set_local $7
+                                          (set_local $6
                                             (i32.add
                                               (i32.add
                                                 (get_local $8)
@@ -5226,9 +5243,9 @@
                                               (i32.shl
                                                 (i32.add
                                                   (i32.div_s
-                                                    (tee_local $10
+                                                    (tee_local $11
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const 9216)
                                                       )
                                                     )
@@ -5242,10 +5259,10 @@
                                           )
                                           (if
                                             (i32.lt_s
-                                              (tee_local $10
+                                              (tee_local $11
                                                 (i32.add
                                                   (i32.rem_s
-                                                    (get_local $10)
+                                                    (get_local $11)
                                                     (i32.const 9)
                                                   )
                                                   (i32.const 1)
@@ -5254,21 +5271,21 @@
                                               (i32.const 9)
                                             )
                                             (block
-                                              (set_local $16
+                                              (set_local $13
                                                 (i32.const 10)
                                               )
                                               (loop $while-in80
-                                                (set_local $16
+                                                (set_local $13
                                                   (i32.mul
-                                                    (get_local $16)
+                                                    (get_local $13)
                                                     (i32.const 10)
                                                   )
                                                 )
                                                 (br_if $while-in80
                                                   (i32.ne
-                                                    (tee_local $10
+                                                    (tee_local $11
                                                       (i32.add
-                                                        (get_local $10)
+                                                        (get_local $11)
                                                         (i32.const 1)
                                                       )
                                                     )
@@ -5277,7 +5294,7 @@
                                                 )
                                               )
                                             )
-                                            (set_local $16
+                                            (set_local $13
                                               (i32.const 10)
                                             )
                                           )
@@ -5285,24 +5302,24 @@
                                             (if
                                               (i32.eqz
                                                 (i32.and
-                                                  (tee_local $36
+                                                  (tee_local $37
                                                     (i32.eq
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const 4)
                                                       )
-                                                      (get_local $9)
+                                                      (get_local $10)
                                                     )
                                                   )
                                                   (i32.eqz
-                                                    (tee_local $10
+                                                    (tee_local $11
                                                       (i32.rem_u
                                                         (tee_local $22
                                                           (i32.load
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                           )
                                                         )
-                                                        (get_local $16)
+                                                        (get_local $13)
                                                       )
                                                     )
                                                   )
@@ -5316,19 +5333,19 @@
                                                     (i32.and
                                                       (i32.div_u
                                                         (get_local $22)
-                                                        (get_local $16)
+                                                        (get_local $13)
                                                       )
                                                       (i32.const 1)
                                                     )
                                                   )
                                                 )
-                                                (set_local $14
+                                                (set_local $15
                                                   (if f64
                                                     (i32.lt_u
-                                                      (get_local $10)
+                                                      (get_local $11)
                                                       (tee_local $44
                                                         (i32.div_s
-                                                          (get_local $16)
+                                                          (get_local $13)
                                                           (i32.const 2)
                                                         )
                                                       )
@@ -5338,9 +5355,9 @@
                                                       (f64.const 1)
                                                       (f64.const 1.5)
                                                       (i32.and
-                                                        (get_local $36)
+                                                        (get_local $37)
                                                         (i32.eq
-                                                          (get_local $10)
+                                                          (get_local $11)
                                                           (get_local $44)
                                                         )
                                                       )
@@ -5363,9 +5380,9 @@
                                                             )
                                                           )
                                                         )
-                                                        (set_local $14
+                                                        (set_local $15
                                                           (f64.neg
-                                                            (get_local $14)
+                                                            (get_local $15)
                                                           )
                                                         )
                                                         (f64.neg
@@ -5377,11 +5394,11 @@
                                                   )
                                                 )
                                                 (i32.store
-                                                  (get_local $7)
-                                                  (tee_local $10
+                                                  (get_local $6)
+                                                  (tee_local $11
                                                     (i32.sub
                                                       (get_local $22)
-                                                      (get_local $10)
+                                                      (get_local $11)
                                                     )
                                                   )
                                                 )
@@ -5389,36 +5406,36 @@
                                                   (f64.eq
                                                     (f64.add
                                                       (get_local $21)
-                                                      (get_local $14)
+                                                      (get_local $15)
                                                     )
                                                     (get_local $21)
                                                   )
                                                 )
                                                 (i32.store
-                                                  (get_local $7)
-                                                  (tee_local $6
+                                                  (get_local $6)
+                                                  (tee_local $7
                                                     (i32.add
-                                                      (get_local $10)
-                                                      (get_local $16)
+                                                      (get_local $11)
+                                                      (get_local $13)
                                                     )
                                                   )
                                                 )
                                                 (if
                                                   (i32.gt_u
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const 999999999)
                                                   )
                                                   (loop $while-in86
                                                     (i32.store
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 0)
                                                     )
                                                     (set_local $5
                                                       (if i32
                                                         (i32.lt_u
-                                                          (tee_local $7
+                                                          (tee_local $6
                                                             (i32.add
-                                                              (get_local $7)
+                                                              (get_local $6)
                                                               (i32.const -4)
                                                             )
                                                           )
@@ -5440,11 +5457,11 @@
                                                       )
                                                     )
                                                     (i32.store
-                                                      (get_local $7)
-                                                      (tee_local $6
+                                                      (get_local $6)
+                                                      (tee_local $7
                                                         (i32.add
                                                           (i32.load
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                           )
                                                           (i32.const 1)
                                                         )
@@ -5452,13 +5469,13 @@
                                                     )
                                                     (br_if $while-in86
                                                       (i32.gt_u
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const 999999999)
                                                       )
                                                     )
                                                   )
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (i32.mul
                                                     (i32.shr_s
                                                       (i32.sub
@@ -5472,7 +5489,7 @@
                                                 )
                                                 (br_if $do-once81
                                                   (i32.lt_u
-                                                    (tee_local $16
+                                                    (tee_local $13
                                                       (i32.load
                                                         (get_local $5)
                                                       )
@@ -5480,22 +5497,22 @@
                                                     (i32.const 10)
                                                   )
                                                 )
-                                                (set_local $10
+                                                (set_local $11
                                                   (i32.const 10)
                                                 )
                                                 (loop $while-in88
-                                                  (set_local $6
+                                                  (set_local $7
                                                     (i32.add
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.const 1)
                                                     )
                                                   )
                                                   (br_if $while-in88
                                                     (i32.ge_u
-                                                      (get_local $16)
-                                                      (tee_local $10
+                                                      (get_local $13)
+                                                      (tee_local $11
                                                         (i32.mul
-                                                          (get_local $10)
+                                                          (get_local $11)
                                                           (i32.const 10)
                                                         )
                                                       )
@@ -5505,55 +5522,55 @@
                                               )
                                             )
                                           )
-                                          (set_local $10
-                                            (get_local $6)
+                                          (set_local $11
+                                            (get_local $7)
                                           )
-                                          (set_local $9
+                                          (set_local $10
                                             (select
-                                              (tee_local $6
+                                              (tee_local $7
                                                 (i32.add
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (i32.const 4)
                                                 )
                                               )
-                                              (get_local $9)
+                                              (get_local $10)
                                               (i32.gt_u
-                                                (get_local $9)
-                                                (get_local $6)
+                                                (get_local $10)
+                                                (get_local $7)
                                               )
                                             )
                                           )
                                           (get_local $5)
                                         )
                                         (block i32
-                                          (set_local $10
-                                            (get_local $6)
+                                          (set_local $11
+                                            (get_local $7)
                                           )
                                           (get_local $5)
                                         )
                                       )
                                     )
-                                    (set_local $36
+                                    (set_local $37
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $10)
+                                        (get_local $11)
                                       )
                                     )
                                     (set_local $5
-                                      (get_local $9)
+                                      (get_local $10)
                                     )
                                     (loop $while-in90
                                       (block $while-out89
                                         (if
                                           (i32.le_u
                                             (get_local $5)
-                                            (get_local $16)
+                                            (get_local $13)
                                           )
                                           (block
                                             (set_local $22
                                               (i32.const 0)
                                             )
-                                            (set_local $7
+                                            (set_local $10
                                               (get_local $5)
                                             )
                                             (br $while-out89)
@@ -5561,7 +5578,7 @@
                                         )
                                         (if
                                           (i32.load
-                                            (tee_local $6
+                                            (tee_local $7
                                               (i32.add
                                                 (get_local $5)
                                                 (i32.const -4)
@@ -5572,25 +5589,25 @@
                                             (set_local $22
                                               (i32.const 1)
                                             )
-                                            (set_local $7
+                                            (set_local $10
                                               (get_local $5)
                                             )
                                           )
                                           (block
                                             (set_local $5
-                                              (get_local $6)
+                                              (get_local $7)
                                             )
                                             (br $while-in90)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $12
+                                    (set_local $17
                                       (block $do-once91 i32
                                         (if i32
-                                          (get_local $43)
+                                          (get_local $36)
                                           (block i32
-                                            (set_local $9
+                                            (set_local $17
                                               (if i32
                                                 (i32.and
                                                   (i32.gt_s
@@ -5603,20 +5620,20 @@
                                                           )
                                                           (i32.const 1)
                                                         )
-                                                        (get_local $18)
+                                                        (get_local $19)
                                                       )
                                                     )
-                                                    (get_local $10)
+                                                    (get_local $11)
                                                   )
                                                   (i32.gt_s
-                                                    (get_local $10)
+                                                    (get_local $11)
                                                     (i32.const -5)
                                                   )
                                                 )
                                                 (block i32
-                                                  (set_local $6
+                                                  (set_local $7
                                                     (i32.add
-                                                      (get_local $12)
+                                                      (get_local $17)
                                                       (i32.const -1)
                                                     )
                                                   )
@@ -5625,13 +5642,13 @@
                                                       (get_local $5)
                                                       (i32.const -1)
                                                     )
-                                                    (get_local $10)
+                                                    (get_local $11)
                                                   )
                                                 )
                                                 (block i32
-                                                  (set_local $6
+                                                  (set_local $7
                                                     (i32.add
-                                                      (get_local $12)
+                                                      (get_local $17)
                                                       (i32.const -2)
                                                     )
                                                   )
@@ -5643,18 +5660,18 @@
                                               )
                                             )
                                             (if
-                                              (tee_local $12
+                                              (tee_local $6
                                                 (i32.and
-                                                  (get_local $11)
+                                                  (get_local $12)
                                                   (i32.const 8)
                                                 )
                                               )
                                               (block
                                                 (set_local $5
-                                                  (get_local $9)
+                                                  (get_local $17)
                                                 )
                                                 (br $do-once91
-                                                  (get_local $12)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -5664,10 +5681,10 @@
                                                 (block
                                                   (if
                                                     (i32.eqz
-                                                      (tee_local $18
+                                                      (tee_local $19
                                                         (i32.load
                                                           (i32.add
-                                                            (get_local $7)
+                                                            (get_local $10)
                                                             (i32.const -4)
                                                           )
                                                         )
@@ -5682,7 +5699,7 @@
                                                   )
                                                   (if
                                                     (i32.rem_u
-                                                      (get_local $18)
+                                                      (get_local $19)
                                                       (i32.const 10)
                                                     )
                                                     (block
@@ -5692,7 +5709,7 @@
                                                       (br $do-once93)
                                                     )
                                                     (block
-                                                      (set_local $12
+                                                      (set_local $6
                                                         (i32.const 10)
                                                       )
                                                       (set_local $5
@@ -5710,10 +5727,10 @@
                                                     (br_if $while-in96
                                                       (i32.eqz
                                                         (i32.rem_u
-                                                          (get_local $18)
-                                                          (tee_local $12
+                                                          (get_local $19)
+                                                          (tee_local $6
                                                             (i32.mul
-                                                              (get_local $12)
+                                                              (get_local $6)
                                                               (i32.const 10)
                                                             )
                                                           )
@@ -5727,12 +5744,12 @@
                                                 )
                                               )
                                             )
-                                            (set_local $12
+                                            (set_local $6
                                               (i32.add
                                                 (i32.mul
                                                   (i32.shr_s
                                                     (i32.sub
-                                                      (get_local $7)
+                                                      (get_local $10)
                                                       (get_local $31)
                                                     )
                                                     (i32.const 2)
@@ -5745,7 +5762,7 @@
                                             (if i32
                                               (i32.eq
                                                 (i32.or
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (i32.const 32)
                                                 )
                                                 (i32.const 102)
@@ -5753,13 +5770,13 @@
                                               (block i32
                                                 (set_local $5
                                                   (select
-                                                    (get_local $9)
+                                                    (get_local $17)
                                                     (tee_local $5
                                                       (select
                                                         (i32.const 0)
                                                         (tee_local $5
                                                           (i32.sub
-                                                            (get_local $12)
+                                                            (get_local $6)
                                                             (get_local $5)
                                                           )
                                                         )
@@ -5770,7 +5787,7 @@
                                                       )
                                                     )
                                                     (i32.lt_s
-                                                      (get_local $9)
+                                                      (get_local $17)
                                                       (get_local $5)
                                                     )
                                                   )
@@ -5780,15 +5797,15 @@
                                               (block i32
                                                 (set_local $5
                                                   (select
-                                                    (get_local $9)
+                                                    (get_local $17)
                                                     (tee_local $5
                                                       (select
                                                         (i32.const 0)
                                                         (tee_local $5
                                                           (i32.sub
                                                             (i32.add
-                                                              (get_local $12)
-                                                              (get_local $10)
+                                                              (get_local $6)
+                                                              (get_local $11)
                                                             )
                                                             (get_local $5)
                                                           )
@@ -5800,7 +5817,7 @@
                                                       )
                                                     )
                                                     (i32.lt_s
-                                                      (get_local $9)
+                                                      (get_local $17)
                                                       (get_local $5)
                                                     )
                                                   )
@@ -5811,26 +5828,26 @@
                                           )
                                           (block i32
                                             (set_local $5
-                                              (get_local $18)
+                                              (get_local $19)
                                             )
-                                            (set_local $6
-                                              (get_local $12)
+                                            (set_local $7
+                                              (get_local $17)
                                             )
                                             (i32.and
-                                              (get_local $11)
+                                              (get_local $12)
                                               (i32.const 8)
                                             )
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $31
+                                    (set_local $29
                                       (i32.and
                                         (i32.ne
-                                          (tee_local $18
+                                          (tee_local $31
                                             (i32.or
                                               (get_local $5)
-                                              (get_local $12)
+                                              (get_local $17)
                                             )
                                           )
                                           (i32.const 0)
@@ -5838,24 +5855,24 @@
                                         (i32.const 1)
                                       )
                                     )
-                                    (set_local $9
+                                    (set_local $19
                                       (if i32
-                                        (tee_local $29
+                                        (tee_local $36
                                           (i32.eq
                                             (i32.or
-                                              (get_local $6)
+                                              (get_local $7)
                                               (i32.const 32)
                                             )
                                             (i32.const 102)
                                           )
                                         )
                                         (block i32
-                                          (set_local $6
+                                          (set_local $7
                                             (select
-                                              (get_local $10)
+                                              (get_local $11)
                                               (i32.const 0)
                                               (i32.gt_s
-                                                (get_local $10)
+                                                (get_local $11)
                                                 (i32.const 0)
                                               )
                                             )
@@ -5867,14 +5884,14 @@
                                             (i32.lt_s
                                               (i32.sub
                                                 (get_local $30)
-                                                (tee_local $9
+                                                (tee_local $6
                                                   (call $_fmt_u
-                                                    (tee_local $9
+                                                    (tee_local $6
                                                       (select
-                                                        (get_local $36)
-                                                        (get_local $10)
+                                                        (get_local $37)
+                                                        (get_local $11)
                                                         (i32.lt_s
-                                                          (get_local $10)
+                                                          (get_local $11)
                                                           (i32.const 0)
                                                         )
                                                       )
@@ -5882,14 +5899,14 @@
                                                     (i32.shr_s
                                                       (i32.shl
                                                         (i32.lt_s
-                                                          (get_local $9)
+                                                          (get_local $6)
                                                           (i32.const 0)
                                                         )
                                                         (i32.const 31)
                                                       )
                                                       (i32.const 31)
                                                     )
-                                                    (get_local $37)
+                                                    (get_local $38)
                                                   )
                                                 )
                                               )
@@ -5897,9 +5914,9 @@
                                             )
                                             (loop $while-in98
                                               (i32.store8
-                                                (tee_local $9
+                                                (tee_local $6
                                                   (i32.add
-                                                    (get_local $9)
+                                                    (get_local $6)
                                                     (i32.const -1)
                                                   )
                                                 )
@@ -5909,7 +5926,7 @@
                                                 (i32.lt_s
                                                   (i32.sub
                                                     (get_local $30)
-                                                    (get_local $9)
+                                                    (get_local $6)
                                                   )
                                                   (i32.const 2)
                                                 )
@@ -5918,13 +5935,13 @@
                                           )
                                           (i32.store8
                                             (i32.add
-                                              (get_local $9)
+                                              (get_local $6)
                                               (i32.const -1)
                                             )
                                             (i32.add
                                               (i32.and
                                                 (i32.shr_s
-                                                  (get_local $10)
+                                                  (get_local $11)
                                                   (i32.const 31)
                                                 )
                                                 (i32.const 2)
@@ -5933,29 +5950,29 @@
                                             )
                                           )
                                           (i32.store8
-                                            (tee_local $9
+                                            (tee_local $6
                                               (i32.add
-                                                (get_local $9)
+                                                (get_local $6)
                                                 (i32.const -2)
                                               )
                                             )
-                                            (get_local $6)
+                                            (get_local $7)
                                           )
-                                          (set_local $6
+                                          (set_local $7
                                             (i32.sub
                                               (get_local $30)
-                                              (get_local $9)
+                                              (get_local $6)
                                             )
                                           )
-                                          (get_local $9)
+                                          (get_local $6)
                                         )
                                       )
                                     )
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $13)
-                                      (tee_local $10
+                                      (get_local $14)
+                                      (tee_local $11
                                         (i32.add
                                           (i32.add
                                             (i32.add
@@ -5965,12 +5982,12 @@
                                               )
                                               (get_local $5)
                                             )
-                                            (get_local $31)
+                                            (get_local $29)
                                           )
-                                          (get_local $6)
+                                          (get_local $7)
                                         )
                                       )
-                                      (get_local $11)
+                                      (get_local $12)
                                     )
                                     (if
                                       (i32.eqz
@@ -5992,34 +6009,34 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 48)
-                                      (get_local $13)
-                                      (get_local $10)
+                                      (get_local $14)
+                                      (get_local $11)
                                       (i32.xor
-                                        (get_local $11)
+                                        (get_local $12)
                                         (i32.const 65536)
                                       )
                                     )
                                     (block $do-once99
                                       (if
-                                        (get_local $29)
+                                        (get_local $36)
                                         (block
-                                          (set_local $9
-                                            (tee_local $12
+                                          (set_local $6
+                                            (tee_local $13
                                               (select
                                                 (get_local $8)
-                                                (get_local $16)
+                                                (get_local $13)
                                                 (i32.gt_u
-                                                  (get_local $16)
+                                                  (get_local $13)
                                                   (get_local $8)
                                                 )
                                               )
                                             )
                                           )
                                           (loop $while-in102
-                                            (set_local $6
+                                            (set_local $7
                                               (call $_fmt_u
                                                 (i32.load
-                                                  (get_local $9)
+                                                  (get_local $6)
                                                 )
                                                 (i32.const 0)
                                                 (get_local $33)
@@ -6028,36 +6045,36 @@
                                             (block $do-once103
                                               (if
                                                 (i32.eq
-                                                  (get_local $9)
-                                                  (get_local $12)
+                                                  (get_local $6)
+                                                  (get_local $13)
                                                 )
                                                 (block
                                                   (br_if $do-once103
                                                     (i32.ne
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (get_local $33)
                                                     )
                                                   )
                                                   (i32.store8
-                                                    (get_local $38)
+                                                    (get_local $39)
                                                     (i32.const 48)
                                                   )
-                                                  (set_local $6
-                                                    (get_local $38)
+                                                  (set_local $7
+                                                    (get_local $39)
                                                   )
                                                 )
                                                 (block
                                                   (br_if $do-once103
                                                     (i32.le_u
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (get_local $24)
                                                     )
                                                   )
                                                   (loop $while-in106
                                                     (i32.store8
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (i32.add
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                           (i32.const -1)
                                                         )
                                                       )
@@ -6065,7 +6082,7 @@
                                                     )
                                                     (br_if $while-in106
                                                       (i32.gt_u
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (get_local $24)
                                                       )
                                                     )
@@ -6084,10 +6101,10 @@
                                               )
                                               (drop
                                                 (call $___fwritex
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (i32.sub
                                                     (get_local $49)
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (get_local $0)
                                                 )
@@ -6095,17 +6112,17 @@
                                             )
                                             (if
                                               (i32.le_u
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (i32.add
-                                                    (get_local $9)
+                                                    (get_local $6)
                                                     (i32.const 4)
                                                   )
                                                 )
                                                 (get_local $8)
                                               )
                                               (block
-                                                (set_local $9
-                                                  (get_local $6)
+                                                (set_local $6
+                                                  (get_local $7)
                                                 )
                                                 (br $while-in102)
                                               )
@@ -6113,7 +6130,7 @@
                                           )
                                           (block $do-once107
                                             (if
-                                              (get_local $18)
+                                              (get_local $31)
                                               (block
                                                 (br_if $do-once107
                                                   (i32.and
@@ -6140,17 +6157,17 @@
                                                 (i32.const 0)
                                               )
                                               (i32.lt_u
-                                                (get_local $6)
                                                 (get_local $7)
+                                                (get_local $10)
                                               )
                                             )
                                             (loop $while-in110
                                               (if
                                                 (i32.gt_u
-                                                  (tee_local $8
+                                                  (tee_local $6
                                                     (call $_fmt_u
                                                       (i32.load
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                       )
                                                       (i32.const 0)
                                                       (get_local $33)
@@ -6160,9 +6177,9 @@
                                                 )
                                                 (loop $while-in112
                                                   (i32.store8
-                                                    (tee_local $8
+                                                    (tee_local $6
                                                       (i32.add
-                                                        (get_local $8)
+                                                        (get_local $6)
                                                         (i32.const -1)
                                                       )
                                                     )
@@ -6170,7 +6187,7 @@
                                                   )
                                                   (br_if $while-in112
                                                     (i32.gt_u
-                                                      (get_local $8)
+                                                      (get_local $6)
                                                       (get_local $24)
                                                     )
                                                   )
@@ -6187,7 +6204,7 @@
                                                 )
                                                 (drop
                                                   (call $___fwritex
-                                                    (get_local $8)
+                                                    (get_local $6)
                                                     (select
                                                       (i32.const 9)
                                                       (get_local $5)
@@ -6200,7 +6217,7 @@
                                                   )
                                                 )
                                               )
-                                              (set_local $8
+                                              (set_local $6
                                                 (i32.add
                                                   (get_local $5)
                                                   (i32.const -9)
@@ -6213,23 +6230,23 @@
                                                     (i32.const 9)
                                                   )
                                                   (i32.lt_u
-                                                    (tee_local $6
+                                                    (tee_local $7
                                                       (i32.add
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $10)
                                                   )
                                                 )
                                                 (block
                                                   (set_local $5
-                                                    (get_local $8)
+                                                    (get_local $6)
                                                   )
                                                   (br $while-in110)
                                                 )
                                                 (set_local $5
-                                                  (get_local $8)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -6246,11 +6263,11 @@
                                           )
                                         )
                                         (block
-                                          (set_local $18
+                                          (set_local $10
                                             (select
-                                              (get_local $7)
+                                              (get_local $10)
                                               (i32.add
-                                                (get_local $16)
+                                                (get_local $13)
                                                 (i32.const 4)
                                               )
                                               (get_local $22)
@@ -6262,25 +6279,25 @@
                                               (i32.const -1)
                                             )
                                             (block
-                                              (set_local $12
+                                              (set_local $17
                                                 (i32.eqz
-                                                  (get_local $12)
+                                                  (get_local $17)
                                                 )
                                               )
-                                              (set_local $8
-                                                (get_local $16)
-                                              )
                                               (set_local $6
+                                                (get_local $13)
+                                              )
+                                              (set_local $7
                                                 (get_local $5)
                                               )
                                               (loop $while-in114
-                                                (set_local $7
+                                                (set_local $8
                                                   (if i32
                                                     (i32.eq
                                                       (tee_local $5
                                                         (call $_fmt_u
                                                           (i32.load
-                                                            (get_local $8)
+                                                            (get_local $6)
                                                           )
                                                           (i32.const 0)
                                                           (get_local $33)
@@ -6290,10 +6307,10 @@
                                                     )
                                                     (block i32
                                                       (i32.store8
-                                                        (get_local $38)
+                                                        (get_local $39)
                                                         (i32.const 48)
                                                       )
-                                                      (get_local $38)
+                                                      (get_local $39)
                                                     )
                                                     (get_local $5)
                                                   )
@@ -6301,13 +6318,13 @@
                                                 (block $do-once115
                                                   (if
                                                     (i32.eq
-                                                      (get_local $8)
-                                                      (get_local $16)
+                                                      (get_local $6)
+                                                      (get_local $13)
                                                     )
                                                     (block
                                                       (set_local $5
                                                         (i32.add
-                                                          (get_local $7)
+                                                          (get_local $8)
                                                           (i32.const 1)
                                                         )
                                                       )
@@ -6322,7 +6339,7 @@
                                                         )
                                                         (drop
                                                           (call $___fwritex
-                                                            (get_local $7)
+                                                            (get_local $8)
                                                             (i32.const 1)
                                                             (get_local $0)
                                                           )
@@ -6330,9 +6347,9 @@
                                                       )
                                                       (br_if $do-once115
                                                         (i32.and
-                                                          (get_local $12)
+                                                          (get_local $17)
                                                           (i32.lt_s
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                             (i32.const 1)
                                                           )
                                                         )
@@ -6356,15 +6373,15 @@
                                                     (block
                                                       (if
                                                         (i32.gt_u
-                                                          (get_local $7)
+                                                          (get_local $8)
                                                           (get_local $24)
                                                         )
                                                         (set_local $5
-                                                          (get_local $7)
+                                                          (get_local $8)
                                                         )
                                                         (block
                                                           (set_local $5
-                                                            (get_local $7)
+                                                            (get_local $8)
                                                           )
                                                           (br $do-once115)
                                                         )
@@ -6389,7 +6406,7 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $7
+                                                (set_local $8
                                                   (i32.sub
                                                     (get_local $49)
                                                     (get_local $5)
@@ -6408,11 +6425,11 @@
                                                     (call $___fwritex
                                                       (get_local $5)
                                                       (select
+                                                        (get_local $8)
                                                         (get_local $7)
-                                                        (get_local $6)
                                                         (i32.gt_s
-                                                          (get_local $6)
                                                           (get_local $7)
+                                                          (get_local $8)
                                                         )
                                                       )
                                                       (get_local $0)
@@ -6422,19 +6439,19 @@
                                                 (br_if $while-in114
                                                   (i32.and
                                                     (i32.lt_u
-                                                      (tee_local $8
+                                                      (tee_local $6
                                                         (i32.add
-                                                          (get_local $8)
+                                                          (get_local $6)
                                                           (i32.const 4)
                                                         )
                                                       )
-                                                      (get_local $18)
+                                                      (get_local $10)
                                                     )
                                                     (i32.gt_s
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (i32.sub
-                                                          (get_local $6)
                                                           (get_local $7)
+                                                          (get_local $8)
                                                         )
                                                       )
                                                       (i32.const -1)
@@ -6442,7 +6459,7 @@
                                                   )
                                                 )
                                                 (set_local $5
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                             )
@@ -6467,10 +6484,10 @@
                                           )
                                           (drop
                                             (call $___fwritex
-                                              (get_local $9)
+                                              (get_local $19)
                                               (i32.sub
                                                 (get_local $30)
-                                                (get_local $9)
+                                                (get_local $19)
                                               )
                                               (get_local $0)
                                             )
@@ -6481,47 +6498,47 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $13)
-                                      (get_local $10)
+                                      (get_local $14)
+                                      (get_local $11)
                                       (i32.xor
-                                        (get_local $11)
+                                        (get_local $12)
                                         (i32.const 8192)
                                       )
                                     )
                                     (select
-                                      (get_local $13)
-                                      (get_local $10)
+                                      (get_local $14)
+                                      (get_local $11)
                                       (i32.lt_s
-                                        (get_local $10)
-                                        (get_local $13)
+                                        (get_local $11)
+                                        (get_local $14)
                                       )
                                     )
                                   )
                                   (block i32
-                                    (set_local $6
+                                    (set_local $7
                                       (select
                                         (i32.const 0)
                                         (get_local $28)
                                         (tee_local $5
                                           (i32.or
                                             (f64.ne
-                                              (get_local $14)
-                                              (get_local $14)
+                                              (get_local $15)
+                                              (get_local $15)
                                             )
                                             (i32.const 0)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $7
+                                    (set_local $6
                                       (select
                                         (select
                                           (i32.const 4135)
                                           (i32.const 4139)
-                                          (tee_local $7
+                                          (tee_local $6
                                             (i32.ne
                                               (i32.and
-                                                (get_local $12)
+                                                (get_local $17)
                                                 (i32.const 32)
                                               )
                                               (i32.const 0)
@@ -6531,7 +6548,7 @@
                                         (select
                                           (i32.const 4127)
                                           (i32.const 4131)
-                                          (get_local $7)
+                                          (get_local $6)
                                         )
                                         (get_local $5)
                                       )
@@ -6539,10 +6556,10 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $13)
+                                      (get_local $14)
                                       (tee_local $5
                                         (i32.add
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.const 3)
                                         )
                                       )
@@ -6565,7 +6582,7 @@
                                               (drop
                                                 (call $___fwritex
                                                   (get_local $35)
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (get_local $0)
                                                 )
                                               )
@@ -6579,7 +6596,7 @@
                                       )
                                       (drop
                                         (call $___fwritex
-                                          (get_local $7)
+                                          (get_local $6)
                                           (i32.const 3)
                                           (get_local $0)
                                         )
@@ -6588,19 +6605,19 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $13)
+                                      (get_local $14)
                                       (get_local $5)
                                       (i32.xor
-                                        (get_local $11)
+                                        (get_local $12)
                                         (i32.const 8192)
                                       )
                                     )
                                     (select
-                                      (get_local $13)
+                                      (get_local $14)
                                       (get_local $5)
                                       (i32.lt_s
                                         (get_local $5)
-                                        (get_local $13)
+                                        (get_local $14)
                                       )
                                     )
                                   )
@@ -6609,26 +6626,26 @@
                             )
                             (br $label$continue$L1)
                           )
-                          (set_local $6
-                            (get_local $1)
+                          (set_local $7
+                            (get_local $9)
                           )
-                          (set_local $10
-                            (get_local $7)
+                          (set_local $11
+                            (get_local $6)
                           )
                           (set_local $8
                             (i32.const 0)
                           )
-                          (set_local $9
+                          (set_local $10
                             (i32.const 4091)
                           )
-                          (set_local $1
+                          (set_local $9
                             (get_local $23)
                           )
                           (br $jumpthreading$outer$7)
                         )
-                        (set_local $9
+                        (set_local $10
                           (i32.and
-                            (get_local $12)
+                            (get_local $17)
                             (i32.const 32)
                           )
                         )
@@ -6637,34 +6654,34 @@
                             (i32.eqz
                               (tee_local $8
                                 (i32.load
-                                  (tee_local $6
-                                    (get_local $17)
+                                  (tee_local $7
+                                    (get_local $18)
                                   )
                                 )
                               )
                             )
                             (i32.eqz
-                              (tee_local $11
+                              (tee_local $12
                                 (i32.load offset=4
-                                  (get_local $6)
+                                  (get_local $7)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $6
+                            (set_local $7
                               (get_local $23)
                             )
                             (set_local $8
                               (i32.const 0)
                             )
-                            (set_local $9
+                            (set_local $10
                               (i32.const 4091)
                             )
                             (br $jumpthreading$inner$7)
                           )
                           (block
-                            (set_local $6
+                            (set_local $7
                               (get_local $8)
                             )
                             (set_local $8
@@ -6682,36 +6699,36 @@
                                   (i32.load8_u
                                     (i32.add
                                       (i32.and
-                                        (get_local $6)
+                                        (get_local $7)
                                         (i32.const 15)
                                       )
                                       (i32.const 4075)
                                     )
                                   )
-                                  (get_local $9)
+                                  (get_local $10)
                                 )
                               )
                               (br_if $while-in123
                                 (i32.eqz
                                   (i32.and
                                     (i32.eqz
-                                      (tee_local $6
+                                      (tee_local $7
                                         (call $_bitshift64Lshr
-                                          (get_local $6)
-                                          (get_local $11)
+                                          (get_local $7)
+                                          (get_local $12)
                                           (i32.const 4)
                                         )
                                       )
                                     )
                                     (i32.eqz
-                                      (tee_local $11
+                                      (tee_local $12
                                         (get_global $tempRet0)
                                       )
                                     )
                                   )
                                 )
                               )
-                              (set_local $6
+                              (set_local $7
                                 (get_local $8)
                               )
                             )
@@ -6719,21 +6736,21 @@
                               (i32.or
                                 (i32.eqz
                                   (i32.and
-                                    (get_local $1)
+                                    (get_local $9)
                                     (i32.const 8)
                                   )
                                 )
                                 (i32.and
                                   (i32.eqz
                                     (i32.load
-                                      (tee_local $11
-                                        (get_local $17)
+                                      (tee_local $12
+                                        (get_local $18)
                                       )
                                     )
                                   )
                                   (i32.eqz
                                     (i32.load offset=4
-                                      (get_local $11)
+                                      (get_local $12)
                                     )
                                   )
                                 )
@@ -6742,7 +6759,7 @@
                                 (set_local $8
                                   (i32.const 0)
                                 )
-                                (set_local $9
+                                (set_local $10
                                   (i32.const 4091)
                                 )
                                 (br $jumpthreading$inner$7)
@@ -6751,11 +6768,11 @@
                                 (set_local $8
                                   (i32.const 2)
                                 )
-                                (set_local $9
+                                (set_local $10
                                   (i32.add
                                     (i32.const 4091)
                                     (i32.shr_s
-                                      (get_local $12)
+                                      (get_local $17)
                                       (i32.const 4)
                                     )
                                   )
@@ -6767,84 +6784,84 @@
                         )
                         (br $jumpthreading$outer$7)
                       )
-                      (set_local $6
+                      (set_local $7
                         (call $_fmt_u
-                          (get_local $1)
-                          (get_local $6)
+                          (get_local $9)
+                          (get_local $7)
                           (get_local $23)
                         )
                       )
-                      (set_local $1
-                        (get_local $11)
+                      (set_local $9
+                        (get_local $12)
                       )
                       (br $jumpthreading$inner$7)
                     )
                     (set_local $26
                       (i32.const 0)
                     )
-                    (set_local $16
+                    (set_local $17
                       (i32.eqz
-                        (tee_local $12
+                        (tee_local $13
                           (call $_memchr
-                            (get_local $1)
+                            (get_local $9)
                             (i32.const 0)
-                            (get_local $7)
+                            (get_local $6)
                           )
                         )
                       )
                     )
-                    (set_local $6
-                      (get_local $1)
+                    (set_local $7
+                      (get_local $9)
                     )
-                    (set_local $11
+                    (set_local $12
                       (get_local $8)
                     )
-                    (set_local $10
+                    (set_local $11
                       (select
-                        (get_local $7)
+                        (get_local $6)
                         (i32.sub
-                          (get_local $12)
-                          (get_local $1)
+                          (get_local $13)
+                          (get_local $9)
                         )
-                        (get_local $16)
+                        (get_local $17)
                       )
                     )
                     (set_local $8
                       (i32.const 0)
                     )
-                    (set_local $9
+                    (set_local $10
                       (i32.const 4091)
                     )
-                    (set_local $1
+                    (set_local $9
                       (select
                         (i32.add
-                          (get_local $1)
-                          (get_local $7)
+                          (get_local $9)
+                          (get_local $6)
                         )
-                        (get_local $12)
-                        (get_local $16)
+                        (get_local $13)
+                        (get_local $17)
                       )
                     )
                     (br $jumpthreading$outer$7)
                   )
-                  (set_local $1
+                  (set_local $9
+                    (i32.const 0)
+                  )
+                  (set_local $7
                     (i32.const 0)
                   )
                   (set_local $6
-                    (i32.const 0)
-                  )
-                  (set_local $8
                     (i32.load
-                      (get_local $17)
+                      (get_local $18)
                     )
                   )
                   (loop $while-in125
                     (block $while-out124
                       (br_if $while-out124
                         (i32.eqz
-                          (tee_local $9
+                          (tee_local $10
                             (i32.load
-                              (get_local $8)
+                              (get_local $6)
                             )
                           )
                         )
@@ -6852,36 +6869,36 @@
                       (br_if $while-out124
                         (i32.or
                           (i32.lt_s
-                            (tee_local $6
+                            (tee_local $7
                               (call $_wctomb
-                                (get_local $40)
-                                (get_local $9)
+                                (get_local $41)
+                                (get_local $10)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.gt_u
-                            (get_local $6)
+                            (get_local $7)
                             (i32.sub
-                              (get_local $7)
-                              (get_local $1)
+                              (get_local $8)
+                              (get_local $9)
                             )
                           )
                         )
                       )
-                      (set_local $8
+                      (set_local $6
                         (i32.add
-                          (get_local $8)
+                          (get_local $6)
                           (i32.const 4)
                         )
                       )
                       (br_if $while-in125
                         (i32.gt_u
-                          (get_local $7)
-                          (tee_local $1
+                          (get_local $8)
+                          (tee_local $9
                             (i32.add
-                              (get_local $6)
-                              (get_local $1)
+                              (get_local $7)
+                              (get_local $9)
                             )
                           )
                         )
@@ -6890,11 +6907,11 @@
                   )
                   (if
                     (i32.lt_s
-                      (get_local $6)
+                      (get_local $7)
                       (i32.const 0)
                     )
                     (block
-                      (set_local $15
+                      (set_local $16
                         (i32.const -1)
                       )
                       (br $label$break$L1)
@@ -6903,19 +6920,19 @@
                   (call $_pad
                     (get_local $0)
                     (i32.const 32)
-                    (get_local $13)
-                    (get_local $1)
-                    (get_local $11)
+                    (get_local $14)
+                    (get_local $9)
+                    (get_local $12)
                   )
                   (if
-                    (get_local $1)
+                    (get_local $9)
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.const 0)
                       )
-                      (set_local $6
+                      (set_local $7
                         (i32.load
-                          (get_local $17)
+                          (get_local $18)
                         )
                       )
                       (loop $while-in127
@@ -6923,41 +6940,41 @@
                           (i32.eqz
                             (tee_local $8
                               (i32.load
-                                (get_local $6)
+                                (get_local $7)
                               )
                             )
                           )
                           (block
-                            (set_local $6
-                              (get_local $1)
+                            (set_local $7
+                              (get_local $9)
                             )
                             (br $jumpthreading$inner$6)
                           )
                         )
-                        (set_local $6
+                        (set_local $7
                           (i32.add
-                            (get_local $6)
+                            (get_local $7)
                             (i32.const 4)
                           )
                         )
                         (if
                           (i32.gt_s
-                            (tee_local $7
+                            (tee_local $6
                               (i32.add
                                 (tee_local $8
                                   (call $_wctomb
-                                    (get_local $40)
+                                    (get_local $41)
                                     (get_local $8)
                                   )
                                 )
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
-                            (get_local $1)
+                            (get_local $9)
                           )
                           (block
-                            (set_local $6
-                              (get_local $1)
+                            (set_local $7
+                              (get_local $9)
                             )
                             (br $jumpthreading$inner$6)
                           )
@@ -6973,7 +6990,7 @@
                           )
                           (drop
                             (call $___fwritex
-                              (get_local $40)
+                              (get_local $41)
                               (get_local $8)
                               (get_local $0)
                             )
@@ -6981,20 +6998,20 @@
                         )
                         (br_if $while-in127
                           (i32.lt_u
-                            (get_local $7)
-                            (get_local $1)
+                            (get_local $6)
+                            (get_local $9)
                           )
                         )
                         (block
-                          (set_local $6
-                            (get_local $1)
+                          (set_local $7
+                            (get_local $9)
                           )
                           (br $jumpthreading$inner$6)
                         )
                       )
                     )
                     (block
-                      (set_local $6
+                      (set_local $7
                         (i32.const 0)
                       )
                       (br $jumpthreading$inner$6)
@@ -7008,23 +7025,23 @@
                 (call $_pad
                   (get_local $0)
                   (i32.const 32)
-                  (get_local $13)
-                  (get_local $6)
+                  (get_local $14)
+                  (get_local $7)
                   (i32.xor
-                    (get_local $11)
+                    (get_local $12)
                     (i32.const 8192)
                   )
                 )
-                (set_local $1
+                (set_local $9
                   (get_local $5)
                 )
                 (set_local $5
                   (select
-                    (get_local $13)
-                    (get_local $6)
+                    (get_local $14)
+                    (get_local $7)
                     (i32.gt_s
-                      (get_local $13)
-                      (get_local $6)
+                      (get_local $14)
+                      (get_local $7)
                     )
                   )
                 )
@@ -7033,39 +7050,39 @@
               (set_local $26
                 (i32.const 0)
               )
-              (set_local $11
+              (set_local $12
                 (select
                   (i32.and
-                    (get_local $1)
+                    (get_local $9)
                     (i32.const -65537)
                   )
-                  (get_local $1)
+                  (get_local $9)
                   (i32.gt_s
-                    (get_local $7)
+                    (get_local $6)
                     (i32.const -1)
                   )
                 )
               )
-              (set_local $6
+              (set_local $7
                 (if i32
                   (i32.or
                     (i32.ne
-                      (get_local $7)
+                      (get_local $6)
                       (i32.const 0)
                     )
-                    (tee_local $1
+                    (tee_local $9
                       (i32.or
                         (i32.ne
                           (i32.load
-                            (tee_local $1
-                              (get_local $17)
+                            (tee_local $9
+                              (get_local $18)
                             )
                           )
                           (i32.const 0)
                         )
                         (i32.ne
                           (i32.load offset=4
-                            (get_local $1)
+                            (get_local $9)
                           )
                           (i32.const 0)
                         )
@@ -7073,40 +7090,40 @@
                     )
                   )
                   (block i32
-                    (set_local $10
+                    (set_local $11
                       (select
-                        (get_local $7)
-                        (tee_local $1
+                        (get_local $6)
+                        (tee_local $9
                           (i32.add
                             (i32.xor
                               (i32.and
-                                (get_local $1)
+                                (get_local $9)
                                 (i32.const 1)
                               )
                               (i32.const 1)
                             )
                             (i32.sub
                               (get_local $45)
-                              (get_local $6)
+                              (get_local $7)
                             )
                           )
                         )
                         (i32.gt_s
-                          (get_local $7)
-                          (get_local $1)
+                          (get_local $6)
+                          (get_local $9)
                         )
                       )
                     )
-                    (set_local $1
+                    (set_local $9
                       (get_local $23)
                     )
-                    (get_local $6)
+                    (get_local $7)
                   )
                   (block i32
-                    (set_local $10
+                    (set_local $11
                       (i32.const 0)
                     )
-                    (set_local $1
+                    (set_local $9
                       (get_local $23)
                     )
                     (get_local $23)
@@ -7117,37 +7134,37 @@
             (call $_pad
               (get_local $0)
               (i32.const 32)
-              (tee_local $7
+              (tee_local $6
                 (select
-                  (tee_local $1
+                  (tee_local $9
                     (i32.add
                       (get_local $8)
-                      (tee_local $10
+                      (tee_local $11
                         (select
-                          (tee_local $12
+                          (tee_local $13
                             (i32.sub
-                              (get_local $1)
-                              (get_local $6)
+                              (get_local $9)
+                              (get_local $7)
                             )
                           )
-                          (get_local $10)
+                          (get_local $11)
                           (i32.lt_s
-                            (get_local $10)
-                            (get_local $12)
+                            (get_local $11)
+                            (get_local $13)
                           )
                         )
                       )
                     )
                   )
-                  (get_local $13)
+                  (get_local $14)
                   (i32.lt_s
-                    (get_local $13)
-                    (get_local $1)
+                    (get_local $14)
+                    (get_local $9)
                   )
                 )
               )
-              (get_local $1)
-              (get_local $11)
+              (get_local $9)
+              (get_local $12)
             )
             (if
               (i32.eqz
@@ -7160,7 +7177,7 @@
               )
               (drop
                 (call $___fwritex
-                  (get_local $9)
+                  (get_local $10)
                   (get_local $8)
                   (get_local $0)
                 )
@@ -7169,18 +7186,18 @@
             (call $_pad
               (get_local $0)
               (i32.const 48)
-              (get_local $7)
-              (get_local $1)
+              (get_local $6)
+              (get_local $9)
               (i32.xor
-                (get_local $11)
+                (get_local $12)
                 (i32.const 65536)
               )
             )
             (call $_pad
               (get_local $0)
               (i32.const 48)
-              (get_local $10)
-              (get_local $12)
+              (get_local $11)
+              (get_local $13)
               (i32.const 0)
             )
             (if
@@ -7194,8 +7211,8 @@
               )
               (drop
                 (call $___fwritex
-                  (get_local $6)
-                  (get_local $12)
+                  (get_local $7)
+                  (get_local $13)
                   (get_local $0)
                 )
               )
@@ -7203,18 +7220,18 @@
             (call $_pad
               (get_local $0)
               (i32.const 32)
-              (get_local $7)
-              (get_local $1)
+              (get_local $6)
+              (get_local $9)
               (i32.xor
-                (get_local $11)
+                (get_local $12)
                 (i32.const 8192)
               )
             )
-            (set_local $1
+            (set_local $9
               (get_local $5)
             )
             (set_local $5
-              (get_local $7)
+              (get_local $6)
             )
             (br $label$continue$L1)
           )
@@ -7226,7 +7243,7 @@
           (get_local $0)
         )
         (if
-          (get_local $19)
+          (get_local $1)
           (block
             (set_local $0
               (i32.const 1)
@@ -7271,7 +7288,7 @@
                   )
                 )
                 (block
-                  (set_local $15
+                  (set_local $16
                     (i32.const 1)
                   )
                   (br $label$break$L343)
@@ -7301,7 +7318,7 @@
                     )
                   )
                   (block
-                    (set_local $15
+                    (set_local $16
                       (i32.const -1)
                     )
                     (br $label$break$L343)
@@ -7318,17 +7335,17 @@
                     )
                     (br $while-in132)
                   )
-                  (set_local $15
+                  (set_local $16
                     (i32.const 1)
                   )
                 )
               )
-              (set_local $15
+              (set_local $16
                 (i32.const 1)
               )
             )
           )
-          (set_local $15
+          (set_local $16
             (i32.const 0)
           )
         )
@@ -7337,7 +7354,7 @@
     (set_global $STACKTOP
       (get_local $25)
     )
-    (get_local $15)
+    (get_local $16)
   )
   (func $_pop_arg_336 (param $0 i32) (param $1 i32) (param $2 i32)
     (local $3 i32)
@@ -7913,23 +7930,23 @@
               (get_local $1)
               (select
                 (i32.const 256)
-                (tee_local $1
+                (tee_local $4
                   (i32.sub
                     (get_local $2)
                     (get_local $3)
                   )
                 )
                 (i32.gt_u
-                  (get_local $1)
+                  (get_local $4)
                   (i32.const 256)
                 )
               )
             )
           )
-          (set_local $4
+          (set_local $7
             (i32.eqz
               (i32.and
-                (tee_local $7
+                (tee_local $1
                   (i32.load
                     (get_local $0)
                   )
@@ -7940,7 +7957,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $1)
+              (get_local $4)
               (i32.const 255)
             )
             (block
@@ -7951,16 +7968,16 @@
                 )
               )
               (set_local $2
-                (get_local $7)
+                (get_local $4)
               )
               (set_local $3
-                (get_local $4)
+                (get_local $7)
               )
               (loop $while-in
                 (set_local $3
                   (i32.eqz
                     (i32.and
-                      (tee_local $2
+                      (tee_local $1
                         (if i32
                           (get_local $3)
                           (block i32
@@ -7975,7 +7992,7 @@
                               (get_local $0)
                             )
                           )
-                          (get_local $2)
+                          (get_local $1)
                         )
                       )
                       (i32.const 32)
@@ -7984,9 +8001,9 @@
                 )
                 (br_if $while-in
                   (i32.gt_u
-                    (tee_local $1
+                    (tee_local $2
                       (i32.add
-                        (get_local $1)
+                        (get_local $2)
                         (i32.const -256)
                       )
                     )
@@ -7994,7 +8011,7 @@
                   )
                 )
               )
-              (set_local $1
+              (set_local $4
                 (i32.and
                   (get_local $8)
                   (i32.const 255)
@@ -8008,14 +8025,14 @@
             )
             (br_if $do-once
               (i32.eqz
-                (get_local $4)
+                (get_local $7)
               )
             )
           )
           (drop
             (call $___fwritex
               (get_local $5)
-              (get_local $1)
+              (get_local $4)
               (get_local $0)
             )
           )
@@ -8060,16 +8077,16 @@
         (block
           (if
             (i32.and
-              (tee_local $2
+              (tee_local $1
                 (i32.shr_u
-                  (tee_local $10
+                  (tee_local $8
                     (i32.load
                       (i32.const 176)
                     )
                   )
-                  (tee_local $7
+                  (tee_local $2
                     (i32.shr_u
-                      (tee_local $4
+                      (tee_local $6
                         (select
                           (i32.const 16)
                           (i32.and
@@ -8097,11 +8114,11 @@
                 (i32.load
                   (tee_local $1
                     (i32.add
-                      (tee_local $7
+                      (tee_local $9
                         (i32.load
-                          (tee_local $3
+                          (tee_local $2
                             (i32.add
-                              (tee_local $2
+                              (tee_local $3
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
@@ -8110,12 +8127,12 @@
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $2)
+                                              (get_local $1)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $7)
+                                          (get_local $2)
                                         )
                                       )
                                       (i32.const 1)
@@ -8136,13 +8153,13 @@
               )
               (if
                 (i32.eq
-                  (get_local $2)
+                  (get_local $3)
                   (get_local $6)
                 )
                 (i32.store
                   (i32.const 176)
                   (i32.and
-                    (get_local $10)
+                    (get_local $8)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
@@ -8172,15 +8189,15 @@
                           )
                         )
                       )
-                      (get_local $7)
+                      (get_local $9)
                     )
                     (block
                       (i32.store
                         (get_local $0)
-                        (get_local $2)
+                        (get_local $3)
                       )
                       (i32.store
-                        (get_local $3)
+                        (get_local $2)
                         (get_local $6)
                       )
                     )
@@ -8189,7 +8206,7 @@
                 )
               )
               (i32.store offset=4
-                (get_local $7)
+                (get_local $9)
                 (i32.or
                   (tee_local $0
                     (i32.shl
@@ -8204,7 +8221,7 @@
                 (tee_local $0
                   (i32.add
                     (i32.add
-                      (get_local $7)
+                      (get_local $9)
                       (get_local $0)
                     )
                     (i32.const 4)
@@ -8224,7 +8241,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $4)
+              (get_local $6)
               (tee_local $0
                 (i32.load
                   (i32.const 184)
@@ -8233,37 +8250,37 @@
             )
             (block
               (if
-                (get_local $2)
+                (get_local $1)
                 (block
-                  (set_local $7
+                  (set_local $3
                     (i32.and
                       (i32.shr_u
-                        (tee_local $3
+                        (tee_local $1
                           (i32.add
                             (i32.and
-                              (tee_local $3
+                              (tee_local $1
                                 (i32.and
                                   (i32.shl
+                                    (get_local $1)
                                     (get_local $2)
-                                    (get_local $7)
                                   )
                                   (i32.or
-                                    (tee_local $3
+                                    (tee_local $1
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $7)
+                                        (get_local $2)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $3)
+                                      (get_local $1)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $3)
+                                (get_local $1)
                               )
                             )
                             (i32.const -1)
@@ -8274,13 +8291,13 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $12
+                  (set_local $11
                     (i32.load
-                      (tee_local $7
+                      (tee_local $3
                         (i32.add
-                          (tee_local $6
+                          (tee_local $4
                             (i32.load
-                              (tee_local $3
+                              (tee_local $1
                                 (i32.add
                                   (tee_local $2
                                     (i32.add
@@ -8293,13 +8310,13 @@
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $3
+                                                      (tee_local $1
                                                         (i32.and
                                                           (i32.shr_u
                                                             (tee_local $2
                                                               (i32.shr_u
+                                                                (get_local $1)
                                                                 (get_local $3)
-                                                                (get_local $7)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -8307,15 +8324,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $7)
+                                                      (get_local $3)
                                                     )
-                                                    (tee_local $3
+                                                    (tee_local $1
                                                       (i32.and
                                                         (i32.shr_u
                                                           (tee_local $2
                                                             (i32.shr_u
                                                               (get_local $2)
-                                                              (get_local $3)
+                                                              (get_local $1)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -8324,13 +8341,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (tee_local $3
+                                                  (tee_local $1
                                                     (i32.and
                                                       (i32.shr_u
                                                         (tee_local $2
                                                           (i32.shr_u
                                                             (get_local $2)
-                                                            (get_local $3)
+                                                            (get_local $1)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -8339,13 +8356,13 @@
                                                     )
                                                   )
                                                 )
-                                                (tee_local $3
+                                                (tee_local $1
                                                   (i32.and
                                                     (i32.shr_u
                                                       (tee_local $2
                                                         (i32.shr_u
                                                           (get_local $2)
-                                                          (get_local $3)
+                                                          (get_local $1)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -8356,7 +8373,7 @@
                                               )
                                               (i32.shr_u
                                                 (get_local $2)
-                                                (get_local $3)
+                                                (get_local $1)
                                               )
                                             )
                                           )
@@ -8379,13 +8396,13 @@
                   (if
                     (i32.eq
                       (get_local $2)
-                      (get_local $12)
+                      (get_local $11)
                     )
                     (block
                       (i32.store
                         (i32.const 176)
                         (i32.and
-                          (get_local $10)
+                          (get_local $8)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
@@ -8402,7 +8419,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $12)
+                          (get_local $11)
                           (i32.load
                             (i32.const 192)
                           )
@@ -8414,12 +8431,12 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $12)
+                                (get_local $11)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $6)
+                          (get_local $4)
                         )
                         (block
                           (i32.store
@@ -8427,8 +8444,8 @@
                             (get_local $2)
                           )
                           (i32.store
-                            (get_local $3)
-                            (get_local $12)
+                            (get_local $1)
+                            (get_local $11)
                           )
                           (set_local $16
                             (i32.load
@@ -8441,27 +8458,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $6)
+                    (get_local $4)
                     (i32.or
-                      (get_local $4)
+                      (get_local $6)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $6
+                    (tee_local $4
                       (i32.add
-                        (get_local $6)
                         (get_local $4)
+                        (get_local $6)
                       )
                     )
                     (i32.or
-                      (tee_local $4
+                      (tee_local $6
                         (i32.sub
                           (i32.shl
                             (get_local $5)
                             (i32.const 3)
                           )
-                          (get_local $4)
+                          (get_local $6)
                         )
                       )
                       (i32.const 1)
@@ -8469,10 +8486,10 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $6)
                       (get_local $4)
+                      (get_local $6)
                     )
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (if
                     (get_local $16)
@@ -8501,7 +8518,7 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $3
+                          (tee_local $1
                             (i32.load
                               (i32.const 176)
                             )
@@ -8517,7 +8534,7 @@
                           (i32.lt_u
                             (tee_local $0
                               (i32.load
-                                (tee_local $3
+                                (tee_local $1
                                   (i32.add
                                     (get_local $2)
                                     (i32.const 8)
@@ -8531,10 +8548,10 @@
                           )
                           (call $_abort)
                           (block
-                            (set_local $15
-                              (get_local $3)
+                            (set_local $7
+                              (get_local $1)
                             )
-                            (set_local $1
+                            (set_local $9
                               (get_local $0)
                             )
                           )
@@ -8543,32 +8560,32 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $3)
+                              (get_local $1)
                               (get_local $0)
                             )
                           )
-                          (set_local $15
+                          (set_local $7
                             (i32.add
                               (get_local $2)
                               (i32.const 8)
                             )
                           )
-                          (set_local $1
+                          (set_local $9
                             (get_local $2)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $15)
+                        (get_local $7)
                         (get_local $5)
                       )
                       (i32.store offset=12
-                        (get_local $1)
+                        (get_local $9)
                         (get_local $5)
                       )
                       (i32.store offset=8
                         (get_local $5)
-                        (get_local $1)
+                        (get_local $9)
                       )
                       (i32.store offset=12
                         (get_local $5)
@@ -8578,14 +8595,14 @@
                   )
                   (i32.store
                     (i32.const 184)
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $6)
+                    (get_local $4)
                   )
                   (return
-                    (get_local $7)
+                    (get_local $3)
                   )
                 )
               )
@@ -8616,7 +8633,7 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $7
+                  (set_local $3
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
@@ -8701,13 +8718,13 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $4)
+                      (get_local $6)
                     )
                   )
-                  (set_local $2
+                  (set_local $1
                     (get_local $0)
                   )
-                  (set_local $1
+                  (set_local $2
                     (get_local $0)
                   )
                   (loop $while-in
@@ -8716,7 +8733,7 @@
                         (i32.eqz
                           (tee_local $0
                             (i32.load offset=16
-                              (get_local $2)
+                              (get_local $1)
                             )
                           )
                         )
@@ -8724,24 +8741,24 @@
                           (i32.eqz
                             (tee_local $0
                               (i32.load offset=20
-                                (get_local $2)
+                                (get_local $1)
                               )
                             )
                           )
                           (block
-                            (set_local $12
-                              (get_local $7)
+                            (set_local $9
+                              (get_local $3)
                             )
-                            (set_local $11
-                              (get_local $1)
+                            (set_local $7
+                              (get_local $2)
                             )
                             (br $while-out)
                           )
                         )
                       )
-                      (set_local $12
+                      (set_local $9
                         (i32.lt_u
-                          (tee_local $2
+                          (tee_local $1
                             (i32.sub
                               (i32.and
                                 (i32.load offset=4
@@ -8749,27 +8766,27 @@
                                 )
                                 (i32.const -8)
                               )
-                              (get_local $4)
+                              (get_local $6)
                             )
                           )
-                          (get_local $7)
+                          (get_local $3)
                         )
                       )
-                      (set_local $7
+                      (set_local $3
                         (select
-                          (get_local $2)
-                          (get_local $7)
-                          (get_local $12)
+                          (get_local $1)
+                          (get_local $3)
+                          (get_local $9)
                         )
-                      )
-                      (set_local $2
-                        (get_local $0)
                       )
                       (set_local $1
+                        (get_local $0)
+                      )
+                      (set_local $2
                         (select
                           (get_local $0)
-                          (get_local $1)
-                          (get_local $12)
+                          (get_local $2)
+                          (get_local $9)
                         )
                       )
                       (br $while-in)
@@ -8777,7 +8794,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $11)
+                      (get_local $7)
                       (tee_local $10
                         (i32.load
                           (i32.const 192)
@@ -8788,11 +8805,11 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $11)
-                      (tee_local $14
+                      (get_local $7)
+                      (tee_local $17
                         (i32.add
-                          (get_local $11)
-                          (get_local $4)
+                          (get_local $7)
+                          (get_local $6)
                         )
                       )
                     )
@@ -8800,7 +8817,7 @@
                   )
                   (set_local $8
                     (i32.load offset=24
-                      (get_local $11)
+                      (get_local $7)
                     )
                   )
                   (block $do-once4
@@ -8808,10 +8825,10 @@
                       (i32.eq
                         (tee_local $0
                           (i32.load offset=12
-                            (get_local $11)
+                            (get_local $7)
                           )
                         )
-                        (get_local $11)
+                        (get_local $7)
                       )
                       (block
                         (if
@@ -8820,7 +8837,7 @@
                               (i32.load
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $11)
+                                    (get_local $7)
                                     (i32.const 20)
                                   )
                                 )
@@ -8833,7 +8850,7 @@
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
-                                      (get_local $11)
+                                      (get_local $7)
                                       (i32.const 16)
                                     )
                                   )
@@ -8841,7 +8858,7 @@
                               )
                             )
                             (block
-                              (set_local $6
+                              (set_local $5
                                 (i32.const 0)
                               )
                               (br $do-once4)
@@ -8852,7 +8869,7 @@
                           (if
                             (tee_local $2
                               (i32.load
-                                (tee_local $7
+                                (tee_local $3
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 20)
@@ -8865,7 +8882,7 @@
                                 (get_local $2)
                               )
                               (set_local $0
-                                (get_local $7)
+                                (get_local $3)
                               )
                               (br $while-in7)
                             )
@@ -8873,7 +8890,7 @@
                           (if
                             (tee_local $2
                               (i32.load
-                                (tee_local $7
+                                (tee_local $3
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 16)
@@ -8886,7 +8903,7 @@
                                 (get_local $2)
                               )
                               (set_local $0
-                                (get_local $7)
+                                (get_local $3)
                               )
                               (br $while-in7)
                             )
@@ -8903,7 +8920,7 @@
                               (get_local $0)
                               (i32.const 0)
                             )
-                            (set_local $6
+                            (set_local $5
                               (get_local $1)
                             )
                           )
@@ -8912,9 +8929,9 @@
                       (block
                         (if
                           (i32.lt_u
-                            (tee_local $7
+                            (tee_local $3
                               (i32.load offset=8
-                                (get_local $11)
+                                (get_local $7)
                               )
                             )
                             (get_local $10)
@@ -8926,12 +8943,12 @@
                             (i32.load
                               (tee_local $2
                                 (i32.add
-                                  (get_local $7)
+                                  (get_local $3)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $11)
+                            (get_local $7)
                           )
                           (call $_abort)
                         )
@@ -8945,7 +8962,7 @@
                                 )
                               )
                             )
-                            (get_local $11)
+                            (get_local $7)
                           )
                           (block
                             (i32.store
@@ -8954,9 +8971,9 @@
                             )
                             (i32.store
                               (get_local $1)
-                              (get_local $7)
+                              (get_local $3)
                             )
-                            (set_local $6
+                            (set_local $5
                               (get_local $0)
                             )
                           )
@@ -8971,7 +8988,7 @@
                       (block
                         (if
                           (i32.eq
-                            (get_local $11)
+                            (get_local $7)
                             (i32.load
                               (tee_local $0
                                 (i32.add
@@ -8979,7 +8996,7 @@
                                   (i32.shl
                                     (tee_local $1
                                       (i32.load offset=28
-                                        (get_local $11)
+                                        (get_local $7)
                                       )
                                     )
                                     (i32.const 2)
@@ -8991,11 +9008,11 @@
                           (block
                             (i32.store
                               (get_local $0)
-                              (get_local $6)
+                              (get_local $5)
                             )
                             (if
                               (i32.eqz
-                                (get_local $6)
+                                (get_local $5)
                               )
                               (block
                                 (i32.store
@@ -9037,27 +9054,27 @@
                                     )
                                   )
                                 )
-                                (get_local $11)
+                                (get_local $7)
                               )
                               (i32.store
                                 (get_local $0)
-                                (get_local $6)
+                                (get_local $5)
                               )
                               (i32.store offset=20
                                 (get_local $8)
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                             (br_if $do-once8
                               (i32.eqz
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $6)
+                            (get_local $5)
                             (tee_local $0
                               (i32.load
                                 (i32.const 192)
@@ -9067,13 +9084,13 @@
                           (call $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $6)
+                          (get_local $5)
                           (get_local $8)
                         )
                         (if
                           (tee_local $1
                             (i32.load offset=16
-                              (get_local $11)
+                              (get_local $7)
                             )
                           )
                           (if
@@ -9084,12 +9101,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $6)
+                                (get_local $5)
                                 (get_local $1)
                               )
                               (i32.store offset=24
                                 (get_local $1)
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                           )
@@ -9097,7 +9114,7 @@
                         (if
                           (tee_local $0
                             (i32.load offset=20
-                              (get_local $11)
+                              (get_local $7)
                             )
                           )
                           (if
@@ -9110,12 +9127,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $6)
+                                (get_local $5)
                                 (get_local $0)
                               )
                               (i32.store offset=24
                                 (get_local $0)
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                           )
@@ -9125,17 +9142,17 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $12)
+                      (get_local $9)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $11)
+                        (get_local $7)
                         (i32.or
                           (tee_local $0
                             (i32.add
-                              (get_local $12)
-                              (get_local $4)
+                              (get_local $9)
+                              (get_local $6)
                             )
                           )
                           (i32.const 3)
@@ -9145,7 +9162,7 @@
                         (tee_local $0
                           (i32.add
                             (i32.add
-                              (get_local $11)
+                              (get_local $7)
                               (get_local $0)
                             )
                             (i32.const 4)
@@ -9161,25 +9178,25 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $11)
+                        (get_local $7)
                         (i32.or
-                          (get_local $4)
+                          (get_local $6)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $14)
+                        (get_local $17)
                         (i32.or
-                          (get_local $12)
+                          (get_local $9)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $14)
-                          (get_local $12)
+                          (get_local $17)
+                          (get_local $9)
                         )
-                        (get_local $12)
+                        (get_local $9)
                       )
                       (if
                         (tee_local $0
@@ -9188,7 +9205,7 @@
                           )
                         )
                         (block
-                          (set_local $4
+                          (set_local $3
                             (i32.load
                               (i32.const 196)
                             )
@@ -9242,10 +9259,10 @@
                               )
                               (call $_abort)
                               (block
-                                (set_local $5
+                                (set_local $11
                                   (get_local $1)
                                 )
-                                (set_local $3
+                                (set_local $4
                                   (get_local $0)
                                 )
                               )
@@ -9258,59 +9275,59 @@
                                   (get_local $0)
                                 )
                               )
-                              (set_local $5
+                              (set_local $11
                                 (i32.add
                                   (get_local $2)
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $3
+                              (set_local $4
                                 (get_local $2)
                               )
                             )
                           )
                           (i32.store
-                            (get_local $5)
-                            (get_local $4)
+                            (get_local $11)
+                            (get_local $3)
                           )
                           (i32.store offset=12
-                            (get_local $3)
                             (get_local $4)
+                            (get_local $3)
                           )
                           (i32.store offset=8
-                            (get_local $4)
                             (get_local $3)
+                            (get_local $4)
                           )
                           (i32.store offset=12
-                            (get_local $4)
+                            (get_local $3)
                             (get_local $2)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $12)
+                        (get_local $9)
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $14)
+                        (get_local $17)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $11)
+                      (get_local $7)
                       (i32.const 8)
                     )
                   )
                 )
                 (set_local $0
-                  (get_local $4)
+                  (get_local $6)
                 )
               )
             )
             (set_local $0
-              (get_local $4)
+              (get_local $6)
             )
           )
         )
@@ -9341,7 +9358,7 @@
                 )
               )
               (block
-                (set_local $3
+                (set_local $9
                   (i32.sub
                     (i32.const 0)
                     (get_local $6)
@@ -9353,7 +9370,7 @@
                       (tee_local $0
                         (i32.load offset=480
                           (i32.shl
-                            (tee_local $17
+                            (tee_local $18
                               (if i32
                                 (tee_local $0
                                   (i32.shr_u
@@ -9382,7 +9399,7 @@
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (tee_local $1
+                                                            (tee_local $4
                                                               (i32.shl
                                                                 (get_local $0)
                                                                 (tee_local $5
@@ -9412,9 +9429,9 @@
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $1
+                                                          (tee_local $4
                                                             (i32.shl
-                                                              (get_local $1)
+                                                              (get_local $4)
                                                               (get_local $0)
                                                             )
                                                           )
@@ -9429,7 +9446,7 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $1)
+                                                  (get_local $4)
                                                   (get_local $0)
                                                 )
                                                 (i32.const 15)
@@ -9455,10 +9472,10 @@
                         )
                       )
                       (block
-                        (set_local $16
+                        (set_local $7
                           (i32.const 0)
                         )
-                        (set_local $18
+                        (set_local $16
                           (i32.shl
                             (get_local $6)
                             (select
@@ -9466,26 +9483,26 @@
                               (i32.sub
                                 (i32.const 25)
                                 (i32.shr_u
-                                  (get_local $17)
+                                  (get_local $18)
                                   (i32.const 1)
                                 )
                               )
                               (i32.eq
-                                (get_local $17)
+                                (get_local $18)
                                 (i32.const 31)
                               )
                             )
                           )
                         )
-                        (set_local $5
+                        (set_local $4
                           (i32.const 0)
                         )
                         (loop $while-in14
                           (if
                             (i32.lt_u
-                              (tee_local $1
+                              (tee_local $5
                                 (i32.sub
-                                  (tee_local $15
+                                  (tee_local $11
                                     (i32.and
                                       (i32.load offset=4
                                         (get_local $0)
@@ -9496,21 +9513,21 @@
                                   (get_local $6)
                                 )
                               )
-                              (get_local $3)
+                              (get_local $9)
                             )
                             (if
                               (i32.eq
-                                (get_local $15)
+                                (get_local $11)
                                 (get_local $6)
                               )
                               (block
-                                (set_local $4
-                                  (get_local $1)
+                                (set_local $2
+                                  (get_local $5)
                                 )
-                                (set_local $7
+                                (set_local $3
                                   (get_local $0)
                                 )
-                                (set_local $2
+                                (set_local $1
                                   (get_local $0)
                                 )
                                 (set_local $19
@@ -9519,21 +9536,18 @@
                                 (br $jumpthreading$outer$2)
                               )
                               (block
-                                (set_local $3
-                                  (get_local $1)
+                                (set_local $9
+                                  (get_local $5)
                                 )
-                                (set_local $1
+                                (set_local $4
                                   (get_local $0)
                                 )
                               )
                             )
-                            (set_local $1
-                              (get_local $5)
-                            )
                           )
                           (set_local $0
                             (select
-                              (get_local $16)
+                              (get_local $7)
                               (tee_local $5
                                 (i32.load offset=20
                                   (get_local $0)
@@ -9545,7 +9559,7 @@
                                 )
                                 (i32.eq
                                   (get_local $5)
-                                  (tee_local $15
+                                  (tee_local $11
                                     (i32.load
                                       (i32.add
                                         (i32.add
@@ -9554,7 +9568,7 @@
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $18)
+                                            (get_local $16)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -9568,12 +9582,12 @@
                           )
                           (set_local $5
                             (i32.shl
-                              (get_local $18)
+                              (get_local $16)
                               (i32.xor
                                 (i32.and
-                                  (tee_local $16
+                                  (tee_local $7
                                     (i32.eqz
-                                      (get_local $15)
+                                      (get_local $11)
                                     )
                                   )
                                   (i32.const 1)
@@ -9583,20 +9597,17 @@
                             )
                           )
                           (br_if $jumpthreading$inner$2
-                            (get_local $16)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $16
+                            (set_local $7
                               (get_local $0)
                             )
-                            (set_local $18
+                            (set_local $16
                               (get_local $5)
                             )
                             (set_local $0
-                              (get_local $15)
-                            )
-                            (set_local $5
-                              (get_local $1)
+                              (get_local $11)
                             )
                             (br $while-in14)
                           )
@@ -9606,7 +9617,7 @@
                         (set_local $0
                           (i32.const 0)
                         )
-                        (set_local $1
+                        (set_local $4
                           (i32.const 0)
                         )
                         (br $jumpthreading$inner$2)
@@ -9622,7 +9633,7 @@
                             (get_local $0)
                           )
                           (i32.eqz
-                            (get_local $1)
+                            (get_local $4)
                           )
                         )
                         (block i32
@@ -9635,7 +9646,7 @@
                                     (tee_local $0
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $17)
+                                        (get_local $18)
                                       )
                                     )
                                     (i32.sub
@@ -9653,7 +9664,7 @@
                               (br $do-once)
                             )
                           )
-                          (set_local $15
+                          (set_local $11
                             (i32.and
                               (i32.shr_u
                                 (tee_local $0
@@ -9686,7 +9697,7 @@
                                               (tee_local $5
                                                 (i32.shr_u
                                                   (get_local $0)
-                                                  (get_local $15)
+                                                  (get_local $11)
                                                 )
                                               )
                                               (i32.const 5)
@@ -9694,7 +9705,7 @@
                                             (i32.const 8)
                                           )
                                         )
-                                        (get_local $15)
+                                        (get_local $11)
                                       )
                                       (tee_local $0
                                         (i32.and
@@ -9754,25 +9765,25 @@
                       )
                     )
                     (block
-                      (set_local $4
-                        (get_local $3)
+                      (set_local $2
+                        (get_local $9)
                       )
-                      (set_local $7
+                      (set_local $3
                         (get_local $0)
                       )
-                      (set_local $2
-                        (get_local $1)
+                      (set_local $1
+                        (get_local $4)
                       )
                       (set_local $19
                         (i32.const 90)
                       )
                     )
                     (block
-                      (set_local $9
-                        (get_local $3)
-                      )
                       (set_local $13
-                        (get_local $1)
+                        (get_local $9)
+                      )
+                      (set_local $12
+                        (get_local $4)
                       )
                     )
                   )
@@ -9783,71 +9794,71 @@
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $1
+                    (set_local $4
                       (i32.lt_u
                         (tee_local $0
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $7)
+                                (get_local $3)
                               )
                               (i32.const -8)
                             )
                             (get_local $6)
                           )
                         )
-                        (get_local $4)
-                      )
-                    )
-                    (set_local $4
-                      (select
-                        (get_local $0)
-                        (get_local $4)
-                        (get_local $1)
+                        (get_local $2)
                       )
                     )
                     (set_local $2
                       (select
-                        (get_local $7)
+                        (get_local $0)
                         (get_local $2)
+                        (get_local $4)
+                      )
+                    )
+                    (set_local $1
+                      (select
+                        (get_local $3)
                         (get_local $1)
+                        (get_local $4)
                       )
                     )
                     (if
                       (tee_local $0
                         (i32.load offset=16
-                          (get_local $7)
+                          (get_local $3)
                         )
                       )
                       (block
-                        (set_local $7
+                        (set_local $3
                           (get_local $0)
                         )
                         (br $while-in16)
                       )
                     )
                     (br_if $while-in16
-                      (tee_local $7
+                      (tee_local $3
                         (i32.load offset=20
-                          (get_local $7)
+                          (get_local $3)
                         )
                       )
                     )
                     (block
-                      (set_local $9
-                        (get_local $4)
-                      )
                       (set_local $13
                         (get_local $2)
+                      )
+                      (set_local $12
+                        (get_local $1)
                       )
                     )
                   )
                 )
                 (if
-                  (get_local $13)
+                  (get_local $12)
                   (if
                     (i32.lt_u
-                      (get_local $9)
+                      (get_local $13)
                       (i32.sub
                         (i32.load
                           (i32.const 184)
@@ -9858,7 +9869,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $13)
+                          (get_local $12)
                           (tee_local $4
                             (i32.load
                               (i32.const 192)
@@ -9869,19 +9880,19 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $13)
+                          (get_local $12)
                           (tee_local $5
                             (i32.add
-                              (get_local $13)
+                              (get_local $12)
                               (get_local $6)
                             )
                           )
                         )
                         (call $_abort)
                       )
-                      (set_local $7
+                      (set_local $9
                         (i32.load offset=24
-                          (get_local $13)
+                          (get_local $12)
                         )
                       )
                       (block $do-once17
@@ -9889,10 +9900,10 @@
                           (i32.eq
                             (tee_local $0
                               (i32.load offset=12
-                                (get_local $13)
+                                (get_local $12)
                               )
                             )
-                            (get_local $13)
+                            (get_local $12)
                           )
                           (block
                             (if
@@ -9901,7 +9912,7 @@
                                   (i32.load
                                     (tee_local $0
                                       (i32.add
-                                        (get_local $13)
+                                        (get_local $12)
                                         (i32.const 20)
                                       )
                                     )
@@ -9914,7 +9925,7 @@
                                     (i32.load
                                       (tee_local $0
                                         (i32.add
-                                          (get_local $13)
+                                          (get_local $12)
                                           (i32.const 16)
                                         )
                                       )
@@ -9922,7 +9933,7 @@
                                   )
                                 )
                                 (block
-                                  (set_local $8
+                                  (set_local $14
                                     (i32.const 0)
                                   )
                                   (br $do-once17)
@@ -9931,9 +9942,9 @@
                             )
                             (loop $while-in20
                               (if
-                                (tee_local $3
+                                (tee_local $2
                                   (i32.load
-                                    (tee_local $2
+                                    (tee_local $3
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 20)
@@ -9943,18 +9954,18 @@
                                 )
                                 (block
                                   (set_local $1
-                                    (get_local $3)
+                                    (get_local $2)
                                   )
                                   (set_local $0
-                                    (get_local $2)
+                                    (get_local $3)
                                   )
                                   (br $while-in20)
                                 )
                               )
                               (if
-                                (tee_local $3
+                                (tee_local $2
                                   (i32.load
-                                    (tee_local $2
+                                    (tee_local $3
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 16)
@@ -9964,10 +9975,10 @@
                                 )
                                 (block
                                   (set_local $1
-                                    (get_local $3)
+                                    (get_local $2)
                                   )
                                   (set_local $0
-                                    (get_local $2)
+                                    (get_local $3)
                                   )
                                   (br $while-in20)
                                 )
@@ -9984,7 +9995,7 @@
                                   (get_local $0)
                                   (i32.const 0)
                                 )
-                                (set_local $8
+                                (set_local $14
                                   (get_local $1)
                                 )
                               )
@@ -9993,9 +10004,9 @@
                           (block
                             (if
                               (i32.lt_u
-                                (tee_local $2
+                                (tee_local $3
                                   (i32.load offset=8
-                                    (get_local $13)
+                                    (get_local $12)
                                   )
                                 )
                                 (get_local $4)
@@ -10005,14 +10016,14 @@
                             (if
                               (i32.ne
                                 (i32.load
-                                  (tee_local $3
+                                  (tee_local $2
                                     (i32.add
-                                      (get_local $2)
+                                      (get_local $3)
                                       (i32.const 12)
                                     )
                                   )
                                 )
-                                (get_local $13)
+                                (get_local $12)
                               )
                               (call $_abort)
                             )
@@ -10026,18 +10037,18 @@
                                     )
                                   )
                                 )
-                                (get_local $13)
+                                (get_local $12)
                               )
                               (block
                                 (i32.store
-                                  (get_local $3)
+                                  (get_local $2)
                                   (get_local $0)
                                 )
                                 (i32.store
                                   (get_local $1)
-                                  (get_local $2)
+                                  (get_local $3)
                                 )
-                                (set_local $8
+                                (set_local $14
                                   (get_local $0)
                                 )
                               )
@@ -10048,11 +10059,11 @@
                       )
                       (block $do-once21
                         (if
-                          (get_local $7)
+                          (get_local $9)
                           (block
                             (if
                               (i32.eq
-                                (get_local $13)
+                                (get_local $12)
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
@@ -10060,7 +10071,7 @@
                                       (i32.shl
                                         (tee_local $1
                                           (i32.load offset=28
-                                            (get_local $13)
+                                            (get_local $12)
                                           )
                                         )
                                         (i32.const 2)
@@ -10072,11 +10083,11 @@
                               (block
                                 (i32.store
                                   (get_local $0)
-                                  (get_local $8)
+                                  (get_local $14)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $8)
+                                    (get_local $14)
                                   )
                                   (block
                                     (i32.store
@@ -10101,7 +10112,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $7)
+                                    (get_local $9)
                                     (i32.load
                                       (i32.const 192)
                                     )
@@ -10113,32 +10124,32 @@
                                     (i32.load
                                       (tee_local $0
                                         (i32.add
-                                          (get_local $7)
+                                          (get_local $9)
                                           (i32.const 16)
                                         )
                                       )
                                     )
-                                    (get_local $13)
+                                    (get_local $12)
                                   )
                                   (i32.store
                                     (get_local $0)
-                                    (get_local $8)
+                                    (get_local $14)
                                   )
                                   (i32.store offset=20
-                                    (get_local $7)
-                                    (get_local $8)
+                                    (get_local $9)
+                                    (get_local $14)
                                   )
                                 )
                                 (br_if $do-once21
                                   (i32.eqz
-                                    (get_local $8)
+                                    (get_local $14)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $8)
+                                (get_local $14)
                                 (tee_local $0
                                   (i32.load
                                     (i32.const 192)
@@ -10148,13 +10159,13 @@
                               (call $_abort)
                             )
                             (i32.store offset=24
-                              (get_local $8)
-                              (get_local $7)
+                              (get_local $14)
+                              (get_local $9)
                             )
                             (if
                               (tee_local $1
                                 (i32.load offset=16
-                                  (get_local $13)
+                                  (get_local $12)
                                 )
                               )
                               (if
@@ -10165,12 +10176,12 @@
                                 (call $_abort)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $8)
+                                    (get_local $14)
                                     (get_local $1)
                                   )
                                   (i32.store offset=24
                                     (get_local $1)
-                                    (get_local $8)
+                                    (get_local $14)
                                   )
                                 )
                               )
@@ -10178,7 +10189,7 @@
                             (if
                               (tee_local $0
                                 (i32.load offset=20
-                                  (get_local $13)
+                                  (get_local $12)
                                 )
                               )
                               (if
@@ -10191,12 +10202,12 @@
                                 (call $_abort)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $8)
+                                    (get_local $14)
                                     (get_local $0)
                                   )
                                   (i32.store offset=24
                                     (get_local $0)
-                                    (get_local $8)
+                                    (get_local $14)
                                   )
                                 )
                               )
@@ -10207,16 +10218,16 @@
                       (block $do-once25
                         (if
                           (i32.lt_u
-                            (get_local $9)
+                            (get_local $13)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $13)
+                              (get_local $12)
                               (i32.or
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $9)
+                                    (get_local $13)
                                     (get_local $6)
                                   )
                                 )
@@ -10227,7 +10238,7 @@
                               (tee_local $0
                                 (i32.add
                                   (i32.add
-                                    (get_local $13)
+                                    (get_local $12)
                                     (get_local $0)
                                   )
                                   (i32.const 4)
@@ -10243,7 +10254,7 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $13)
+                              (get_local $12)
                               (i32.or
                                 (get_local $6)
                                 (i32.const 3)
@@ -10252,30 +10263,30 @@
                             (i32.store offset=4
                               (get_local $5)
                               (i32.or
-                                (get_local $9)
+                                (get_local $13)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
                                 (get_local $5)
-                                (get_local $9)
+                                (get_local $13)
                               )
-                              (get_local $9)
+                              (get_local $13)
                             )
                             (set_local $0
                               (i32.shr_u
-                                (get_local $9)
+                                (get_local $13)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $9)
+                                (get_local $13)
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $3
+                                (set_local $2
                                   (i32.add
                                     (i32.const 216)
                                     (i32.shl
@@ -10307,7 +10318,7 @@
                                         (i32.load
                                           (tee_local $1
                                             (i32.add
-                                              (get_local $3)
+                                              (get_local $2)
                                               (i32.const 8)
                                             )
                                           )
@@ -10322,7 +10333,7 @@
                                       (set_local $20
                                         (get_local $1)
                                       )
-                                      (set_local $10
+                                      (set_local $8
                                         (get_local $0)
                                       )
                                     )
@@ -10337,12 +10348,12 @@
                                     )
                                     (set_local $20
                                       (i32.add
-                                        (get_local $3)
+                                        (get_local $2)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $10
-                                      (get_local $3)
+                                    (set_local $8
+                                      (get_local $2)
                                     )
                                   )
                                 )
@@ -10351,16 +10362,16 @@
                                   (get_local $5)
                                 )
                                 (i32.store offset=12
-                                  (get_local $10)
+                                  (get_local $8)
                                   (get_local $5)
                                 )
                                 (i32.store offset=8
                                   (get_local $5)
-                                  (get_local $10)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=12
                                   (get_local $5)
-                                  (get_local $3)
+                                  (get_local $2)
                                 )
                                 (br $do-once25)
                               )
@@ -10373,20 +10384,20 @@
                                     (if i32
                                       (tee_local $0
                                         (i32.shr_u
-                                          (get_local $9)
+                                          (get_local $13)
                                           (i32.const 8)
                                         )
                                       )
                                       (if i32
                                         (i32.gt_u
-                                          (get_local $9)
+                                          (get_local $13)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $9)
+                                              (get_local $13)
                                               (i32.add
                                                 (tee_local $0
                                                   (i32.add
@@ -10401,7 +10412,7 @@
                                                                   (tee_local $1
                                                                     (i32.shl
                                                                       (get_local $0)
-                                                                      (tee_local $3
+                                                                      (tee_local $2
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
@@ -10422,7 +10433,7 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $3)
+                                                          (get_local $2)
                                                         )
                                                         (tee_local $0
                                                           (i32.and
@@ -10532,7 +10543,7 @@
                             )
                             (set_local $3
                               (i32.shl
-                                (get_local $9)
+                                (get_local $13)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
@@ -10566,7 +10577,7 @@
                                           )
                                           (i32.const -8)
                                         )
-                                        (get_local $9)
+                                        (get_local $13)
                                       )
                                     )
                                     (set_local $2
@@ -10642,9 +10653,9 @@
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (tee_local $2
+                                    (tee_local $3
                                       (i32.load
-                                        (tee_local $3
+                                        (tee_local $2
                                           (i32.add
                                             (get_local $0)
                                             (i32.const 8)
@@ -10665,16 +10676,16 @@
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $2)
+                                    (get_local $3)
                                     (get_local $5)
                                   )
                                   (i32.store
-                                    (get_local $3)
+                                    (get_local $2)
                                     (get_local $5)
                                   )
                                   (i32.store offset=8
                                     (get_local $5)
-                                    (get_local $2)
+                                    (get_local $3)
                                   )
                                   (i32.store offset=12
                                     (get_local $5)
@@ -10693,7 +10704,7 @@
                       )
                       (return
                         (i32.add
-                          (get_local $13)
+                          (get_local $12)
                           (i32.const 8)
                         )
                       )
@@ -10725,14 +10736,14 @@
         (get_local $0)
       )
       (block
-        (set_local $2
+        (set_local $3
           (i32.load
             (i32.const 196)
           )
         )
         (if
           (i32.gt_u
-            (tee_local $3
+            (tee_local $2
               (i32.sub
                 (get_local $1)
                 (get_local $0)
@@ -10745,31 +10756,31 @@
               (i32.const 196)
               (tee_local $1
                 (i32.add
-                  (get_local $2)
+                  (get_local $3)
                   (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 184)
-              (get_local $3)
+              (get_local $2)
             )
             (i32.store offset=4
               (get_local $1)
               (i32.or
-                (get_local $3)
+                (get_local $2)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $1)
-                (get_local $3)
+                (get_local $2)
               )
-              (get_local $3)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $2)
+              (get_local $3)
               (i32.or
                 (get_local $0)
                 (i32.const 3)
@@ -10786,7 +10797,7 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $2)
+              (get_local $3)
               (i32.or
                 (get_local $1)
                 (i32.const 3)
@@ -10796,7 +10807,7 @@
               (tee_local $0
                 (i32.add
                   (i32.add
-                    (get_local $2)
+                    (get_local $3)
                     (get_local $1)
                   )
                   (i32.const 4)
@@ -10813,7 +10824,7 @@
         )
         (return
           (i32.add
-            (get_local $2)
+            (get_local $3)
             (i32.const 8)
           )
         )
@@ -10831,7 +10842,7 @@
       (block
         (i32.store
           (i32.const 188)
-          (tee_local $3
+          (tee_local $2
             (i32.sub
               (get_local $1)
               (get_local $0)
@@ -10842,7 +10853,7 @@
           (i32.const 200)
           (tee_local $1
             (i32.add
-              (tee_local $2
+              (tee_local $3
                 (i32.load
                   (i32.const 200)
                 )
@@ -10854,12 +10865,12 @@
         (i32.store offset=4
           (get_local $1)
           (i32.or
-            (get_local $3)
+            (get_local $2)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $2)
+          (get_local $3)
           (i32.or
             (get_local $0)
             (i32.const 3)
@@ -10867,7 +10878,7 @@
         )
         (return
           (i32.add
-            (get_local $2)
+            (get_local $3)
             (i32.const 8)
           )
         )
@@ -10932,7 +10943,7 @@
         )
       )
     )
-    (set_local $10
+    (set_local $11
       (i32.add
         (get_local $0)
         (i32.const 48)
@@ -10940,7 +10951,7 @@
     )
     (if
       (i32.le_u
-        (tee_local $8
+        (tee_local $7
           (i32.and
             (tee_local $6
               (i32.add
@@ -10957,7 +10968,7 @@
                 )
               )
             )
-            (tee_local $7
+            (tee_local $9
               (i32.sub
                 (i32.const 0)
                 (get_local $1)
@@ -10972,7 +10983,7 @@
       )
     )
     (if
-      (tee_local $2
+      (tee_local $3
         (i32.load
           (i32.const 616)
         )
@@ -10982,19 +10993,19 @@
           (i32.le_u
             (tee_local $1
               (i32.add
-                (tee_local $3
+                (tee_local $2
                   (i32.load
                     (i32.const 608)
                   )
                 )
-                (get_local $8)
+                (get_local $7)
               )
             )
-            (get_local $3)
+            (get_local $2)
           )
           (i32.gt_u
             (get_local $1)
-            (get_local $2)
+            (get_local $3)
           )
         )
         (return
@@ -11019,7 +11030,7 @@
                 (block $jumpthreading$inner$3
                   (br_if $jumpthreading$inner$3
                     (i32.eqz
-                      (tee_local $4
+                      (tee_local $3
                         (i32.load
                           (i32.const 200)
                         )
@@ -11033,17 +11044,17 @@
                     (block $while-out33
                       (if
                         (i32.le_u
-                          (tee_local $3
+                          (tee_local $2
                             (i32.load
                               (get_local $1)
                             )
                           )
-                          (get_local $4)
+                          (get_local $3)
                         )
                         (if
                           (i32.gt_u
                             (i32.add
-                              (get_local $3)
+                              (get_local $2)
                               (i32.load
                                 (tee_local $2
                                   (i32.add
@@ -11053,7 +11064,7 @@
                                 )
                               )
                             )
-                            (get_local $4)
+                            (get_local $3)
                           )
                           (block
                             (set_local $4
@@ -11083,7 +11094,7 @@
                               (i32.const 188)
                             )
                           )
-                          (get_local $7)
+                          (get_local $9)
                         )
                       )
                       (i32.const 2147483647)
@@ -11104,10 +11115,16 @@
                           )
                         )
                       )
-                      (br_if $jumpthreading$inner$12
+                      (if
                         (i32.ne
                           (get_local $3)
                           (i32.const -1)
+                        )
+                        (block
+                          (set_local $2
+                            (get_local $1)
+                          )
+                          (br $jumpthreading$inner$12)
                         )
                       )
                       (br $jumpthreading$inner$4)
@@ -11127,7 +11144,7 @@
                   (block
                     (set_local $4
                       (i32.add
-                        (tee_local $7
+                        (tee_local $9
                           (i32.load
                             (i32.const 608)
                           )
@@ -11151,7 +11168,7 @@
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $8)
+                                (get_local $7)
                                 (get_local $1)
                               )
                               (i32.and
@@ -11165,7 +11182,7 @@
                                 )
                               )
                             )
-                            (get_local $8)
+                            (get_local $7)
                           )
                         )
                       )
@@ -11192,7 +11209,7 @@
                             (i32.or
                               (i32.le_u
                                 (get_local $4)
-                                (get_local $7)
+                                (get_local $9)
                               )
                               (i32.gt_u
                                 (get_local $4)
@@ -11201,7 +11218,7 @@
                             )
                           )
                         )
-                        (br_if $jumpthreading$inner$12
+                        (if
                           (i32.eq
                             (tee_local $2
                               (call $_sbrk
@@ -11210,12 +11227,18 @@
                             )
                             (get_local $3)
                           )
-                        )
-                        (block
-                          (set_local $3
-                            (get_local $2)
+                          (block
+                            (set_local $2
+                              (get_local $1)
+                            )
+                            (br $jumpthreading$inner$12)
                           )
-                          (br $jumpthreading$inner$4)
+                          (block
+                            (set_local $3
+                              (get_local $2)
+                            )
+                            (br $jumpthreading$inner$4)
+                          )
                         )
                       )
                     )
@@ -11232,7 +11255,7 @@
               (if
                 (i32.and
                   (i32.gt_u
-                    (get_local $10)
+                    (get_local $11)
                     (get_local $1)
                   )
                   (i32.and
@@ -11293,10 +11316,16 @@
                   )
                 )
               )
-              (br_if $jumpthreading$inner$12
+              (if
                 (i32.ne
                   (get_local $3)
                   (i32.const -1)
+                )
+                (block
+                  (set_local $2
+                    (get_local $1)
+                  )
+                  (br $jumpthreading$inner$12)
                 )
               )
             )
@@ -11313,7 +11342,7 @@
         )
         (if
           (i32.lt_u
-            (get_local $8)
+            (get_local $7)
             (i32.const 2147483647)
           )
           (if
@@ -11321,7 +11350,7 @@
               (i32.lt_u
                 (tee_local $3
                   (call $_sbrk
-                    (get_local $8)
+                    (get_local $7)
                   )
                 )
                 (tee_local $1
@@ -11343,7 +11372,7 @@
             )
             (br_if $jumpthreading$inner$12
               (i32.gt_u
-                (tee_local $1
+                (tee_local $2
                   (i32.sub
                     (get_local $1)
                     (get_local $3)
@@ -11361,36 +11390,36 @@
       )
       (i32.store
         (i32.const 608)
-        (tee_local $2
+        (tee_local $1
           (i32.add
             (i32.load
               (i32.const 608)
             )
-            (get_local $1)
+            (get_local $2)
           )
         )
       )
       (if
         (i32.gt_u
-          (get_local $2)
+          (get_local $1)
           (i32.load
             (i32.const 612)
           )
         )
         (i32.store
           (i32.const 612)
-          (get_local $2)
+          (get_local $1)
         )
       )
       (block $do-once40
         (if
-          (tee_local $9
+          (tee_local $8
             (i32.load
               (i32.const 200)
             )
           )
           (block
-            (set_local $2
+            (set_local $1
               (i32.const 624)
             )
             (block $jumpthreading$outer$9
@@ -11402,14 +11431,14 @@
                       (i32.add
                         (tee_local $6
                           (i32.load
-                            (get_local $2)
+                            (get_local $1)
                           )
                         )
-                        (tee_local $7
+                        (tee_local $9
                           (i32.load
                             (tee_local $4
                               (i32.add
-                                (get_local $2)
+                                (get_local $1)
                                 (i32.const 4)
                               )
                             )
@@ -11419,9 +11448,9 @@
                     )
                   )
                   (br_if $while-in45
-                    (tee_local $2
+                    (tee_local $1
                       (i32.load offset=8
-                        (get_local $2)
+                        (get_local $1)
                       )
                     )
                   )
@@ -11432,7 +11461,7 @@
                 (i32.eqz
                   (i32.and
                     (i32.load offset=12
-                      (get_local $2)
+                      (get_local $1)
                     )
                     (i32.const 8)
                   )
@@ -11440,11 +11469,11 @@
                 (if
                   (i32.and
                     (i32.lt_u
-                      (get_local $9)
+                      (get_local $8)
                       (get_local $3)
                     )
                     (i32.ge_u
-                      (get_local $9)
+                      (get_local $8)
                       (get_local $6)
                     )
                   )
@@ -11452,21 +11481,21 @@
                     (i32.store
                       (get_local $4)
                       (i32.add
-                        (get_local $7)
-                        (get_local $1)
+                        (get_local $9)
+                        (get_local $2)
                       )
                     )
-                    (set_local $2
+                    (set_local $3
                       (i32.add
-                        (get_local $9)
-                        (tee_local $3
+                        (get_local $8)
+                        (tee_local $1
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (tee_local $3
+                                (tee_local $1
                                   (i32.add
-                                    (get_local $9)
+                                    (get_local $8)
                                     (i32.const 8)
                                   )
                                 )
@@ -11475,7 +11504,7 @@
                             )
                             (i32.const 0)
                             (i32.and
-                              (get_local $3)
+                              (get_local $1)
                               (i32.const 7)
                             )
                           )
@@ -11485,8 +11514,8 @@
                     (set_local $1
                       (i32.add
                         (i32.sub
+                          (get_local $2)
                           (get_local $1)
-                          (get_local $3)
                         )
                         (i32.load
                           (i32.const 188)
@@ -11495,14 +11524,14 @@
                     )
                     (i32.store
                       (i32.const 200)
-                      (get_local $2)
+                      (get_local $3)
                     )
                     (i32.store
                       (i32.const 188)
                       (get_local $1)
                     )
                     (i32.store offset=4
-                      (get_local $2)
+                      (get_local $3)
                       (i32.or
                         (get_local $1)
                         (i32.const 1)
@@ -11510,7 +11539,7 @@
                     )
                     (i32.store offset=4
                       (i32.add
-                        (get_local $2)
+                        (get_local $3)
                         (get_local $1)
                       )
                       (i32.const 40)
@@ -11530,7 +11559,7 @@
               (if i32
                 (i32.lt_u
                   (get_local $3)
-                  (tee_local $2
+                  (tee_local $1
                     (i32.load
                       (i32.const 192)
                     )
@@ -11543,16 +11572,16 @@
                   )
                   (get_local $3)
                 )
-                (get_local $2)
-              )
-            )
-            (set_local $7
-              (i32.add
-                (get_local $3)
                 (get_local $1)
               )
             )
-            (set_local $2
+            (set_local $9
+              (i32.add
+                (get_local $3)
+                (get_local $2)
+              )
+            )
+            (set_local $1
               (i32.const 624)
             )
             (block $jumpthreading$outer$10
@@ -11561,21 +11590,21 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $2)
+                        (get_local $1)
                       )
-                      (get_local $7)
+                      (get_local $9)
                     )
                     (block
                       (set_local $4
-                        (get_local $2)
+                        (get_local $1)
                       )
                       (br $jumpthreading$inner$10)
                     )
                   )
                   (br_if $while-in47
-                    (tee_local $2
+                    (tee_local $1
                       (i32.load offset=8
-                        (get_local $2)
+                        (get_local $1)
                       )
                     )
                   )
@@ -11588,7 +11617,7 @@
               (if
                 (i32.and
                   (i32.load offset=12
-                    (get_local $2)
+                    (get_local $1)
                   )
                   (i32.const 8)
                 )
@@ -11601,20 +11630,20 @@
                     (get_local $3)
                   )
                   (i32.store
-                    (tee_local $2
+                    (tee_local $1
                       (i32.add
-                        (get_local $2)
+                        (get_local $1)
                         (i32.const 4)
                       )
                     )
                     (i32.add
                       (i32.load
-                        (get_local $2)
+                        (get_local $1)
                       )
-                      (get_local $1)
+                      (get_local $2)
                     )
                   )
-                  (set_local $8
+                  (set_local $10
                     (i32.add
                       (tee_local $6
                         (i32.add
@@ -11646,16 +11675,16 @@
                   (set_local $4
                     (i32.sub
                       (i32.sub
-                        (tee_local $10
+                        (tee_local $7
                           (i32.add
-                            (get_local $7)
+                            (get_local $9)
                             (select
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
                                   (tee_local $1
                                     (i32.add
-                                      (get_local $7)
+                                      (get_local $9)
                                       (i32.const 8)
                                     )
                                   )
@@ -11685,8 +11714,8 @@
                   (block $do-once48
                     (if
                       (i32.eq
-                        (get_local $10)
-                        (get_local $9)
+                        (get_local $7)
+                        (get_local $8)
                       )
                       (block
                         (i32.store
@@ -11702,10 +11731,10 @@
                         )
                         (i32.store
                           (i32.const 200)
-                          (get_local $8)
+                          (get_local $10)
                         )
                         (i32.store offset=4
-                          (get_local $8)
+                          (get_local $10)
                           (i32.or
                             (get_local $0)
                             (i32.const 1)
@@ -11715,7 +11744,7 @@
                       (block
                         (if
                           (i32.eq
-                            (get_local $10)
+                            (get_local $7)
                             (i32.load
                               (i32.const 196)
                             )
@@ -11734,10 +11763,10 @@
                             )
                             (i32.store
                               (i32.const 196)
-                              (get_local $8)
+                              (get_local $10)
                             )
                             (i32.store offset=4
-                              (get_local $8)
+                              (get_local $10)
                               (i32.or
                                 (get_local $0)
                                 (i32.const 1)
@@ -11745,7 +11774,7 @@
                             )
                             (i32.store
                               (i32.add
-                                (get_local $8)
+                                (get_local $10)
                                 (get_local $0)
                               )
                               (get_local $0)
@@ -11761,7 +11790,7 @@
                                   (i32.and
                                     (tee_local $0
                                       (i32.load offset=4
-                                        (get_local $10)
+                                        (get_local $7)
                                       )
                                     )
                                     (i32.const 3)
@@ -11769,7 +11798,7 @@
                                   (i32.const 1)
                                 )
                                 (block i32
-                                  (set_local $7
+                                  (set_local $9
                                     (i32.and
                                       (get_local $0)
                                       (i32.const -8)
@@ -11788,17 +11817,17 @@
                                         (i32.const 256)
                                       )
                                       (block
-                                        (set_local $2
+                                        (set_local $3
                                           (i32.load offset=12
-                                            (get_local $10)
+                                            (get_local $7)
                                           )
                                         )
                                         (block $do-once51
                                           (if
                                             (i32.ne
-                                              (tee_local $3
+                                              (tee_local $2
                                                 (i32.load offset=8
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                 )
                                               )
                                               (tee_local $0
@@ -11817,7 +11846,7 @@
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $3)
+                                                  (get_local $2)
                                                   (get_local $5)
                                                 )
                                                 (call $_abort)
@@ -11825,9 +11854,9 @@
                                               (br_if $do-once51
                                                 (i32.eq
                                                   (i32.load offset=12
-                                                    (get_local $3)
+                                                    (get_local $2)
                                                   )
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                 )
                                               )
                                               (call $_abort)
@@ -11836,8 +11865,8 @@
                                         )
                                         (if
                                           (i32.eq
-                                            (get_local $2)
                                             (get_local $3)
+                                            (get_local $2)
                                           )
                                           (block
                                             (i32.store
@@ -11861,19 +11890,19 @@
                                         (block $do-once53
                                           (if
                                             (i32.eq
-                                              (get_local $2)
+                                              (get_local $3)
                                               (get_local $0)
                                             )
                                             (set_local $21
                                               (i32.add
-                                                (get_local $2)
+                                                (get_local $3)
                                                 (i32.const 8)
                                               )
                                             )
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $2)
+                                                  (get_local $3)
                                                   (get_local $5)
                                                 )
                                                 (call $_abort)
@@ -11883,12 +11912,12 @@
                                                   (i32.load
                                                     (tee_local $0
                                                       (i32.add
-                                                        (get_local $2)
+                                                        (get_local $3)
                                                         (i32.const 8)
                                                       )
                                                     )
                                                   )
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                 )
                                                 (block
                                                   (set_local $21
@@ -11902,18 +11931,18 @@
                                           )
                                         )
                                         (i32.store offset=12
-                                          (get_local $3)
                                           (get_local $2)
+                                          (get_local $3)
                                         )
                                         (i32.store
                                           (get_local $21)
-                                          (get_local $3)
+                                          (get_local $2)
                                         )
                                       )
                                       (block
-                                        (set_local $12
+                                        (set_local $11
                                           (i32.load offset=24
-                                            (get_local $10)
+                                            (get_local $7)
                                           )
                                         )
                                         (block $do-once55
@@ -11921,10 +11950,10 @@
                                             (i32.eq
                                               (tee_local $0
                                                 (i32.load offset=12
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                 )
                                               )
-                                              (get_local $10)
+                                              (get_local $7)
                                             )
                                             (block
                                               (if
@@ -11933,9 +11962,9 @@
                                                     (i32.load
                                                       (tee_local $0
                                                         (i32.add
-                                                          (tee_local $3
+                                                          (tee_local $2
                                                             (i32.add
-                                                              (get_local $10)
+                                                              (get_local $7)
                                                               (i32.const 16)
                                                             )
                                                           )
@@ -11948,14 +11977,14 @@
                                                 (if
                                                   (tee_local $1
                                                     (i32.load
-                                                      (get_local $3)
+                                                      (get_local $2)
                                                     )
                                                   )
                                                   (set_local $0
-                                                    (get_local $3)
+                                                    (get_local $2)
                                                   )
                                                   (block
-                                                    (set_local $14
+                                                    (set_local $15
                                                       (i32.const 0)
                                                     )
                                                     (br $do-once55)
@@ -11964,9 +11993,9 @@
                                               )
                                               (loop $while-in58
                                                 (if
-                                                  (tee_local $3
+                                                  (tee_local $2
                                                     (i32.load
-                                                      (tee_local $2
+                                                      (tee_local $3
                                                         (i32.add
                                                           (get_local $1)
                                                           (i32.const 20)
@@ -11976,18 +12005,18 @@
                                                   )
                                                   (block
                                                     (set_local $1
-                                                      (get_local $3)
+                                                      (get_local $2)
                                                     )
                                                     (set_local $0
-                                                      (get_local $2)
+                                                      (get_local $3)
                                                     )
                                                     (br $while-in58)
                                                   )
                                                 )
                                                 (if
-                                                  (tee_local $3
+                                                  (tee_local $2
                                                     (i32.load
-                                                      (tee_local $2
+                                                      (tee_local $3
                                                         (i32.add
                                                           (get_local $1)
                                                           (i32.const 16)
@@ -11997,10 +12026,10 @@
                                                   )
                                                   (block
                                                     (set_local $1
-                                                      (get_local $3)
+                                                      (get_local $2)
                                                     )
                                                     (set_local $0
-                                                      (get_local $2)
+                                                      (get_local $3)
                                                     )
                                                     (br $while-in58)
                                                   )
@@ -12017,7 +12046,7 @@
                                                     (get_local $0)
                                                     (i32.const 0)
                                                   )
-                                                  (set_local $14
+                                                  (set_local $15
                                                     (get_local $1)
                                                   )
                                                 )
@@ -12026,9 +12055,9 @@
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (tee_local $2
+                                                  (tee_local $3
                                                     (i32.load offset=8
-                                                      (get_local $10)
+                                                      (get_local $7)
                                                     )
                                                   )
                                                   (get_local $5)
@@ -12038,14 +12067,14 @@
                                               (if
                                                 (i32.ne
                                                   (i32.load
-                                                    (tee_local $3
+                                                    (tee_local $2
                                                       (i32.add
-                                                        (get_local $2)
+                                                        (get_local $3)
                                                         (i32.const 12)
                                                       )
                                                     )
                                                   )
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                 )
                                                 (call $_abort)
                                               )
@@ -12059,18 +12088,18 @@
                                                       )
                                                     )
                                                   )
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                 )
                                                 (block
                                                   (i32.store
-                                                    (get_local $3)
+                                                    (get_local $2)
                                                     (get_local $0)
                                                   )
                                                   (i32.store
                                                     (get_local $1)
-                                                    (get_local $2)
+                                                    (get_local $3)
                                                   )
-                                                  (set_local $14
+                                                  (set_local $15
                                                     (get_local $0)
                                                   )
                                                 )
@@ -12081,13 +12110,13 @@
                                         )
                                         (br_if $label$break$L331
                                           (i32.eqz
-                                            (get_local $12)
+                                            (get_local $11)
                                           )
                                         )
                                         (block $do-once59
                                           (if
                                             (i32.eq
-                                              (get_local $10)
+                                              (get_local $7)
                                               (i32.load
                                                 (tee_local $0
                                                   (i32.add
@@ -12095,7 +12124,7 @@
                                                     (i32.shl
                                                       (tee_local $1
                                                         (i32.load offset=28
-                                                          (get_local $10)
+                                                          (get_local $7)
                                                         )
                                                       )
                                                       (i32.const 2)
@@ -12107,10 +12136,10 @@
                                             (block
                                               (i32.store
                                                 (get_local $0)
-                                                (get_local $14)
+                                                (get_local $15)
                                               )
                                               (br_if $do-once59
-                                                (get_local $14)
+                                                (get_local $15)
                                               )
                                               (i32.store
                                                 (i32.const 180)
@@ -12132,7 +12161,7 @@
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $12)
+                                                  (get_local $11)
                                                   (i32.load
                                                     (i32.const 192)
                                                   )
@@ -12144,25 +12173,25 @@
                                                   (i32.load
                                                     (tee_local $0
                                                       (i32.add
-                                                        (get_local $12)
+                                                        (get_local $11)
                                                         (i32.const 16)
                                                       )
                                                     )
                                                   )
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                 )
                                                 (i32.store
                                                   (get_local $0)
-                                                  (get_local $14)
+                                                  (get_local $15)
                                                 )
                                                 (i32.store offset=20
-                                                  (get_local $12)
-                                                  (get_local $14)
+                                                  (get_local $11)
+                                                  (get_local $15)
                                                 )
                                               )
                                               (br_if $label$break$L331
                                                 (i32.eqz
-                                                  (get_local $14)
+                                                  (get_local $15)
                                                 )
                                               )
                                             )
@@ -12170,7 +12199,7 @@
                                         )
                                         (if
                                           (i32.lt_u
-                                            (get_local $14)
+                                            (get_local $15)
                                             (tee_local $1
                                               (i32.load
                                                 (i32.const 192)
@@ -12180,15 +12209,15 @@
                                           (call $_abort)
                                         )
                                         (i32.store offset=24
-                                          (get_local $14)
-                                          (get_local $12)
+                                          (get_local $15)
+                                          (get_local $11)
                                         )
                                         (if
-                                          (tee_local $3
+                                          (tee_local $2
                                             (i32.load
                                               (tee_local $0
                                                 (i32.add
-                                                  (get_local $10)
+                                                  (get_local $7)
                                                   (i32.const 16)
                                                 )
                                               )
@@ -12196,18 +12225,18 @@
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $3)
+                                              (get_local $2)
                                               (get_local $1)
                                             )
                                             (call $_abort)
                                             (block
                                               (i32.store offset=16
-                                                (get_local $14)
-                                                (get_local $3)
+                                                (get_local $15)
+                                                (get_local $2)
                                               )
                                               (i32.store offset=24
-                                                (get_local $3)
-                                                (get_local $14)
+                                                (get_local $2)
+                                                (get_local $15)
                                               )
                                             )
                                           )
@@ -12231,12 +12260,12 @@
                                           (call $_abort)
                                           (block
                                             (i32.store offset=20
-                                              (get_local $14)
+                                              (get_local $15)
                                               (get_local $0)
                                             )
                                             (i32.store offset=24
                                               (get_local $0)
-                                              (get_local $14)
+                                              (get_local $15)
                                             )
                                           )
                                         )
@@ -12245,16 +12274,16 @@
                                   )
                                   (set_local $4
                                     (i32.add
-                                      (get_local $7)
+                                      (get_local $9)
                                       (get_local $4)
                                     )
                                   )
                                   (i32.add
-                                    (get_local $10)
                                     (get_local $7)
+                                    (get_local $9)
                                   )
                                 )
-                                (get_local $10)
+                                (get_local $7)
                               )
                               (i32.const 4)
                             )
@@ -12267,7 +12296,7 @@
                           )
                         )
                         (i32.store offset=4
-                          (get_local $8)
+                          (get_local $10)
                           (i32.or
                             (get_local $4)
                             (i32.const 1)
@@ -12275,7 +12304,7 @@
                         )
                         (i32.store
                           (i32.add
-                            (get_local $8)
+                            (get_local $10)
                             (get_local $4)
                           )
                           (get_local $4)
@@ -12292,7 +12321,7 @@
                             (i32.const 256)
                           )
                           (block
-                            (set_local $3
+                            (set_local $2
                               (i32.add
                                 (i32.const 216)
                                 (i32.shl
@@ -12326,7 +12355,7 @@
                                         (i32.load
                                           (tee_local $1
                                             (i32.add
-                                              (get_local $3)
+                                              (get_local $2)
                                               (i32.const 8)
                                             )
                                           )
@@ -12340,7 +12369,7 @@
                                       (set_local $22
                                         (get_local $1)
                                       )
-                                      (set_local $11
+                                      (set_local $17
                                         (get_local $0)
                                       )
                                       (br $do-once63)
@@ -12358,31 +12387,31 @@
                                   )
                                   (set_local $22
                                     (i32.add
-                                      (get_local $3)
+                                      (get_local $2)
                                       (i32.const 8)
                                     )
                                   )
-                                  (set_local $11
-                                    (get_local $3)
+                                  (set_local $17
+                                    (get_local $2)
                                   )
                                 )
                               )
                             )
                             (i32.store
                               (get_local $22)
-                              (get_local $8)
+                              (get_local $10)
                             )
                             (i32.store offset=12
-                              (get_local $11)
-                              (get_local $8)
+                              (get_local $17)
+                              (get_local $10)
                             )
                             (i32.store offset=8
-                              (get_local $8)
-                              (get_local $11)
+                              (get_local $10)
+                              (get_local $17)
                             )
                             (i32.store offset=12
-                              (get_local $8)
-                              (get_local $3)
+                              (get_local $10)
+                              (get_local $2)
                             )
                             (br $do-once48)
                           )
@@ -12428,7 +12457,7 @@
                                                                 (tee_local $1
                                                                   (i32.shl
                                                                     (get_local $0)
-                                                                    (tee_local $3
+                                                                    (tee_local $2
                                                                       (i32.and
                                                                         (i32.shr_u
                                                                           (i32.add
@@ -12449,7 +12478,7 @@
                                                             (i32.const 4)
                                                           )
                                                         )
-                                                        (get_local $3)
+                                                        (get_local $2)
                                                       )
                                                       (tee_local $0
                                                         (i32.and
@@ -12499,13 +12528,13 @@
                           )
                         )
                         (i32.store offset=28
-                          (get_local $8)
+                          (get_local $10)
                           (get_local $3)
                         )
                         (i32.store offset=4
                           (tee_local $0
                             (i32.add
-                              (get_local $8)
+                              (get_local $10)
                               (i32.const 16)
                             )
                           )
@@ -12541,19 +12570,19 @@
                             )
                             (i32.store
                               (get_local $2)
-                              (get_local $8)
+                              (get_local $10)
                             )
                             (i32.store offset=24
-                              (get_local $8)
+                              (get_local $10)
                               (get_local $2)
                             )
                             (i32.store offset=12
-                              (get_local $8)
-                              (get_local $8)
+                              (get_local $10)
+                              (get_local $10)
                             )
                             (i32.store offset=8
-                              (get_local $8)
-                              (get_local $8)
+                              (get_local $10)
+                              (get_local $10)
                             )
                             (br $do-once48)
                           )
@@ -12648,19 +12677,19 @@
                               (block
                                 (i32.store
                                   (get_local $3)
-                                  (get_local $8)
+                                  (get_local $10)
                                 )
                                 (i32.store offset=24
-                                  (get_local $8)
+                                  (get_local $10)
                                   (get_local $0)
                                 )
                                 (i32.store offset=12
-                                  (get_local $8)
-                                  (get_local $8)
+                                  (get_local $10)
+                                  (get_local $10)
                                 )
                                 (i32.store offset=8
-                                  (get_local $8)
-                                  (get_local $8)
+                                  (get_local $10)
+                                  (get_local $10)
                                 )
                                 (br $do-once48)
                               )
@@ -12670,9 +12699,9 @@
                           (if
                             (i32.and
                               (i32.ge_u
-                                (tee_local $2
+                                (tee_local $3
                                   (i32.load
-                                    (tee_local $3
+                                    (tee_local $2
                                       (i32.add
                                         (get_local $0)
                                         (i32.const 8)
@@ -12693,23 +12722,23 @@
                             )
                             (block
                               (i32.store offset=12
-                                (get_local $2)
-                                (get_local $8)
+                                (get_local $3)
+                                (get_local $10)
                               )
                               (i32.store
-                                (get_local $3)
-                                (get_local $8)
+                                (get_local $2)
+                                (get_local $10)
                               )
                               (i32.store offset=8
-                                (get_local $8)
-                                (get_local $2)
+                                (get_local $10)
+                                (get_local $3)
                               )
                               (i32.store offset=12
-                                (get_local $8)
+                                (get_local $10)
                                 (get_local $0)
                               )
                               (i32.store offset=24
-                                (get_local $8)
+                                (get_local $10)
                                 (i32.const 0)
                               )
                             )
@@ -12732,24 +12761,30 @@
               (block $while-out69
                 (if
                   (i32.le_u
-                    (tee_local $2
+                    (tee_local $1
                       (i32.load
                         (get_local $4)
                       )
                     )
-                    (get_local $9)
+                    (get_local $8)
                   )
-                  (br_if $while-out69
+                  (if
                     (i32.gt_u
-                      (tee_local $2
+                      (tee_local $1
                         (i32.add
-                          (get_local $2)
+                          (get_local $1)
                           (i32.load offset=4
                             (get_local $4)
                           )
                         )
                       )
-                      (get_local $9)
+                      (get_local $8)
+                    )
+                    (block
+                      (set_local $4
+                        (get_local $1)
+                      )
+                      (br $while-out69)
                     )
                   )
                 )
@@ -12761,11 +12796,11 @@
                 (br $while-in70)
               )
             )
-            (set_local $7
+            (set_local $9
               (i32.add
-                (tee_local $4
+                (tee_local $1
                   (i32.add
-                    (get_local $2)
+                    (get_local $4)
                     (i32.const -47)
                   )
                 )
@@ -12776,31 +12811,31 @@
               (i32.add
                 (tee_local $11
                   (select
-                    (get_local $9)
-                    (tee_local $4
+                    (get_local $8)
+                    (tee_local $1
                       (i32.add
-                        (get_local $4)
+                        (get_local $1)
                         (select
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (get_local $7)
+                              (get_local $9)
                             )
                             (i32.const 7)
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $7)
+                            (get_local $9)
                             (i32.const 7)
                           )
                         )
                       )
                     )
                     (i32.lt_u
-                      (get_local $4)
-                      (tee_local $7
+                      (get_local $1)
+                      (tee_local $9
                         (i32.add
-                          (get_local $9)
+                          (get_local $8)
                           (i32.const 16)
                         )
                       )
@@ -12815,12 +12850,12 @@
               (tee_local $6
                 (i32.add
                   (get_local $3)
-                  (tee_local $4
+                  (tee_local $1
                     (select
                       (i32.and
                         (i32.sub
                           (i32.const 0)
-                          (tee_local $4
+                          (tee_local $1
                             (i32.add
                               (get_local $3)
                               (i32.const 8)
@@ -12831,7 +12866,7 @@
                       )
                       (i32.const 0)
                       (i32.and
-                        (get_local $4)
+                        (get_local $1)
                         (i32.const 7)
                       )
                     )
@@ -12841,27 +12876,27 @@
             )
             (i32.store
               (i32.const 188)
-              (tee_local $4
+              (tee_local $1
                 (i32.sub
                   (i32.add
-                    (get_local $1)
+                    (get_local $2)
                     (i32.const -40)
                   )
-                  (get_local $4)
+                  (get_local $1)
                 )
               )
             )
             (i32.store offset=4
               (get_local $6)
               (i32.or
-                (get_local $4)
+                (get_local $1)
                 (i32.const 1)
               )
             )
             (i32.store offset=4
               (i32.add
                 (get_local $6)
-                (get_local $4)
+                (get_local $1)
               )
               (i32.const 40)
             )
@@ -12872,7 +12907,7 @@
               )
             )
             (i32.store
-              (tee_local $4
+              (tee_local $6
                 (i32.add
                   (get_local $11)
                   (i32.const 4)
@@ -12910,7 +12945,7 @@
             )
             (i32.store
               (i32.const 628)
-              (get_local $1)
+              (get_local $2)
             )
             (i32.store
               (i32.const 636)
@@ -12942,32 +12977,32 @@
                     (get_local $1)
                     (i32.const 4)
                   )
-                  (get_local $2)
+                  (get_local $4)
                 )
               )
             )
             (if
               (i32.ne
                 (get_local $11)
-                (get_local $9)
+                (get_local $8)
               )
               (block
                 (i32.store
-                  (get_local $4)
+                  (get_local $6)
                   (i32.and
                     (i32.load
-                      (get_local $4)
+                      (get_local $6)
                     )
                     (i32.const -2)
                   )
                 )
                 (i32.store offset=4
-                  (get_local $9)
+                  (get_local $8)
                   (i32.or
                     (tee_local $6
                       (i32.sub
                         (get_local $11)
-                        (get_local $9)
+                        (get_local $8)
                       )
                     )
                     (i32.const 1)
@@ -12989,7 +13024,7 @@
                     (i32.const 256)
                   )
                   (block
-                    (set_local $2
+                    (set_local $3
                       (i32.add
                         (i32.const 216)
                         (i32.shl
@@ -13003,7 +13038,7 @@
                     )
                     (if
                       (i32.and
-                        (tee_local $3
+                        (tee_local $2
                           (i32.load
                             (i32.const 176)
                           )
@@ -13019,9 +13054,9 @@
                         (i32.lt_u
                           (tee_local $1
                             (i32.load
-                              (tee_local $3
+                              (tee_local $2
                                 (i32.add
-                                  (get_local $2)
+                                  (get_local $3)
                                   (i32.const 8)
                                 )
                               )
@@ -13034,9 +13069,9 @@
                         (call $_abort)
                         (block
                           (set_local $23
-                            (get_local $3)
+                            (get_local $2)
                           )
-                          (set_local $12
+                          (set_local $10
                             (get_local $1)
                           )
                         )
@@ -13045,45 +13080,45 @@
                         (i32.store
                           (i32.const 176)
                           (i32.or
-                            (get_local $3)
+                            (get_local $2)
                             (get_local $1)
                           )
                         )
                         (set_local $23
                           (i32.add
-                            (get_local $2)
+                            (get_local $3)
                             (i32.const 8)
                           )
                         )
-                        (set_local $12
-                          (get_local $2)
+                        (set_local $10
+                          (get_local $3)
                         )
                       )
                     )
                     (i32.store
                       (get_local $23)
-                      (get_local $9)
+                      (get_local $8)
                     )
                     (i32.store offset=12
-                      (get_local $12)
-                      (get_local $9)
+                      (get_local $10)
+                      (get_local $8)
                     )
                     (i32.store offset=8
-                      (get_local $9)
-                      (get_local $12)
+                      (get_local $8)
+                      (get_local $10)
                     )
                     (i32.store offset=12
-                      (get_local $9)
-                      (get_local $2)
+                      (get_local $8)
+                      (get_local $3)
                     )
                     (br $do-once40)
                   )
                 )
-                (set_local $4
+                (set_local $3
                   (i32.add
                     (i32.const 480)
                     (i32.shl
-                      (tee_local $2
+                      (tee_local $4
                         (if i32
                           (tee_local $1
                             (i32.shr_u
@@ -13112,10 +13147,10 @@
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (tee_local $3
+                                                      (tee_local $2
                                                         (i32.shl
                                                           (get_local $1)
-                                                          (tee_local $2
+                                                          (tee_local $3
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
@@ -13136,15 +13171,15 @@
                                                   (i32.const 4)
                                                 )
                                               )
-                                              (get_local $2)
+                                              (get_local $3)
                                             )
                                             (tee_local $1
                                               (i32.and
                                                 (i32.shr_u
                                                   (i32.add
-                                                    (tee_local $3
+                                                    (tee_local $2
                                                       (i32.shl
-                                                        (get_local $3)
+                                                        (get_local $2)
                                                         (get_local $1)
                                                       )
                                                     )
@@ -13159,7 +13194,7 @@
                                         )
                                         (i32.shr_u
                                           (i32.shl
-                                            (get_local $3)
+                                            (get_local $2)
                                             (get_local $1)
                                           )
                                           (i32.const 15)
@@ -13185,21 +13220,21 @@
                   )
                 )
                 (i32.store offset=28
-                  (get_local $9)
-                  (get_local $2)
+                  (get_local $8)
+                  (get_local $4)
                 )
                 (i32.store offset=20
-                  (get_local $9)
+                  (get_local $8)
                   (i32.const 0)
                 )
                 (i32.store
-                  (get_local $7)
+                  (get_local $9)
                   (i32.const 0)
                 )
                 (if
                   (i32.eqz
                     (i32.and
-                      (tee_local $3
+                      (tee_local $2
                         (i32.load
                           (i32.const 180)
                         )
@@ -13207,7 +13242,7 @@
                       (tee_local $1
                         (i32.shl
                           (i32.const 1)
-                          (get_local $2)
+                          (get_local $4)
                         )
                       )
                     )
@@ -13216,30 +13251,30 @@
                     (i32.store
                       (i32.const 180)
                       (i32.or
-                        (get_local $3)
+                        (get_local $2)
                         (get_local $1)
                       )
                     )
                     (i32.store
-                      (get_local $4)
-                      (get_local $9)
+                      (get_local $3)
+                      (get_local $8)
                     )
                     (i32.store offset=24
-                      (get_local $9)
-                      (get_local $4)
+                      (get_local $8)
+                      (get_local $3)
                     )
                     (i32.store offset=12
-                      (get_local $9)
-                      (get_local $9)
+                      (get_local $8)
+                      (get_local $8)
                     )
                     (i32.store offset=8
-                      (get_local $9)
-                      (get_local $9)
+                      (get_local $8)
+                      (get_local $8)
                     )
                     (br $do-once40)
                   )
                 )
-                (set_local $2
+                (set_local $4
                   (i32.shl
                     (get_local $6)
                     (select
@@ -13247,12 +13282,12 @@
                       (i32.sub
                         (i32.const 25)
                         (i32.shr_u
-                          (get_local $2)
+                          (get_local $4)
                           (i32.const 1)
                         )
                       )
                       (i32.eq
-                        (get_local $2)
+                        (get_local $4)
                         (i32.const 31)
                       )
                     )
@@ -13260,7 +13295,7 @@
                 )
                 (set_local $1
                   (i32.load
-                    (get_local $4)
+                    (get_local $3)
                   )
                 )
                 (block $jumpthreading$outer$8
@@ -13278,17 +13313,17 @@
                             (get_local $6)
                           )
                         )
-                        (set_local $4
+                        (set_local $3
                           (i32.shl
-                            (get_local $2)
+                            (get_local $4)
                             (i32.const 1)
                           )
                         )
                         (br_if $jumpthreading$inner$7
                           (i32.eqz
-                            (tee_local $3
+                            (tee_local $2
                               (i32.load
-                                (tee_local $2
+                                (tee_local $4
                                   (i32.add
                                     (i32.add
                                       (get_local $1)
@@ -13296,7 +13331,7 @@
                                     )
                                     (i32.shl
                                       (i32.shr_u
-                                        (get_local $2)
+                                        (get_local $4)
                                         (i32.const 31)
                                       )
                                       (i32.const 2)
@@ -13308,11 +13343,11 @@
                           )
                         )
                         (block
-                          (set_local $2
-                            (get_local $4)
+                          (set_local $4
+                            (get_local $3)
                           )
                           (set_local $1
-                            (get_local $3)
+                            (get_local $2)
                           )
                           (br $while-in74)
                         )
@@ -13320,7 +13355,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $2)
+                        (get_local $4)
                         (i32.load
                           (i32.const 192)
                         )
@@ -13328,20 +13363,20 @@
                       (call $_abort)
                       (block
                         (i32.store
-                          (get_local $2)
-                          (get_local $9)
+                          (get_local $4)
+                          (get_local $8)
                         )
                         (i32.store offset=24
-                          (get_local $9)
+                          (get_local $8)
                           (get_local $1)
                         )
                         (i32.store offset=12
-                          (get_local $9)
-                          (get_local $9)
+                          (get_local $8)
+                          (get_local $8)
                         )
                         (i32.store offset=8
-                          (get_local $9)
-                          (get_local $9)
+                          (get_local $8)
+                          (get_local $8)
                         )
                         (br $do-once40)
                       )
@@ -13353,7 +13388,7 @@
                       (i32.ge_u
                         (tee_local $4
                           (i32.load
-                            (tee_local $2
+                            (tee_local $3
                               (i32.add
                                 (get_local $1)
                                 (i32.const 8)
@@ -13361,7 +13396,7 @@
                             )
                           )
                         )
-                        (tee_local $3
+                        (tee_local $2
                           (i32.load
                             (i32.const 192)
                           )
@@ -13369,28 +13404,28 @@
                       )
                       (i32.ge_u
                         (get_local $1)
-                        (get_local $3)
+                        (get_local $2)
                       )
                     )
                     (block
                       (i32.store offset=12
                         (get_local $4)
-                        (get_local $9)
+                        (get_local $8)
                       )
                       (i32.store
-                        (get_local $2)
-                        (get_local $9)
+                        (get_local $3)
+                        (get_local $8)
                       )
                       (i32.store offset=8
-                        (get_local $9)
+                        (get_local $8)
                         (get_local $4)
                       )
                       (i32.store offset=12
-                        (get_local $9)
+                        (get_local $8)
                         (get_local $1)
                       )
                       (i32.store offset=24
-                        (get_local $9)
+                        (get_local $8)
                         (i32.const 0)
                       )
                     )
@@ -13404,7 +13439,7 @@
             (if
               (i32.or
                 (i32.eqz
-                  (tee_local $2
+                  (tee_local $1
                     (i32.load
                       (i32.const 192)
                     )
@@ -13412,7 +13447,7 @@
                 )
                 (i32.lt_u
                   (get_local $3)
-                  (get_local $2)
+                  (get_local $1)
                 )
               )
               (i32.store
@@ -13426,7 +13461,7 @@
             )
             (i32.store
               (i32.const 628)
-              (get_local $1)
+              (get_local $2)
             )
             (i32.store
               (i32.const 636)
@@ -13442,7 +13477,7 @@
               (i32.const 208)
               (i32.const -1)
             )
-            (set_local $2
+            (set_local $1
               (i32.const 0)
             )
             (loop $while-in43
@@ -13452,7 +13487,7 @@
                     (i32.const 216)
                     (i32.shl
                       (i32.shl
-                        (get_local $2)
+                        (get_local $1)
                         (i32.const 1)
                       )
                       (i32.const 2)
@@ -13467,9 +13502,9 @@
               )
               (br_if $while-in43
                 (i32.ne
-                  (tee_local $2
+                  (tee_local $1
                     (i32.add
-                      (get_local $2)
+                      (get_local $1)
                       (i32.const 1)
                     )
                   )
@@ -13479,15 +13514,15 @@
             )
             (i32.store
               (i32.const 200)
-              (tee_local $2
+              (tee_local $3
                 (i32.add
                   (get_local $3)
-                  (tee_local $3
+                  (tee_local $1
                     (select
                       (i32.and
                         (i32.sub
                           (i32.const 0)
-                          (tee_local $3
+                          (tee_local $1
                             (i32.add
                               (get_local $3)
                               (i32.const 8)
@@ -13498,7 +13533,7 @@
                       )
                       (i32.const 0)
                       (i32.and
-                        (get_local $3)
+                        (get_local $1)
                         (i32.const 7)
                       )
                     )
@@ -13511,15 +13546,15 @@
               (tee_local $1
                 (i32.sub
                   (i32.add
-                    (get_local $1)
+                    (get_local $2)
                     (i32.const -40)
                   )
-                  (get_local $3)
+                  (get_local $1)
                 )
               )
             )
             (i32.store offset=4
-              (get_local $2)
+              (get_local $3)
               (i32.or
                 (get_local $1)
                 (i32.const 1)
@@ -13527,7 +13562,7 @@
             )
             (i32.store offset=4
               (i32.add
-                (get_local $2)
+                (get_local $3)
                 (get_local $1)
               )
               (i32.const 40)
@@ -13553,7 +13588,7 @@
         (block
           (i32.store
             (i32.const 188)
-            (tee_local $3
+            (tee_local $2
               (i32.sub
                 (get_local $1)
                 (get_local $0)
@@ -13564,7 +13599,7 @@
             (i32.const 200)
             (tee_local $1
               (i32.add
-                (tee_local $2
+                (tee_local $3
                   (i32.load
                     (i32.const 200)
                   )
@@ -13576,12 +13611,12 @@
           (i32.store offset=4
             (get_local $1)
             (i32.or
-              (get_local $3)
+              (get_local $2)
               (i32.const 1)
             )
           )
           (i32.store offset=4
-            (get_local $2)
+            (get_local $3)
             (i32.or
               (get_local $0)
               (i32.const 3)
@@ -13589,7 +13624,7 @@
           )
           (return
             (i32.add
-              (get_local $2)
+              (get_local $3)
               (i32.const 8)
             )
           )
@@ -13626,7 +13661,7 @@
     )
     (if
       (i32.lt_u
-        (tee_local $1
+        (tee_local $4
           (i32.add
             (get_local $0)
             (i32.const -8)
@@ -13642,9 +13677,9 @@
     )
     (if
       (i32.eq
-        (tee_local $5
+        (tee_local $10
           (i32.and
-            (tee_local $7
+            (tee_local $2
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -13659,12 +13694,12 @@
       )
       (call $_abort)
     )
-    (set_local $8
+    (set_local $6
       (i32.add
-        (get_local $1)
+        (get_local $4)
         (tee_local $0
           (i32.and
-            (get_local $7)
+            (get_local $2)
             (i32.const -8)
           )
         )
@@ -13673,43 +13708,43 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $7)
+          (get_local $2)
           (i32.const 1)
         )
         (block
           (set_local $3
-            (get_local $1)
+            (get_local $4)
           )
-          (set_local $4
+          (set_local $1
             (get_local $0)
           )
         )
         (block
-          (set_local $7
+          (set_local $8
             (i32.load
-              (get_local $1)
+              (get_local $4)
             )
           )
           (if
             (i32.eqz
-              (get_local $5)
+              (get_local $10)
             )
             (return)
           )
-          (set_local $0
+          (set_local $2
             (i32.add
-              (get_local $7)
+              (get_local $8)
               (get_local $0)
             )
           )
           (if
             (i32.lt_u
-              (tee_local $1
+              (tee_local $0
                 (i32.add
-                  (get_local $1)
+                  (get_local $4)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $7)
+                    (get_local $8)
                   )
                 )
               )
@@ -13719,7 +13754,7 @@
           )
           (if
             (i32.eq
-              (get_local $1)
+              (get_local $0)
               (i32.load
                 (i32.const 196)
               )
@@ -13728,11 +13763,11 @@
               (if
                 (i32.ne
                   (i32.and
-                    (tee_local $4
+                    (tee_local $3
                       (i32.load
-                        (tee_local $3
+                        (tee_local $1
                           (i32.add
-                            (get_local $8)
+                            (get_local $6)
                             (i32.const 4)
                           )
                         )
@@ -13744,72 +13779,72 @@
                 )
                 (block
                   (set_local $3
-                    (get_local $1)
-                  )
-                  (set_local $4
                     (get_local $0)
+                  )
+                  (set_local $1
+                    (get_local $2)
                   )
                   (br $do-once)
                 )
               )
               (i32.store
                 (i32.const 184)
-                (get_local $0)
+                (get_local $2)
               )
               (i32.store
-                (get_local $3)
+                (get_local $1)
                 (i32.and
-                  (get_local $4)
+                  (get_local $3)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $1)
+                (get_local $0)
                 (i32.or
-                  (get_local $0)
+                  (get_local $2)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
-                  (get_local $1)
                   (get_local $0)
+                  (get_local $2)
                 )
-                (get_local $0)
+                (get_local $2)
               )
               (return)
             )
           )
-          (set_local $5
+          (set_local $10
             (i32.shr_u
-              (get_local $7)
+              (get_local $8)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $7)
+              (get_local $8)
               (i32.const 256)
             )
             (block
-              (set_local $6
+              (set_local $3
                 (i32.load offset=12
-                  (get_local $1)
+                  (get_local $0)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $3
+                  (tee_local $4
                     (i32.load offset=8
-                      (get_local $1)
+                      (get_local $0)
                     )
                   )
-                  (tee_local $4
+                  (tee_local $1
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $5)
+                          (get_local $10)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -13820,7 +13855,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $3)
+                      (get_local $4)
                       (get_local $11)
                     )
                     (call $_abort)
@@ -13828,9 +13863,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $3)
+                        (get_local $4)
                       )
-                      (get_local $1)
+                      (get_local $0)
                     )
                     (call $_abort)
                   )
@@ -13838,8 +13873,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $6)
                   (get_local $3)
+                  (get_local $4)
                 )
                 (block
                   (i32.store
@@ -13851,36 +13886,36 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $5)
+                          (get_local $10)
                         )
                         (i32.const -1)
                       )
                     )
                   )
                   (set_local $3
-                    (get_local $1)
-                  )
-                  (set_local $4
                     (get_local $0)
+                  )
+                  (set_local $1
+                    (get_local $2)
                   )
                   (br $do-once)
                 )
               )
               (if
                 (i32.eq
-                  (get_local $6)
-                  (get_local $4)
+                  (get_local $3)
+                  (get_local $1)
                 )
-                (set_local $2
+                (set_local $5
                   (i32.add
-                    (get_local $6)
+                    (get_local $3)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $6)
+                      (get_local $3)
                       (get_local $11)
                     )
                     (call $_abort)
@@ -13888,84 +13923,84 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $4
+                        (tee_local $1
                           (i32.add
-                            (get_local $6)
+                            (get_local $3)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $1)
+                      (get_local $0)
                     )
-                    (set_local $2
-                      (get_local $4)
+                    (set_local $5
+                      (get_local $1)
                     )
                     (call $_abort)
                   )
                 )
               )
               (i32.store offset=12
+                (get_local $4)
                 (get_local $3)
-                (get_local $6)
               )
               (i32.store
-                (get_local $2)
-                (get_local $3)
+                (get_local $5)
+                (get_local $4)
               )
               (set_local $3
-                (get_local $1)
-              )
-              (set_local $4
                 (get_local $0)
+              )
+              (set_local $1
+                (get_local $2)
               )
               (br $do-once)
             )
           )
           (set_local $12
             (i32.load offset=24
-              (get_local $1)
+              (get_local $0)
             )
           )
           (block $do-once0
             (if
               (i32.eq
-                (tee_local $2
+                (tee_local $4
                   (i32.load offset=12
-                    (get_local $1)
+                    (get_local $0)
                   )
                 )
-                (get_local $1)
+                (get_local $0)
               )
               (block
                 (if
-                  (i32.eqz
-                    (tee_local $5
-                      (i32.load
-                        (tee_local $2
-                          (i32.add
-                            (tee_local $7
-                              (i32.add
-                                (get_local $1)
-                                (i32.const 16)
-                              )
+                  (tee_local $4
+                    (i32.load
+                      (tee_local $8
+                        (i32.add
+                          (tee_local $5
+                            (i32.add
+                              (get_local $0)
+                              (i32.const 16)
                             )
-                            (i32.const 4)
                           )
+                          (i32.const 4)
                         )
                       )
                     )
                   )
+                  (set_local $5
+                    (get_local $8)
+                  )
                   (if
-                    (tee_local $5
-                      (i32.load
-                        (get_local $7)
+                    (i32.eqz
+                      (tee_local $4
+                        (i32.load
+                          (get_local $5)
+                        )
                       )
                     )
-                    (set_local $2
-                      (get_local $7)
-                    )
                     (block
-                      (set_local $6
+                      (set_local $7
                         (i32.const 0)
                       )
                       (br $do-once0)
@@ -13974,43 +14009,43 @@
                 )
                 (loop $while-in
                   (if
-                    (tee_local $7
+                    (tee_local $10
                       (i32.load
-                        (tee_local $10
+                        (tee_local $8
                           (i32.add
-                            (get_local $5)
+                            (get_local $4)
                             (i32.const 20)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $5
-                        (get_local $7)
-                      )
-                      (set_local $2
+                      (set_local $4
                         (get_local $10)
+                      )
+                      (set_local $5
+                        (get_local $8)
                       )
                       (br $while-in)
                     )
                   )
                   (if
-                    (tee_local $7
+                    (tee_local $10
                       (i32.load
-                        (tee_local $10
+                        (tee_local $8
                           (i32.add
-                            (get_local $5)
+                            (get_local $4)
                             (i32.const 16)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $5
-                        (get_local $7)
-                      )
-                      (set_local $2
+                      (set_local $4
                         (get_local $10)
+                      )
+                      (set_local $5
+                        (get_local $8)
                       )
                       (br $while-in)
                     )
@@ -14018,17 +14053,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $2)
+                    (get_local $5)
                     (get_local $11)
                   )
                   (call $_abort)
                   (block
                     (i32.store
-                      (get_local $2)
+                      (get_local $5)
                       (i32.const 0)
                     )
-                    (set_local $6
-                      (get_local $5)
+                    (set_local $7
+                      (get_local $4)
                     )
                   )
                 )
@@ -14036,9 +14071,9 @@
               (block
                 (if
                   (i32.lt_u
-                    (tee_local $10
+                    (tee_local $5
                       (i32.load offset=8
-                        (get_local $1)
+                        (get_local $0)
                       )
                     )
                     (get_local $11)
@@ -14048,40 +14083,40 @@
                 (if
                   (i32.ne
                     (i32.load
-                      (tee_local $7
+                      (tee_local $8
                         (i32.add
-                          (get_local $10)
+                          (get_local $5)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $1)
+                    (get_local $0)
                   )
                   (call $_abort)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $5
+                      (tee_local $10
                         (i32.add
-                          (get_local $2)
+                          (get_local $4)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $1)
+                    (get_local $0)
                   )
                   (block
                     (i32.store
-                      (get_local $7)
-                      (get_local $2)
+                      (get_local $8)
+                      (get_local $4)
                     )
                     (i32.store
-                      (get_local $5)
                       (get_local $10)
+                      (get_local $5)
                     )
-                    (set_local $6
-                      (get_local $2)
+                    (set_local $7
+                      (get_local $4)
                     )
                   )
                   (call $_abort)
@@ -14094,15 +14129,15 @@
             (block
               (if
                 (i32.eq
-                  (get_local $1)
+                  (get_local $0)
                   (i32.load
-                    (tee_local $2
+                    (tee_local $5
                       (i32.add
                         (i32.const 480)
                         (i32.shl
-                          (tee_local $5
+                          (tee_local $4
                             (i32.load offset=28
-                              (get_local $1)
+                              (get_local $0)
                             )
                           )
                           (i32.const 2)
@@ -14113,12 +14148,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $2)
-                    (get_local $6)
+                    (get_local $5)
+                    (get_local $7)
                   )
                   (if
                     (i32.eqz
-                      (get_local $6)
+                      (get_local $7)
                     )
                     (block
                       (i32.store
@@ -14130,17 +14165,17 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $5)
+                              (get_local $4)
                             )
                             (i32.const -1)
                           )
                         )
                       )
                       (set_local $3
-                        (get_local $1)
-                      )
-                      (set_local $4
                         (get_local $0)
+                      )
+                      (set_local $1
+                        (get_local $2)
                       )
                       (br $do-once)
                     )
@@ -14159,34 +14194,34 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $2
+                        (tee_local $4
                           (i32.add
                             (get_local $12)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $1)
+                      (get_local $0)
                     )
                     (i32.store
-                      (get_local $2)
-                      (get_local $6)
+                      (get_local $4)
+                      (get_local $7)
                     )
                     (i32.store offset=20
                       (get_local $12)
-                      (get_local $6)
+                      (get_local $7)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $6)
+                      (get_local $7)
                     )
                     (block
                       (set_local $3
-                        (get_local $1)
-                      )
-                      (set_local $4
                         (get_local $0)
+                      )
+                      (set_local $1
+                        (get_local $2)
                       )
                       (br $do-once)
                     )
@@ -14195,7 +14230,7 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $6)
+                  (get_local $7)
                   (tee_local $5
                     (i32.load
                       (i32.const 192)
@@ -14205,15 +14240,15 @@
                 (call $_abort)
               )
               (i32.store offset=24
-                (get_local $6)
+                (get_local $7)
                 (get_local $12)
               )
               (if
-                (tee_local $7
+                (tee_local $4
                   (i32.load
-                    (tee_local $2
+                    (tee_local $8
                       (i32.add
-                        (get_local $1)
+                        (get_local $0)
                         (i32.const 16)
                       )
                     )
@@ -14221,31 +14256,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $7)
+                    (get_local $4)
                     (get_local $5)
                   )
                   (call $_abort)
                   (block
                     (i32.store offset=16
-                      (get_local $6)
                       (get_local $7)
+                      (get_local $4)
                     )
                     (i32.store offset=24
+                      (get_local $4)
                       (get_local $7)
-                      (get_local $6)
                     )
                   )
                 )
               )
               (if
-                (tee_local $2
+                (tee_local $4
                   (i32.load offset=4
-                    (get_local $2)
+                    (get_local $8)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $2)
+                    (get_local $4)
                     (i32.load
                       (i32.const 192)
                     )
@@ -14253,37 +14288,37 @@
                   (call $_abort)
                   (block
                     (i32.store offset=20
-                      (get_local $6)
-                      (get_local $2)
+                      (get_local $7)
+                      (get_local $4)
                     )
                     (i32.store offset=24
-                      (get_local $2)
-                      (get_local $6)
+                      (get_local $4)
+                      (get_local $7)
                     )
                     (set_local $3
-                      (get_local $1)
-                    )
-                    (set_local $4
                       (get_local $0)
+                    )
+                    (set_local $1
+                      (get_local $2)
                     )
                   )
                 )
                 (block
                   (set_local $3
-                    (get_local $1)
-                  )
-                  (set_local $4
                     (get_local $0)
+                  )
+                  (set_local $1
+                    (get_local $2)
                   )
                 )
               )
             )
             (block
               (set_local $3
-                (get_local $1)
-              )
-              (set_local $4
                 (get_local $0)
+              )
+              (set_local $1
+                (get_local $2)
               )
             )
           )
@@ -14293,18 +14328,18 @@
     (if
       (i32.ge_u
         (get_local $3)
-        (get_local $8)
+        (get_local $6)
       )
       (call $_abort)
     )
     (if
       (i32.eqz
         (i32.and
-          (tee_local $1
+          (tee_local $0
             (i32.load
-              (tee_local $0
+              (tee_local $2
                 (i32.add
-                  (get_local $8)
+                  (get_local $6)
                   (i32.const 4)
                 )
               )
@@ -14317,36 +14352,36 @@
     )
     (if
       (i32.and
-        (get_local $1)
+        (get_local $0)
         (i32.const 2)
       )
       (block
         (i32.store
-          (get_local $0)
+          (get_local $2)
           (i32.and
-            (get_local $1)
+            (get_local $0)
             (i32.const -2)
           )
         )
         (i32.store offset=4
           (get_local $3)
           (i32.or
-            (get_local $4)
+            (get_local $1)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $3)
-            (get_local $4)
+            (get_local $1)
           )
-          (get_local $4)
+          (get_local $1)
         )
       )
       (block
         (if
           (i32.eq
-            (get_local $8)
+            (get_local $6)
             (i32.load
               (i32.const 200)
             )
@@ -14359,7 +14394,7 @@
                   (i32.load
                     (i32.const 188)
                   )
-                  (get_local $4)
+                  (get_local $1)
                 )
               )
             )
@@ -14396,7 +14431,7 @@
         )
         (if
           (i32.eq
-            (get_local $8)
+            (get_local $6)
             (i32.load
               (i32.const 196)
             )
@@ -14409,7 +14444,7 @@
                   (i32.load
                     (i32.const 184)
                   )
-                  (get_local $4)
+                  (get_local $1)
                 )
               )
             )
@@ -14437,35 +14472,35 @@
         (set_local $5
           (i32.add
             (i32.and
-              (get_local $1)
+              (get_local $0)
               (i32.const -8)
             )
-            (get_local $4)
+            (get_local $1)
           )
         )
         (set_local $4
           (i32.shr_u
-            (get_local $1)
+            (get_local $0)
             (i32.const 3)
           )
         )
         (block $do-once4
           (if
             (i32.lt_u
-              (get_local $1)
+              (get_local $0)
               (i32.const 256)
             )
             (block
-              (set_local $2
+              (set_local $1
                 (i32.load offset=12
-                  (get_local $8)
+                  (get_local $6)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $1
+                  (tee_local $2
                     (i32.load offset=8
-                      (get_local $8)
+                      (get_local $6)
                     )
                   )
                   (tee_local $0
@@ -14484,7 +14519,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $2)
                       (i32.load
                         (i32.const 192)
                       )
@@ -14494,9 +14529,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $1)
+                        (get_local $2)
                       )
-                      (get_local $8)
+                      (get_local $6)
                     )
                     (call $_abort)
                   )
@@ -14504,8 +14539,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $2)
                   (get_local $1)
+                  (get_local $2)
                 )
                 (block
                   (i32.store
@@ -14528,19 +14563,19 @@
               )
               (if
                 (i32.eq
-                  (get_local $2)
+                  (get_local $1)
                   (get_local $0)
                 )
                 (set_local $14
                   (i32.add
-                    (get_local $2)
+                    (get_local $1)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $2)
+                      (get_local $1)
                       (i32.load
                         (i32.const 192)
                       )
@@ -14552,12 +14587,12 @@
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $2)
+                            (get_local $1)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $8)
+                      (get_local $6)
                     )
                     (set_local $14
                       (get_local $0)
@@ -14567,18 +14602,18 @@
                 )
               )
               (i32.store offset=12
-                (get_local $1)
                 (get_local $2)
+                (get_local $1)
               )
               (i32.store
                 (get_local $14)
-                (get_local $1)
+                (get_local $2)
               )
             )
             (block
-              (set_local $6
+              (set_local $7
                 (i32.load offset=24
-                  (get_local $8)
+                  (get_local $6)
                 )
               )
               (block $do-once6
@@ -14586,38 +14621,38 @@
                   (i32.eq
                     (tee_local $0
                       (i32.load offset=12
-                        (get_local $8)
+                        (get_local $6)
                       )
                     )
-                    (get_local $8)
+                    (get_local $6)
                   )
                   (block
                     (if
-                      (i32.eqz
-                        (tee_local $4
-                          (i32.load
-                            (tee_local $0
-                              (i32.add
-                                (tee_local $1
-                                  (i32.add
-                                    (get_local $8)
-                                    (i32.const 16)
-                                  )
+                      (tee_local $0
+                        (i32.load
+                          (tee_local $2
+                            (i32.add
+                              (tee_local $1
+                                (i32.add
+                                  (get_local $6)
+                                  (i32.const 16)
                                 )
-                                (i32.const 4)
                               )
+                              (i32.const 4)
                             )
                           )
                         )
                       )
+                      (set_local $1
+                        (get_local $2)
+                      )
                       (if
-                        (tee_local $4
-                          (i32.load
-                            (get_local $1)
+                        (i32.eqz
+                          (tee_local $0
+                            (i32.load
+                              (get_local $1)
+                            )
                           )
-                        )
-                        (set_local $0
-                          (get_local $1)
                         )
                         (block
                           (set_local $9
@@ -14629,42 +14664,42 @@
                     )
                     (loop $while-in9
                       (if
-                        (tee_local $1
+                        (tee_local $4
                           (i32.load
                             (tee_local $2
                               (i32.add
-                                (get_local $4)
+                                (get_local $0)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $4
-                            (get_local $1)
-                          )
                           (set_local $0
+                            (get_local $4)
+                          )
+                          (set_local $1
                             (get_local $2)
                           )
                           (br $while-in9)
                         )
                       )
                       (if
-                        (tee_local $1
+                        (tee_local $4
                           (i32.load
                             (tee_local $2
                               (i32.add
-                                (get_local $4)
+                                (get_local $0)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $4
-                            (get_local $1)
-                          )
                           (set_local $0
+                            (get_local $4)
+                          )
+                          (set_local $1
                             (get_local $2)
                           )
                           (br $while-in9)
@@ -14673,7 +14708,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $0)
+                        (get_local $1)
                         (i32.load
                           (i32.const 192)
                         )
@@ -14681,11 +14716,11 @@
                       (call $_abort)
                       (block
                         (i32.store
-                          (get_local $0)
+                          (get_local $1)
                           (i32.const 0)
                         )
                         (set_local $9
-                          (get_local $4)
+                          (get_local $0)
                         )
                       )
                     )
@@ -14693,9 +14728,9 @@
                   (block
                     (if
                       (i32.lt_u
-                        (tee_local $2
+                        (tee_local $1
                           (i32.load offset=8
-                            (get_local $8)
+                            (get_local $6)
                           )
                         )
                         (i32.load
@@ -14707,14 +14742,14 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (tee_local $1
+                          (tee_local $2
                             (i32.add
-                              (get_local $2)
+                              (get_local $1)
                               (i32.const 12)
                             )
                           )
                         )
-                        (get_local $8)
+                        (get_local $6)
                       )
                       (call $_abort)
                     )
@@ -14728,16 +14763,16 @@
                             )
                           )
                         )
-                        (get_local $8)
+                        (get_local $6)
                       )
                       (block
                         (i32.store
-                          (get_local $1)
+                          (get_local $2)
                           (get_local $0)
                         )
                         (i32.store
                           (get_local $4)
-                          (get_local $2)
+                          (get_local $1)
                         )
                         (set_local $9
                           (get_local $0)
@@ -14749,19 +14784,19 @@
                 )
               )
               (if
-                (get_local $6)
+                (get_local $7)
                 (block
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $6)
                       (i32.load
-                        (tee_local $0
+                        (tee_local $1
                           (i32.add
                             (i32.const 480)
                             (i32.shl
-                              (tee_local $4
+                              (tee_local $0
                                 (i32.load offset=28
-                                  (get_local $8)
+                                  (get_local $6)
                                 )
                               )
                               (i32.const 2)
@@ -14772,7 +14807,7 @@
                     )
                     (block
                       (i32.store
-                        (get_local $0)
+                        (get_local $1)
                         (get_local $9)
                       )
                       (if
@@ -14789,7 +14824,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $4)
+                                  (get_local $0)
                                 )
                                 (i32.const -1)
                               )
@@ -14802,7 +14837,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $6)
+                          (get_local $7)
                           (i32.load
                             (i32.const 192)
                           )
@@ -14814,19 +14849,19 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $6)
+                                (get_local $7)
                                 (i32.const 16)
                               )
                             )
                           )
-                          (get_local $8)
+                          (get_local $6)
                         )
                         (i32.store
                           (get_local $0)
                           (get_local $9)
                         )
                         (i32.store offset=20
-                          (get_local $6)
+                          (get_local $7)
                           (get_local $9)
                         )
                       )
@@ -14840,7 +14875,7 @@
                   (if
                     (i32.lt_u
                       (get_local $9)
-                      (tee_local $4
+                      (tee_local $1
                         (i32.load
                           (i32.const 192)
                         )
@@ -14850,14 +14885,14 @@
                   )
                   (i32.store offset=24
                     (get_local $9)
-                    (get_local $6)
+                    (get_local $7)
                   )
                   (if
-                    (tee_local $1
+                    (tee_local $0
                       (i32.load
-                        (tee_local $0
+                        (tee_local $2
                           (i32.add
-                            (get_local $8)
+                            (get_local $6)
                             (i32.const 16)
                           )
                         )
@@ -14865,17 +14900,17 @@
                     )
                     (if
                       (i32.lt_u
+                        (get_local $0)
                         (get_local $1)
-                        (get_local $4)
                       )
                       (call $_abort)
                       (block
                         (i32.store offset=16
                           (get_local $9)
-                          (get_local $1)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $1)
+                          (get_local $0)
                           (get_local $9)
                         )
                       )
@@ -14884,7 +14919,7 @@
                   (if
                     (tee_local $0
                       (i32.load offset=4
-                        (get_local $0)
+                        (get_local $2)
                       )
                     )
                     (if
@@ -14940,30 +14975,30 @@
             )
             (return)
           )
-          (set_local $4
+          (set_local $1
             (get_local $5)
           )
         )
       )
     )
-    (set_local $0
+    (set_local $2
       (i32.shr_u
-        (get_local $4)
+        (get_local $1)
         (i32.const 3)
       )
     )
     (if
       (i32.lt_u
-        (get_local $4)
+        (get_local $1)
         (i32.const 256)
       )
       (block
-        (set_local $1
+        (set_local $0
           (i32.add
             (i32.const 216)
             (i32.shl
               (i32.shl
-                (get_local $0)
+                (get_local $2)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -14972,25 +15007,25 @@
         )
         (if
           (i32.and
-            (tee_local $4
+            (tee_local $1
               (i32.load
                 (i32.const 176)
               )
             )
-            (tee_local $0
+            (tee_local $2
               (i32.shl
                 (i32.const 1)
-                (get_local $0)
+                (get_local $2)
               )
             )
           )
           (if
             (i32.lt_u
-              (tee_local $0
+              (tee_local $2
                 (i32.load
-                  (tee_local $4
+                  (tee_local $1
                     (i32.add
-                      (get_local $1)
+                      (get_local $0)
                       (i32.const 8)
                     )
                   )
@@ -15003,10 +15038,10 @@
             (call $_abort)
             (block
               (set_local $15
-                (get_local $4)
+                (get_local $1)
               )
               (set_local $13
-                (get_local $0)
+                (get_local $2)
               )
             )
           )
@@ -15014,18 +15049,18 @@
             (i32.store
               (i32.const 176)
               (i32.or
-                (get_local $4)
-                (get_local $0)
+                (get_local $1)
+                (get_local $2)
               )
             )
             (set_local $15
               (i32.add
-                (get_local $1)
+                (get_local $0)
                 (i32.const 8)
               )
             )
             (set_local $13
-              (get_local $1)
+              (get_local $0)
             )
           )
         )
@@ -15043,33 +15078,33 @@
         )
         (i32.store offset=12
           (get_local $3)
-          (get_local $1)
+          (get_local $0)
         )
         (return)
       )
     )
-    (set_local $5
+    (set_local $4
       (i32.add
         (i32.const 480)
         (i32.shl
-          (tee_local $2
+          (tee_local $0
             (if i32
               (tee_local $0
                 (i32.shr_u
-                  (get_local $4)
+                  (get_local $1)
                   (i32.const 8)
                 )
               )
               (if i32
                 (i32.gt_u
-                  (get_local $4)
+                  (get_local $1)
                   (i32.const 16777215)
                 )
                 (i32.const 31)
                 (i32.or
                   (i32.and
                     (i32.shr_u
-                      (get_local $4)
+                      (get_local $1)
                       (i32.add
                         (tee_local $0
                           (i32.add
@@ -15077,14 +15112,14 @@
                               (i32.const 14)
                               (i32.or
                                 (i32.or
-                                  (tee_local $0
+                                  (tee_local $4
                                     (i32.and
                                       (i32.shr_u
                                         (i32.add
-                                          (tee_local $1
+                                          (tee_local $2
                                             (i32.shl
                                               (get_local $0)
-                                              (tee_local $2
+                                              (tee_local $0
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
@@ -15105,16 +15140,16 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $2)
+                                  (get_local $0)
                                 )
-                                (tee_local $0
+                                (tee_local $2
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (tee_local $1
+                                        (tee_local $0
                                           (i32.shl
-                                            (get_local $1)
-                                            (get_local $0)
+                                            (get_local $2)
+                                            (get_local $4)
                                           )
                                         )
                                         (i32.const 245760)
@@ -15128,8 +15163,8 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $1)
                                 (get_local $0)
+                                (get_local $2)
                               )
                               (i32.const 15)
                             )
@@ -15155,7 +15190,7 @@
     )
     (i32.store offset=28
       (get_local $3)
-      (get_local $2)
+      (get_local $0)
     )
     (i32.store offset=20
       (get_local $3)
@@ -15168,33 +15203,33 @@
     (block $do-once12
       (if
         (i32.and
-          (tee_local $1
+          (tee_local $2
             (i32.load
               (i32.const 180)
             )
           )
-          (tee_local $0
+          (tee_local $5
             (i32.shl
               (i32.const 1)
-              (get_local $2)
+              (get_local $0)
             )
           )
         )
         (block
           (set_local $2
             (i32.shl
-              (get_local $4)
+              (get_local $1)
               (select
                 (i32.const 0)
                 (i32.sub
                   (i32.const 25)
                   (i32.shr_u
-                    (get_local $2)
+                    (get_local $0)
                     (i32.const 1)
                   )
                 )
                 (i32.eq
-                  (get_local $2)
+                  (get_local $0)
                   (i32.const 31)
                 )
               )
@@ -15202,7 +15237,7 @@
           )
           (set_local $0
             (i32.load
-              (get_local $5)
+              (get_local $4)
             )
           )
           (block $jumpthreading$outer$1
@@ -15217,52 +15252,59 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $4)
+                      (get_local $1)
                     )
                   )
-                  (set_local $5
+                  (set_local $4
                     (i32.shl
                       (get_local $2)
                       (i32.const 1)
                     )
                   )
-                  (br_if $jumpthreading$inner$0
-                    (i32.eqz
-                      (tee_local $1
-                        (i32.load
-                          (tee_local $2
+                  (if
+                    (tee_local $5
+                      (i32.load
+                        (tee_local $2
+                          (i32.add
                             (i32.add
-                              (i32.add
-                                (get_local $0)
-                                (i32.const 16)
+                              (get_local $0)
+                              (i32.const 16)
+                            )
+                            (i32.shl
+                              (i32.shr_u
+                                (get_local $2)
+                                (i32.const 31)
                               )
-                              (i32.shl
-                                (i32.shr_u
-                                  (get_local $2)
-                                  (i32.const 31)
-                                )
-                                (i32.const 2)
-                              )
+                              (i32.const 2)
                             )
                           )
                         )
                       )
                     )
-                  )
-                  (block
-                    (set_local $2
-                      (get_local $5)
+                    (block
+                      (set_local $2
+                        (get_local $4)
+                      )
+                      (set_local $0
+                        (get_local $5)
+                      )
+                      (br $while-in15)
                     )
-                    (set_local $0
-                      (get_local $1)
+                    (block
+                      (set_local $1
+                        (get_local $0)
+                      )
+                      (set_local $0
+                        (get_local $2)
+                      )
+                      (br $jumpthreading$inner$0)
                     )
-                    (br $while-in15)
                   )
                 )
               )
               (if
                 (i32.lt_u
-                  (get_local $2)
+                  (get_local $0)
                   (i32.load
                     (i32.const 192)
                   )
@@ -15270,12 +15312,12 @@
                 (call $_abort)
                 (block
                   (i32.store
-                    (get_local $2)
+                    (get_local $0)
                     (get_local $3)
                   )
                   (i32.store offset=24
                     (get_local $3)
-                    (get_local $0)
+                    (get_local $1)
                   )
                   (i32.store offset=12
                     (get_local $3)
@@ -15293,9 +15335,9 @@
             (if
               (i32.and
                 (i32.ge_u
-                  (tee_local $2
+                  (tee_local $1
                     (i32.load
-                      (tee_local $1
+                      (tee_local $2
                         (i32.add
                           (get_local $0)
                           (i32.const 8)
@@ -15316,16 +15358,16 @@
               )
               (block
                 (i32.store offset=12
-                  (get_local $2)
+                  (get_local $1)
                   (get_local $3)
                 )
                 (i32.store
-                  (get_local $1)
+                  (get_local $2)
                   (get_local $3)
                 )
                 (i32.store offset=8
                   (get_local $3)
-                  (get_local $2)
+                  (get_local $1)
                 )
                 (i32.store offset=12
                   (get_local $3)
@@ -15344,17 +15386,17 @@
           (i32.store
             (i32.const 180)
             (i32.or
-              (get_local $1)
-              (get_local $0)
+              (get_local $2)
+              (get_local $5)
             )
           )
           (i32.store
-            (get_local $5)
+            (get_local $4)
             (get_local $3)
           )
           (i32.store offset=24
             (get_local $3)
-            (get_local $5)
+            (get_local $4)
           )
           (i32.store offset=12
             (get_local $3)
@@ -15388,7 +15430,7 @@
     (loop $while-in17
       (set_local $0
         (i32.add
-          (tee_local $4
+          (tee_local $1
             (i32.load
               (get_local $0)
             )
@@ -15397,7 +15439,7 @@
         )
       )
       (br_if $while-in17
-        (get_local $4)
+        (get_local $1)
       )
     )
     (i32.store

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -791,7 +791,7 @@
     (local $12 i32)
     (local $13 i32)
     (local $14 i32)
-    (set_local $8
+    (set_local $7
       (get_global $STACKTOP)
     )
     (set_global $STACKTOP
@@ -807,23 +807,23 @@
       )
       (call $abort)
     )
-    (set_local $9
+    (set_local $8
       (i32.add
-        (get_local $8)
+        (get_local $7)
         (i32.const 16)
       )
     )
-    (set_local $10
-      (get_local $8)
+    (set_local $9
+      (get_local $7)
     )
     (i32.store
       (tee_local $3
         (i32.add
-          (get_local $8)
+          (get_local $7)
           (i32.const 32)
         )
       )
-      (tee_local $4
+      (tee_local $5
         (i32.load
           (tee_local $6
             (i32.add
@@ -836,17 +836,17 @@
     )
     (i32.store offset=4
       (get_local $3)
-      (tee_local $7
+      (tee_local $4
         (i32.sub
           (i32.load
-            (tee_local $11
+            (tee_local $10
               (i32.add
                 (get_local $0)
                 (i32.const 20)
               )
             )
           )
-          (get_local $4)
+          (get_local $5)
         )
       )
     )
@@ -873,12 +873,12 @@
     (set_local $1
       (get_local $3)
     )
-    (set_local $4
+    (set_local $5
       (i32.const 2)
     )
-    (set_local $7
+    (set_local $11
       (i32.add
-        (get_local $7)
+        (get_local $4)
         (get_local $2)
       )
     )
@@ -889,8 +889,8 @@
             (loop $while-in
               (br_if $jumpthreading$inner$0
                 (i32.eq
-                  (get_local $7)
-                  (tee_local $5
+                  (get_local $11)
+                  (tee_local $4
                     (if i32
                       (i32.load
                         (i32.const 16)
@@ -901,24 +901,24 @@
                           (get_local $0)
                         )
                         (i32.store
-                          (get_local $10)
+                          (get_local $9)
                           (i32.load
                             (get_local $13)
                           )
                         )
                         (i32.store offset=4
-                          (get_local $10)
+                          (get_local $9)
                           (get_local $1)
                         )
                         (i32.store offset=8
-                          (get_local $10)
-                          (get_local $4)
+                          (get_local $9)
+                          (get_local $5)
                         )
                         (set_local $3
                           (call $___syscall_ret
                             (call $___syscall146
                               (i32.const 146)
-                              (get_local $10)
+                              (get_local $9)
                             )
                           )
                         )
@@ -929,23 +929,23 @@
                       )
                       (block i32
                         (i32.store
-                          (get_local $9)
+                          (get_local $8)
                           (i32.load
                             (get_local $13)
                           )
                         )
                         (i32.store offset=4
-                          (get_local $9)
+                          (get_local $8)
                           (get_local $1)
                         )
                         (i32.store offset=8
-                          (get_local $9)
-                          (get_local $4)
+                          (get_local $8)
+                          (get_local $5)
                         )
                         (call $___syscall_ret
                           (call $___syscall146
                             (i32.const 146)
-                            (get_local $9)
+                            (get_local $8)
                           )
                         )
                       )
@@ -955,21 +955,21 @@
               )
               (br_if $jumpthreading$inner$1
                 (i32.lt_s
-                  (get_local $5)
+                  (get_local $4)
                   (i32.const 0)
                 )
               )
               (block
-                (set_local $7
+                (set_local $11
                   (i32.sub
-                    (get_local $7)
-                    (get_local $5)
+                    (get_local $11)
+                    (get_local $4)
                   )
                 )
                 (set_local $1
                   (if i32
                     (i32.gt_u
-                      (get_local $5)
+                      (get_local $4)
                       (tee_local $12
                         (i32.load offset=4
                           (get_local $1)
@@ -986,12 +986,12 @@
                         )
                       )
                       (i32.store
-                        (get_local $11)
+                        (get_local $10)
                         (get_local $3)
                       )
-                      (set_local $5
+                      (set_local $4
                         (i32.sub
-                          (get_local $5)
+                          (get_local $4)
                           (get_local $12)
                         )
                       )
@@ -1001,9 +1001,9 @@
                           (i32.const 8)
                         )
                       )
-                      (set_local $4
+                      (set_local $5
                         (i32.add
-                          (get_local $4)
+                          (get_local $5)
                           (i32.const -1)
                         )
                       )
@@ -1013,7 +1013,7 @@
                     )
                     (if i32
                       (i32.eq
-                        (get_local $4)
+                        (get_local $5)
                         (i32.const 2)
                       )
                       (block i32
@@ -1023,13 +1023,13 @@
                             (i32.load
                               (get_local $6)
                             )
-                            (get_local $5)
+                            (get_local $4)
                           )
                         )
                         (set_local $3
                           (get_local $1)
                         )
-                        (set_local $4
+                        (set_local $5
                           (i32.const 2)
                         )
                         (get_local $12)
@@ -1049,14 +1049,14 @@
                     (i32.load
                       (get_local $3)
                     )
-                    (get_local $5)
+                    (get_local $4)
                   )
                 )
                 (i32.store offset=4
                   (get_local $3)
                   (i32.sub
                     (get_local $1)
-                    (get_local $5)
+                    (get_local $4)
                   )
                 )
                 (set_local $1
@@ -1086,7 +1086,7 @@
             )
           )
           (i32.store
-            (get_local $11)
+            (get_local $10)
             (get_local $0)
           )
           (br $jumpthreading$outer$1
@@ -1102,7 +1102,7 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $11)
+          (get_local $10)
           (i32.const 0)
         )
         (i32.store
@@ -1123,14 +1123,14 @@
             )
           )
           (i32.eq
-            (get_local $4)
+            (get_local $5)
             (i32.const 2)
           )
         )
       )
     )
     (set_global $STACKTOP
-      (get_local $8)
+      (get_local $7)
     )
     (get_local $0)
   )
@@ -8079,14 +8079,14 @@
             (i32.and
               (tee_local $1
                 (i32.shr_u
-                  (tee_local $8
+                  (tee_local $10
                     (i32.load
                       (i32.const 176)
                     )
                   )
                   (tee_local $2
                     (i32.shr_u
-                      (tee_local $6
+                      (tee_local $3
                         (select
                           (i32.const 16)
                           (i32.and
@@ -8159,7 +8159,7 @@
                 (i32.store
                   (i32.const 176)
                   (i32.and
-                    (get_local $8)
+                    (get_local $10)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
@@ -8241,7 +8241,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $6)
+              (get_local $3)
               (tee_local $0
                 (i32.load
                   (i32.const 184)
@@ -8252,7 +8252,7 @@
               (if
                 (get_local $1)
                 (block
-                  (set_local $3
+                  (set_local $4
                     (i32.and
                       (i32.shr_u
                         (tee_local $1
@@ -8291,11 +8291,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $11
+                  (set_local $12
                     (i32.load
-                      (tee_local $3
+                      (tee_local $4
                         (i32.add
-                          (tee_local $4
+                          (tee_local $6
                             (i32.load
                               (tee_local $1
                                 (i32.add
@@ -8316,7 +8316,7 @@
                                                             (tee_local $2
                                                               (i32.shr_u
                                                                 (get_local $1)
-                                                                (get_local $3)
+                                                                (get_local $4)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -8324,7 +8324,7 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $3)
+                                                      (get_local $4)
                                                     )
                                                     (tee_local $1
                                                       (i32.and
@@ -8396,13 +8396,13 @@
                   (if
                     (i32.eq
                       (get_local $2)
-                      (get_local $11)
+                      (get_local $12)
                     )
                     (block
                       (i32.store
                         (i32.const 176)
                         (i32.and
-                          (get_local $8)
+                          (get_local $10)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
@@ -8419,7 +8419,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $11)
+                          (get_local $12)
                           (i32.load
                             (i32.const 192)
                           )
@@ -8431,12 +8431,12 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $11)
+                                (get_local $12)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $4)
+                          (get_local $6)
                         )
                         (block
                           (i32.store
@@ -8445,7 +8445,7 @@
                           )
                           (i32.store
                             (get_local $1)
-                            (get_local $11)
+                            (get_local $12)
                           )
                           (set_local $16
                             (i32.load
@@ -8458,27 +8458,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $4)
+                    (get_local $6)
                     (i32.or
-                      (get_local $6)
+                      (get_local $3)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $4
+                    (tee_local $6
                       (i32.add
-                        (get_local $4)
                         (get_local $6)
+                        (get_local $3)
                       )
                     )
                     (i32.or
-                      (tee_local $6
+                      (tee_local $3
                         (i32.sub
                           (i32.shl
                             (get_local $5)
                             (i32.const 3)
                           )
-                          (get_local $6)
+                          (get_local $3)
                         )
                       )
                       (i32.const 1)
@@ -8486,10 +8486,10 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $4)
                       (get_local $6)
+                      (get_local $3)
                     )
-                    (get_local $6)
+                    (get_local $3)
                   )
                   (if
                     (get_local $16)
@@ -8548,7 +8548,7 @@
                           )
                           (call $_abort)
                           (block
-                            (set_local $7
+                            (set_local $15
                               (get_local $1)
                             )
                             (set_local $9
@@ -8564,7 +8564,7 @@
                               (get_local $0)
                             )
                           )
-                          (set_local $7
+                          (set_local $15
                             (i32.add
                               (get_local $2)
                               (i32.const 8)
@@ -8576,7 +8576,7 @@
                         )
                       )
                       (i32.store
-                        (get_local $7)
+                        (get_local $15)
                         (get_local $5)
                       )
                       (i32.store offset=12
@@ -8595,14 +8595,14 @@
                   )
                   (i32.store
                     (i32.const 184)
-                    (get_local $6)
+                    (get_local $3)
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (return
-                    (get_local $3)
+                    (get_local $4)
                   )
                 )
               )
@@ -8633,7 +8633,7 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $3
+                  (set_local $9
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
@@ -8718,7 +8718,7 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $6)
+                      (get_local $3)
                     )
                   )
                   (set_local $1
@@ -8746,17 +8746,17 @@
                             )
                           )
                           (block
-                            (set_local $9
-                              (get_local $3)
+                            (set_local $12
+                              (get_local $9)
                             )
-                            (set_local $7
+                            (set_local $11
                               (get_local $2)
                             )
                             (br $while-out)
                           )
                         )
                       )
-                      (set_local $9
+                      (set_local $12
                         (i32.lt_u
                           (tee_local $1
                             (i32.sub
@@ -8766,17 +8766,17 @@
                                 )
                                 (i32.const -8)
                               )
-                              (get_local $6)
+                              (get_local $3)
                             )
                           )
-                          (get_local $3)
+                          (get_local $9)
                         )
                       )
-                      (set_local $3
+                      (set_local $9
                         (select
                           (get_local $1)
-                          (get_local $3)
                           (get_local $9)
+                          (get_local $12)
                         )
                       )
                       (set_local $1
@@ -8786,7 +8786,7 @@
                         (select
                           (get_local $0)
                           (get_local $2)
-                          (get_local $9)
+                          (get_local $12)
                         )
                       )
                       (br $while-in)
@@ -8794,7 +8794,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $11)
                       (tee_local $10
                         (i32.load
                           (i32.const 192)
@@ -8805,19 +8805,19 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $7)
-                      (tee_local $17
+                      (get_local $11)
+                      (tee_local $14
                         (i32.add
-                          (get_local $7)
-                          (get_local $6)
+                          (get_local $11)
+                          (get_local $3)
                         )
                       )
                     )
                     (call $_abort)
                   )
-                  (set_local $8
+                  (set_local $7
                     (i32.load offset=24
-                      (get_local $7)
+                      (get_local $11)
                     )
                   )
                   (block $do-once4
@@ -8825,10 +8825,10 @@
                       (i32.eq
                         (tee_local $0
                           (i32.load offset=12
-                            (get_local $7)
+                            (get_local $11)
                           )
                         )
-                        (get_local $7)
+                        (get_local $11)
                       )
                       (block
                         (if
@@ -8837,7 +8837,7 @@
                               (i32.load
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $7)
+                                    (get_local $11)
                                     (i32.const 20)
                                   )
                                 )
@@ -8850,7 +8850,7 @@
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
-                                      (get_local $7)
+                                      (get_local $11)
                                       (i32.const 16)
                                     )
                                   )
@@ -8858,7 +8858,7 @@
                               )
                             )
                             (block
-                              (set_local $5
+                              (set_local $6
                                 (i32.const 0)
                               )
                               (br $do-once4)
@@ -8869,7 +8869,7 @@
                           (if
                             (tee_local $2
                               (i32.load
-                                (tee_local $3
+                                (tee_local $9
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 20)
@@ -8882,7 +8882,7 @@
                                 (get_local $2)
                               )
                               (set_local $0
-                                (get_local $3)
+                                (get_local $9)
                               )
                               (br $while-in7)
                             )
@@ -8890,7 +8890,7 @@
                           (if
                             (tee_local $2
                               (i32.load
-                                (tee_local $3
+                                (tee_local $9
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 16)
@@ -8903,7 +8903,7 @@
                                 (get_local $2)
                               )
                               (set_local $0
-                                (get_local $3)
+                                (get_local $9)
                               )
                               (br $while-in7)
                             )
@@ -8920,7 +8920,7 @@
                               (get_local $0)
                               (i32.const 0)
                             )
-                            (set_local $5
+                            (set_local $6
                               (get_local $1)
                             )
                           )
@@ -8929,9 +8929,9 @@
                       (block
                         (if
                           (i32.lt_u
-                            (tee_local $3
+                            (tee_local $9
                               (i32.load offset=8
-                                (get_local $7)
+                                (get_local $11)
                               )
                             )
                             (get_local $10)
@@ -8943,12 +8943,12 @@
                             (i32.load
                               (tee_local $2
                                 (i32.add
-                                  (get_local $3)
+                                  (get_local $9)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $7)
+                            (get_local $11)
                           )
                           (call $_abort)
                         )
@@ -8962,7 +8962,7 @@
                                 )
                               )
                             )
-                            (get_local $7)
+                            (get_local $11)
                           )
                           (block
                             (i32.store
@@ -8971,9 +8971,9 @@
                             )
                             (i32.store
                               (get_local $1)
-                              (get_local $3)
+                              (get_local $9)
                             )
-                            (set_local $5
+                            (set_local $6
                               (get_local $0)
                             )
                           )
@@ -8984,11 +8984,11 @@
                   )
                   (block $do-once8
                     (if
-                      (get_local $8)
+                      (get_local $7)
                       (block
                         (if
                           (i32.eq
-                            (get_local $7)
+                            (get_local $11)
                             (i32.load
                               (tee_local $0
                                 (i32.add
@@ -8996,7 +8996,7 @@
                                   (i32.shl
                                     (tee_local $1
                                       (i32.load offset=28
-                                        (get_local $7)
+                                        (get_local $11)
                                       )
                                     )
                                     (i32.const 2)
@@ -9008,11 +9008,11 @@
                           (block
                             (i32.store
                               (get_local $0)
-                              (get_local $5)
+                              (get_local $6)
                             )
                             (if
                               (i32.eqz
-                                (get_local $5)
+                                (get_local $6)
                               )
                               (block
                                 (i32.store
@@ -9037,7 +9037,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -9049,32 +9049,32 @@
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
-                                      (get_local $8)
+                                      (get_local $7)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $7)
+                                (get_local $11)
                               )
                               (i32.store
                                 (get_local $0)
-                                (get_local $5)
+                                (get_local $6)
                               )
                               (i32.store offset=20
-                                (get_local $8)
-                                (get_local $5)
+                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                             (br_if $do-once8
                               (i32.eqz
-                                (get_local $5)
+                                (get_local $6)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $5)
+                            (get_local $6)
                             (tee_local $0
                               (i32.load
                                 (i32.const 192)
@@ -9084,13 +9084,13 @@
                           (call $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $5)
-                          (get_local $8)
+                          (get_local $6)
+                          (get_local $7)
                         )
                         (if
                           (tee_local $1
                             (i32.load offset=16
-                              (get_local $7)
+                              (get_local $11)
                             )
                           )
                           (if
@@ -9101,12 +9101,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $5)
+                                (get_local $6)
                                 (get_local $1)
                               )
                               (i32.store offset=24
                                 (get_local $1)
-                                (get_local $5)
+                                (get_local $6)
                               )
                             )
                           )
@@ -9114,7 +9114,7 @@
                         (if
                           (tee_local $0
                             (i32.load offset=20
-                              (get_local $7)
+                              (get_local $11)
                             )
                           )
                           (if
@@ -9127,12 +9127,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $5)
+                                (get_local $6)
                                 (get_local $0)
                               )
                               (i32.store offset=24
                                 (get_local $0)
-                                (get_local $5)
+                                (get_local $6)
                               )
                             )
                           )
@@ -9142,17 +9142,17 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $9)
+                      (get_local $12)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $7)
+                        (get_local $11)
                         (i32.or
                           (tee_local $0
                             (i32.add
-                              (get_local $9)
-                              (get_local $6)
+                              (get_local $12)
+                              (get_local $3)
                             )
                           )
                           (i32.const 3)
@@ -9162,7 +9162,7 @@
                         (tee_local $0
                           (i32.add
                             (i32.add
-                              (get_local $7)
+                              (get_local $11)
                               (get_local $0)
                             )
                             (i32.const 4)
@@ -9178,25 +9178,25 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $7)
+                        (get_local $11)
                         (i32.or
-                          (get_local $6)
+                          (get_local $3)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $17)
+                        (get_local $14)
                         (i32.or
-                          (get_local $9)
+                          (get_local $12)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $17)
-                          (get_local $9)
+                          (get_local $14)
+                          (get_local $12)
                         )
-                        (get_local $9)
+                        (get_local $12)
                       )
                       (if
                         (tee_local $0
@@ -9259,7 +9259,7 @@
                               )
                               (call $_abort)
                               (block
-                                (set_local $11
+                                (set_local $5
                                   (get_local $1)
                                 )
                                 (set_local $4
@@ -9275,7 +9275,7 @@
                                   (get_local $0)
                                 )
                               )
-                              (set_local $11
+                              (set_local $5
                                 (i32.add
                                   (get_local $2)
                                   (i32.const 8)
@@ -9287,7 +9287,7 @@
                             )
                           )
                           (i32.store
-                            (get_local $11)
+                            (get_local $5)
                             (get_local $3)
                           )
                           (i32.store offset=12
@@ -9306,28 +9306,28 @@
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $9)
+                        (get_local $12)
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $17)
+                        (get_local $14)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $7)
+                      (get_local $11)
                       (i32.const 8)
                     )
                   )
                 )
                 (set_local $0
-                  (get_local $6)
+                  (get_local $3)
                 )
               )
             )
             (set_local $0
-              (get_local $6)
+              (get_local $3)
             )
           )
         )
@@ -9370,7 +9370,7 @@
                       (tee_local $0
                         (i32.load offset=480
                           (i32.shl
-                            (tee_local $18
+                            (tee_local $17
                               (if i32
                                 (tee_local $0
                                   (i32.shr_u
@@ -9472,10 +9472,10 @@
                         )
                       )
                       (block
-                        (set_local $7
+                        (set_local $16
                           (i32.const 0)
                         )
-                        (set_local $16
+                        (set_local $18
                           (i32.shl
                             (get_local $6)
                             (select
@@ -9483,12 +9483,12 @@
                               (i32.sub
                                 (i32.const 25)
                                 (i32.shr_u
-                                  (get_local $18)
+                                  (get_local $17)
                                   (i32.const 1)
                                 )
                               )
                               (i32.eq
-                                (get_local $18)
+                                (get_local $17)
                                 (i32.const 31)
                               )
                             )
@@ -9502,7 +9502,7 @@
                             (i32.lt_u
                               (tee_local $5
                                 (i32.sub
-                                  (tee_local $11
+                                  (tee_local $15
                                     (i32.and
                                       (i32.load offset=4
                                         (get_local $0)
@@ -9517,7 +9517,7 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $11)
+                                (get_local $15)
                                 (get_local $6)
                               )
                               (block
@@ -9547,7 +9547,7 @@
                           )
                           (set_local $0
                             (select
-                              (get_local $7)
+                              (get_local $16)
                               (tee_local $5
                                 (i32.load offset=20
                                   (get_local $0)
@@ -9559,7 +9559,7 @@
                                 )
                                 (i32.eq
                                   (get_local $5)
-                                  (tee_local $11
+                                  (tee_local $15
                                     (i32.load
                                       (i32.add
                                         (i32.add
@@ -9568,7 +9568,7 @@
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $16)
+                                            (get_local $18)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -9582,12 +9582,12 @@
                           )
                           (set_local $5
                             (i32.shl
-                              (get_local $16)
+                              (get_local $18)
                               (i32.xor
                                 (i32.and
-                                  (tee_local $7
+                                  (tee_local $16
                                     (i32.eqz
-                                      (get_local $11)
+                                      (get_local $15)
                                     )
                                   )
                                   (i32.const 1)
@@ -9597,17 +9597,17 @@
                             )
                           )
                           (br_if $jumpthreading$inner$2
-                            (get_local $7)
+                            (get_local $16)
                           )
                           (block
-                            (set_local $7
+                            (set_local $16
                               (get_local $0)
                             )
-                            (set_local $16
+                            (set_local $18
                               (get_local $5)
                             )
                             (set_local $0
-                              (get_local $11)
+                              (get_local $15)
                             )
                             (br $while-in14)
                           )
@@ -9646,7 +9646,7 @@
                                     (tee_local $0
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $18)
+                                        (get_local $17)
                                       )
                                     )
                                     (i32.sub
@@ -9664,7 +9664,7 @@
                               (br $do-once)
                             )
                           )
-                          (set_local $11
+                          (set_local $15
                             (i32.and
                               (i32.shr_u
                                 (tee_local $0
@@ -9697,7 +9697,7 @@
                                               (tee_local $5
                                                 (i32.shr_u
                                                   (get_local $0)
-                                                  (get_local $11)
+                                                  (get_local $15)
                                                 )
                                               )
                                               (i32.const 5)
@@ -9705,7 +9705,7 @@
                                             (i32.const 8)
                                           )
                                         )
-                                        (get_local $11)
+                                        (get_local $15)
                                       )
                                       (tee_local $0
                                         (i32.and
@@ -9779,10 +9779,10 @@
                       )
                     )
                     (block
-                      (set_local $13
+                      (set_local $8
                         (get_local $9)
                       )
-                      (set_local $12
+                      (set_local $13
                         (get_local $4)
                       )
                     )
@@ -9845,20 +9845,20 @@
                       )
                     )
                     (block
-                      (set_local $13
+                      (set_local $8
                         (get_local $2)
                       )
-                      (set_local $12
+                      (set_local $13
                         (get_local $1)
                       )
                     )
                   )
                 )
                 (if
-                  (get_local $12)
+                  (get_local $13)
                   (if
                     (i32.lt_u
-                      (get_local $13)
+                      (get_local $8)
                       (i32.sub
                         (i32.load
                           (i32.const 184)
@@ -9869,7 +9869,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $12)
+                          (get_local $13)
                           (tee_local $4
                             (i32.load
                               (i32.const 192)
@@ -9880,10 +9880,10 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $12)
+                          (get_local $13)
                           (tee_local $5
                             (i32.add
-                              (get_local $12)
+                              (get_local $13)
                               (get_local $6)
                             )
                           )
@@ -9892,7 +9892,7 @@
                       )
                       (set_local $9
                         (i32.load offset=24
-                          (get_local $12)
+                          (get_local $13)
                         )
                       )
                       (block $do-once17
@@ -9900,10 +9900,10 @@
                           (i32.eq
                             (tee_local $0
                               (i32.load offset=12
-                                (get_local $12)
+                                (get_local $13)
                               )
                             )
-                            (get_local $12)
+                            (get_local $13)
                           )
                           (block
                             (if
@@ -9912,7 +9912,7 @@
                                   (i32.load
                                     (tee_local $0
                                       (i32.add
-                                        (get_local $12)
+                                        (get_local $13)
                                         (i32.const 20)
                                       )
                                     )
@@ -9925,7 +9925,7 @@
                                     (i32.load
                                       (tee_local $0
                                         (i32.add
-                                          (get_local $12)
+                                          (get_local $13)
                                           (i32.const 16)
                                         )
                                       )
@@ -9933,7 +9933,7 @@
                                   )
                                 )
                                 (block
-                                  (set_local $14
+                                  (set_local $7
                                     (i32.const 0)
                                   )
                                   (br $do-once17)
@@ -9995,7 +9995,7 @@
                                   (get_local $0)
                                   (i32.const 0)
                                 )
-                                (set_local $14
+                                (set_local $7
                                   (get_local $1)
                                 )
                               )
@@ -10006,7 +10006,7 @@
                               (i32.lt_u
                                 (tee_local $3
                                   (i32.load offset=8
-                                    (get_local $12)
+                                    (get_local $13)
                                   )
                                 )
                                 (get_local $4)
@@ -10023,7 +10023,7 @@
                                     )
                                   )
                                 )
-                                (get_local $12)
+                                (get_local $13)
                               )
                               (call $_abort)
                             )
@@ -10037,7 +10037,7 @@
                                     )
                                   )
                                 )
-                                (get_local $12)
+                                (get_local $13)
                               )
                               (block
                                 (i32.store
@@ -10048,7 +10048,7 @@
                                   (get_local $1)
                                   (get_local $3)
                                 )
-                                (set_local $14
+                                (set_local $7
                                   (get_local $0)
                                 )
                               )
@@ -10063,7 +10063,7 @@
                           (block
                             (if
                               (i32.eq
-                                (get_local $12)
+                                (get_local $13)
                                 (i32.load
                                   (tee_local $0
                                     (i32.add
@@ -10071,7 +10071,7 @@
                                       (i32.shl
                                         (tee_local $1
                                           (i32.load offset=28
-                                            (get_local $12)
+                                            (get_local $13)
                                           )
                                         )
                                         (i32.const 2)
@@ -10083,11 +10083,11 @@
                               (block
                                 (i32.store
                                   (get_local $0)
-                                  (get_local $14)
+                                  (get_local $7)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $14)
+                                    (get_local $7)
                                   )
                                   (block
                                     (i32.store
@@ -10129,27 +10129,27 @@
                                         )
                                       )
                                     )
-                                    (get_local $12)
+                                    (get_local $13)
                                   )
                                   (i32.store
                                     (get_local $0)
-                                    (get_local $14)
+                                    (get_local $7)
                                   )
                                   (i32.store offset=20
                                     (get_local $9)
-                                    (get_local $14)
+                                    (get_local $7)
                                   )
                                 )
                                 (br_if $do-once21
                                   (i32.eqz
-                                    (get_local $14)
+                                    (get_local $7)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $14)
+                                (get_local $7)
                                 (tee_local $0
                                   (i32.load
                                     (i32.const 192)
@@ -10159,13 +10159,13 @@
                               (call $_abort)
                             )
                             (i32.store offset=24
-                              (get_local $14)
+                              (get_local $7)
                               (get_local $9)
                             )
                             (if
                               (tee_local $1
                                 (i32.load offset=16
-                                  (get_local $12)
+                                  (get_local $13)
                                 )
                               )
                               (if
@@ -10176,12 +10176,12 @@
                                 (call $_abort)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $14)
+                                    (get_local $7)
                                     (get_local $1)
                                   )
                                   (i32.store offset=24
                                     (get_local $1)
-                                    (get_local $14)
+                                    (get_local $7)
                                   )
                                 )
                               )
@@ -10189,7 +10189,7 @@
                             (if
                               (tee_local $0
                                 (i32.load offset=20
-                                  (get_local $12)
+                                  (get_local $13)
                                 )
                               )
                               (if
@@ -10202,12 +10202,12 @@
                                 (call $_abort)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $14)
+                                    (get_local $7)
                                     (get_local $0)
                                   )
                                   (i32.store offset=24
                                     (get_local $0)
-                                    (get_local $14)
+                                    (get_local $7)
                                   )
                                 )
                               )
@@ -10218,16 +10218,16 @@
                       (block $do-once25
                         (if
                           (i32.lt_u
-                            (get_local $13)
+                            (get_local $8)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $12)
+                              (get_local $13)
                               (i32.or
                                 (tee_local $0
                                   (i32.add
-                                    (get_local $13)
+                                    (get_local $8)
                                     (get_local $6)
                                   )
                                 )
@@ -10238,7 +10238,7 @@
                               (tee_local $0
                                 (i32.add
                                   (i32.add
-                                    (get_local $12)
+                                    (get_local $13)
                                     (get_local $0)
                                   )
                                   (i32.const 4)
@@ -10254,7 +10254,7 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $12)
+                              (get_local $13)
                               (i32.or
                                 (get_local $6)
                                 (i32.const 3)
@@ -10263,26 +10263,26 @@
                             (i32.store offset=4
                               (get_local $5)
                               (i32.or
-                                (get_local $13)
+                                (get_local $8)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
                                 (get_local $5)
-                                (get_local $13)
+                                (get_local $8)
                               )
-                              (get_local $13)
+                              (get_local $8)
                             )
                             (set_local $0
                               (i32.shr_u
-                                (get_local $13)
+                                (get_local $8)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $13)
+                                (get_local $8)
                                 (i32.const 256)
                               )
                               (block
@@ -10333,7 +10333,7 @@
                                       (set_local $20
                                         (get_local $1)
                                       )
-                                      (set_local $8
+                                      (set_local $10
                                         (get_local $0)
                                       )
                                     )
@@ -10352,7 +10352,7 @@
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $8
+                                    (set_local $10
                                       (get_local $2)
                                     )
                                   )
@@ -10362,12 +10362,12 @@
                                   (get_local $5)
                                 )
                                 (i32.store offset=12
-                                  (get_local $8)
+                                  (get_local $10)
                                   (get_local $5)
                                 )
                                 (i32.store offset=8
                                   (get_local $5)
-                                  (get_local $8)
+                                  (get_local $10)
                                 )
                                 (i32.store offset=12
                                   (get_local $5)
@@ -10384,20 +10384,20 @@
                                     (if i32
                                       (tee_local $0
                                         (i32.shr_u
-                                          (get_local $13)
+                                          (get_local $8)
                                           (i32.const 8)
                                         )
                                       )
                                       (if i32
                                         (i32.gt_u
-                                          (get_local $13)
+                                          (get_local $8)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $13)
+                                              (get_local $8)
                                               (i32.add
                                                 (tee_local $0
                                                   (i32.add
@@ -10543,7 +10543,7 @@
                             )
                             (set_local $3
                               (i32.shl
-                                (get_local $13)
+                                (get_local $8)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
@@ -10577,7 +10577,7 @@
                                           )
                                           (i32.const -8)
                                         )
-                                        (get_local $13)
+                                        (get_local $8)
                                       )
                                     )
                                     (set_local $2
@@ -10704,7 +10704,7 @@
                       )
                       (return
                         (i32.add
-                          (get_local $12)
+                          (get_local $13)
                           (i32.const 8)
                         )
                       )
@@ -10943,7 +10943,7 @@
         )
       )
     )
-    (set_local $11
+    (set_local $10
       (i32.add
         (get_local $0)
         (i32.const 48)
@@ -11030,7 +11030,7 @@
                 (block $jumpthreading$inner$3
                   (br_if $jumpthreading$inner$3
                     (i32.eqz
-                      (tee_local $3
+                      (tee_local $4
                         (i32.load
                           (i32.const 200)
                         )
@@ -11049,14 +11049,14 @@
                               (get_local $1)
                             )
                           )
-                          (get_local $3)
+                          (get_local $4)
                         )
                         (if
                           (i32.gt_u
                             (i32.add
                               (get_local $2)
                               (i32.load
-                                (tee_local $2
+                                (tee_local $3
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 4)
@@ -11064,7 +11064,7 @@
                                 )
                               )
                             )
-                            (get_local $3)
+                            (get_local $4)
                           )
                           (block
                             (set_local $4
@@ -11101,7 +11101,7 @@
                     )
                     (if
                       (i32.eq
-                        (tee_local $3
+                        (tee_local $2
                           (call $_sbrk
                             (get_local $1)
                           )
@@ -11111,20 +11111,14 @@
                             (get_local $4)
                           )
                           (i32.load
-                            (get_local $2)
+                            (get_local $3)
                           )
                         )
                       )
-                      (if
+                      (br_if $jumpthreading$inner$12
                         (i32.ne
-                          (get_local $3)
+                          (get_local $2)
                           (i32.const -1)
-                        )
-                        (block
-                          (set_local $2
-                            (get_local $1)
-                          )
-                          (br $jumpthreading$inner$12)
                         )
                       )
                       (br $jumpthreading$inner$4)
@@ -11134,7 +11128,7 @@
                 )
                 (if
                   (i32.ne
-                    (tee_local $3
+                    (tee_local $2
                       (call $_sbrk
                         (i32.const 0)
                       )
@@ -11152,7 +11146,7 @@
                         (tee_local $1
                           (if i32
                             (i32.and
-                              (tee_local $2
+                              (tee_local $3
                                 (i32.add
                                   (tee_local $4
                                     (i32.load
@@ -11163,7 +11157,7 @@
                                 )
                               )
                               (tee_local $1
-                                (get_local $3)
+                                (get_local $2)
                               )
                             )
                             (i32.add
@@ -11173,7 +11167,7 @@
                               )
                               (i32.and
                                 (i32.add
-                                  (get_local $2)
+                                  (get_local $3)
                                   (get_local $1)
                                 )
                                 (i32.sub
@@ -11200,7 +11194,7 @@
                       )
                       (block
                         (if
-                          (tee_local $2
+                          (tee_local $3
                             (i32.load
                               (i32.const 616)
                             )
@@ -11213,32 +11207,26 @@
                               )
                               (i32.gt_u
                                 (get_local $4)
-                                (get_local $2)
+                                (get_local $3)
                               )
                             )
                           )
                         )
-                        (if
+                        (br_if $jumpthreading$inner$12
                           (i32.eq
-                            (tee_local $2
+                            (tee_local $3
                               (call $_sbrk
                                 (get_local $1)
                               )
                             )
+                            (get_local $2)
+                          )
+                        )
+                        (block
+                          (set_local $2
                             (get_local $3)
                           )
-                          (block
-                            (set_local $2
-                              (get_local $1)
-                            )
-                            (br $jumpthreading$inner$12)
-                          )
-                          (block
-                            (set_local $3
-                              (get_local $2)
-                            )
-                            (br $jumpthreading$inner$4)
-                          )
+                          (br $jumpthreading$inner$4)
                         )
                       )
                     )
@@ -11255,7 +11243,7 @@
               (if
                 (i32.and
                   (i32.gt_u
-                    (get_local $11)
+                    (get_local $10)
                     (get_local $1)
                   )
                   (i32.and
@@ -11264,21 +11252,21 @@
                       (i32.const 2147483647)
                     )
                     (i32.ne
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const -1)
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (tee_local $2
+                    (tee_local $3
                       (i32.and
                         (i32.add
                           (i32.sub
                             (get_local $5)
                             (get_local $1)
                           )
-                          (tee_local $2
+                          (tee_local $3
                             (i32.load
                               (i32.const 656)
                             )
@@ -11286,7 +11274,7 @@
                         )
                         (i32.sub
                           (i32.const 0)
-                          (get_local $2)
+                          (get_local $3)
                         )
                       )
                     )
@@ -11295,7 +11283,7 @@
                   (if
                     (i32.eq
                       (call $_sbrk
-                        (get_local $2)
+                        (get_local $3)
                       )
                       (i32.const -1)
                     )
@@ -11309,23 +11297,17 @@
                     )
                     (set_local $1
                       (i32.add
-                        (get_local $2)
+                        (get_local $3)
                         (get_local $1)
                       )
                     )
                   )
                 )
               )
-              (if
+              (br_if $jumpthreading$inner$12
                 (i32.ne
-                  (get_local $3)
+                  (get_local $2)
                   (i32.const -1)
-                )
-                (block
-                  (set_local $2
-                    (get_local $1)
-                  )
-                  (br $jumpthreading$inner$12)
                 )
               )
             )
@@ -11348,7 +11330,7 @@
           (if
             (i32.and
               (i32.lt_u
-                (tee_local $3
+                (tee_local $2
                   (call $_sbrk
                     (get_local $7)
                   )
@@ -11361,7 +11343,7 @@
               )
               (i32.and
                 (i32.ne
-                  (get_local $3)
+                  (get_local $2)
                   (i32.const -1)
                 )
                 (i32.ne
@@ -11372,10 +11354,10 @@
             )
             (br_if $jumpthreading$inner$12
               (i32.gt_u
-                (tee_local $2
+                (tee_local $1
                   (i32.sub
                     (get_local $1)
-                    (get_local $3)
+                    (get_local $2)
                   )
                 )
                 (i32.add
@@ -11390,25 +11372,25 @@
       )
       (i32.store
         (i32.const 608)
-        (tee_local $1
+        (tee_local $3
           (i32.add
             (i32.load
               (i32.const 608)
             )
-            (get_local $2)
+            (get_local $1)
           )
         )
       )
       (if
         (i32.gt_u
-          (get_local $1)
+          (get_local $3)
           (i32.load
             (i32.const 612)
           )
         )
         (i32.store
           (i32.const 612)
-          (get_local $1)
+          (get_local $3)
         )
       )
       (block $do-once40
@@ -11419,7 +11401,7 @@
             )
           )
           (block
-            (set_local $1
+            (set_local $3
               (i32.const 624)
             )
             (block $jumpthreading$outer$9
@@ -11427,18 +11409,18 @@
                 (loop $while-in45
                   (br_if $jumpthreading$inner$9
                     (i32.eq
-                      (get_local $3)
+                      (get_local $2)
                       (i32.add
                         (tee_local $6
                           (i32.load
-                            (get_local $1)
+                            (get_local $3)
                           )
                         )
                         (tee_local $9
                           (i32.load
                             (tee_local $4
                               (i32.add
-                                (get_local $1)
+                                (get_local $3)
                                 (i32.const 4)
                               )
                             )
@@ -11448,9 +11430,9 @@
                     )
                   )
                   (br_if $while-in45
-                    (tee_local $1
+                    (tee_local $3
                       (i32.load offset=8
-                        (get_local $1)
+                        (get_local $3)
                       )
                     )
                   )
@@ -11461,7 +11443,7 @@
                 (i32.eqz
                   (i32.and
                     (i32.load offset=12
-                      (get_local $1)
+                      (get_local $3)
                     )
                     (i32.const 8)
                   )
@@ -11470,7 +11452,7 @@
                   (i32.and
                     (i32.lt_u
                       (get_local $8)
-                      (get_local $3)
+                      (get_local $2)
                     )
                     (i32.ge_u
                       (get_local $8)
@@ -11482,18 +11464,18 @@
                       (get_local $4)
                       (i32.add
                         (get_local $9)
-                        (get_local $2)
+                        (get_local $1)
                       )
                     )
                     (set_local $3
                       (i32.add
                         (get_local $8)
-                        (tee_local $1
+                        (tee_local $2
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (tee_local $1
+                                (tee_local $2
                                   (i32.add
                                     (get_local $8)
                                     (i32.const 8)
@@ -11504,7 +11486,7 @@
                             )
                             (i32.const 0)
                             (i32.and
-                              (get_local $1)
+                              (get_local $2)
                               (i32.const 7)
                             )
                           )
@@ -11514,8 +11496,8 @@
                     (set_local $1
                       (i32.add
                         (i32.sub
-                          (get_local $2)
                           (get_local $1)
+                          (get_local $2)
                         )
                         (i32.load
                           (i32.const 188)
@@ -11558,8 +11540,8 @@
             (set_local $5
               (if i32
                 (i32.lt_u
-                  (get_local $3)
-                  (tee_local $1
+                  (get_local $2)
+                  (tee_local $3
                     (i32.load
                       (i32.const 192)
                     )
@@ -11568,20 +11550,20 @@
                 (block i32
                   (i32.store
                     (i32.const 192)
-                    (get_local $3)
+                    (get_local $2)
                   )
-                  (get_local $3)
+                  (get_local $2)
                 )
-                (get_local $1)
+                (get_local $3)
               )
             )
             (set_local $9
               (i32.add
-                (get_local $3)
                 (get_local $2)
+                (get_local $1)
               )
             )
-            (set_local $1
+            (set_local $3
               (i32.const 624)
             )
             (block $jumpthreading$outer$10
@@ -11590,21 +11572,21 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $1)
+                        (get_local $3)
                       )
                       (get_local $9)
                     )
                     (block
                       (set_local $4
-                        (get_local $1)
+                        (get_local $3)
                       )
                       (br $jumpthreading$inner$10)
                     )
                   )
                   (br_if $while-in47
-                    (tee_local $1
+                    (tee_local $3
                       (i32.load offset=8
-                        (get_local $1)
+                        (get_local $3)
                       )
                     )
                   )
@@ -11617,7 +11599,7 @@
               (if
                 (i32.and
                   (i32.load offset=12
-                    (get_local $1)
+                    (get_local $3)
                   )
                   (i32.const 8)
                 )
@@ -11627,34 +11609,34 @@
                 (block
                   (i32.store
                     (get_local $4)
-                    (get_local $3)
+                    (get_local $2)
                   )
                   (i32.store
-                    (tee_local $1
+                    (tee_local $3
                       (i32.add
-                        (get_local $1)
+                        (get_local $3)
                         (i32.const 4)
                       )
                     )
                     (i32.add
                       (i32.load
-                        (get_local $1)
+                        (get_local $3)
                       )
-                      (get_local $2)
+                      (get_local $1)
                     )
                   )
-                  (set_local $10
+                  (set_local $7
                     (i32.add
                       (tee_local $6
                         (i32.add
-                          (get_local $3)
+                          (get_local $2)
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
                                 (tee_local $1
                                   (i32.add
-                                    (get_local $3)
+                                    (get_local $2)
                                     (i32.const 8)
                                   )
                                 )
@@ -11675,7 +11657,7 @@
                   (set_local $4
                     (i32.sub
                       (i32.sub
-                        (tee_local $7
+                        (tee_local $10
                           (i32.add
                             (get_local $9)
                             (select
@@ -11714,7 +11696,7 @@
                   (block $do-once48
                     (if
                       (i32.eq
-                        (get_local $7)
+                        (get_local $10)
                         (get_local $8)
                       )
                       (block
@@ -11731,10 +11713,10 @@
                         )
                         (i32.store
                           (i32.const 200)
-                          (get_local $10)
+                          (get_local $7)
                         )
                         (i32.store offset=4
-                          (get_local $10)
+                          (get_local $7)
                           (i32.or
                             (get_local $0)
                             (i32.const 1)
@@ -11744,7 +11726,7 @@
                       (block
                         (if
                           (i32.eq
-                            (get_local $7)
+                            (get_local $10)
                             (i32.load
                               (i32.const 196)
                             )
@@ -11763,10 +11745,10 @@
                             )
                             (i32.store
                               (i32.const 196)
-                              (get_local $10)
+                              (get_local $7)
                             )
                             (i32.store offset=4
-                              (get_local $10)
+                              (get_local $7)
                               (i32.or
                                 (get_local $0)
                                 (i32.const 1)
@@ -11774,7 +11756,7 @@
                             )
                             (i32.store
                               (i32.add
-                                (get_local $10)
+                                (get_local $7)
                                 (get_local $0)
                               )
                               (get_local $0)
@@ -11790,7 +11772,7 @@
                                   (i32.and
                                     (tee_local $0
                                       (i32.load offset=4
-                                        (get_local $7)
+                                        (get_local $10)
                                       )
                                     )
                                     (i32.const 3)
@@ -11819,7 +11801,7 @@
                                       (block
                                         (set_local $3
                                           (i32.load offset=12
-                                            (get_local $7)
+                                            (get_local $10)
                                           )
                                         )
                                         (block $do-once51
@@ -11827,7 +11809,7 @@
                                             (i32.ne
                                               (tee_local $2
                                                 (i32.load offset=8
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                 )
                                               )
                                               (tee_local $0
@@ -11856,7 +11838,7 @@
                                                   (i32.load offset=12
                                                     (get_local $2)
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                 )
                                               )
                                               (call $_abort)
@@ -11917,7 +11899,7 @@
                                                       )
                                                     )
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                 )
                                                 (block
                                                   (set_local $21
@@ -11940,9 +11922,9 @@
                                         )
                                       )
                                       (block
-                                        (set_local $11
+                                        (set_local $12
                                           (i32.load offset=24
-                                            (get_local $7)
+                                            (get_local $10)
                                           )
                                         )
                                         (block $do-once55
@@ -11950,10 +11932,10 @@
                                             (i32.eq
                                               (tee_local $0
                                                 (i32.load offset=12
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                 )
                                               )
-                                              (get_local $7)
+                                              (get_local $10)
                                             )
                                             (block
                                               (if
@@ -11964,7 +11946,7 @@
                                                         (i32.add
                                                           (tee_local $2
                                                             (i32.add
-                                                              (get_local $7)
+                                                              (get_local $10)
                                                               (i32.const 16)
                                                             )
                                                           )
@@ -11984,7 +11966,7 @@
                                                     (get_local $2)
                                                   )
                                                   (block
-                                                    (set_local $15
+                                                    (set_local $14
                                                       (i32.const 0)
                                                     )
                                                     (br $do-once55)
@@ -12046,7 +12028,7 @@
                                                     (get_local $0)
                                                     (i32.const 0)
                                                   )
-                                                  (set_local $15
+                                                  (set_local $14
                                                     (get_local $1)
                                                   )
                                                 )
@@ -12057,7 +12039,7 @@
                                                 (i32.lt_u
                                                   (tee_local $3
                                                     (i32.load offset=8
-                                                      (get_local $7)
+                                                      (get_local $10)
                                                     )
                                                   )
                                                   (get_local $5)
@@ -12074,7 +12056,7 @@
                                                       )
                                                     )
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                 )
                                                 (call $_abort)
                                               )
@@ -12088,7 +12070,7 @@
                                                       )
                                                     )
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                 )
                                                 (block
                                                   (i32.store
@@ -12099,7 +12081,7 @@
                                                     (get_local $1)
                                                     (get_local $3)
                                                   )
-                                                  (set_local $15
+                                                  (set_local $14
                                                     (get_local $0)
                                                   )
                                                 )
@@ -12110,13 +12092,13 @@
                                         )
                                         (br_if $label$break$L331
                                           (i32.eqz
-                                            (get_local $11)
+                                            (get_local $12)
                                           )
                                         )
                                         (block $do-once59
                                           (if
                                             (i32.eq
-                                              (get_local $7)
+                                              (get_local $10)
                                               (i32.load
                                                 (tee_local $0
                                                   (i32.add
@@ -12124,7 +12106,7 @@
                                                     (i32.shl
                                                       (tee_local $1
                                                         (i32.load offset=28
-                                                          (get_local $7)
+                                                          (get_local $10)
                                                         )
                                                       )
                                                       (i32.const 2)
@@ -12136,10 +12118,10 @@
                                             (block
                                               (i32.store
                                                 (get_local $0)
-                                                (get_local $15)
+                                                (get_local $14)
                                               )
                                               (br_if $do-once59
-                                                (get_local $15)
+                                                (get_local $14)
                                               )
                                               (i32.store
                                                 (i32.const 180)
@@ -12161,7 +12143,7 @@
                                             (block
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $11)
+                                                  (get_local $12)
                                                   (i32.load
                                                     (i32.const 192)
                                                   )
@@ -12173,25 +12155,25 @@
                                                   (i32.load
                                                     (tee_local $0
                                                       (i32.add
-                                                        (get_local $11)
+                                                        (get_local $12)
                                                         (i32.const 16)
                                                       )
                                                     )
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                 )
                                                 (i32.store
                                                   (get_local $0)
-                                                  (get_local $15)
+                                                  (get_local $14)
                                                 )
                                                 (i32.store offset=20
-                                                  (get_local $11)
-                                                  (get_local $15)
+                                                  (get_local $12)
+                                                  (get_local $14)
                                                 )
                                               )
                                               (br_if $label$break$L331
                                                 (i32.eqz
-                                                  (get_local $15)
+                                                  (get_local $14)
                                                 )
                                               )
                                             )
@@ -12199,7 +12181,7 @@
                                         )
                                         (if
                                           (i32.lt_u
-                                            (get_local $15)
+                                            (get_local $14)
                                             (tee_local $1
                                               (i32.load
                                                 (i32.const 192)
@@ -12209,15 +12191,15 @@
                                           (call $_abort)
                                         )
                                         (i32.store offset=24
-                                          (get_local $15)
-                                          (get_local $11)
+                                          (get_local $14)
+                                          (get_local $12)
                                         )
                                         (if
                                           (tee_local $2
                                             (i32.load
                                               (tee_local $0
                                                 (i32.add
-                                                  (get_local $7)
+                                                  (get_local $10)
                                                   (i32.const 16)
                                                 )
                                               )
@@ -12231,12 +12213,12 @@
                                             (call $_abort)
                                             (block
                                               (i32.store offset=16
-                                                (get_local $15)
+                                                (get_local $14)
                                                 (get_local $2)
                                               )
                                               (i32.store offset=24
                                                 (get_local $2)
-                                                (get_local $15)
+                                                (get_local $14)
                                               )
                                             )
                                           )
@@ -12260,12 +12242,12 @@
                                           (call $_abort)
                                           (block
                                             (i32.store offset=20
-                                              (get_local $15)
+                                              (get_local $14)
                                               (get_local $0)
                                             )
                                             (i32.store offset=24
                                               (get_local $0)
-                                              (get_local $15)
+                                              (get_local $14)
                                             )
                                           )
                                         )
@@ -12279,11 +12261,11 @@
                                     )
                                   )
                                   (i32.add
-                                    (get_local $7)
+                                    (get_local $10)
                                     (get_local $9)
                                   )
                                 )
-                                (get_local $7)
+                                (get_local $10)
                               )
                               (i32.const 4)
                             )
@@ -12296,7 +12278,7 @@
                           )
                         )
                         (i32.store offset=4
-                          (get_local $10)
+                          (get_local $7)
                           (i32.or
                             (get_local $4)
                             (i32.const 1)
@@ -12304,7 +12286,7 @@
                         )
                         (i32.store
                           (i32.add
-                            (get_local $10)
+                            (get_local $7)
                             (get_local $4)
                           )
                           (get_local $4)
@@ -12369,7 +12351,7 @@
                                       (set_local $22
                                         (get_local $1)
                                       )
-                                      (set_local $17
+                                      (set_local $11
                                         (get_local $0)
                                       )
                                       (br $do-once63)
@@ -12391,7 +12373,7 @@
                                       (i32.const 8)
                                     )
                                   )
-                                  (set_local $17
+                                  (set_local $11
                                     (get_local $2)
                                   )
                                 )
@@ -12399,18 +12381,18 @@
                             )
                             (i32.store
                               (get_local $22)
-                              (get_local $10)
+                              (get_local $7)
                             )
                             (i32.store offset=12
-                              (get_local $17)
-                              (get_local $10)
+                              (get_local $11)
+                              (get_local $7)
                             )
                             (i32.store offset=8
-                              (get_local $10)
-                              (get_local $17)
+                              (get_local $7)
+                              (get_local $11)
                             )
                             (i32.store offset=12
-                              (get_local $10)
+                              (get_local $7)
                               (get_local $2)
                             )
                             (br $do-once48)
@@ -12528,13 +12510,13 @@
                           )
                         )
                         (i32.store offset=28
-                          (get_local $10)
+                          (get_local $7)
                           (get_local $3)
                         )
                         (i32.store offset=4
                           (tee_local $0
                             (i32.add
-                              (get_local $10)
+                              (get_local $7)
                               (i32.const 16)
                             )
                           )
@@ -12570,19 +12552,19 @@
                             )
                             (i32.store
                               (get_local $2)
-                              (get_local $10)
+                              (get_local $7)
                             )
                             (i32.store offset=24
-                              (get_local $10)
+                              (get_local $7)
                               (get_local $2)
                             )
                             (i32.store offset=12
-                              (get_local $10)
-                              (get_local $10)
+                              (get_local $7)
+                              (get_local $7)
                             )
                             (i32.store offset=8
-                              (get_local $10)
-                              (get_local $10)
+                              (get_local $7)
+                              (get_local $7)
                             )
                             (br $do-once48)
                           )
@@ -12677,19 +12659,19 @@
                               (block
                                 (i32.store
                                   (get_local $3)
-                                  (get_local $10)
+                                  (get_local $7)
                                 )
                                 (i32.store offset=24
-                                  (get_local $10)
+                                  (get_local $7)
                                   (get_local $0)
                                 )
                                 (i32.store offset=12
-                                  (get_local $10)
-                                  (get_local $10)
+                                  (get_local $7)
+                                  (get_local $7)
                                 )
                                 (i32.store offset=8
-                                  (get_local $10)
-                                  (get_local $10)
+                                  (get_local $7)
+                                  (get_local $7)
                                 )
                                 (br $do-once48)
                               )
@@ -12723,22 +12705,22 @@
                             (block
                               (i32.store offset=12
                                 (get_local $3)
-                                (get_local $10)
+                                (get_local $7)
                               )
                               (i32.store
                                 (get_local $2)
-                                (get_local $10)
+                                (get_local $7)
                               )
                               (i32.store offset=8
-                                (get_local $10)
+                                (get_local $7)
                                 (get_local $3)
                               )
                               (i32.store offset=12
-                                (get_local $10)
+                                (get_local $7)
                                 (get_local $0)
                               )
                               (i32.store offset=24
-                                (get_local $10)
+                                (get_local $7)
                                 (i32.const 0)
                               )
                             )
@@ -12761,30 +12743,24 @@
               (block $while-out69
                 (if
                   (i32.le_u
-                    (tee_local $1
+                    (tee_local $3
                       (i32.load
                         (get_local $4)
                       )
                     )
                     (get_local $8)
                   )
-                  (if
+                  (br_if $while-out69
                     (i32.gt_u
-                      (tee_local $1
+                      (tee_local $3
                         (i32.add
-                          (get_local $1)
+                          (get_local $3)
                           (i32.load offset=4
                             (get_local $4)
                           )
                         )
                       )
                       (get_local $8)
-                    )
-                    (block
-                      (set_local $4
-                        (get_local $1)
-                      )
-                      (br $while-out69)
                     )
                   )
                 )
@@ -12798,9 +12774,9 @@
             )
             (set_local $9
               (i32.add
-                (tee_local $1
+                (tee_local $4
                   (i32.add
-                    (get_local $4)
+                    (get_local $3)
                     (i32.const -47)
                   )
                 )
@@ -12812,9 +12788,9 @@
                 (tee_local $11
                   (select
                     (get_local $8)
-                    (tee_local $1
+                    (tee_local $4
                       (i32.add
-                        (get_local $1)
+                        (get_local $4)
                         (select
                           (i32.and
                             (i32.sub
@@ -12832,7 +12808,7 @@
                       )
                     )
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $4)
                       (tee_local $9
                         (i32.add
                           (get_local $8)
@@ -12849,15 +12825,15 @@
               (i32.const 200)
               (tee_local $6
                 (i32.add
-                  (get_local $3)
-                  (tee_local $1
+                  (get_local $2)
+                  (tee_local $4
                     (select
                       (i32.and
                         (i32.sub
                           (i32.const 0)
-                          (tee_local $1
+                          (tee_local $4
                             (i32.add
-                              (get_local $3)
+                              (get_local $2)
                               (i32.const 8)
                             )
                           )
@@ -12866,7 +12842,7 @@
                       )
                       (i32.const 0)
                       (i32.and
-                        (get_local $1)
+                        (get_local $4)
                         (i32.const 7)
                       )
                     )
@@ -12876,27 +12852,27 @@
             )
             (i32.store
               (i32.const 188)
-              (tee_local $1
+              (tee_local $4
                 (i32.sub
                   (i32.add
-                    (get_local $2)
+                    (get_local $1)
                     (i32.const -40)
                   )
-                  (get_local $1)
+                  (get_local $4)
                 )
               )
             )
             (i32.store offset=4
               (get_local $6)
               (i32.or
-                (get_local $1)
+                (get_local $4)
                 (i32.const 1)
               )
             )
             (i32.store offset=4
               (i32.add
                 (get_local $6)
-                (get_local $1)
+                (get_local $4)
               )
               (i32.const 40)
             )
@@ -12907,7 +12883,7 @@
               )
             )
             (i32.store
-              (tee_local $6
+              (tee_local $4
                 (i32.add
                   (get_local $11)
                   (i32.const 4)
@@ -12941,11 +12917,11 @@
             )
             (i32.store
               (i32.const 624)
-              (get_local $3)
+              (get_local $2)
             )
             (i32.store
               (i32.const 628)
-              (get_local $2)
+              (get_local $1)
             )
             (i32.store
               (i32.const 636)
@@ -12977,7 +12953,7 @@
                     (get_local $1)
                     (i32.const 4)
                   )
-                  (get_local $4)
+                  (get_local $3)
                 )
               )
             )
@@ -12988,10 +12964,10 @@
               )
               (block
                 (i32.store
-                  (get_local $6)
+                  (get_local $4)
                   (i32.and
                     (i32.load
-                      (get_local $6)
+                      (get_local $4)
                     )
                     (i32.const -2)
                   )
@@ -13071,7 +13047,7 @@
                           (set_local $23
                             (get_local $2)
                           )
-                          (set_local $10
+                          (set_local $12
                             (get_local $1)
                           )
                         )
@@ -13090,7 +13066,7 @@
                             (i32.const 8)
                           )
                         )
-                        (set_local $10
+                        (set_local $12
                           (get_local $3)
                         )
                       )
@@ -13100,12 +13076,12 @@
                       (get_local $8)
                     )
                     (i32.store offset=12
-                      (get_local $10)
+                      (get_local $12)
                       (get_local $8)
                     )
                     (i32.store offset=8
                       (get_local $8)
-                      (get_local $10)
+                      (get_local $12)
                     )
                     (i32.store offset=12
                       (get_local $8)
@@ -13439,29 +13415,29 @@
             (if
               (i32.or
                 (i32.eqz
-                  (tee_local $1
+                  (tee_local $3
                     (i32.load
                       (i32.const 192)
                     )
                   )
                 )
                 (i32.lt_u
+                  (get_local $2)
                   (get_local $3)
-                  (get_local $1)
                 )
               )
               (i32.store
                 (i32.const 192)
-                (get_local $3)
+                (get_local $2)
               )
             )
             (i32.store
               (i32.const 624)
-              (get_local $3)
+              (get_local $2)
             )
             (i32.store
               (i32.const 628)
-              (get_local $2)
+              (get_local $1)
             )
             (i32.store
               (i32.const 636)
@@ -13477,7 +13453,7 @@
               (i32.const 208)
               (i32.const -1)
             )
-            (set_local $1
+            (set_local $3
               (i32.const 0)
             )
             (loop $while-in43
@@ -13487,7 +13463,7 @@
                     (i32.const 216)
                     (i32.shl
                       (i32.shl
-                        (get_local $1)
+                        (get_local $3)
                         (i32.const 1)
                       )
                       (i32.const 2)
@@ -13502,9 +13478,9 @@
               )
               (br_if $while-in43
                 (i32.ne
-                  (tee_local $1
+                  (tee_local $3
                     (i32.add
-                      (get_local $1)
+                      (get_local $3)
                       (i32.const 1)
                     )
                   )
@@ -13516,15 +13492,15 @@
               (i32.const 200)
               (tee_local $3
                 (i32.add
-                  (get_local $3)
-                  (tee_local $1
+                  (get_local $2)
+                  (tee_local $2
                     (select
                       (i32.and
                         (i32.sub
                           (i32.const 0)
-                          (tee_local $1
+                          (tee_local $2
                             (i32.add
-                              (get_local $3)
+                              (get_local $2)
                               (i32.const 8)
                             )
                           )
@@ -13533,7 +13509,7 @@
                       )
                       (i32.const 0)
                       (i32.and
-                        (get_local $1)
+                        (get_local $2)
                         (i32.const 7)
                       )
                     )
@@ -13546,10 +13522,10 @@
               (tee_local $1
                 (i32.sub
                   (i32.add
-                    (get_local $2)
+                    (get_local $1)
                     (i32.const -40)
                   )
-                  (get_local $1)
+                  (get_local $2)
                 )
               )
             )
@@ -13661,7 +13637,7 @@
     )
     (if
       (i32.lt_u
-        (tee_local $4
+        (tee_local $1
           (i32.add
             (get_local $0)
             (i32.const -8)
@@ -13677,9 +13653,9 @@
     )
     (if
       (i32.eq
-        (tee_local $10
+        (tee_local $5
           (i32.and
-            (tee_local $2
+            (tee_local $7
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -13694,12 +13670,12 @@
       )
       (call $_abort)
     )
-    (set_local $6
+    (set_local $8
       (i32.add
-        (get_local $4)
+        (get_local $1)
         (tee_local $0
           (i32.and
-            (get_local $2)
+            (get_local $7)
             (i32.const -8)
           )
         )
@@ -13708,43 +13684,43 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $2)
+          (get_local $7)
           (i32.const 1)
         )
         (block
-          (set_local $3
-            (get_local $4)
+          (set_local $2
+            (get_local $1)
           )
-          (set_local $1
+          (set_local $3
             (get_local $0)
           )
         )
         (block
-          (set_local $8
+          (set_local $7
             (i32.load
-              (get_local $4)
+              (get_local $1)
             )
           )
           (if
             (i32.eqz
-              (get_local $10)
+              (get_local $5)
             )
             (return)
           )
-          (set_local $2
+          (set_local $0
             (i32.add
-              (get_local $8)
+              (get_local $7)
               (get_local $0)
             )
           )
           (if
             (i32.lt_u
-              (tee_local $0
+              (tee_local $1
                 (i32.add
-                  (get_local $4)
+                  (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $8)
+                    (get_local $7)
                   )
                 )
               )
@@ -13754,7 +13730,7 @@
           )
           (if
             (i32.eq
-              (get_local $0)
+              (get_local $1)
               (i32.load
                 (i32.const 196)
               )
@@ -13765,9 +13741,9 @@
                   (i32.and
                     (tee_local $3
                       (i32.load
-                        (tee_local $1
+                        (tee_local $2
                           (i32.add
-                            (get_local $6)
+                            (get_local $8)
                             (i32.const 4)
                           )
                         )
@@ -13778,73 +13754,73 @@
                   (i32.const 3)
                 )
                 (block
+                  (set_local $2
+                    (get_local $1)
+                  )
                   (set_local $3
                     (get_local $0)
-                  )
-                  (set_local $1
-                    (get_local $2)
                   )
                   (br $do-once)
                 )
               )
               (i32.store
                 (i32.const 184)
-                (get_local $2)
+                (get_local $0)
               )
               (i32.store
-                (get_local $1)
+                (get_local $2)
                 (i32.and
                   (get_local $3)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $0)
+                (get_local $1)
                 (i32.or
-                  (get_local $2)
+                  (get_local $0)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
+                  (get_local $1)
                   (get_local $0)
-                  (get_local $2)
                 )
-                (get_local $2)
+                (get_local $0)
               )
               (return)
             )
           )
-          (set_local $10
+          (set_local $5
             (i32.shr_u
-              (get_local $8)
+              (get_local $7)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $8)
+              (get_local $7)
               (i32.const 256)
             )
             (block
-              (set_local $3
+              (set_local $6
                 (i32.load offset=12
-                  (get_local $0)
+                  (get_local $1)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $4
+                  (tee_local $2
                     (i32.load offset=8
-                      (get_local $0)
+                      (get_local $1)
                     )
                   )
-                  (tee_local $1
+                  (tee_local $3
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $10)
+                          (get_local $5)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -13855,7 +13831,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $4)
+                      (get_local $2)
                       (get_local $11)
                     )
                     (call $_abort)
@@ -13863,9 +13839,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $4)
+                        (get_local $2)
                       )
-                      (get_local $0)
+                      (get_local $1)
                     )
                     (call $_abort)
                   )
@@ -13873,8 +13849,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $3)
-                  (get_local $4)
+                  (get_local $6)
+                  (get_local $2)
                 )
                 (block
                   (i32.store
@@ -13886,36 +13862,36 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $10)
+                          (get_local $5)
                         )
                         (i32.const -1)
                       )
                     )
                   )
+                  (set_local $2
+                    (get_local $1)
+                  )
                   (set_local $3
                     (get_local $0)
-                  )
-                  (set_local $1
-                    (get_local $2)
                   )
                   (br $do-once)
                 )
               )
               (if
                 (i32.eq
+                  (get_local $6)
                   (get_local $3)
-                  (get_local $1)
                 )
-                (set_local $5
+                (set_local $4
                   (i32.add
-                    (get_local $3)
+                    (get_local $6)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $3)
+                      (get_local $6)
                       (get_local $11)
                     )
                     (call $_abort)
@@ -13923,42 +13899,42 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $1
+                        (tee_local $3
                           (i32.add
-                            (get_local $3)
+                            (get_local $6)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $0)
-                    )
-                    (set_local $5
                       (get_local $1)
+                    )
+                    (set_local $4
+                      (get_local $3)
                     )
                     (call $_abort)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $4)
-                (get_local $3)
+                (get_local $2)
+                (get_local $6)
               )
               (i32.store
-                (get_local $5)
                 (get_local $4)
+                (get_local $2)
+              )
+              (set_local $2
+                (get_local $1)
               )
               (set_local $3
                 (get_local $0)
-              )
-              (set_local $1
-                (get_local $2)
               )
               (br $do-once)
             )
           )
           (set_local $12
             (i32.load offset=24
-              (get_local $0)
+              (get_local $1)
             )
           )
           (block $do-once0
@@ -13966,41 +13942,41 @@
               (i32.eq
                 (tee_local $4
                   (i32.load offset=12
-                    (get_local $0)
+                    (get_local $1)
                   )
                 )
-                (get_local $0)
+                (get_local $1)
               )
               (block
                 (if
-                  (tee_local $4
-                    (i32.load
-                      (tee_local $8
-                        (i32.add
-                          (tee_local $5
-                            (i32.add
-                              (get_local $0)
-                              (i32.const 16)
+                  (i32.eqz
+                    (tee_local $5
+                      (i32.load
+                        (tee_local $4
+                          (i32.add
+                            (tee_local $7
+                              (i32.add
+                                (get_local $1)
+                                (i32.const 16)
+                              )
                             )
+                            (i32.const 4)
                           )
-                          (i32.const 4)
                         )
                       )
                     )
-                  )
-                  (set_local $5
-                    (get_local $8)
                   )
                   (if
-                    (i32.eqz
-                      (tee_local $4
-                        (i32.load
-                          (get_local $5)
-                        )
+                    (tee_local $5
+                      (i32.load
+                        (get_local $7)
                       )
                     )
+                    (set_local $4
+                      (get_local $7)
+                    )
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.const 0)
                       )
                       (br $do-once0)
@@ -14009,43 +13985,43 @@
                 )
                 (loop $while-in
                   (if
-                    (tee_local $10
+                    (tee_local $7
                       (i32.load
-                        (tee_local $8
+                        (tee_local $10
                           (i32.add
-                            (get_local $4)
+                            (get_local $5)
                             (i32.const 20)
                           )
                         )
                       )
                     )
                     (block
+                      (set_local $5
+                        (get_local $7)
+                      )
                       (set_local $4
                         (get_local $10)
-                      )
-                      (set_local $5
-                        (get_local $8)
                       )
                       (br $while-in)
                     )
                   )
                   (if
-                    (tee_local $10
+                    (tee_local $7
                       (i32.load
-                        (tee_local $8
+                        (tee_local $10
                           (i32.add
-                            (get_local $4)
+                            (get_local $5)
                             (i32.const 16)
                           )
                         )
                       )
                     )
                     (block
+                      (set_local $5
+                        (get_local $7)
+                      )
                       (set_local $4
                         (get_local $10)
-                      )
-                      (set_local $5
-                        (get_local $8)
                       )
                       (br $while-in)
                     )
@@ -14053,17 +14029,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $5)
+                    (get_local $4)
                     (get_local $11)
                   )
                   (call $_abort)
                   (block
                     (i32.store
-                      (get_local $5)
+                      (get_local $4)
                       (i32.const 0)
                     )
-                    (set_local $7
-                      (get_local $4)
+                    (set_local $6
+                      (get_local $5)
                     )
                   )
                 )
@@ -14071,9 +14047,9 @@
               (block
                 (if
                   (i32.lt_u
-                    (tee_local $5
+                    (tee_local $10
                       (i32.load offset=8
-                        (get_local $0)
+                        (get_local $1)
                       )
                     )
                     (get_local $11)
@@ -14083,39 +14059,39 @@
                 (if
                   (i32.ne
                     (i32.load
-                      (tee_local $8
+                      (tee_local $7
                         (i32.add
-                          (get_local $5)
+                          (get_local $10)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $1)
                   )
                   (call $_abort)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $10
+                      (tee_local $5
                         (i32.add
                           (get_local $4)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $1)
                   )
                   (block
                     (i32.store
-                      (get_local $8)
+                      (get_local $7)
                       (get_local $4)
                     )
                     (i32.store
-                      (get_local $10)
                       (get_local $5)
+                      (get_local $10)
                     )
-                    (set_local $7
+                    (set_local $6
                       (get_local $4)
                     )
                   )
@@ -14129,15 +14105,15 @@
             (block
               (if
                 (i32.eq
-                  (get_local $0)
+                  (get_local $1)
                   (i32.load
-                    (tee_local $5
+                    (tee_local $4
                       (i32.add
                         (i32.const 480)
                         (i32.shl
-                          (tee_local $4
+                          (tee_local $5
                             (i32.load offset=28
-                              (get_local $0)
+                              (get_local $1)
                             )
                           )
                           (i32.const 2)
@@ -14148,12 +14124,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $5)
-                    (get_local $7)
+                    (get_local $4)
+                    (get_local $6)
                   )
                   (if
                     (i32.eqz
-                      (get_local $7)
+                      (get_local $6)
                     )
                     (block
                       (i32.store
@@ -14165,17 +14141,17 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $4)
+                              (get_local $5)
                             )
                             (i32.const -1)
                           )
                         )
                       )
+                      (set_local $2
+                        (get_local $1)
+                      )
                       (set_local $3
                         (get_local $0)
-                      )
-                      (set_local $1
-                        (get_local $2)
                       )
                       (br $do-once)
                     )
@@ -14201,27 +14177,27 @@
                           )
                         )
                       )
-                      (get_local $0)
+                      (get_local $1)
                     )
                     (i32.store
                       (get_local $4)
-                      (get_local $7)
+                      (get_local $6)
                     )
                     (i32.store offset=20
                       (get_local $12)
-                      (get_local $7)
+                      (get_local $6)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $7)
+                      (get_local $6)
                     )
                     (block
+                      (set_local $2
+                        (get_local $1)
+                      )
                       (set_local $3
                         (get_local $0)
-                      )
-                      (set_local $1
-                        (get_local $2)
                       )
                       (br $do-once)
                     )
@@ -14230,7 +14206,7 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $7)
+                  (get_local $6)
                   (tee_local $5
                     (i32.load
                       (i32.const 192)
@@ -14240,15 +14216,15 @@
                 (call $_abort)
               )
               (i32.store offset=24
-                (get_local $7)
+                (get_local $6)
                 (get_local $12)
               )
               (if
-                (tee_local $4
+                (tee_local $7
                   (i32.load
-                    (tee_local $8
+                    (tee_local $4
                       (i32.add
-                        (get_local $0)
+                        (get_local $1)
                         (i32.const 16)
                       )
                     )
@@ -14256,18 +14232,18 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $4)
+                    (get_local $7)
                     (get_local $5)
                   )
                   (call $_abort)
                   (block
                     (i32.store offset=16
+                      (get_local $6)
                       (get_local $7)
-                      (get_local $4)
                     )
                     (i32.store offset=24
-                      (get_local $4)
                       (get_local $7)
+                      (get_local $6)
                     )
                   )
                 )
@@ -14275,7 +14251,7 @@
               (if
                 (tee_local $4
                   (i32.load offset=4
-                    (get_local $8)
+                    (get_local $4)
                   )
                 )
                 (if
@@ -14288,37 +14264,37 @@
                   (call $_abort)
                   (block
                     (i32.store offset=20
-                      (get_local $7)
+                      (get_local $6)
                       (get_local $4)
                     )
                     (i32.store offset=24
                       (get_local $4)
-                      (get_local $7)
+                      (get_local $6)
+                    )
+                    (set_local $2
+                      (get_local $1)
                     )
                     (set_local $3
                       (get_local $0)
                     )
-                    (set_local $1
-                      (get_local $2)
-                    )
                   )
                 )
                 (block
+                  (set_local $2
+                    (get_local $1)
+                  )
                   (set_local $3
                     (get_local $0)
-                  )
-                  (set_local $1
-                    (get_local $2)
                   )
                 )
               )
             )
             (block
+              (set_local $2
+                (get_local $1)
+              )
               (set_local $3
                 (get_local $0)
-              )
-              (set_local $1
-                (get_local $2)
               )
             )
           )
@@ -14327,19 +14303,19 @@
     )
     (if
       (i32.ge_u
-        (get_local $3)
-        (get_local $6)
+        (get_local $2)
+        (get_local $8)
       )
       (call $_abort)
     )
     (if
       (i32.eqz
         (i32.and
-          (tee_local $0
+          (tee_local $1
             (i32.load
-              (tee_local $2
+              (tee_local $0
                 (i32.add
-                  (get_local $6)
+                  (get_local $8)
                   (i32.const 4)
                 )
               )
@@ -14352,36 +14328,36 @@
     )
     (if
       (i32.and
-        (get_local $0)
+        (get_local $1)
         (i32.const 2)
       )
       (block
         (i32.store
-          (get_local $2)
+          (get_local $0)
           (i32.and
-            (get_local $0)
+            (get_local $1)
             (i32.const -2)
           )
         )
         (i32.store offset=4
-          (get_local $3)
+          (get_local $2)
           (i32.or
-            (get_local $1)
+            (get_local $3)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
+            (get_local $2)
             (get_local $3)
-            (get_local $1)
           )
-          (get_local $1)
+          (get_local $3)
         )
       )
       (block
         (if
           (i32.eq
-            (get_local $6)
+            (get_local $8)
             (i32.load
               (i32.const 200)
             )
@@ -14394,16 +14370,16 @@
                   (i32.load
                     (i32.const 188)
                   )
-                  (get_local $1)
+                  (get_local $3)
                 )
               )
             )
             (i32.store
               (i32.const 200)
-              (get_local $3)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
                 (get_local $0)
                 (i32.const 1)
@@ -14411,7 +14387,7 @@
             )
             (if
               (i32.ne
-                (get_local $3)
+                (get_local $2)
                 (i32.load
                   (i32.const 196)
                 )
@@ -14431,7 +14407,7 @@
         )
         (if
           (i32.eq
-            (get_local $6)
+            (get_local $8)
             (i32.load
               (i32.const 196)
             )
@@ -14444,16 +14420,16 @@
                   (i32.load
                     (i32.const 184)
                   )
-                  (get_local $1)
+                  (get_local $3)
                 )
               )
             )
             (i32.store
               (i32.const 196)
-              (get_local $3)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $3)
+              (get_local $2)
               (i32.or
                 (get_local $0)
                 (i32.const 1)
@@ -14461,7 +14437,7 @@
             )
             (i32.store
               (i32.add
-                (get_local $3)
+                (get_local $2)
                 (get_local $0)
               )
               (get_local $0)
@@ -14472,35 +14448,35 @@
         (set_local $5
           (i32.add
             (i32.and
-              (get_local $0)
+              (get_local $1)
               (i32.const -8)
             )
-            (get_local $1)
+            (get_local $3)
           )
         )
-        (set_local $4
+        (set_local $3
           (i32.shr_u
-            (get_local $0)
+            (get_local $1)
             (i32.const 3)
           )
         )
         (block $do-once4
           (if
             (i32.lt_u
-              (get_local $0)
+              (get_local $1)
               (i32.const 256)
             )
             (block
-              (set_local $1
+              (set_local $4
                 (i32.load offset=12
-                  (get_local $6)
+                  (get_local $8)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $2
+                  (tee_local $1
                     (i32.load offset=8
-                      (get_local $6)
+                      (get_local $8)
                     )
                   )
                   (tee_local $0
@@ -14508,68 +14484,12 @@
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $4)
+                          (get_local $3)
                           (i32.const 1)
                         )
                         (i32.const 2)
                       )
                     )
-                  )
-                )
-                (block
-                  (if
-                    (i32.lt_u
-                      (get_local $2)
-                      (i32.load
-                        (i32.const 192)
-                      )
-                    )
-                    (call $_abort)
-                  )
-                  (if
-                    (i32.ne
-                      (i32.load offset=12
-                        (get_local $2)
-                      )
-                      (get_local $6)
-                    )
-                    (call $_abort)
-                  )
-                )
-              )
-              (if
-                (i32.eq
-                  (get_local $1)
-                  (get_local $2)
-                )
-                (block
-                  (i32.store
-                    (i32.const 176)
-                    (i32.and
-                      (i32.load
-                        (i32.const 176)
-                      )
-                      (i32.xor
-                        (i32.shl
-                          (i32.const 1)
-                          (get_local $4)
-                        )
-                        (i32.const -1)
-                      )
-                    )
-                  )
-                  (br $do-once4)
-                )
-              )
-              (if
-                (i32.eq
-                  (get_local $1)
-                  (get_local $0)
-                )
-                (set_local $14
-                  (i32.add
-                    (get_local $1)
-                    (i32.const 8)
                   )
                 )
                 (block
@@ -14583,16 +14503,72 @@
                     (call $_abort)
                   )
                   (if
+                    (i32.ne
+                      (i32.load offset=12
+                        (get_local $1)
+                      )
+                      (get_local $8)
+                    )
+                    (call $_abort)
+                  )
+                )
+              )
+              (if
+                (i32.eq
+                  (get_local $4)
+                  (get_local $1)
+                )
+                (block
+                  (i32.store
+                    (i32.const 176)
+                    (i32.and
+                      (i32.load
+                        (i32.const 176)
+                      )
+                      (i32.xor
+                        (i32.shl
+                          (i32.const 1)
+                          (get_local $3)
+                        )
+                        (i32.const -1)
+                      )
+                    )
+                  )
+                  (br $do-once4)
+                )
+              )
+              (if
+                (i32.eq
+                  (get_local $4)
+                  (get_local $0)
+                )
+                (set_local $14
+                  (i32.add
+                    (get_local $4)
+                    (i32.const 8)
+                  )
+                )
+                (block
+                  (if
+                    (i32.lt_u
+                      (get_local $4)
+                      (i32.load
+                        (i32.const 192)
+                      )
+                    )
+                    (call $_abort)
+                  )
+                  (if
                     (i32.eq
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $1)
+                            (get_local $4)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $6)
+                      (get_local $8)
                     )
                     (set_local $14
                       (get_local $0)
@@ -14602,18 +14578,18 @@
                 )
               )
               (i32.store offset=12
-                (get_local $2)
                 (get_local $1)
+                (get_local $4)
               )
               (i32.store
                 (get_local $14)
-                (get_local $2)
+                (get_local $1)
               )
             )
             (block
-              (set_local $7
+              (set_local $6
                 (i32.load offset=24
-                  (get_local $6)
+                  (get_local $8)
                 )
               )
               (block $do-once6
@@ -14621,38 +14597,38 @@
                   (i32.eq
                     (tee_local $0
                       (i32.load offset=12
-                        (get_local $6)
+                        (get_local $8)
                       )
                     )
-                    (get_local $6)
+                    (get_local $8)
                   )
                   (block
                     (if
-                      (tee_local $0
-                        (i32.load
-                          (tee_local $2
-                            (i32.add
-                              (tee_local $1
-                                (i32.add
-                                  (get_local $6)
-                                  (i32.const 16)
+                      (i32.eqz
+                        (tee_local $3
+                          (i32.load
+                            (tee_local $0
+                              (i32.add
+                                (tee_local $1
+                                  (i32.add
+                                    (get_local $8)
+                                    (i32.const 16)
+                                  )
                                 )
+                                (i32.const 4)
                               )
-                              (i32.const 4)
                             )
                           )
                         )
                       )
-                      (set_local $1
-                        (get_local $2)
-                      )
                       (if
-                        (i32.eqz
-                          (tee_local $0
-                            (i32.load
-                              (get_local $1)
-                            )
+                        (tee_local $3
+                          (i32.load
+                            (get_local $1)
                           )
+                        )
+                        (set_local $0
+                          (get_local $1)
                         )
                         (block
                           (set_local $9
@@ -14664,43 +14640,43 @@
                     )
                     (loop $while-in9
                       (if
-                        (tee_local $4
+                        (tee_local $1
                           (i32.load
-                            (tee_local $2
+                            (tee_local $4
                               (i32.add
-                                (get_local $0)
+                                (get_local $3)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
+                          (set_local $3
+                            (get_local $1)
+                          )
                           (set_local $0
                             (get_local $4)
-                          )
-                          (set_local $1
-                            (get_local $2)
                           )
                           (br $while-in9)
                         )
                       )
                       (if
-                        (tee_local $4
+                        (tee_local $1
                           (i32.load
-                            (tee_local $2
+                            (tee_local $4
                               (i32.add
-                                (get_local $0)
+                                (get_local $3)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
+                          (set_local $3
+                            (get_local $1)
+                          )
                           (set_local $0
                             (get_local $4)
-                          )
-                          (set_local $1
-                            (get_local $2)
                           )
                           (br $while-in9)
                         )
@@ -14708,7 +14684,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $0)
                         (i32.load
                           (i32.const 192)
                         )
@@ -14716,11 +14692,11 @@
                       (call $_abort)
                       (block
                         (i32.store
-                          (get_local $1)
+                          (get_local $0)
                           (i32.const 0)
                         )
                         (set_local $9
-                          (get_local $0)
+                          (get_local $3)
                         )
                       )
                     )
@@ -14728,9 +14704,9 @@
                   (block
                     (if
                       (i32.lt_u
-                        (tee_local $1
+                        (tee_local $4
                           (i32.load offset=8
-                            (get_local $6)
+                            (get_local $8)
                           )
                         )
                         (i32.load
@@ -14742,37 +14718,37 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (tee_local $2
+                          (tee_local $1
                             (i32.add
-                              (get_local $1)
+                              (get_local $4)
                               (i32.const 12)
                             )
                           )
                         )
-                        (get_local $6)
+                        (get_local $8)
                       )
                       (call $_abort)
                     )
                     (if
                       (i32.eq
                         (i32.load
-                          (tee_local $4
+                          (tee_local $3
                             (i32.add
                               (get_local $0)
                               (i32.const 8)
                             )
                           )
                         )
-                        (get_local $6)
+                        (get_local $8)
                       )
                       (block
                         (i32.store
-                          (get_local $2)
+                          (get_local $1)
                           (get_local $0)
                         )
                         (i32.store
+                          (get_local $3)
                           (get_local $4)
-                          (get_local $1)
                         )
                         (set_local $9
                           (get_local $0)
@@ -14784,19 +14760,19 @@
                 )
               )
               (if
-                (get_local $7)
+                (get_local $6)
                 (block
                   (if
                     (i32.eq
-                      (get_local $6)
+                      (get_local $8)
                       (i32.load
-                        (tee_local $1
+                        (tee_local $0
                           (i32.add
                             (i32.const 480)
                             (i32.shl
-                              (tee_local $0
+                              (tee_local $3
                                 (i32.load offset=28
-                                  (get_local $6)
+                                  (get_local $8)
                                 )
                               )
                               (i32.const 2)
@@ -14807,7 +14783,7 @@
                     )
                     (block
                       (i32.store
-                        (get_local $1)
+                        (get_local $0)
                         (get_local $9)
                       )
                       (if
@@ -14824,7 +14800,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $0)
+                                  (get_local $3)
                                 )
                                 (i32.const -1)
                               )
@@ -14837,7 +14813,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $7)
+                          (get_local $6)
                           (i32.load
                             (i32.const 192)
                           )
@@ -14849,19 +14825,19 @@
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $7)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                             )
                           )
-                          (get_local $6)
+                          (get_local $8)
                         )
                         (i32.store
                           (get_local $0)
                           (get_local $9)
                         )
                         (i32.store offset=20
-                          (get_local $7)
+                          (get_local $6)
                           (get_local $9)
                         )
                       )
@@ -14875,7 +14851,7 @@
                   (if
                     (i32.lt_u
                       (get_local $9)
-                      (tee_local $1
+                      (tee_local $3
                         (i32.load
                           (i32.const 192)
                         )
@@ -14885,14 +14861,14 @@
                   )
                   (i32.store offset=24
                     (get_local $9)
-                    (get_local $7)
+                    (get_local $6)
                   )
                   (if
-                    (tee_local $0
+                    (tee_local $1
                       (i32.load
-                        (tee_local $2
+                        (tee_local $0
                           (i32.add
-                            (get_local $6)
+                            (get_local $8)
                             (i32.const 16)
                           )
                         )
@@ -14900,17 +14876,17 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $0)
                         (get_local $1)
+                        (get_local $3)
                       )
                       (call $_abort)
                       (block
                         (i32.store offset=16
                           (get_local $9)
-                          (get_local $0)
+                          (get_local $1)
                         )
                         (i32.store offset=24
-                          (get_local $0)
+                          (get_local $1)
                           (get_local $9)
                         )
                       )
@@ -14919,7 +14895,7 @@
                   (if
                     (tee_local $0
                       (i32.load offset=4
-                        (get_local $2)
+                        (get_local $0)
                       )
                     )
                     (if
@@ -14948,7 +14924,7 @@
           )
         )
         (i32.store offset=4
-          (get_local $3)
+          (get_local $2)
           (i32.or
             (get_local $5)
             (i32.const 1)
@@ -14956,14 +14932,14 @@
         )
         (i32.store
           (i32.add
-            (get_local $3)
+            (get_local $2)
             (get_local $5)
           )
           (get_local $5)
         )
         (if
           (i32.eq
-            (get_local $3)
+            (get_local $2)
             (i32.load
               (i32.const 196)
             )
@@ -14975,30 +14951,30 @@
             )
             (return)
           )
-          (set_local $1
+          (set_local $3
             (get_local $5)
           )
         )
       )
     )
-    (set_local $2
+    (set_local $0
       (i32.shr_u
-        (get_local $1)
+        (get_local $3)
         (i32.const 3)
       )
     )
     (if
       (i32.lt_u
-        (get_local $1)
+        (get_local $3)
         (i32.const 256)
       )
       (block
-        (set_local $0
+        (set_local $1
           (i32.add
             (i32.const 216)
             (i32.shl
               (i32.shl
-                (get_local $2)
+                (get_local $0)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -15007,25 +14983,25 @@
         )
         (if
           (i32.and
-            (tee_local $1
+            (tee_local $3
               (i32.load
                 (i32.const 176)
               )
             )
-            (tee_local $2
+            (tee_local $0
               (i32.shl
                 (i32.const 1)
-                (get_local $2)
+                (get_local $0)
               )
             )
           )
           (if
             (i32.lt_u
-              (tee_local $2
+              (tee_local $0
                 (i32.load
-                  (tee_local $1
+                  (tee_local $3
                     (i32.add
-                      (get_local $0)
+                      (get_local $1)
                       (i32.const 8)
                     )
                   )
@@ -15038,10 +15014,10 @@
             (call $_abort)
             (block
               (set_local $15
-                (get_local $1)
+                (get_local $3)
               )
               (set_local $13
-                (get_local $2)
+                (get_local $0)
               )
             )
           )
@@ -15049,36 +15025,36 @@
             (i32.store
               (i32.const 176)
               (i32.or
-                (get_local $1)
-                (get_local $2)
+                (get_local $3)
+                (get_local $0)
               )
             )
             (set_local $15
               (i32.add
-                (get_local $0)
+                (get_local $1)
                 (i32.const 8)
               )
             )
             (set_local $13
-              (get_local $0)
+              (get_local $1)
             )
           )
         )
         (i32.store
           (get_local $15)
-          (get_local $3)
+          (get_local $2)
         )
         (i32.store offset=12
           (get_local $13)
-          (get_local $3)
+          (get_local $2)
         )
         (i32.store offset=8
-          (get_local $3)
+          (get_local $2)
           (get_local $13)
         )
         (i32.store offset=12
-          (get_local $3)
-          (get_local $0)
+          (get_local $2)
+          (get_local $1)
         )
         (return)
       )
@@ -15087,24 +15063,24 @@
       (i32.add
         (i32.const 480)
         (i32.shl
-          (tee_local $0
+          (tee_local $5
             (if i32
               (tee_local $0
                 (i32.shr_u
-                  (get_local $1)
+                  (get_local $3)
                   (i32.const 8)
                 )
               )
               (if i32
                 (i32.gt_u
-                  (get_local $1)
+                  (get_local $3)
                   (i32.const 16777215)
                 )
                 (i32.const 31)
                 (i32.or
                   (i32.and
                     (i32.shr_u
-                      (get_local $1)
+                      (get_local $3)
                       (i32.add
                         (tee_local $0
                           (i32.add
@@ -15112,14 +15088,14 @@
                               (i32.const 14)
                               (i32.or
                                 (i32.or
-                                  (tee_local $4
+                                  (tee_local $0
                                     (i32.and
                                       (i32.shr_u
                                         (i32.add
-                                          (tee_local $2
+                                          (tee_local $1
                                             (i32.shl
                                               (get_local $0)
-                                              (tee_local $0
+                                              (tee_local $4
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
@@ -15140,16 +15116,16 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $0)
+                                  (get_local $4)
                                 )
-                                (tee_local $2
+                                (tee_local $0
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (tee_local $0
+                                        (tee_local $1
                                           (i32.shl
-                                            (get_local $2)
-                                            (get_local $4)
+                                            (get_local $1)
+                                            (get_local $0)
                                           )
                                         )
                                         (i32.const 245760)
@@ -15163,8 +15139,8 @@
                             )
                             (i32.shr_u
                               (i32.shl
+                                (get_local $1)
                                 (get_local $0)
-                                (get_local $2)
                               )
                               (i32.const 15)
                             )
@@ -15189,47 +15165,47 @@
       )
     )
     (i32.store offset=28
-      (get_local $3)
-      (get_local $0)
+      (get_local $2)
+      (get_local $5)
     )
     (i32.store offset=20
-      (get_local $3)
+      (get_local $2)
       (i32.const 0)
     )
     (i32.store offset=16
-      (get_local $3)
+      (get_local $2)
       (i32.const 0)
     )
     (block $do-once12
       (if
         (i32.and
-          (tee_local $2
+          (tee_local $1
             (i32.load
               (i32.const 180)
             )
           )
-          (tee_local $5
+          (tee_local $0
             (i32.shl
               (i32.const 1)
-              (get_local $0)
+              (get_local $5)
             )
           )
         )
         (block
-          (set_local $2
+          (set_local $5
             (i32.shl
-              (get_local $1)
+              (get_local $3)
               (select
                 (i32.const 0)
                 (i32.sub
                   (i32.const 25)
                   (i32.shr_u
-                    (get_local $0)
+                    (get_local $5)
                     (i32.const 1)
                   )
                 )
                 (i32.eq
-                  (get_local $0)
+                  (get_local $5)
                   (i32.const 31)
                 )
               )
@@ -15252,59 +15228,52 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $1)
+                      (get_local $3)
                     )
                   )
                   (set_local $4
                     (i32.shl
-                      (get_local $2)
+                      (get_local $5)
                       (i32.const 1)
                     )
                   )
-                  (if
-                    (tee_local $5
-                      (i32.load
-                        (tee_local $2
-                          (i32.add
+                  (br_if $jumpthreading$inner$0
+                    (i32.eqz
+                      (tee_local $1
+                        (i32.load
+                          (tee_local $5
                             (i32.add
-                              (get_local $0)
-                              (i32.const 16)
-                            )
-                            (i32.shl
-                              (i32.shr_u
-                                (get_local $2)
-                                (i32.const 31)
+                              (i32.add
+                                (get_local $0)
+                                (i32.const 16)
                               )
-                              (i32.const 2)
+                              (i32.shl
+                                (i32.shr_u
+                                  (get_local $5)
+                                  (i32.const 31)
+                                )
+                                (i32.const 2)
+                              )
                             )
                           )
                         )
                       )
                     )
-                    (block
-                      (set_local $2
-                        (get_local $4)
-                      )
-                      (set_local $0
-                        (get_local $5)
-                      )
-                      (br $while-in15)
+                  )
+                  (block
+                    (set_local $5
+                      (get_local $4)
                     )
-                    (block
-                      (set_local $1
-                        (get_local $0)
-                      )
-                      (set_local $0
-                        (get_local $2)
-                      )
-                      (br $jumpthreading$inner$0)
+                    (set_local $0
+                      (get_local $1)
                     )
+                    (br $while-in15)
                   )
                 )
               )
               (if
                 (i32.lt_u
-                  (get_local $0)
+                  (get_local $5)
                   (i32.load
                     (i32.const 192)
                   )
@@ -15312,20 +15281,20 @@
                 (call $_abort)
                 (block
                   (i32.store
-                    (get_local $0)
-                    (get_local $3)
+                    (get_local $5)
+                    (get_local $2)
                   )
                   (i32.store offset=24
-                    (get_local $3)
-                    (get_local $1)
+                    (get_local $2)
+                    (get_local $0)
                   )
                   (i32.store offset=12
-                    (get_local $3)
-                    (get_local $3)
+                    (get_local $2)
+                    (get_local $2)
                   )
                   (i32.store offset=8
-                    (get_local $3)
-                    (get_local $3)
+                    (get_local $2)
+                    (get_local $2)
                   )
                   (br $do-once12)
                 )
@@ -15335,9 +15304,9 @@
             (if
               (i32.and
                 (i32.ge_u
-                  (tee_local $1
+                  (tee_local $4
                     (i32.load
-                      (tee_local $2
+                      (tee_local $1
                         (i32.add
                           (get_local $0)
                           (i32.const 8)
@@ -15345,7 +15314,7 @@
                       )
                     )
                   )
-                  (tee_local $4
+                  (tee_local $3
                     (i32.load
                       (i32.const 192)
                     )
@@ -15353,28 +15322,28 @@
                 )
                 (i32.ge_u
                   (get_local $0)
-                  (get_local $4)
+                  (get_local $3)
                 )
               )
               (block
                 (i32.store offset=12
-                  (get_local $1)
-                  (get_local $3)
+                  (get_local $4)
+                  (get_local $2)
                 )
                 (i32.store
+                  (get_local $1)
                   (get_local $2)
-                  (get_local $3)
                 )
                 (i32.store offset=8
-                  (get_local $3)
-                  (get_local $1)
+                  (get_local $2)
+                  (get_local $4)
                 )
                 (i32.store offset=12
-                  (get_local $3)
+                  (get_local $2)
                   (get_local $0)
                 )
                 (i32.store offset=24
-                  (get_local $3)
+                  (get_local $2)
                   (i32.const 0)
                 )
               )
@@ -15386,25 +15355,25 @@
           (i32.store
             (i32.const 180)
             (i32.or
-              (get_local $2)
-              (get_local $5)
+              (get_local $1)
+              (get_local $0)
             )
           )
           (i32.store
             (get_local $4)
-            (get_local $3)
+            (get_local $2)
           )
           (i32.store offset=24
-            (get_local $3)
+            (get_local $2)
             (get_local $4)
           )
           (i32.store offset=12
-            (get_local $3)
-            (get_local $3)
+            (get_local $2)
+            (get_local $2)
           )
           (i32.store offset=8
-            (get_local $3)
-            (get_local $3)
+            (get_local $2)
+            (get_local $2)
           )
         )
       )
@@ -15430,7 +15399,7 @@
     (loop $while-in17
       (set_local $0
         (i32.add
-          (tee_local $1
+          (tee_local $3
             (i32.load
               (get_local $0)
             )
@@ -15439,7 +15408,7 @@
         )
       )
       (br_if $while-in17
-        (get_local $1)
+        (get_local $3)
       )
     )
     (i32.store

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -164,9 +164,9 @@
                       (i32.const 1208)
                     )
                   )
-                  (tee_local $2
+                  (tee_local $0
                     (i32.shr_u
-                      (tee_local $0
+                      (tee_local $3
                         (select
                           (i32.const 16)
                           (i32.and
@@ -190,20 +190,20 @@
               (i32.const 3)
             )
             (block
-              (set_local $2
+              (set_local $6
                 (i32.load
-                  (tee_local $0
+                  (tee_local $3
                     (i32.add
                       (tee_local $4
                         (i32.load
-                          (tee_local $16
+                          (tee_local $13
                             (i32.add
-                              (tee_local $7
+                              (tee_local $8
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
                                     (i32.shl
-                                      (tee_local $6
+                                      (tee_local $0
                                         (i32.add
                                           (i32.xor
                                             (i32.and
@@ -212,7 +212,7 @@
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $2)
+                                          (get_local $0)
                                         )
                                       )
                                       (i32.const 1)
@@ -233,8 +233,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $7)
-                  (get_local $2)
+                  (get_local $8)
+                  (get_local $6)
                 )
                 (i32.store
                   (i32.const 1208)
@@ -243,7 +243,7 @@
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $6)
+                        (get_local $0)
                       )
                       (i32.const -1)
                     )
@@ -252,7 +252,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $2)
+                      (get_local $6)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -262,9 +262,9 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $8
+                        (tee_local $7
                           (i32.add
-                            (get_local $2)
+                            (get_local $6)
                             (i32.const 12)
                           )
                         )
@@ -273,12 +273,12 @@
                     )
                     (block
                       (i32.store
-                        (get_local $8)
                         (get_local $7)
+                        (get_local $8)
                       )
                       (i32.store
-                        (get_local $16)
-                        (get_local $2)
+                        (get_local $13)
+                        (get_local $6)
                       )
                     )
                     (call $qa)
@@ -288,9 +288,9 @@
               (i32.store offset=4
                 (get_local $4)
                 (i32.or
-                  (tee_local $2
+                  (tee_local $6
                     (i32.shl
-                      (get_local $6)
+                      (get_local $0)
                       (i32.const 3)
                     )
                   )
@@ -298,18 +298,18 @@
                 )
               )
               (i32.store
-                (tee_local $16
+                (tee_local $13
                   (i32.add
                     (i32.add
                       (get_local $4)
-                      (get_local $2)
+                      (get_local $6)
                     )
                     (i32.const 4)
                   )
                 )
                 (i32.or
                   (i32.load
-                    (get_local $16)
+                    (get_local $13)
                   )
                   (i32.const 1)
                 )
@@ -318,14 +318,14 @@
                 (get_local $25)
               )
               (return
-                (get_local $0)
+                (get_local $3)
               )
             )
           )
           (if
             (i32.gt_u
-              (get_local $0)
-              (tee_local $16
+              (get_local $3)
+              (tee_local $13
                 (i32.load
                   (i32.const 1216)
                 )
@@ -335,35 +335,35 @@
               (if
                 (get_local $4)
                 (block
-                  (set_local $7
+                  (set_local $8
                     (i32.and
                       (i32.shr_u
-                        (tee_local $2
+                        (tee_local $6
                           (i32.add
                             (i32.and
-                              (tee_local $7
+                              (tee_local $8
                                 (i32.and
                                   (i32.shl
                                     (get_local $4)
-                                    (get_local $2)
+                                    (get_local $0)
                                   )
                                   (i32.or
-                                    (tee_local $2
+                                    (tee_local $6
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $2)
+                                        (get_local $0)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $2)
+                                      (get_local $6)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $7)
+                                (get_local $8)
                               )
                             )
                             (i32.const -1)
@@ -374,32 +374,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $7
+                  (set_local $8
                     (i32.load
-                      (tee_local $8
+                      (tee_local $7
                         (i32.add
                           (tee_local $9
                             (i32.load
-                              (tee_local $15
+                              (tee_local $16
                                 (i32.add
                                   (tee_local $1
                                     (i32.add
                                       (i32.const 1248)
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $14
+                                          (tee_local $15
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $2
+                                                      (tee_local $6
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $8
+                                                            (tee_local $7
                                                               (i32.shr_u
-                                                                (get_local $2)
-                                                                (get_local $7)
+                                                                (get_local $6)
+                                                                (get_local $8)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -407,15 +407,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $7)
+                                                      (get_local $8)
                                                     )
-                                                    (tee_local $8
+                                                    (tee_local $7
                                                       (i32.and
                                                         (i32.shr_u
                                                           (tee_local $9
                                                             (i32.shr_u
-                                                              (get_local $8)
-                                                              (get_local $2)
+                                                              (get_local $7)
+                                                              (get_local $6)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -430,7 +430,7 @@
                                                         (tee_local $1
                                                           (i32.shr_u
                                                             (get_local $9)
-                                                            (get_local $8)
+                                                            (get_local $7)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -442,7 +442,7 @@
                                                 (tee_local $1
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (tee_local $15
+                                                      (tee_local $16
                                                         (i32.shr_u
                                                           (get_local $1)
                                                           (get_local $9)
@@ -455,7 +455,7 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $15)
+                                                (get_local $16)
                                                 (get_local $1)
                                               )
                                             )
@@ -479,7 +479,7 @@
                   (if
                     (i32.eq
                       (get_local $1)
-                      (get_local $7)
+                      (get_local $8)
                     )
                     (block
                       (i32.store
@@ -489,20 +489,20 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $14)
+                              (get_local $15)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $33
-                        (get_local $16)
+                      (set_local $34
+                        (get_local $13)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $7)
+                          (get_local $8)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -512,9 +512,9 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $2
+                            (tee_local $6
                               (i32.add
-                                (get_local $7)
+                                (get_local $8)
                                 (i32.const 12)
                               )
                             )
@@ -523,14 +523,14 @@
                         )
                         (block
                           (i32.store
-                            (get_local $2)
+                            (get_local $6)
                             (get_local $1)
                           )
                           (i32.store
-                            (get_local $15)
-                            (get_local $7)
+                            (get_local $16)
+                            (get_local $8)
                           )
-                          (set_local $33
+                          (set_local $34
                             (i32.load
                               (i32.const 1216)
                             )
@@ -543,25 +543,25 @@
                   (i32.store offset=4
                     (get_local $9)
                     (i32.or
-                      (get_local $0)
+                      (get_local $3)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $15
+                    (tee_local $16
                       (i32.add
                         (get_local $9)
-                        (get_local $0)
+                        (get_local $3)
                       )
                     )
                     (i32.or
-                      (tee_local $7
+                      (tee_local $8
                         (i32.sub
                           (i32.shl
-                            (get_local $14)
+                            (get_local $15)
                             (i32.const 3)
                           )
-                          (get_local $0)
+                          (get_local $3)
                         )
                       )
                       (i32.const 1)
@@ -569,13 +569,13 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $15)
-                      (get_local $7)
+                      (get_local $16)
+                      (get_local $8)
                     )
-                    (get_local $7)
+                    (get_local $8)
                   )
                   (if
-                    (get_local $33)
+                    (get_local $34)
                     (block
                       (set_local $1
                         (i32.load
@@ -587,9 +587,9 @@
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (tee_local $16
+                              (tee_local $13
                                 (i32.shr_u
-                                  (get_local $33)
+                                  (get_local $34)
                                   (i32.const 3)
                                 )
                               )
@@ -601,7 +601,7 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $2
+                          (tee_local $0
                             (i32.load
                               (i32.const 1208)
                             )
@@ -609,13 +609,13 @@
                           (tee_local $4
                             (i32.shl
                               (i32.const 1)
-                              (get_local $16)
+                              (get_local $13)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $2
+                            (tee_local $0
                               (i32.load
                                 (tee_local $4
                                   (i32.add
@@ -634,8 +634,8 @@
                             (set_local $41
                               (get_local $4)
                             )
-                            (set_local $34
-                              (get_local $2)
+                            (set_local $35
+                              (get_local $0)
                             )
                           )
                         )
@@ -643,7 +643,7 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $2)
+                              (get_local $0)
                               (get_local $4)
                             )
                           )
@@ -653,7 +653,7 @@
                               (i32.const 8)
                             )
                           )
-                          (set_local $34
+                          (set_local $35
                             (get_local $5)
                           )
                         )
@@ -663,12 +663,12 @@
                         (get_local $1)
                       )
                       (i32.store offset=12
-                        (get_local $34)
+                        (get_local $35)
                         (get_local $1)
                       )
                       (i32.store offset=8
                         (get_local $1)
-                        (get_local $34)
+                        (get_local $35)
                       )
                       (i32.store offset=12
                         (get_local $1)
@@ -678,37 +678,37 @@
                   )
                   (i32.store
                     (i32.const 1216)
-                    (get_local $7)
+                    (get_local $8)
                   )
                   (i32.store
                     (i32.const 1228)
-                    (get_local $15)
+                    (get_local $16)
                   )
                   (set_global $r
                     (get_local $25)
                   )
                   (return
-                    (get_local $8)
+                    (get_local $7)
                   )
                 )
               )
               (if
-                (tee_local $15
+                (tee_local $16
                   (i32.load
                     (i32.const 1212)
                   )
                 )
                 (block
-                  (set_local $15
+                  (set_local $16
                     (i32.and
                       (i32.shr_u
-                        (tee_local $7
+                        (tee_local $8
                           (i32.add
                             (i32.and
-                              (get_local $15)
+                              (get_local $16)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $15)
+                                (get_local $16)
                               )
                             )
                             (i32.const -1)
@@ -719,11 +719,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $2
+                  (set_local $0
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (tee_local $16
+                          (tee_local $13
                             (i32.load
                               (i32.add
                                 (i32.shl
@@ -732,13 +732,13 @@
                                       (i32.or
                                         (i32.or
                                           (i32.or
-                                            (tee_local $7
+                                            (tee_local $8
                                               (i32.and
                                                 (i32.shr_u
                                                   (tee_local $5
                                                     (i32.shr_u
-                                                      (get_local $7)
-                                                      (get_local $15)
+                                                      (get_local $8)
+                                                      (get_local $16)
                                                     )
                                                   )
                                                   (i32.const 5)
@@ -746,7 +746,7 @@
                                                 (i32.const 8)
                                               )
                                             )
-                                            (get_local $15)
+                                            (get_local $16)
                                           )
                                           (tee_local $5
                                             (i32.and
@@ -754,7 +754,7 @@
                                                 (tee_local $1
                                                   (i32.shr_u
                                                     (get_local $5)
-                                                    (get_local $7)
+                                                    (get_local $8)
                                                   )
                                                 )
                                                 (i32.const 2)
@@ -766,7 +766,7 @@
                                         (tee_local $1
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $2
+                                              (tee_local $0
                                                 (i32.shr_u
                                                   (get_local $1)
                                                   (get_local $5)
@@ -778,12 +778,12 @@
                                           )
                                         )
                                       )
-                                      (tee_local $2
+                                      (tee_local $0
                                         (i32.and
                                           (i32.shr_u
                                             (tee_local $4
                                               (i32.shr_u
-                                                (get_local $2)
+                                                (get_local $0)
                                                 (get_local $1)
                                               )
                                             )
@@ -795,7 +795,7 @@
                                     )
                                     (i32.shr_u
                                       (get_local $4)
-                                      (get_local $2)
+                                      (get_local $0)
                                     )
                                   )
                                   (i32.const 2)
@@ -807,25 +807,25 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $0)
+                      (get_local $3)
                     )
                   )
                   (set_local $4
-                    (get_local $16)
+                    (get_local $13)
                   )
                   (set_local $1
-                    (get_local $16)
+                    (get_local $13)
                   )
                   (loop $while-in
                     (block $while-out
                       (if
-                        (tee_local $16
+                        (tee_local $13
                           (i32.load offset=16
                             (get_local $4)
                           )
                         )
                         (set_local $6
-                          (get_local $16)
+                          (get_local $13)
                         )
                         (if
                           (tee_local $5
@@ -837,10 +837,10 @@
                             (get_local $5)
                           )
                           (block
-                            (set_local $7
-                              (get_local $2)
-                            )
                             (set_local $6
+                              (get_local $0)
+                            )
+                            (set_local $2
                               (get_local $1)
                             )
                             (br $while-out)
@@ -849,7 +849,7 @@
                       )
                       (set_local $5
                         (i32.lt_u
-                          (tee_local $16
+                          (tee_local $13
                             (i32.sub
                               (i32.and
                                 (i32.load offset=4
@@ -857,16 +857,16 @@
                                 )
                                 (i32.const -8)
                               )
-                              (get_local $0)
+                              (get_local $3)
                             )
                           )
-                          (get_local $2)
+                          (get_local $0)
                         )
                       )
-                      (set_local $2
+                      (set_local $0
                         (select
-                          (get_local $16)
-                          (get_local $2)
+                          (get_local $13)
+                          (get_local $0)
                           (get_local $5)
                         )
                       )
@@ -885,7 +885,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $6)
+                      (get_local $2)
                       (tee_local $1
                         (i32.load
                           (i32.const 1224)
@@ -896,46 +896,46 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $6)
+                      (get_local $2)
                       (tee_local $4
                         (i32.add
-                          (get_local $6)
-                          (get_local $0)
+                          (get_local $2)
+                          (get_local $3)
                         )
                       )
                     )
                     (call $qa)
                   )
-                  (set_local $2
+                  (set_local $0
                     (i32.load offset=24
-                      (get_local $6)
+                      (get_local $2)
                     )
                   )
                   (block $do-once4
                     (if
                       (i32.eq
-                        (tee_local $8
+                        (tee_local $7
                           (i32.load offset=12
-                            (get_local $6)
+                            (get_local $2)
                           )
                         )
-                        (get_local $6)
+                        (get_local $2)
                       )
                       (block
                         (if
-                          (tee_local $14
+                          (tee_local $15
                             (i32.load
                               (tee_local $9
                                 (i32.add
-                                  (get_local $6)
+                                  (get_local $2)
                                   (i32.const 20)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $16
-                              (get_local $14)
+                            (set_local $13
+                              (get_local $15)
                             )
                             (set_local $5
                               (get_local $9)
@@ -943,11 +943,11 @@
                           )
                           (if
                             (i32.eqz
-                              (tee_local $16
+                              (tee_local $13
                                 (i32.load
                                   (tee_local $5
                                     (i32.add
-                                      (get_local $6)
+                                      (get_local $2)
                                       (i32.const 16)
                                     )
                                   )
@@ -955,7 +955,7 @@
                               )
                             )
                             (block
-                              (set_local $21
+                              (set_local $23
                                 (i32.const 0)
                               )
                               (br $do-once4)
@@ -964,19 +964,19 @@
                         )
                         (loop $while-in7
                           (if
-                            (tee_local $14
+                            (tee_local $15
                               (i32.load
                                 (tee_local $9
                                   (i32.add
-                                    (get_local $16)
+                                    (get_local $13)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $16
-                                (get_local $14)
+                              (set_local $13
+                                (get_local $15)
                               )
                               (set_local $5
                                 (get_local $9)
@@ -985,19 +985,19 @@
                             )
                           )
                           (if
-                            (tee_local $14
+                            (tee_local $15
                               (i32.load
                                 (tee_local $9
                                   (i32.add
-                                    (get_local $16)
+                                    (get_local $13)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $16
-                                (get_local $14)
+                              (set_local $13
+                                (get_local $15)
                               )
                               (set_local $5
                                 (get_local $9)
@@ -1017,8 +1017,8 @@
                               (get_local $5)
                               (i32.const 0)
                             )
-                            (set_local $21
-                              (get_local $16)
+                            (set_local $23
+                              (get_local $13)
                             )
                           )
                         )
@@ -1028,7 +1028,7 @@
                           (i32.lt_u
                             (tee_local $9
                               (i32.load offset=8
-                                (get_local $6)
+                                (get_local $2)
                               )
                             )
                             (get_local $1)
@@ -1038,14 +1038,14 @@
                         (if
                           (i32.ne
                             (i32.load
-                              (tee_local $14
+                              (tee_local $15
                                 (i32.add
                                   (get_local $9)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $6)
+                            (get_local $2)
                           )
                           (call $qa)
                         )
@@ -1054,24 +1054,24 @@
                             (i32.load
                               (tee_local $5
                                 (i32.add
-                                  (get_local $8)
+                                  (get_local $7)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $6)
+                            (get_local $2)
                           )
                           (block
                             (i32.store
-                              (get_local $14)
-                              (get_local $8)
+                              (get_local $15)
+                              (get_local $7)
                             )
                             (i32.store
                               (get_local $5)
                               (get_local $9)
                             )
-                            (set_local $21
-                              (get_local $8)
+                            (set_local $23
+                              (get_local $7)
                             )
                           )
                           (call $qa)
@@ -1081,19 +1081,19 @@
                   )
                   (block $do-once8
                     (if
-                      (get_local $2)
+                      (get_local $0)
                       (block
                         (if
                           (i32.eq
-                            (get_local $6)
+                            (get_local $2)
                             (i32.load
                               (tee_local $1
                                 (i32.add
                                   (i32.const 1512)
                                   (i32.shl
-                                    (tee_local $8
+                                    (tee_local $7
                                       (i32.load offset=28
-                                        (get_local $6)
+                                        (get_local $2)
                                       )
                                     )
                                     (i32.const 2)
@@ -1105,11 +1105,11 @@
                           (block
                             (i32.store
                               (get_local $1)
-                              (get_local $21)
+                              (get_local $23)
                             )
                             (if
                               (i32.eqz
-                                (get_local $21)
+                                (get_local $23)
                               )
                               (block
                                 (i32.store
@@ -1121,7 +1121,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $8)
+                                        (get_local $7)
                                       )
                                       (i32.const -1)
                                     )
@@ -1134,7 +1134,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $2)
+                                (get_local $0)
                                 (i32.load
                                   (i32.const 1224)
                                 )
@@ -1144,35 +1144,35 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $8
+                                  (tee_local $7
                                     (i32.add
-                                      (get_local $2)
+                                      (get_local $0)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $2)
                               )
                               (i32.store
-                                (get_local $8)
-                                (get_local $21)
+                                (get_local $7)
+                                (get_local $23)
                               )
                               (i32.store offset=20
-                                (get_local $2)
-                                (get_local $21)
+                                (get_local $0)
+                                (get_local $23)
                               )
                             )
                             (br_if $do-once8
                               (i32.eqz
-                                (get_local $21)
+                                (get_local $23)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $21)
-                            (tee_local $8
+                            (get_local $23)
+                            (tee_local $7
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1181,29 +1181,29 @@
                           (call $qa)
                         )
                         (i32.store offset=24
-                          (get_local $21)
-                          (get_local $2)
+                          (get_local $23)
+                          (get_local $0)
                         )
                         (if
                           (tee_local $1
                             (i32.load offset=16
-                              (get_local $6)
+                              (get_local $2)
                             )
                           )
                           (if
                             (i32.lt_u
                               (get_local $1)
-                              (get_local $8)
+                              (get_local $7)
                             )
                             (call $qa)
                             (block
                               (i32.store offset=16
-                                (get_local $21)
+                                (get_local $23)
                                 (get_local $1)
                               )
                               (i32.store offset=24
                                 (get_local $1)
-                                (get_local $21)
+                                (get_local $23)
                               )
                             )
                           )
@@ -1211,7 +1211,7 @@
                         (if
                           (tee_local $1
                             (i32.load offset=20
-                              (get_local $6)
+                              (get_local $2)
                             )
                           )
                           (if
@@ -1224,12 +1224,12 @@
                             (call $qa)
                             (block
                               (i32.store offset=20
-                                (get_local $21)
+                                (get_local $23)
                                 (get_local $1)
                               )
                               (i32.store offset=24
                                 (get_local $1)
-                                (get_local $21)
+                                (get_local $23)
                               )
                             )
                           )
@@ -1239,17 +1239,17 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $6)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $6)
+                        (get_local $2)
                         (i32.or
-                          (tee_local $2
+                          (tee_local $0
                             (i32.add
-                              (get_local $7)
-                              (get_local $0)
+                              (get_local $6)
+                              (get_local $3)
                             )
                           )
                           (i32.const 3)
@@ -1259,8 +1259,8 @@
                         (tee_local $1
                           (i32.add
                             (i32.add
-                              (get_local $6)
                               (get_local $2)
+                              (get_local $0)
                             )
                             (i32.const 4)
                           )
@@ -1275,25 +1275,25 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $6)
+                        (get_local $2)
                         (i32.or
-                          (get_local $0)
+                          (get_local $3)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
                         (get_local $4)
                         (i32.or
-                          (get_local $7)
+                          (get_local $6)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
                           (get_local $4)
-                          (get_local $7)
+                          (get_local $6)
                         )
-                        (get_local $7)
+                        (get_local $6)
                       )
                       (if
                         (tee_local $1
@@ -1302,7 +1302,7 @@
                           )
                         )
                         (block
-                          (set_local $2
+                          (set_local $0
                             (i32.load
                               (i32.const 1228)
                             )
@@ -1312,7 +1312,7 @@
                               (i32.const 1248)
                               (i32.shl
                                 (i32.shl
-                                  (tee_local $8
+                                  (tee_local $7
                                     (i32.shr_u
                                       (get_local $1)
                                       (i32.const 3)
@@ -1334,7 +1334,7 @@
                               (tee_local $5
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $8)
+                                  (get_local $7)
                                 )
                               )
                             )
@@ -1359,7 +1359,7 @@
                                 (set_local $42
                                   (get_local $5)
                                 )
-                                (set_local $35
+                                (set_local $27
                                   (get_local $9)
                                 )
                               )
@@ -1378,32 +1378,32 @@
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $35
+                              (set_local $27
                                 (get_local $1)
                               )
                             )
                           )
                           (i32.store
                             (get_local $42)
-                            (get_local $2)
+                            (get_local $0)
                           )
                           (i32.store offset=12
-                            (get_local $35)
-                            (get_local $2)
+                            (get_local $27)
+                            (get_local $0)
                           )
                           (i32.store offset=8
-                            (get_local $2)
-                            (get_local $35)
+                            (get_local $0)
+                            (get_local $27)
                           )
                           (i32.store offset=12
-                            (get_local $2)
+                            (get_local $0)
                             (get_local $1)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 1216)
-                        (get_local $7)
+                        (get_local $6)
                       )
                       (i32.store
                         (i32.const 1228)
@@ -1416,18 +1416,18 @@
                   )
                   (return
                     (i32.add
-                      (get_local $6)
+                      (get_local $2)
                       (i32.const 8)
                     )
                   )
                 )
                 (set_local $4
-                  (get_local $0)
+                  (get_local $3)
                 )
               )
             )
             (set_local $4
-              (get_local $0)
+              (get_local $3)
             )
           )
         )
@@ -1440,7 +1440,7 @@
             (i32.const -1)
           )
           (block
-            (set_local $2
+            (set_local $0
               (i32.and
                 (tee_local $1
                   (i32.add
@@ -1461,18 +1461,18 @@
                 (set_local $5
                   (i32.sub
                     (i32.const 0)
-                    (get_local $2)
+                    (get_local $0)
                   )
                 )
                 (block $label$break$a
                   (if
-                    (tee_local $15
+                    (tee_local $16
                       (i32.load
                         (i32.add
                           (i32.shl
-                            (tee_local $21
+                            (tee_local $27
                               (if i32
-                                (tee_local $8
+                                (tee_local $7
                                   (i32.shr_u
                                     (get_local $1)
                                     (i32.const 8)
@@ -1480,33 +1480,33 @@
                                 )
                                 (if i32
                                   (i32.gt_u
-                                    (get_local $2)
+                                    (get_local $0)
                                     (i32.const 16777215)
                                   )
                                   (i32.const 31)
                                   (i32.or
                                     (i32.and
                                       (i32.shr_u
-                                        (get_local $2)
+                                        (get_local $0)
                                         (i32.add
-                                          (tee_local $15
+                                          (tee_local $16
                                             (i32.add
                                               (i32.sub
                                                 (i32.const 14)
                                                 (i32.or
                                                   (i32.or
-                                                    (tee_local $8
+                                                    (tee_local $7
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (tee_local $14
+                                                            (tee_local $15
                                                               (i32.shl
-                                                                (get_local $8)
+                                                                (get_local $7)
                                                                 (tee_local $1
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
-                                                                        (get_local $8)
+                                                                        (get_local $7)
                                                                         (i32.const 1048320)
                                                                       )
                                                                       (i32.const 16)
@@ -1525,14 +1525,14 @@
                                                     )
                                                     (get_local $1)
                                                   )
-                                                  (tee_local $14
+                                                  (tee_local $15
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $16
+                                                          (tee_local $13
                                                             (i32.shl
-                                                              (get_local $14)
-                                                              (get_local $8)
+                                                              (get_local $15)
+                                                              (get_local $7)
                                                             )
                                                           )
                                                           (i32.const 245760)
@@ -1546,8 +1546,8 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $16)
-                                                  (get_local $14)
+                                                  (get_local $13)
+                                                  (get_local $15)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -1559,7 +1559,7 @@
                                       (i32.const 1)
                                     )
                                     (i32.shl
-                                      (get_local $15)
+                                      (get_local $16)
                                       (i32.const 1)
                                     )
                                   )
@@ -1574,35 +1574,35 @@
                       )
                     )
                     (block
-                      (set_local $14
+                      (set_local $15
                         (get_local $5)
                       )
-                      (set_local $16
+                      (set_local $13
                         (i32.const 0)
                       )
                       (set_local $1
                         (i32.shl
-                          (get_local $2)
+                          (get_local $0)
                           (select
                             (i32.const 0)
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $21)
+                                (get_local $27)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $21)
+                              (get_local $27)
                               (i32.const 31)
                             )
                           )
                         )
                       )
-                      (set_local $8
-                        (get_local $15)
-                      )
                       (set_local $7
+                        (get_local $16)
+                      )
+                      (set_local $8
                         (i32.const 0)
                       )
                       (loop $while-in14
@@ -1610,55 +1610,55 @@
                           (i32.lt_u
                             (tee_local $4
                               (i32.sub
-                                (tee_local $0
+                                (tee_local $3
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $8)
+                                      (get_local $7)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $2)
+                                (get_local $0)
                               )
                             )
-                            (get_local $14)
+                            (get_local $15)
                           )
                           (if
                             (i32.eq
+                              (get_local $3)
                               (get_local $0)
-                              (get_local $2)
                             )
                             (block
-                              (set_local $28
+                              (set_local $29
                                 (get_local $4)
                               )
-                              (set_local $27
-                                (get_local $8)
+                              (set_local $28
+                                (get_local $7)
                               )
-                              (set_local $31
-                                (get_local $8)
+                              (set_local $32
+                                (get_local $7)
                               )
-                              (set_local $8
+                              (set_local $7
                                 (i32.const 90)
                               )
                               (br $label$break$a)
                             )
                             (block
-                              (set_local $14
+                              (set_local $15
                                 (get_local $4)
                               )
-                              (set_local $7
-                                (get_local $8)
+                              (set_local $8
+                                (get_local $7)
                               )
                             )
                           )
                         )
-                        (set_local $0
+                        (set_local $3
                           (select
-                            (get_local $16)
+                            (get_local $13)
                             (tee_local $4
                               (i32.load offset=20
-                                (get_local $8)
+                                (get_local $7)
                               )
                             )
                             (i32.or
@@ -1667,11 +1667,11 @@
                               )
                               (i32.eq
                                 (get_local $4)
-                                (tee_local $8
+                                (tee_local $7
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $8)
+                                        (get_local $7)
                                         (i32.const 16)
                                       )
                                       (i32.shl
@@ -1691,26 +1691,26 @@
                         (if
                           (tee_local $4
                             (i32.eqz
-                              (get_local $8)
+                              (get_local $7)
                             )
                           )
                           (block
                             (set_local $36
-                              (get_local $14)
+                              (get_local $15)
                             )
                             (set_local $37
-                              (get_local $0)
+                              (get_local $3)
                             )
-                            (set_local $32
-                              (get_local $7)
+                            (set_local $33
+                              (get_local $8)
                             )
-                            (set_local $8
+                            (set_local $7
                               (i32.const 86)
                             )
                           )
                           (block
-                            (set_local $16
-                              (get_local $0)
+                            (set_local $13
+                              (get_local $3)
                             )
                             (set_local $1
                               (i32.shl
@@ -1736,10 +1736,10 @@
                       (set_local $37
                         (i32.const 0)
                       )
-                      (set_local $32
+                      (set_local $33
                         (i32.const 0)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 86)
                       )
                     )
@@ -1747,18 +1747,18 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $7)
                     (i32.const 86)
                   )
                   (if
-                    (tee_local $0
+                    (tee_local $3
                       (if i32
                         (i32.and
                           (i32.eqz
                             (get_local $37)
                           )
                           (i32.eqz
-                            (get_local $32)
+                            (get_local $33)
                           )
                         )
                         (block i32
@@ -1768,15 +1768,15 @@
                                 (i32.and
                                   (get_local $9)
                                   (i32.or
-                                    (tee_local $15
+                                    (tee_local $16
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $21)
+                                        (get_local $27)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $15)
+                                      (get_local $16)
                                     )
                                   )
                                 )
@@ -1784,7 +1784,7 @@
                             )
                             (block
                               (set_local $4
-                                (get_local $2)
+                                (get_local $0)
                               )
                               (br $do-once)
                             )
@@ -1792,7 +1792,7 @@
                           (set_local $5
                             (i32.and
                               (i32.shr_u
-                                (tee_local $15
+                                (tee_local $16
                                   (i32.add
                                     (i32.and
                                       (get_local $5)
@@ -1817,12 +1817,12 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (tee_local $15
+                                          (tee_local $16
                                             (i32.and
                                               (i32.shr_u
-                                                (tee_local $0
+                                                (tee_local $3
                                                   (i32.shr_u
-                                                    (get_local $15)
+                                                    (get_local $16)
                                                     (get_local $5)
                                                   )
                                                 )
@@ -1833,13 +1833,13 @@
                                           )
                                           (get_local $5)
                                         )
-                                        (tee_local $0
+                                        (tee_local $3
                                           (i32.and
                                             (i32.shr_u
                                               (tee_local $4
                                                 (i32.shr_u
-                                                  (get_local $0)
-                                                  (get_local $15)
+                                                  (get_local $3)
+                                                  (get_local $16)
                                                 )
                                               )
                                               (i32.const 2)
@@ -1851,10 +1851,10 @@
                                       (tee_local $4
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $7
+                                            (tee_local $8
                                               (i32.shr_u
                                                 (get_local $4)
-                                                (get_local $0)
+                                                (get_local $3)
                                               )
                                             )
                                             (i32.const 1)
@@ -1863,12 +1863,12 @@
                                         )
                                       )
                                     )
-                                    (tee_local $7
+                                    (tee_local $8
                                       (i32.and
                                         (i32.shr_u
                                           (tee_local $1
                                             (i32.shr_u
-                                              (get_local $7)
+                                              (get_local $8)
                                               (get_local $4)
                                             )
                                           )
@@ -1880,7 +1880,7 @@
                                   )
                                   (i32.shr_u
                                     (get_local $1)
-                                    (get_local $7)
+                                    (get_local $8)
                                   )
                                 )
                                 (i32.const 2)
@@ -1893,16 +1893,16 @@
                       )
                     )
                     (block
-                      (set_local $28
+                      (set_local $29
                         (get_local $36)
                       )
-                      (set_local $27
-                        (get_local $0)
+                      (set_local $28
+                        (get_local $3)
                       )
-                      (set_local $31
-                        (get_local $32)
+                      (set_local $32
+                        (get_local $33)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 90)
                       )
                     )
@@ -1911,81 +1911,81 @@
                         (get_local $36)
                       )
                       (set_local $10
-                        (get_local $32)
+                        (get_local $33)
                       )
                     )
                   )
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $7)
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $8
+                    (set_local $7
                       (i32.const 0)
                     )
                     (set_local $1
                       (i32.lt_u
-                        (tee_local $7
+                        (tee_local $8
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $27)
+                                (get_local $28)
                               )
                               (i32.const -8)
                             )
-                            (get_local $2)
+                            (get_local $0)
                           )
                         )
-                        (get_local $28)
+                        (get_local $29)
                       )
                     )
                     (set_local $4
                       (select
-                        (get_local $7)
-                        (get_local $28)
+                        (get_local $8)
+                        (get_local $29)
                         (get_local $1)
                       )
                     )
-                    (set_local $7
+                    (set_local $8
                       (select
-                        (get_local $27)
-                        (get_local $31)
+                        (get_local $28)
+                        (get_local $32)
                         (get_local $1)
                       )
                     )
                     (if
                       (tee_local $1
                         (i32.load offset=16
-                          (get_local $27)
+                          (get_local $28)
                         )
                       )
                       (block
-                        (set_local $28
+                        (set_local $29
                           (get_local $4)
                         )
-                        (set_local $27
+                        (set_local $28
                           (get_local $1)
                         )
-                        (set_local $31
-                          (get_local $7)
+                        (set_local $32
+                          (get_local $8)
                         )
                         (br $while-in16)
                       )
                     )
                     (if
-                      (tee_local $27
+                      (tee_local $28
                         (i32.load offset=20
-                          (get_local $27)
+                          (get_local $28)
                         )
                       )
                       (block
-                        (set_local $28
+                        (set_local $29
                           (get_local $4)
                         )
-                        (set_local $31
-                          (get_local $7)
+                        (set_local $32
+                          (get_local $8)
                         )
                         (br $while-in16)
                       )
@@ -1994,7 +1994,7 @@
                           (get_local $4)
                         )
                         (set_local $10
-                          (get_local $7)
+                          (get_local $8)
                         )
                       )
                     )
@@ -2009,7 +2009,7 @@
                         (i32.load
                           (i32.const 1216)
                         )
-                        (get_local $2)
+                        (get_local $0)
                       )
                     )
                     (block
@@ -2027,10 +2027,10 @@
                       (if
                         (i32.ge_u
                           (get_local $10)
-                          (tee_local $7
+                          (tee_local $8
                             (i32.add
                               (get_local $10)
-                              (get_local $2)
+                              (get_local $0)
                             )
                           )
                         )
@@ -2055,7 +2055,7 @@
                             (if
                               (tee_local $5
                                 (i32.load
-                                  (tee_local $0
+                                  (tee_local $3
                                     (i32.add
                                       (get_local $10)
                                       (i32.const 20)
@@ -2064,17 +2064,17 @@
                                 )
                               )
                               (block
-                                (set_local $16
+                                (set_local $13
                                   (get_local $5)
                                 )
                                 (set_local $1
-                                  (get_local $0)
+                                  (get_local $3)
                                 )
                               )
                               (if
-                                (tee_local $16
+                                (tee_local $13
                                   (i32.load
-                                    (tee_local $15
+                                    (tee_local $16
                                       (i32.add
                                         (get_local $10)
                                         (i32.const 16)
@@ -2083,10 +2083,10 @@
                                   )
                                 )
                                 (set_local $1
-                                  (get_local $15)
+                                  (get_local $16)
                                 )
                                 (block
-                                  (set_local $23
+                                  (set_local $22
                                     (i32.const 0)
                                   )
                                   (br $do-once17)
@@ -2097,20 +2097,20 @@
                               (if
                                 (tee_local $5
                                   (i32.load
-                                    (tee_local $0
+                                    (tee_local $3
                                       (i32.add
-                                        (get_local $16)
+                                        (get_local $13)
                                         (i32.const 20)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $16
+                                  (set_local $13
                                     (get_local $5)
                                   )
                                   (set_local $1
-                                    (get_local $0)
+                                    (get_local $3)
                                   )
                                   (br $while-in20)
                                 )
@@ -2118,20 +2118,20 @@
                               (if
                                 (tee_local $5
                                   (i32.load
-                                    (tee_local $0
+                                    (tee_local $3
                                       (i32.add
-                                        (get_local $16)
+                                        (get_local $13)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $16
+                                  (set_local $13
                                     (get_local $5)
                                   )
                                   (set_local $1
-                                    (get_local $0)
+                                    (get_local $3)
                                   )
                                   (br $while-in20)
                                 )
@@ -2148,8 +2148,8 @@
                                   (get_local $1)
                                   (i32.const 0)
                                 )
-                                (set_local $23
-                                  (get_local $16)
+                                (set_local $22
+                                  (get_local $13)
                                 )
                               )
                             )
@@ -2157,7 +2157,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (tee_local $0
+                                (tee_local $3
                                   (i32.load offset=8
                                     (get_local $10)
                                   )
@@ -2171,7 +2171,7 @@
                                 (i32.load
                                   (tee_local $5
                                     (i32.add
-                                      (get_local $0)
+                                      (get_local $3)
                                       (i32.const 12)
                                     )
                                   )
@@ -2183,7 +2183,7 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $15
+                                  (tee_local $16
                                     (i32.add
                                       (get_local $1)
                                       (i32.const 8)
@@ -2198,10 +2198,10 @@
                                   (get_local $1)
                                 )
                                 (i32.store
-                                  (get_local $15)
-                                  (get_local $0)
+                                  (get_local $16)
+                                  (get_local $3)
                                 )
-                                (set_local $23
+                                (set_local $22
                                   (get_local $1)
                                 )
                               )
@@ -2236,11 +2236,11 @@
                               (block
                                 (i32.store
                                   (get_local $9)
-                                  (get_local $23)
+                                  (get_local $22)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $23)
+                                    (get_local $22)
                                   )
                                   (block
                                     (i32.store
@@ -2286,23 +2286,23 @@
                                   )
                                   (i32.store
                                     (get_local $1)
-                                    (get_local $23)
+                                    (get_local $22)
                                   )
                                   (i32.store offset=20
                                     (get_local $4)
-                                    (get_local $23)
+                                    (get_local $22)
                                   )
                                 )
                                 (br_if $do-once21
                                   (i32.eqz
-                                    (get_local $23)
+                                    (get_local $22)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $23)
+                                (get_local $22)
                                 (tee_local $1
                                   (i32.load
                                     (i32.const 1224)
@@ -2312,7 +2312,7 @@
                               (call $qa)
                             )
                             (i32.store offset=24
-                              (get_local $23)
+                              (get_local $22)
                               (get_local $4)
                             )
                             (if
@@ -2329,12 +2329,12 @@
                                 (call $qa)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $23)
+                                    (get_local $22)
                                     (get_local $9)
                                   )
                                   (i32.store offset=24
                                     (get_local $9)
-                                    (get_local $23)
+                                    (get_local $22)
                                   )
                                 )
                               )
@@ -2355,12 +2355,12 @@
                                 (call $qa)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $23)
+                                    (get_local $22)
                                     (get_local $9)
                                   )
                                   (i32.store offset=24
                                     (get_local $9)
-                                    (get_local $23)
+                                    (get_local $22)
                                   )
                                 )
                               )
@@ -2381,7 +2381,7 @@
                                 (tee_local $4
                                   (i32.add
                                     (get_local $18)
-                                    (get_local $2)
+                                    (get_local $0)
                                   )
                                 )
                                 (i32.const 3)
@@ -2409,12 +2409,12 @@
                             (i32.store offset=4
                               (get_local $10)
                               (i32.or
-                                (get_local $2)
+                                (get_local $0)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
-                              (get_local $7)
+                              (get_local $8)
                               (i32.or
                                 (get_local $18)
                                 (i32.const 1)
@@ -2422,7 +2422,7 @@
                             )
                             (i32.store
                               (i32.add
-                                (get_local $7)
+                                (get_local $8)
                                 (get_local $18)
                               )
                               (get_local $18)
@@ -2458,7 +2458,7 @@
                                         (i32.const 1208)
                                       )
                                     )
-                                    (tee_local $0
+                                    (tee_local $3
                                       (i32.shl
                                         (i32.const 1)
                                         (get_local $9)
@@ -2469,7 +2469,7 @@
                                     (i32.lt_u
                                       (tee_local $1
                                         (i32.load
-                                          (tee_local $0
+                                          (tee_local $3
                                             (i32.add
                                               (get_local $4)
                                               (i32.const 8)
@@ -2484,7 +2484,7 @@
                                     (call $qa)
                                     (block
                                       (set_local $19
-                                        (get_local $0)
+                                        (get_local $3)
                                       )
                                       (set_local $6
                                         (get_local $1)
@@ -2496,7 +2496,7 @@
                                       (i32.const 1208)
                                       (i32.or
                                         (get_local $1)
-                                        (get_local $0)
+                                        (get_local $3)
                                       )
                                     )
                                     (set_local $19
@@ -2512,28 +2512,28 @@
                                 )
                                 (i32.store
                                   (get_local $19)
-                                  (get_local $7)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=12
                                   (get_local $6)
-                                  (get_local $7)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=8
-                                  (get_local $7)
+                                  (get_local $8)
                                   (get_local $6)
                                 )
                                 (i32.store offset=12
-                                  (get_local $7)
+                                  (get_local $8)
                                   (get_local $4)
                                 )
                                 (br $do-once25)
                               )
                             )
-                            (set_local $15
+                            (set_local $16
                               (i32.add
                                 (i32.const 1512)
                                 (i32.shl
-                                  (tee_local $14
+                                  (tee_local $15
                                     (if i32
                                       (tee_local $4
                                         (i32.shr_u
@@ -2552,7 +2552,7 @@
                                             (i32.shr_u
                                               (get_local $18)
                                               (i32.add
-                                                (tee_local $15
+                                                (tee_local $16
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
@@ -2562,7 +2562,7 @@
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (tee_local $0
+                                                                  (tee_local $3
                                                                     (i32.shl
                                                                       (get_local $4)
                                                                       (tee_local $1
@@ -2588,13 +2588,13 @@
                                                           )
                                                           (get_local $1)
                                                         )
-                                                        (tee_local $0
+                                                        (tee_local $3
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
                                                                 (tee_local $9
                                                                   (i32.shl
-                                                                    (get_local $0)
+                                                                    (get_local $3)
                                                                     (get_local $4)
                                                                   )
                                                                 )
@@ -2610,7 +2610,7 @@
                                                     (i32.shr_u
                                                       (i32.shl
                                                         (get_local $9)
-                                                        (get_local $0)
+                                                        (get_local $3)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -2622,7 +2622,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $15)
+                                            (get_local $16)
                                             (i32.const 1)
                                           )
                                         )
@@ -2635,26 +2635,26 @@
                               )
                             )
                             (i32.store offset=28
-                              (get_local $7)
-                              (get_local $14)
+                              (get_local $8)
+                              (get_local $15)
                             )
                             (i32.store offset=4
-                              (tee_local $0
+                              (tee_local $3
                                 (i32.add
-                                  (get_local $7)
+                                  (get_local $8)
                                   (i32.const 16)
                                 )
                               )
                               (i32.const 0)
                             )
                             (i32.store
-                              (get_local $0)
+                              (get_local $3)
                               (i32.const 0)
                             )
                             (if
                               (i32.eqz
                                 (i32.and
-                                  (tee_local $0
+                                  (tee_local $3
                                     (i32.load
                                       (i32.const 1212)
                                     )
@@ -2662,7 +2662,7 @@
                                   (tee_local $9
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $14)
+                                      (get_local $15)
                                     )
                                   )
                                 )
@@ -2671,25 +2671,25 @@
                                 (i32.store
                                   (i32.const 1212)
                                   (i32.or
-                                    (get_local $0)
+                                    (get_local $3)
                                     (get_local $9)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $15)
-                                  (get_local $7)
+                                  (get_local $16)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=24
-                                  (get_local $7)
-                                  (get_local $15)
+                                  (get_local $8)
+                                  (get_local $16)
                                 )
                                 (i32.store offset=12
-                                  (get_local $7)
-                                  (get_local $7)
+                                  (get_local $8)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=8
-                                  (get_local $7)
-                                  (get_local $7)
+                                  (get_local $8)
+                                  (get_local $8)
                                 )
                                 (br $do-once25)
                               )
@@ -2702,20 +2702,20 @@
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $14)
+                                      (get_local $15)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $14)
+                                    (get_local $15)
                                     (i32.const 31)
                                   )
                                 )
                               )
                             )
-                            (set_local $0
+                            (set_local $3
                               (i32.load
-                                (get_local $15)
+                                (get_local $16)
                               )
                             )
                             (loop $while-in28
@@ -2724,7 +2724,7 @@
                                   (i32.eq
                                     (i32.and
                                       (i32.load offset=4
-                                        (get_local $0)
+                                        (get_local $3)
                                       )
                                       (i32.const -8)
                                     )
@@ -2732,9 +2732,9 @@
                                   )
                                   (block
                                     (set_local $17
-                                      (get_local $0)
+                                      (get_local $3)
                                     )
-                                    (set_local $8
+                                    (set_local $7
                                       (i32.const 148)
                                     )
                                     (br $while-out27)
@@ -2743,10 +2743,10 @@
                                 (if
                                   (tee_local $1
                                     (i32.load
-                                      (tee_local $15
+                                      (tee_local $16
                                         (i32.add
                                           (i32.add
-                                            (get_local $0)
+                                            (get_local $3)
                                             (i32.const 16)
                                           )
                                           (i32.shl
@@ -2767,19 +2767,19 @@
                                         (i32.const 1)
                                       )
                                     )
-                                    (set_local $0
+                                    (set_local $3
                                       (get_local $1)
                                     )
                                     (br $while-in28)
                                   )
                                   (block
-                                    (set_local $22
-                                      (get_local $15)
+                                    (set_local $21
+                                      (get_local $16)
                                     )
-                                    (set_local $13
-                                      (get_local $0)
+                                    (set_local $14
+                                      (get_local $3)
                                     )
-                                    (set_local $8
+                                    (set_local $7
                                       (i32.const 145)
                                     )
                                   )
@@ -2788,12 +2788,12 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.const 145)
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $22)
+                                  (get_local $21)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2801,26 +2801,26 @@
                                 (call $qa)
                                 (block
                                   (i32.store
-                                    (get_local $22)
-                                    (get_local $7)
+                                    (get_local $21)
+                                    (get_local $8)
                                   )
                                   (i32.store offset=24
-                                    (get_local $7)
-                                    (get_local $13)
+                                    (get_local $8)
+                                    (get_local $14)
                                   )
                                   (i32.store offset=12
-                                    (get_local $7)
-                                    (get_local $7)
+                                    (get_local $8)
+                                    (get_local $8)
                                   )
                                   (i32.store offset=8
-                                    (get_local $7)
-                                    (get_local $7)
+                                    (get_local $8)
+                                    (get_local $8)
                                   )
                                 )
                               )
                               (if
                                 (i32.eq
-                                  (get_local $8)
+                                  (get_local $7)
                                   (i32.const 148)
                                 )
                                 (if
@@ -2828,7 +2828,7 @@
                                     (i32.ge_u
                                       (tee_local $9
                                         (i32.load
-                                          (tee_local $0
+                                          (tee_local $3
                                             (i32.add
                                               (get_local $17)
                                               (i32.const 8)
@@ -2850,22 +2850,22 @@
                                   (block
                                     (i32.store offset=12
                                       (get_local $9)
-                                      (get_local $7)
+                                      (get_local $8)
                                     )
                                     (i32.store
-                                      (get_local $0)
-                                      (get_local $7)
+                                      (get_local $3)
+                                      (get_local $8)
                                     )
                                     (i32.store offset=8
-                                      (get_local $7)
+                                      (get_local $8)
                                       (get_local $9)
                                     )
                                     (i32.store offset=12
-                                      (get_local $7)
+                                      (get_local $8)
                                       (get_local $17)
                                     )
                                     (i32.store offset=24
-                                      (get_local $7)
+                                      (get_local $8)
                                       (i32.const 0)
                                     )
                                   )
@@ -2887,16 +2887,16 @@
                       )
                     )
                     (set_local $4
-                      (get_local $2)
+                      (get_local $0)
                     )
                   )
                   (set_local $4
-                    (get_local $2)
+                    (get_local $0)
                   )
                 )
               )
               (set_local $4
-                (get_local $2)
+                (get_local $0)
               )
             )
           )
@@ -2913,7 +2913,7 @@
         (get_local $4)
       )
       (block
-        (set_local $13
+        (set_local $14
           (i32.load
             (i32.const 1228)
           )
@@ -2931,9 +2931,9 @@
           (block
             (i32.store
               (i32.const 1228)
-              (tee_local $22
+              (tee_local $21
                 (i32.add
-                  (get_local $13)
+                  (get_local $14)
                   (get_local $4)
                 )
               )
@@ -2943,7 +2943,7 @@
               (get_local $17)
             )
             (i32.store offset=4
-              (get_local $22)
+              (get_local $21)
               (i32.or
                 (get_local $17)
                 (i32.const 1)
@@ -2951,13 +2951,13 @@
             )
             (i32.store
               (i32.add
-                (get_local $22)
+                (get_local $21)
                 (get_local $17)
               )
               (get_local $17)
             )
             (i32.store offset=4
-              (get_local $13)
+              (get_local $14)
               (i32.or
                 (get_local $4)
                 (i32.const 3)
@@ -2974,7 +2974,7 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $13)
+              (get_local $14)
               (i32.or
                 (get_local $10)
                 (i32.const 3)
@@ -2984,7 +2984,7 @@
               (tee_local $17
                 (i32.add
                   (i32.add
-                    (get_local $13)
+                    (get_local $14)
                     (get_local $10)
                   )
                   (i32.const 4)
@@ -3004,7 +3004,7 @@
         )
         (return
           (i32.add
-            (get_local $13)
+            (get_local $14)
             (i32.const 8)
           )
         )
@@ -3012,7 +3012,7 @@
     )
     (if
       (i32.gt_u
-        (tee_local $13
+        (tee_local $14
           (i32.load
             (i32.const 1220)
           )
@@ -3024,7 +3024,7 @@
           (i32.const 1220)
           (tee_local $17
             (i32.sub
-              (get_local $13)
+              (get_local $14)
               (get_local $4)
             )
           )
@@ -3033,7 +3033,7 @@
           (i32.const 1232)
           (tee_local $10
             (i32.add
-              (tee_local $13
+              (tee_local $14
                 (i32.load
                   (i32.const 1232)
                 )
@@ -3050,7 +3050,7 @@
           )
         )
         (i32.store offset=4
-          (get_local $13)
+          (get_local $14)
           (i32.or
             (get_local $4)
             (i32.const 3)
@@ -3061,7 +3061,7 @@
         )
         (return
           (i32.add
-            (get_local $13)
+            (get_local $14)
             (i32.const 8)
           )
         )
@@ -3100,7 +3100,7 @@
         )
         (i32.store
           (get_local $12)
-          (tee_local $13
+          (tee_local $14
             (i32.xor
               (i32.and
                 (get_local $12)
@@ -3112,11 +3112,11 @@
         )
         (i32.store
           (i32.const 1680)
-          (get_local $13)
+          (get_local $14)
         )
       )
     )
-    (set_local $13
+    (set_local $14
       (i32.add
         (get_local $4)
         (i32.const 48)
@@ -3141,7 +3141,7 @@
                 )
               )
             )
-            (tee_local $22
+            (tee_local $21
               (i32.sub
                 (i32.const 0)
                 (get_local $12)
@@ -3171,7 +3171,7 @@
           (i32.le_u
             (tee_local $6
               (i32.add
-                (tee_local $14
+                (tee_local $15
                   (i32.load
                     (i32.const 1640)
                   )
@@ -3179,7 +3179,7 @@
                 (get_local $12)
               )
             )
-            (get_local $14)
+            (get_local $15)
           )
           (i32.gt_u
             (get_local $6)
@@ -3198,7 +3198,7 @@
     )
     (if
       (i32.eq
-        (tee_local $8
+        (tee_local $7
           (block $label$break$b i32
             (if i32
               (i32.and
@@ -3224,7 +3224,7 @@
                         (block $while-out31
                           (if
                             (i32.le_u
-                              (tee_local $14
+                              (tee_local $15
                                 (i32.load
                                   (get_local $6)
                                 )
@@ -3234,7 +3234,7 @@
                             (if
                               (i32.gt_u
                                 (i32.add
-                                  (get_local $14)
+                                  (get_local $15)
                                   (i32.load
                                     (tee_local $19
                                       (i32.add
@@ -3247,7 +3247,7 @@
                                 (get_local $18)
                               )
                               (block
-                                (set_local $2
+                                (set_local $0
                                   (get_local $6)
                                 )
                                 (set_local $5
@@ -3264,7 +3264,7 @@
                               )
                             )
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.const 171)
                           )
                           (br $label$break$c)
@@ -3280,7 +3280,7 @@
                                   (i32.const 1220)
                                 )
                               )
-                              (get_local $22)
+                              (get_local $21)
                             )
                           )
                           (i32.const 2147483647)
@@ -3294,7 +3294,7 @@
                             )
                             (i32.add
                               (i32.load
-                                (get_local $2)
+                                (get_local $0)
                               )
                               (i32.load
                                 (get_local $5)
@@ -3322,17 +3322,17 @@
                             (set_local $11
                               (get_local $19)
                             )
-                            (set_local $3
+                            (set_local $2
                               (get_local $6)
                             )
-                            (set_local $8
+                            (set_local $7
                               (i32.const 181)
                             )
                           )
                         )
                       )
                     )
-                    (set_local $8
+                    (set_local $7
                       (i32.const 171)
                     )
                   )
@@ -3340,7 +3340,7 @@
                 (block $do-once33
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 171)
                     )
                     (if
@@ -3353,7 +3353,7 @@
                         (i32.const -1)
                       )
                       (block
-                        (set_local $0
+                        (set_local $3
                           (if i32
                             (i32.and
                               (tee_local $19
@@ -3366,19 +3366,19 @@
                                   (i32.const -1)
                                 )
                               )
-                              (tee_local $2
+                              (tee_local $0
                                 (get_local $18)
                               )
                             )
                             (i32.add
                               (i32.sub
                                 (get_local $12)
-                                (get_local $2)
+                                (get_local $0)
                               )
                               (i32.and
                                 (i32.add
                                   (get_local $19)
-                                  (get_local $2)
+                                  (get_local $0)
                                 )
                                 (i32.sub
                                   (i32.const 0)
@@ -3389,24 +3389,24 @@
                             (get_local $12)
                           )
                         )
-                        (set_local $2
+                        (set_local $0
                           (i32.add
                             (tee_local $6
                               (i32.load
                                 (i32.const 1640)
                               )
                             )
-                            (get_local $0)
+                            (get_local $3)
                           )
                         )
                         (if
                           (i32.and
                             (i32.gt_u
-                              (get_local $0)
+                              (get_local $3)
                               (get_local $4)
                             )
                             (i32.lt_u
-                              (get_local $0)
+                              (get_local $3)
                               (i32.const 2147483647)
                             )
                           )
@@ -3420,11 +3420,11 @@
                               (br_if $do-once33
                                 (i32.or
                                   (i32.le_u
-                                    (get_local $2)
+                                    (get_local $0)
                                     (get_local $6)
                                   )
                                   (i32.gt_u
-                                    (get_local $2)
+                                    (get_local $0)
                                     (get_local $19)
                                   )
                                 )
@@ -3434,7 +3434,7 @@
                               (i32.eq
                                 (tee_local $19
                                   (call $ta
-                                    (get_local $0)
+                                    (get_local $3)
                                   )
                                 )
                                 (get_local $18)
@@ -3444,7 +3444,7 @@
                                   (get_local $18)
                                 )
                                 (set_local $26
-                                  (get_local $0)
+                                  (get_local $3)
                                 )
                                 (br $label$break$b
                                   (i32.const 191)
@@ -3454,10 +3454,10 @@
                                 (set_local $11
                                   (get_local $19)
                                 )
-                                (set_local $3
-                                  (get_local $0)
+                                (set_local $2
+                                  (get_local $3)
                                 )
-                                (set_local $8
+                                (set_local $7
                                   (i32.const 181)
                                 )
                               )
@@ -3471,25 +3471,25 @@
                 (block $label$break$d
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 181)
                     )
                     (block
                       (set_local $19
                         (i32.sub
                           (i32.const 0)
-                          (get_local $3)
+                          (get_local $2)
                         )
                       )
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $13)
-                            (get_local $3)
+                            (get_local $14)
+                            (get_local $2)
                           )
                           (i32.and
                             (i32.lt_u
-                              (get_local $3)
+                              (get_local $2)
                               (i32.const 2147483647)
                             )
                             (i32.ne
@@ -3500,12 +3500,12 @@
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $2
+                            (tee_local $0
                               (i32.and
                                 (i32.add
                                   (i32.sub
                                     (get_local $17)
-                                    (get_local $3)
+                                    (get_local $2)
                                   )
                                   (tee_local $18
                                     (i32.load
@@ -3524,7 +3524,7 @@
                           (if
                             (i32.eq
                               (call $ta
-                                (get_local $2)
+                                (get_local $0)
                               )
                               (i32.const -1)
                             )
@@ -3538,17 +3538,17 @@
                             )
                             (set_local $1
                               (i32.add
+                                (get_local $0)
                                 (get_local $2)
-                                (get_local $3)
                               )
                             )
                           )
                           (set_local $1
-                            (get_local $3)
+                            (get_local $2)
                           )
                         )
                         (set_local $1
-                          (get_local $3)
+                          (get_local $2)
                         )
                       )
                       (if
@@ -3637,7 +3637,7 @@
               (set_local $26
                 (get_local $11)
               )
-              (set_local $8
+              (set_local $7
                 (i32.const 191)
               )
             )
@@ -3647,7 +3647,7 @@
     )
     (if
       (i32.eq
-        (get_local $8)
+        (get_local $7)
         (i32.const 191)
       )
       (block
@@ -3682,7 +3682,7 @@
               )
             )
             (block
-              (set_local $3
+              (set_local $2
                 (i32.const 1656)
               )
               (loop $do-in41
@@ -3693,14 +3693,14 @@
                       (i32.add
                         (tee_local $1
                           (i32.load
-                            (get_local $3)
+                            (get_local $2)
                           )
                         )
                         (tee_local $17
                           (i32.load
                             (tee_local $12
                               (i32.add
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 4)
                               )
                             )
@@ -3719,9 +3719,9 @@
                         (get_local $17)
                       )
                       (set_local $52
-                        (get_local $3)
+                        (get_local $2)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 201)
                       )
                       (br $do-out40)
@@ -3729,9 +3729,9 @@
                   )
                   (br_if $do-in41
                     (i32.ne
-                      (tee_local $3
+                      (tee_local $2
                         (i32.load offset=8
-                          (get_local $3)
+                          (get_local $2)
                         )
                       )
                       (i32.const 0)
@@ -3741,7 +3741,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $8)
+                  (get_local $7)
                   (i32.const 201)
                 )
                 (if
@@ -3772,7 +3772,7 @@
                           (get_local $26)
                         )
                       )
-                      (set_local $3
+                      (set_local $2
                         (i32.add
                           (get_local $11)
                           (tee_local $17
@@ -3780,7 +3780,7 @@
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (tee_local $3
+                                  (tee_local $2
                                     (i32.add
                                       (get_local $11)
                                       (i32.const 8)
@@ -3791,7 +3791,7 @@
                               )
                               (i32.const 0)
                               (i32.and
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 7)
                               )
                             )
@@ -3811,14 +3811,14 @@
                       )
                       (i32.store
                         (i32.const 1232)
-                        (get_local $3)
+                        (get_local $2)
                       )
                       (i32.store
                         (i32.const 1220)
                         (get_local $12)
                       )
                       (i32.store offset=4
-                        (get_local $3)
+                        (get_local $2)
                         (i32.or
                           (get_local $12)
                           (i32.const 1)
@@ -3826,7 +3826,7 @@
                       )
                       (i32.store offset=4
                         (i32.add
-                          (get_local $3)
+                          (get_local $2)
                           (get_local $12)
                         )
                         (i32.const 40)
@@ -3842,7 +3842,7 @@
                   )
                 )
               )
-              (set_local $7
+              (set_local $13
                 (if i32
                   (i32.lt_u
                     (get_local $20)
@@ -3868,7 +3868,7 @@
                   (get_local $26)
                 )
               )
-              (set_local $3
+              (set_local $2
                 (i32.const 1656)
               )
               (loop $while-in43
@@ -3876,38 +3876,38 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $3)
+                        (get_local $2)
                       )
                       (get_local $12)
                     )
                     (block
                       (set_local $53
-                        (get_local $3)
+                        (get_local $2)
                       )
                       (set_local $43
-                        (get_local $3)
+                        (get_local $2)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 209)
                       )
                       (br $while-out42)
                     )
                   )
                   (br_if $while-in43
-                    (tee_local $3
+                    (tee_local $2
                       (i32.load offset=8
-                        (get_local $3)
+                        (get_local $2)
                       )
                     )
                   )
-                  (set_local $29
+                  (set_local $30
                     (i32.const 1656)
                   )
                 )
               )
               (if
                 (i32.eq
-                  (get_local $8)
+                  (get_local $7)
                   (i32.const 209)
                 )
                 (if
@@ -3917,7 +3917,7 @@
                     )
                     (i32.const 8)
                   )
-                  (set_local $29
+                  (set_local $30
                     (i32.const 1656)
                   )
                   (block
@@ -3926,7 +3926,7 @@
                       (get_local $20)
                     )
                     (i32.store
-                      (tee_local $3
+                      (tee_local $2
                         (i32.add
                           (get_local $43)
                           (i32.const 4)
@@ -3934,7 +3934,7 @@
                       )
                       (i32.add
                         (i32.load
-                          (get_local $3)
+                          (get_local $2)
                         )
                         (get_local $26)
                       )
@@ -3946,7 +3946,7 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $3
+                              (tee_local $2
                                 (i32.add
                                   (get_local $20)
                                   (i32.const 8)
@@ -3957,7 +3957,7 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $3)
+                            (get_local $2)
                             (i32.const 7)
                           )
                         )
@@ -3970,7 +3970,7 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $3
+                              (tee_local $2
                                 (i32.add
                                   (get_local $12)
                                   (i32.const 8)
@@ -3981,19 +3981,19 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $3)
+                            (get_local $2)
                             (i32.const 7)
                           )
                         )
                       )
                     )
-                    (set_local $3
+                    (set_local $2
                       (i32.add
                         (get_local $17)
                         (get_local $4)
                       )
                     )
-                    (set_local $13
+                    (set_local $14
                       (i32.sub
                         (i32.sub
                           (get_local $1)
@@ -4018,23 +4018,23 @@
                         (block
                           (i32.store
                             (i32.const 1220)
-                            (tee_local $0
+                            (tee_local $3
                               (i32.add
                                 (i32.load
                                   (i32.const 1220)
                                 )
-                                (get_local $13)
+                                (get_local $14)
                               )
                             )
                           )
                           (i32.store
                             (i32.const 1232)
-                            (get_local $3)
+                            (get_local $2)
                           )
                           (i32.store offset=4
-                            (get_local $3)
+                            (get_local $2)
                             (i32.or
-                              (get_local $0)
+                              (get_local $3)
                               (i32.const 1)
                             )
                           )
@@ -4050,43 +4050,43 @@
                             (block
                               (i32.store
                                 (i32.const 1216)
-                                (tee_local $0
+                                (tee_local $3
                                   (i32.add
                                     (i32.load
                                       (i32.const 1216)
                                     )
-                                    (get_local $13)
+                                    (get_local $14)
                                   )
                                 )
                               )
                               (i32.store
                                 (i32.const 1228)
-                                (get_local $3)
+                                (get_local $2)
                               )
                               (i32.store offset=4
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.or
-                                  (get_local $0)
+                                  (get_local $3)
                                   (i32.const 1)
                                 )
                               )
                               (i32.store
                                 (i32.add
+                                  (get_local $2)
                                   (get_local $3)
-                                  (get_local $0)
                                 )
-                                (get_local $0)
+                                (get_local $3)
                               )
                               (br $do-once44)
                             )
                           )
                           (i32.store
-                            (tee_local $2
+                            (tee_local $0
                               (i32.add
                                 (if i32
                                   (i32.eq
                                     (i32.and
-                                      (tee_local $0
+                                      (tee_local $3
                                         (i32.load offset=4
                                           (get_local $1)
                                         )
@@ -4098,20 +4098,20 @@
                                   (block i32
                                     (set_local $5
                                       (i32.and
-                                        (get_local $0)
+                                        (get_local $3)
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $2
+                                    (set_local $0
                                       (i32.shr_u
-                                        (get_local $0)
+                                        (get_local $3)
                                         (i32.const 3)
                                       )
                                     )
                                     (block $label$break$e
                                       (if
                                         (i32.lt_u
-                                          (get_local $0)
+                                          (get_local $3)
                                           (i32.const 256)
                                         )
                                         (block
@@ -4123,7 +4123,7 @@
                                           (block $do-once47
                                             (if
                                               (i32.ne
-                                                (tee_local $22
+                                                (tee_local $21
                                                   (i32.load offset=8
                                                     (get_local $1)
                                                   )
@@ -4133,7 +4133,7 @@
                                                     (i32.const 1248)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $2)
+                                                        (get_local $0)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4144,15 +4144,15 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $22)
-                                                    (get_local $7)
+                                                    (get_local $21)
+                                                    (get_local $13)
                                                   )
                                                   (call $qa)
                                                 )
                                                 (br_if $do-once47
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $22)
+                                                      (get_local $21)
                                                     )
                                                     (get_local $1)
                                                   )
@@ -4164,7 +4164,7 @@
                                           (if
                                             (i32.eq
                                               (get_local $10)
-                                              (get_local $22)
+                                              (get_local $21)
                                             )
                                             (block
                                               (i32.store
@@ -4176,7 +4176,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $2)
+                                                      (get_local $0)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4201,14 +4201,14 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $10)
-                                                    (get_local $7)
+                                                    (get_local $13)
                                                   )
                                                   (call $qa)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $2
+                                                      (tee_local $0
                                                         (i32.add
                                                           (get_local $10)
                                                           (i32.const 8)
@@ -4219,7 +4219,7 @@
                                                   )
                                                   (block
                                                     (set_local $44
-                                                      (get_local $2)
+                                                      (get_local $0)
                                                     )
                                                     (br $do-once49)
                                                   )
@@ -4229,12 +4229,12 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $22)
+                                            (get_local $21)
                                             (get_local $10)
                                           )
                                           (i32.store
                                             (get_local $44)
-                                            (get_local $22)
+                                            (get_local $21)
                                           )
                                         )
                                         (block
@@ -4246,7 +4246,7 @@
                                           (block $do-once51
                                             (if
                                               (i32.eq
-                                                (tee_local $2
+                                                (tee_local $0
                                                   (i32.load offset=12
                                                     (get_local $1)
                                                   )
@@ -4255,7 +4255,7 @@
                                               )
                                               (block
                                                 (if
-                                                  (tee_local $14
+                                                  (tee_local $15
                                                     (i32.load
                                                       (tee_local $6
                                                         (i32.add
@@ -4271,24 +4271,24 @@
                                                     )
                                                   )
                                                   (block
-                                                    (set_local $0
-                                                      (get_local $14)
+                                                    (set_local $3
+                                                      (get_local $15)
                                                     )
-                                                    (set_local $2
+                                                    (set_local $0
                                                       (get_local $6)
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $23
+                                                    (tee_local $22
                                                       (i32.load
                                                         (get_local $18)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $0
-                                                        (get_local $23)
+                                                      (set_local $3
+                                                        (get_local $22)
                                                       )
-                                                      (set_local $2
+                                                      (set_local $0
                                                         (get_local $18)
                                                       )
                                                     )
@@ -4302,42 +4302,42 @@
                                                 )
                                                 (loop $while-in54
                                                   (if
-                                                    (tee_local $14
+                                                    (tee_local $15
                                                       (i32.load
                                                         (tee_local $6
                                                           (i32.add
-                                                            (get_local $0)
+                                                            (get_local $3)
                                                             (i32.const 20)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $0
-                                                        (get_local $14)
+                                                      (set_local $3
+                                                        (get_local $15)
                                                       )
-                                                      (set_local $2
+                                                      (set_local $0
                                                         (get_local $6)
                                                       )
                                                       (br $while-in54)
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $14
+                                                    (tee_local $15
                                                       (i32.load
                                                         (tee_local $6
                                                           (i32.add
-                                                            (get_local $0)
+                                                            (get_local $3)
                                                             (i32.const 16)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $0
-                                                        (get_local $14)
+                                                      (set_local $3
+                                                        (get_local $15)
                                                       )
-                                                      (set_local $2
+                                                      (set_local $0
                                                         (get_local $6)
                                                       )
                                                       (br $while-in54)
@@ -4346,17 +4346,17 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $2)
-                                                    (get_local $7)
+                                                    (get_local $0)
+                                                    (get_local $13)
                                                   )
                                                   (call $qa)
                                                   (block
                                                     (i32.store
-                                                      (get_local $2)
+                                                      (get_local $0)
                                                       (i32.const 0)
                                                     )
                                                     (set_local $24
-                                                      (get_local $0)
+                                                      (get_local $3)
                                                     )
                                                   )
                                                 )
@@ -4369,14 +4369,14 @@
                                                         (get_local $1)
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $13)
                                                   )
                                                   (call $qa)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (tee_local $14
+                                                      (tee_local $15
                                                         (i32.add
                                                           (get_local $6)
                                                           (i32.const 12)
@@ -4392,7 +4392,7 @@
                                                     (i32.load
                                                       (tee_local $18
                                                         (i32.add
-                                                          (get_local $2)
+                                                          (get_local $0)
                                                           (i32.const 8)
                                                         )
                                                       )
@@ -4401,15 +4401,15 @@
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $14)
-                                                      (get_local $2)
+                                                      (get_local $15)
+                                                      (get_local $0)
                                                     )
                                                     (i32.store
                                                       (get_local $18)
                                                       (get_local $6)
                                                     )
                                                     (set_local $24
-                                                      (get_local $2)
+                                                      (get_local $0)
                                                     )
                                                   )
                                                   (call $qa)
@@ -4427,11 +4427,11 @@
                                               (i32.eq
                                                 (get_local $1)
                                                 (i32.load
-                                                  (tee_local $22
+                                                  (tee_local $21
                                                     (i32.add
                                                       (i32.const 1512)
                                                       (i32.shl
-                                                        (tee_local $2
+                                                        (tee_local $0
                                                           (i32.load offset=28
                                                             (get_local $1)
                                                           )
@@ -4444,7 +4444,7 @@
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $22)
+                                                  (get_local $21)
                                                   (get_local $24)
                                                 )
                                                 (br_if $do-once55
@@ -4459,7 +4459,7 @@
                                                     (i32.xor
                                                       (i32.shl
                                                         (i32.const 1)
-                                                        (get_local $2)
+                                                        (get_local $0)
                                                       )
                                                       (i32.const -1)
                                                     )
@@ -4509,7 +4509,7 @@
                                           (if
                                             (i32.lt_u
                                               (get_local $24)
-                                              (tee_local $2
+                                              (tee_local $0
                                                 (i32.load
                                                   (i32.const 1224)
                                                 )
@@ -4524,7 +4524,7 @@
                                           (if
                                             (tee_local $10
                                               (i32.load
-                                                (tee_local $22
+                                                (tee_local $21
                                                   (i32.add
                                                     (get_local $1)
                                                     (i32.const 16)
@@ -4535,7 +4535,7 @@
                                             (if
                                               (i32.lt_u
                                                 (get_local $10)
-                                                (get_local $2)
+                                                (get_local $0)
                                               )
                                               (call $qa)
                                               (block
@@ -4554,7 +4554,7 @@
                                             (i32.eqz
                                               (tee_local $10
                                                 (i32.load offset=4
-                                                  (get_local $22)
+                                                  (get_local $21)
                                                 )
                                               )
                                             )
@@ -4581,10 +4581,10 @@
                                         )
                                       )
                                     )
-                                    (set_local $13
+                                    (set_local $14
                                       (i32.add
                                         (get_local $5)
-                                        (get_local $13)
+                                        (get_local $14)
                                       )
                                     )
                                     (i32.add
@@ -4599,43 +4599,43 @@
                             )
                             (i32.and
                               (i32.load
-                                (get_local $2)
+                                (get_local $0)
                               )
                               (i32.const -2)
                             )
                           )
                           (i32.store offset=4
-                            (get_local $3)
+                            (get_local $2)
                             (i32.or
-                              (get_local $13)
+                              (get_local $14)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $3)
-                              (get_local $13)
+                              (get_local $2)
+                              (get_local $14)
                             )
-                            (get_local $13)
+                            (get_local $14)
                           )
-                          (set_local $2
+                          (set_local $0
                             (i32.shr_u
-                              (get_local $13)
+                              (get_local $14)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $13)
+                              (get_local $14)
                               (i32.const 256)
                             )
                             (block
-                              (set_local $0
+                              (set_local $3
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $2)
+                                      (get_local $0)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4650,10 +4650,10 @@
                                         (i32.const 1208)
                                       )
                                     )
-                                    (tee_local $2
+                                    (tee_local $0
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $2)
+                                        (get_local $0)
                                       )
                                     )
                                   )
@@ -4662,9 +4662,9 @@
                                       (i32.ge_u
                                         (tee_local $19
                                           (i32.load
-                                            (tee_local $2
+                                            (tee_local $0
                                               (i32.add
-                                                (get_local $0)
+                                                (get_local $3)
                                                 (i32.const 8)
                                               )
                                             )
@@ -4676,7 +4676,7 @@
                                       )
                                       (block
                                         (set_local $45
-                                          (get_local $2)
+                                          (get_local $0)
                                         )
                                         (set_local $38
                                           (get_local $19)
@@ -4691,50 +4691,50 @@
                                       (i32.const 1208)
                                       (i32.or
                                         (get_local $10)
-                                        (get_local $2)
+                                        (get_local $0)
                                       )
                                     )
                                     (set_local $45
                                       (i32.add
-                                        (get_local $0)
+                                        (get_local $3)
                                         (i32.const 8)
                                       )
                                     )
                                     (set_local $38
-                                      (get_local $0)
+                                      (get_local $3)
                                     )
                                   )
                                 )
                               )
                               (i32.store
                                 (get_local $45)
-                                (get_local $3)
+                                (get_local $2)
                               )
                               (i32.store offset=12
                                 (get_local $38)
-                                (get_local $3)
+                                (get_local $2)
                               )
                               (i32.store offset=8
-                                (get_local $3)
+                                (get_local $2)
                                 (get_local $38)
                               )
                               (i32.store offset=12
+                                (get_local $2)
                                 (get_local $3)
-                                (get_local $0)
                               )
                               (br $do-once44)
                             )
                           )
-                          (set_local $2
+                          (set_local $0
                             (i32.add
                               (i32.const 1512)
                               (i32.shl
                                 (tee_local $5
                                   (block $do-once61 i32
                                     (if i32
-                                      (tee_local $2
+                                      (tee_local $0
                                         (i32.shr_u
-                                          (get_local $13)
+                                          (get_local $14)
                                           (i32.const 8)
                                         )
                                       )
@@ -4743,7 +4743,7 @@
                                           (br_if $do-once61
                                             (i32.const 31)
                                             (i32.gt_u
-                                              (get_local $13)
+                                              (get_local $14)
                                               (i32.const 16777215)
                                             )
                                           )
@@ -4751,7 +4751,7 @@
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $13)
+                                              (get_local $14)
                                               (i32.add
                                                 (tee_local $6
                                                   (i32.add
@@ -4765,12 +4765,12 @@
                                                                 (i32.add
                                                                   (tee_local $5
                                                                     (i32.shl
-                                                                      (get_local $2)
+                                                                      (get_local $0)
                                                                       (tee_local $10
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $2)
+                                                                              (get_local $0)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -4793,7 +4793,7 @@
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $2
+                                                                (tee_local $0
                                                                   (i32.shl
                                                                     (get_local $5)
                                                                     (get_local $19)
@@ -4810,7 +4810,7 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $2)
+                                                        (get_local $0)
                                                         (get_local $5)
                                                       )
                                                       (i32.const 15)
@@ -4837,26 +4837,26 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $3)
+                            (get_local $2)
                             (get_local $5)
                           )
                           (i32.store offset=4
-                            (tee_local $0
+                            (tee_local $3
                               (i32.add
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 16)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $0)
+                            (get_local $3)
                             (i32.const 0)
                           )
                           (if
                             (i32.eqz
                               (i32.and
-                                (tee_local $0
+                                (tee_local $3
                                   (i32.load
                                     (i32.const 1212)
                                   )
@@ -4873,32 +4873,32 @@
                               (i32.store
                                 (i32.const 1212)
                                 (i32.or
-                                  (get_local $0)
+                                  (get_local $3)
                                   (get_local $6)
                                 )
                               )
                               (i32.store
+                                (get_local $0)
                                 (get_local $2)
-                                (get_local $3)
                               )
                               (i32.store offset=24
-                                (get_local $3)
                                 (get_local $2)
+                                (get_local $0)
                               )
                               (i32.store offset=12
-                                (get_local $3)
-                                (get_local $3)
+                                (get_local $2)
+                                (get_local $2)
                               )
                               (i32.store offset=8
-                                (get_local $3)
-                                (get_local $3)
+                                (get_local $2)
+                                (get_local $2)
                               )
                               (br $do-once44)
                             )
                           )
                           (set_local $6
                             (i32.shl
-                              (get_local $13)
+                              (get_local $14)
                               (select
                                 (i32.const 0)
                                 (i32.sub
@@ -4915,9 +4915,9 @@
                               )
                             )
                           )
-                          (set_local $0
+                          (set_local $3
                             (i32.load
-                              (get_local $2)
+                              (get_local $0)
                             )
                           )
                           (loop $while-in64
@@ -4926,17 +4926,17 @@
                                 (i32.eq
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $0)
+                                      (get_local $3)
                                     )
                                     (i32.const -8)
                                   )
-                                  (get_local $13)
+                                  (get_local $14)
                                 )
                                 (block
                                   (set_local $39
-                                    (get_local $0)
+                                    (get_local $3)
                                   )
-                                  (set_local $8
+                                  (set_local $7
                                     (i32.const 279)
                                   )
                                   (br $while-out63)
@@ -4945,10 +4945,10 @@
                               (if
                                 (tee_local $5
                                   (i32.load
-                                    (tee_local $2
+                                    (tee_local $0
                                       (i32.add
                                         (i32.add
-                                          (get_local $0)
+                                          (get_local $3)
                                           (i32.const 16)
                                         )
                                         (i32.shl
@@ -4969,19 +4969,19 @@
                                       (i32.const 1)
                                     )
                                   )
-                                  (set_local $0
+                                  (set_local $3
                                     (get_local $5)
                                   )
                                   (br $while-in64)
                                 )
                                 (block
                                   (set_local $46
-                                    (get_local $2)
-                                  )
-                                  (set_local $54
                                     (get_local $0)
                                   )
-                                  (set_local $8
+                                  (set_local $54
+                                    (get_local $3)
+                                  )
+                                  (set_local $7
                                     (i32.const 276)
                                   )
                                 )
@@ -4990,7 +4990,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $8)
+                              (get_local $7)
                               (i32.const 276)
                             )
                             (if
@@ -5004,25 +5004,25 @@
                               (block
                                 (i32.store
                                   (get_local $46)
-                                  (get_local $3)
+                                  (get_local $2)
                                 )
                                 (i32.store offset=24
-                                  (get_local $3)
+                                  (get_local $2)
                                   (get_local $54)
                                 )
                                 (i32.store offset=12
-                                  (get_local $3)
-                                  (get_local $3)
+                                  (get_local $2)
+                                  (get_local $2)
                                 )
                                 (i32.store offset=8
-                                  (get_local $3)
-                                  (get_local $3)
+                                  (get_local $2)
+                                  (get_local $2)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.const 279)
                               )
                               (if
@@ -5030,7 +5030,7 @@
                                   (i32.ge_u
                                     (tee_local $6
                                       (i32.load
-                                        (tee_local $0
+                                        (tee_local $3
                                           (i32.add
                                             (get_local $39)
                                             (i32.const 8)
@@ -5052,22 +5052,22 @@
                                 (block
                                   (i32.store offset=12
                                     (get_local $6)
-                                    (get_local $3)
+                                    (get_local $2)
                                   )
                                   (i32.store
-                                    (get_local $0)
                                     (get_local $3)
+                                    (get_local $2)
                                   )
                                   (i32.store offset=8
-                                    (get_local $3)
+                                    (get_local $2)
                                     (get_local $6)
                                   )
                                   (i32.store offset=12
-                                    (get_local $3)
+                                    (get_local $2)
                                     (get_local $39)
                                   )
                                   (i32.store offset=24
-                                    (get_local $3)
+                                    (get_local $2)
                                     (i32.const 0)
                                   )
                                 )
@@ -5094,20 +5094,20 @@
                 (block $while-out65
                   (if
                     (i32.le_u
-                      (tee_local $3
+                      (tee_local $2
                         (i32.load
-                          (get_local $29)
+                          (get_local $30)
                         )
                       )
                       (get_local $11)
                     )
                     (if
                       (i32.gt_u
-                        (tee_local $13
+                        (tee_local $14
                           (i32.add
-                            (get_local $3)
+                            (get_local $2)
                             (i32.load offset=4
-                              (get_local $29)
+                              (get_local $30)
                             )
                           )
                         )
@@ -5115,21 +5115,21 @@
                       )
                       (block
                         (set_local $0
-                          (get_local $13)
+                          (get_local $14)
                         )
                         (br $while-out65)
                       )
                     )
                   )
-                  (set_local $29
+                  (set_local $30
                     (i32.load offset=8
-                      (get_local $29)
+                      (get_local $30)
                     )
                   )
                   (br $while-in66)
                 )
               )
-              (set_local $13
+              (set_local $14
                 (i32.add
                   (tee_local $17
                     (i32.add
@@ -5140,33 +5140,33 @@
                   (i32.const 8)
                 )
               )
-              (set_local $3
+              (set_local $2
                 (i32.add
                   (tee_local $17
                     (select
                       (get_local $11)
-                      (tee_local $3
+                      (tee_local $2
                         (i32.add
                           (get_local $17)
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $13)
+                                (get_local $14)
                               )
                               (i32.const 7)
                             )
                             (i32.const 0)
                             (i32.and
-                              (get_local $13)
+                              (get_local $14)
                               (i32.const 7)
                             )
                           )
                         )
                       )
                       (i32.lt_u
-                        (get_local $3)
-                        (tee_local $13
+                        (get_local $2)
+                        (tee_local $14
                           (i32.add
                             (get_local $11)
                             (i32.const 16)
@@ -5249,25 +5249,25 @@
                 (i32.const 27)
               )
               (i32.store
-                (get_local $3)
+                (get_local $2)
                 (i32.load
                   (i32.const 1656)
                 )
               )
               (i32.store offset=4
-                (get_local $3)
+                (get_local $2)
                 (i32.load
                   (i32.const 1660)
                 )
               )
               (i32.store offset=8
-                (get_local $3)
+                (get_local $2)
                 (i32.load
                   (i32.const 1664)
                 )
               )
               (i32.store offset=12
-                (get_local $3)
+                (get_local $2)
                 (i32.load
                   (i32.const 1668)
                 )
@@ -5286,9 +5286,9 @@
               )
               (i32.store
                 (i32.const 1664)
-                (get_local $3)
+                (get_local $2)
               )
-              (set_local $3
+              (set_local $2
                 (i32.add
                   (get_local $17)
                   (i32.const 24)
@@ -5296,9 +5296,9 @@
               )
               (loop $do-in68
                 (i32.store
-                  (tee_local $3
+                  (tee_local $2
                     (i32.add
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const 4)
                     )
                   )
@@ -5307,7 +5307,7 @@
                 (br_if $do-in68
                   (i32.lt_u
                     (i32.add
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const 4)
                     )
                     (get_local $0)
@@ -5332,7 +5332,7 @@
                   (i32.store offset=4
                     (get_local $11)
                     (i32.or
-                      (tee_local $3
+                      (tee_local $2
                         (i32.sub
                           (get_local $17)
                           (get_local $11)
@@ -5343,17 +5343,17 @@
                   )
                   (i32.store
                     (get_local $17)
-                    (get_local $3)
+                    (get_local $2)
                   )
                   (set_local $1
                     (i32.shr_u
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const 256)
                     )
                     (block
@@ -5371,7 +5371,7 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $0
+                          (tee_local $3
                             (i32.load
                               (i32.const 1208)
                             )
@@ -5385,7 +5385,7 @@
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $0
+                            (tee_local $3
                               (i32.load
                                 (tee_local $5
                                   (i32.add
@@ -5405,7 +5405,7 @@
                               (get_local $5)
                             )
                             (set_local $40
-                              (get_local $0)
+                              (get_local $3)
                             )
                           )
                         )
@@ -5413,7 +5413,7 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $0)
+                              (get_local $3)
                               (get_local $5)
                             )
                           )
@@ -5447,30 +5447,30 @@
                       (br $do-once38)
                     )
                   )
-                  (set_local $2
+                  (set_local $0
                     (i32.add
                       (i32.const 1512)
                       (i32.shl
-                        (tee_local $0
+                        (tee_local $3
                           (if i32
                             (tee_local $12
                               (i32.shr_u
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 8)
                               )
                             )
                             (if i32
                               (i32.gt_u
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $3)
+                                    (get_local $2)
                                     (i32.add
-                                      (tee_local $2
+                                      (tee_local $0
                                         (i32.add
                                           (i32.sub
                                             (i32.const 14)
@@ -5483,7 +5483,7 @@
                                                         (tee_local $5
                                                           (i32.shl
                                                             (get_local $12)
-                                                            (tee_local $0
+                                                            (tee_local $3
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
@@ -5504,7 +5504,7 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $0)
+                                                (get_local $3)
                                               )
                                               (tee_local $5
                                                 (i32.and
@@ -5540,7 +5540,7 @@
                                   (i32.const 1)
                                 )
                                 (i32.shl
-                                  (get_local $2)
+                                  (get_local $0)
                                   (i32.const 1)
                                 )
                               )
@@ -5554,14 +5554,14 @@
                   )
                   (i32.store offset=28
                     (get_local $11)
-                    (get_local $0)
+                    (get_local $3)
                   )
                   (i32.store offset=20
                     (get_local $11)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $13)
+                    (get_local $14)
                     (i32.const 0)
                   )
                   (if
@@ -5575,7 +5575,7 @@
                         (tee_local $1
                           (i32.shl
                             (i32.const 1)
-                            (get_local $0)
+                            (get_local $3)
                           )
                         )
                       )
@@ -5589,12 +5589,12 @@
                         )
                       )
                       (i32.store
-                        (get_local $2)
+                        (get_local $0)
                         (get_local $11)
                       )
                       (i32.store offset=24
                         (get_local $11)
-                        (get_local $2)
+                        (get_local $0)
                       )
                       (i32.store offset=12
                         (get_local $11)
@@ -5609,18 +5609,18 @@
                   )
                   (set_local $1
                     (i32.shl
-                      (get_local $3)
+                      (get_local $2)
                       (select
                         (i32.const 0)
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $0)
+                            (get_local $3)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $0)
+                          (get_local $3)
                           (i32.const 31)
                         )
                       )
@@ -5628,7 +5628,7 @@
                   )
                   (set_local $5
                     (i32.load
-                      (get_local $2)
+                      (get_local $0)
                     )
                   )
                   (loop $while-in70
@@ -5641,22 +5641,22 @@
                             )
                             (i32.const -8)
                           )
-                          (get_local $3)
+                          (get_local $2)
                         )
                         (block
-                          (set_local $30
+                          (set_local $31
                             (get_local $5)
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.const 305)
                           )
                           (br $while-out69)
                         )
                       )
                       (if
-                        (tee_local $0
+                        (tee_local $3
                           (i32.load
-                            (tee_local $2
+                            (tee_local $0
                               (i32.add
                                 (i32.add
                                   (get_local $5)
@@ -5681,18 +5681,18 @@
                             )
                           )
                           (set_local $5
-                            (get_local $0)
+                            (get_local $3)
                           )
                           (br $while-in70)
                         )
                         (block
                           (set_local $48
-                            (get_local $2)
+                            (get_local $0)
                           )
                           (set_local $55
                             (get_local $5)
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.const 302)
                           )
                         )
@@ -5701,7 +5701,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 302)
                     )
                     (if
@@ -5733,7 +5733,7 @@
                     )
                     (if
                       (i32.eq
-                        (get_local $8)
+                        (get_local $7)
                         (i32.const 305)
                       )
                       (if
@@ -5743,21 +5743,21 @@
                               (i32.load
                                 (tee_local $5
                                   (i32.add
-                                    (get_local $30)
+                                    (get_local $31)
                                     (i32.const 8)
                                   )
                                 )
                               )
                             )
-                            (tee_local $3
+                            (tee_local $2
                               (i32.load
                                 (i32.const 1224)
                               )
                             )
                           )
                           (i32.ge_u
-                            (get_local $30)
-                            (get_local $3)
+                            (get_local $31)
+                            (get_local $2)
                           )
                         )
                         (block
@@ -5775,7 +5775,7 @@
                           )
                           (i32.store offset=12
                             (get_local $11)
-                            (get_local $30)
+                            (get_local $31)
                           )
                           (i32.store offset=24
                             (get_local $11)
@@ -5897,7 +5897,7 @@
               )
               (i32.store
                 (i32.const 1220)
-                (tee_local $3
+                (tee_local $2
                   (i32.sub
                     (i32.add
                       (get_local $26)
@@ -5910,14 +5910,14 @@
               (i32.store offset=4
                 (get_local $1)
                 (i32.or
-                  (get_local $3)
+                  (get_local $2)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
                   (get_local $1)
-                  (get_local $3)
+                  (get_local $2)
                 )
                 (i32.const 40)
               )
@@ -5942,7 +5942,7 @@
           (block
             (i32.store
               (i32.const 1220)
-              (tee_local $30
+              (tee_local $31
                 (i32.sub
                   (get_local $11)
                   (get_local $4)
@@ -5951,7 +5951,7 @@
             )
             (i32.store
               (i32.const 1232)
-              (tee_local $8
+              (tee_local $7
                 (i32.add
                   (tee_local $11
                     (i32.load
@@ -5963,9 +5963,9 @@
               )
             )
             (i32.store offset=4
-              (get_local $8)
+              (get_local $7)
               (i32.or
-                (get_local $30)
+                (get_local $31)
                 (i32.const 1)
               )
             )
@@ -6044,7 +6044,7 @@
       (i32.eq
         (tee_local $0
           (i32.and
-            (tee_local $3
+            (tee_local $4
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -6062,9 +6062,9 @@
     (set_local $8
       (i32.add
         (get_local $1)
-        (tee_local $6
+        (tee_local $7
           (i32.and
-            (get_local $3)
+            (get_local $4)
             (i32.const -8)
           )
         )
@@ -6073,19 +6073,19 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $3)
+          (get_local $4)
           (i32.const 1)
         )
         (block
           (set_local $2
             (get_local $1)
           )
-          (set_local $5
-            (get_local $6)
+          (set_local $6
+            (get_local $7)
           )
         )
         (block
-          (set_local $11
+          (set_local $10
             (i32.load
               (get_local $1)
             )
@@ -6096,20 +6096,20 @@
             )
             (return)
           )
-          (set_local $6
+          (set_local $7
             (i32.add
-              (get_local $11)
-              (get_local $6)
+              (get_local $10)
+              (get_local $7)
             )
           )
           (if
             (i32.lt_u
-              (tee_local $3
+              (tee_local $1
                 (i32.add
                   (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $11)
+                    (get_local $10)
                   )
                 )
               )
@@ -6119,7 +6119,7 @@
           )
           (if
             (i32.eq
-              (get_local $3)
+              (get_local $1)
               (i32.load
                 (i32.const 1228)
               )
@@ -6128,7 +6128,7 @@
               (if
                 (i32.ne
                   (i32.and
-                    (tee_local $7
+                    (tee_local $3
                       (i32.load
                         (tee_local $0
                           (i32.add
@@ -6144,72 +6144,72 @@
                 )
                 (block
                   (set_local $2
-                    (get_local $3)
+                    (get_local $1)
                   )
-                  (set_local $5
-                    (get_local $6)
+                  (set_local $6
+                    (get_local $7)
                   )
                   (br $do-once)
                 )
               )
               (i32.store
                 (i32.const 1216)
-                (get_local $6)
+                (get_local $7)
               )
               (i32.store
                 (get_local $0)
                 (i32.and
-                  (get_local $7)
+                  (get_local $3)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $3)
+                (get_local $1)
                 (i32.or
-                  (get_local $6)
+                  (get_local $7)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
-                  (get_local $3)
-                  (get_local $6)
+                  (get_local $1)
+                  (get_local $7)
                 )
-                (get_local $6)
+                (get_local $7)
               )
               (return)
             )
           )
-          (set_local $7
+          (set_local $3
             (i32.shr_u
-              (get_local $11)
+              (get_local $10)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $11)
+              (get_local $10)
               (i32.const 256)
             )
             (block
               (set_local $0
                 (i32.load offset=12
-                  (get_local $3)
+                  (get_local $1)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $11
+                  (tee_local $10
                     (i32.load offset=8
-                      (get_local $3)
+                      (get_local $1)
                     )
                   )
-                  (tee_local $1
+                  (tee_local $4
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $7)
+                          (get_local $3)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6220,7 +6220,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $11)
+                      (get_local $10)
                       (get_local $14)
                     )
                     (call $qa)
@@ -6228,9 +6228,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $11)
+                        (get_local $10)
                       )
-                      (get_local $3)
+                      (get_local $1)
                     )
                     (call $qa)
                   )
@@ -6239,7 +6239,7 @@
               (if
                 (i32.eq
                   (get_local $0)
-                  (get_local $11)
+                  (get_local $10)
                 )
                 (block
                   (i32.store
@@ -6251,17 +6251,17 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $7)
+                          (get_local $3)
                         )
                         (i32.const -1)
                       )
                     )
                   )
                   (set_local $2
-                    (get_local $3)
+                    (get_local $1)
                   )
-                  (set_local $5
-                    (get_local $6)
+                  (set_local $6
+                    (get_local $7)
                   )
                   (br $do-once)
                 )
@@ -6269,9 +6269,9 @@
               (if
                 (i32.eq
                   (get_local $0)
-                  (get_local $1)
+                  (get_local $4)
                 )
-                (set_local $10
+                (set_local $9
                   (i32.add
                     (get_local $0)
                     (i32.const 8)
@@ -6288,42 +6288,42 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $1
+                        (tee_local $4
                           (i32.add
                             (get_local $0)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $3)
-                    )
-                    (set_local $10
                       (get_local $1)
+                    )
+                    (set_local $9
+                      (get_local $4)
                     )
                     (call $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $11)
+                (get_local $10)
                 (get_local $0)
               )
               (i32.store
+                (get_local $9)
                 (get_local $10)
-                (get_local $11)
               )
               (set_local $2
-                (get_local $3)
+                (get_local $1)
               )
-              (set_local $5
-                (get_local $6)
+              (set_local $6
+                (get_local $7)
               )
               (br $do-once)
             )
           )
-          (set_local $11
+          (set_local $10
             (i32.load offset=24
-              (get_local $3)
+              (get_local $1)
             )
           )
           (block $do-once0
@@ -6331,20 +6331,20 @@
               (i32.eq
                 (tee_local $0
                   (i32.load offset=12
-                    (get_local $3)
+                    (get_local $1)
                   )
                 )
-                (get_local $3)
+                (get_local $1)
               )
               (block
                 (if
-                  (tee_local $10
+                  (tee_local $9
                     (i32.load
-                      (tee_local $7
+                      (tee_local $3
                         (i32.add
-                          (tee_local $1
+                          (tee_local $4
                             (i32.add
-                              (get_local $3)
+                              (get_local $1)
                               (i32.const 16)
                             )
                           )
@@ -6355,22 +6355,22 @@
                   )
                   (block
                     (set_local $0
-                      (get_local $10)
+                      (get_local $9)
                     )
-                    (set_local $1
-                      (get_local $7)
+                    (set_local $4
+                      (get_local $3)
                     )
                   )
                   (if
                     (i32.eqz
                       (tee_local $0
                         (i32.load
-                          (get_local $1)
+                          (get_local $4)
                         )
                       )
                     )
                     (block
-                      (set_local $4
+                      (set_local $5
                         (i32.const 0)
                       )
                       (br $do-once0)
@@ -6379,9 +6379,9 @@
                 )
                 (loop $while-in
                   (if
-                    (tee_local $10
+                    (tee_local $9
                       (i32.load
-                        (tee_local $7
+                        (tee_local $3
                           (i32.add
                             (get_local $0)
                             (i32.const 20)
@@ -6391,18 +6391,18 @@
                     )
                     (block
                       (set_local $0
-                        (get_local $10)
+                        (get_local $9)
                       )
-                      (set_local $1
-                        (get_local $7)
+                      (set_local $4
+                        (get_local $3)
                       )
                       (br $while-in)
                     )
                   )
                   (if
-                    (tee_local $10
+                    (tee_local $9
                       (i32.load
-                        (tee_local $7
+                        (tee_local $3
                           (i32.add
                             (get_local $0)
                             (i32.const 16)
@@ -6412,36 +6412,36 @@
                     )
                     (block
                       (set_local $0
-                        (get_local $10)
+                        (get_local $9)
                       )
-                      (set_local $1
-                        (get_local $7)
+                      (set_local $4
+                        (get_local $3)
                       )
                       (br $while-in)
                     )
                     (block
-                      (set_local $7
+                      (set_local $12
                         (get_local $0)
                       )
-                      (set_local $9
-                        (get_local $1)
+                      (set_local $3
+                        (get_local $4)
                       )
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $9)
+                    (get_local $3)
                     (get_local $14)
                   )
                   (call $qa)
                   (block
                     (i32.store
-                      (get_local $9)
+                      (get_local $3)
                       (i32.const 0)
                     )
-                    (set_local $4
-                      (get_local $7)
+                    (set_local $5
+                      (get_local $12)
                     )
                   )
                 )
@@ -6449,9 +6449,9 @@
               (block
                 (if
                   (i32.lt_u
-                    (tee_local $7
+                    (tee_local $3
                       (i32.load offset=8
-                        (get_local $3)
+                        (get_local $1)
                       )
                     )
                     (get_local $14)
@@ -6461,39 +6461,39 @@
                 (if
                   (i32.ne
                     (i32.load
-                      (tee_local $10
+                      (tee_local $9
                         (i32.add
-                          (get_local $7)
+                          (get_local $3)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $3)
+                    (get_local $1)
                   )
                   (call $qa)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $1
+                      (tee_local $4
                         (i32.add
                           (get_local $0)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $3)
+                    (get_local $1)
                   )
                   (block
                     (i32.store
-                      (get_local $10)
+                      (get_local $9)
                       (get_local $0)
                     )
                     (i32.store
-                      (get_local $1)
-                      (get_local $7)
+                      (get_local $4)
+                      (get_local $3)
                     )
-                    (set_local $4
+                    (set_local $5
                       (get_local $0)
                     )
                   )
@@ -6503,19 +6503,19 @@
             )
           )
           (if
-            (get_local $11)
+            (get_local $10)
             (block
               (if
                 (i32.eq
-                  (get_local $3)
+                  (get_local $1)
                   (i32.load
-                    (tee_local $7
+                    (tee_local $3
                       (i32.add
                         (i32.const 1512)
                         (i32.shl
                           (tee_local $0
                             (i32.load offset=28
-                              (get_local $3)
+                              (get_local $1)
                             )
                           )
                           (i32.const 2)
@@ -6526,12 +6526,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $7)
-                    (get_local $4)
+                    (get_local $3)
+                    (get_local $5)
                   )
                   (if
                     (i32.eqz
-                      (get_local $4)
+                      (get_local $5)
                     )
                     (block
                       (i32.store
@@ -6550,10 +6550,10 @@
                         )
                       )
                       (set_local $2
-                        (get_local $3)
+                        (get_local $1)
                       )
-                      (set_local $5
-                        (get_local $6)
+                      (set_local $6
+                        (get_local $7)
                       )
                       (br $do-once)
                     )
@@ -6562,7 +6562,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $11)
+                      (get_local $10)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6574,32 +6574,32 @@
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $11)
+                            (get_local $10)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $3)
+                      (get_local $1)
                     )
                     (i32.store
                       (get_local $0)
-                      (get_local $4)
+                      (get_local $5)
                     )
                     (i32.store offset=20
-                      (get_local $11)
-                      (get_local $4)
+                      (get_local $10)
+                      (get_local $5)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $4)
+                      (get_local $5)
                     )
                     (block
                       (set_local $2
-                        (get_local $3)
+                        (get_local $1)
                       )
-                      (set_local $5
-                        (get_local $6)
+                      (set_local $6
+                        (get_local $7)
                       )
                       (br $do-once)
                     )
@@ -6608,7 +6608,7 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $4)
+                  (get_local $5)
                   (tee_local $0
                     (i32.load
                       (i32.const 1224)
@@ -6618,15 +6618,15 @@
                 (call $qa)
               )
               (i32.store offset=24
-                (get_local $4)
-                (get_local $11)
+                (get_local $5)
+                (get_local $10)
               )
               (if
-                (tee_local $1
+                (tee_local $4
                   (i32.load
-                    (tee_local $7
+                    (tee_local $3
                       (i32.add
-                        (get_local $3)
+                        (get_local $1)
                         (i32.const 16)
                       )
                     )
@@ -6634,31 +6634,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $1)
+                    (get_local $4)
                     (get_local $0)
                   )
                   (call $qa)
                   (block
                     (i32.store offset=16
+                      (get_local $5)
                       (get_local $4)
-                      (get_local $1)
                     )
                     (i32.store offset=24
-                      (get_local $1)
                       (get_local $4)
+                      (get_local $5)
                     )
                   )
                 )
               )
               (if
-                (tee_local $1
+                (tee_local $4
                   (i32.load offset=4
-                    (get_local $7)
+                    (get_local $3)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $1)
+                    (get_local $4)
                     (i32.load
                       (i32.const 1224)
                     )
@@ -6666,37 +6666,37 @@
                   (call $qa)
                   (block
                     (i32.store offset=20
+                      (get_local $5)
                       (get_local $4)
-                      (get_local $1)
                     )
                     (i32.store offset=24
-                      (get_local $1)
                       (get_local $4)
+                      (get_local $5)
                     )
                     (set_local $2
-                      (get_local $3)
+                      (get_local $1)
                     )
-                    (set_local $5
-                      (get_local $6)
+                    (set_local $6
+                      (get_local $7)
                     )
                   )
                 )
                 (block
                   (set_local $2
-                    (get_local $3)
+                    (get_local $1)
                   )
-                  (set_local $5
-                    (get_local $6)
+                  (set_local $6
+                    (get_local $7)
                   )
                 )
               )
             )
             (block
               (set_local $2
-                (get_local $3)
+                (get_local $1)
               )
-              (set_local $5
-                (get_local $6)
+              (set_local $6
+                (get_local $7)
               )
             )
           )
@@ -6715,7 +6715,7 @@
         (i32.and
           (tee_local $1
             (i32.load
-              (tee_local $6
+              (tee_local $7
                 (i32.add
                   (get_local $8)
                   (i32.const 4)
@@ -6735,7 +6735,7 @@
       )
       (block
         (i32.store
-          (get_local $6)
+          (get_local $7)
           (i32.and
             (get_local $1)
             (i32.const -2)
@@ -6744,19 +6744,19 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $5)
+            (get_local $6)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $5)
+            (get_local $6)
           )
-          (get_local $5)
+          (get_local $6)
         )
         (set_local $0
-          (get_local $5)
+          (get_local $6)
         )
       )
       (block
@@ -6770,12 +6770,12 @@
           (block
             (i32.store
               (i32.const 1220)
-              (tee_local $4
+              (tee_local $5
                 (i32.add
                   (i32.load
                     (i32.const 1220)
                   )
-                  (get_local $5)
+                  (get_local $6)
                 )
               )
             )
@@ -6786,7 +6786,7 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $4)
+                (get_local $5)
                 (i32.const 1)
               )
             )
@@ -6820,12 +6820,12 @@
           (block
             (i32.store
               (i32.const 1216)
-              (tee_local $4
+              (tee_local $5
                 (i32.add
                   (i32.load
                     (i32.const 1216)
                   )
-                  (get_local $5)
+                  (get_local $6)
                 )
               )
             )
@@ -6836,27 +6836,27 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $4)
+                (get_local $5)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $2)
-                (get_local $4)
+                (get_local $5)
               )
-              (get_local $4)
+              (get_local $5)
             )
             (return)
           )
         )
-        (set_local $4
+        (set_local $5
           (i32.add
             (i32.and
               (get_local $1)
               (i32.const -8)
             )
-            (get_local $5)
+            (get_local $6)
           )
         )
         (set_local $14
@@ -6872,19 +6872,19 @@
               (i32.const 256)
             )
             (block
-              (set_local $9
+              (set_local $3
                 (i32.load offset=12
                   (get_local $8)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $7
+                  (tee_local $12
                     (i32.load offset=8
                       (get_local $8)
                     )
                   )
-                  (tee_local $1
+                  (tee_local $4
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
@@ -6900,7 +6900,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $12)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6910,7 +6910,7 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $7)
+                        (get_local $12)
                       )
                       (get_local $8)
                     )
@@ -6920,8 +6920,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $9)
-                  (get_local $7)
+                  (get_local $3)
+                  (get_local $12)
                 )
                 (block
                   (i32.store
@@ -6944,19 +6944,19 @@
               )
               (if
                 (i32.eq
-                  (get_local $9)
-                  (get_local $1)
+                  (get_local $3)
+                  (get_local $4)
                 )
                 (set_local $17
                   (i32.add
-                    (get_local $9)
+                    (get_local $3)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $9)
+                      (get_local $3)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6966,9 +6966,9 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $1
+                        (tee_local $4
                           (i32.add
-                            (get_local $9)
+                            (get_local $3)
                             (i32.const 8)
                           )
                         )
@@ -6976,23 +6976,23 @@
                       (get_local $8)
                     )
                     (set_local $17
-                      (get_local $1)
+                      (get_local $4)
                     )
                     (call $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $7)
-                (get_local $9)
+                (get_local $12)
+                (get_local $3)
               )
               (i32.store
                 (get_local $17)
-                (get_local $7)
+                (get_local $12)
               )
             )
             (block
-              (set_local $7
+              (set_local $12
                 (i32.load offset=24
                   (get_local $8)
                 )
@@ -7000,7 +7000,7 @@
               (block $do-once6
                 (if
                   (i32.eq
-                    (tee_local $9
+                    (tee_local $3
                       (i32.load offset=12
                         (get_local $8)
                       )
@@ -7009,11 +7009,11 @@
                   )
                   (block
                     (if
-                      (tee_local $10
+                      (tee_local $9
                         (i32.load
                           (tee_local $0
                             (i32.add
-                              (tee_local $1
+                              (tee_local $4
                                 (i32.add
                                   (get_local $8)
                                   (i32.const 16)
@@ -7025,24 +7025,24 @@
                         )
                       )
                       (block
-                        (set_local $5
-                          (get_local $10)
+                        (set_local $6
+                          (get_local $9)
                         )
-                        (set_local $1
+                        (set_local $4
                           (get_local $0)
                         )
                       )
                       (if
                         (tee_local $0
                           (i32.load
-                            (get_local $1)
+                            (get_local $4)
                           )
                         )
-                        (set_local $5
+                        (set_local $6
                           (get_local $0)
                         )
                         (block
-                          (set_local $12
+                          (set_local $11
                             (i32.const 0)
                           )
                           (br $do-once6)
@@ -7051,42 +7051,42 @@
                     )
                     (loop $while-in9
                       (if
-                        (tee_local $10
+                        (tee_local $9
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $5)
+                                (get_local $6)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $5
-                            (get_local $10)
+                          (set_local $6
+                            (get_local $9)
                           )
-                          (set_local $1
+                          (set_local $4
                             (get_local $0)
                           )
                           (br $while-in9)
                         )
                       )
                       (if
-                        (tee_local $10
+                        (tee_local $9
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $5)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $5
-                            (get_local $10)
+                          (set_local $6
+                            (get_local $9)
                           )
-                          (set_local $1
+                          (set_local $4
                             (get_local $0)
                           )
                           (br $while-in9)
@@ -7095,7 +7095,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $4)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7103,11 +7103,11 @@
                       (call $qa)
                       (block
                         (i32.store
-                          (get_local $1)
+                          (get_local $4)
                           (i32.const 0)
                         )
-                        (set_local $12
-                          (get_local $5)
+                        (set_local $11
+                          (get_local $6)
                         )
                       )
                     )
@@ -7129,7 +7129,7 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (tee_local $10
+                          (tee_local $9
                             (i32.add
                               (get_local $0)
                               (i32.const 12)
@@ -7143,9 +7143,9 @@
                     (if
                       (i32.eq
                         (i32.load
-                          (tee_local $1
+                          (tee_local $4
                             (i32.add
-                              (get_local $9)
+                              (get_local $3)
                               (i32.const 8)
                             )
                           )
@@ -7154,15 +7154,15 @@
                       )
                       (block
                         (i32.store
-                          (get_local $10)
                           (get_local $9)
+                          (get_local $3)
                         )
                         (i32.store
-                          (get_local $1)
+                          (get_local $4)
                           (get_local $0)
                         )
-                        (set_local $12
-                          (get_local $9)
+                        (set_local $11
+                          (get_local $3)
                         )
                       )
                       (call $qa)
@@ -7171,17 +7171,17 @@
                 )
               )
               (if
-                (get_local $7)
+                (get_local $12)
                 (block
                   (if
                     (i32.eq
                       (get_local $8)
                       (i32.load
-                        (tee_local $6
+                        (tee_local $7
                           (i32.add
                             (i32.const 1512)
                             (i32.shl
-                              (tee_local $9
+                              (tee_local $3
                                 (i32.load offset=28
                                   (get_local $8)
                                 )
@@ -7194,12 +7194,12 @@
                     )
                     (block
                       (i32.store
-                        (get_local $6)
-                        (get_local $12)
+                        (get_local $7)
+                        (get_local $11)
                       )
                       (if
                         (i32.eqz
-                          (get_local $12)
+                          (get_local $11)
                         )
                         (block
                           (i32.store
@@ -7211,7 +7211,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $9)
+                                  (get_local $3)
                                 )
                                 (i32.const -1)
                               )
@@ -7224,7 +7224,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $7)
+                          (get_local $12)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -7234,9 +7234,9 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $9
+                            (tee_local $3
                               (i32.add
-                                (get_local $7)
+                                (get_local $12)
                                 (i32.const 16)
                               )
                             )
@@ -7244,25 +7244,25 @@
                           (get_local $8)
                         )
                         (i32.store
-                          (get_local $9)
-                          (get_local $12)
+                          (get_local $3)
+                          (get_local $11)
                         )
                         (i32.store offset=20
-                          (get_local $7)
                           (get_local $12)
+                          (get_local $11)
                         )
                       )
                       (br_if $do-once4
                         (i32.eqz
-                          (get_local $12)
+                          (get_local $11)
                         )
                       )
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $12)
-                      (tee_local $9
+                      (get_local $11)
+                      (tee_local $3
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7271,13 +7271,13 @@
                     (call $qa)
                   )
                   (i32.store offset=24
+                    (get_local $11)
                     (get_local $12)
-                    (get_local $7)
                   )
                   (if
-                    (tee_local $3
+                    (tee_local $1
                       (i32.load
-                        (tee_local $6
+                        (tee_local $7
                           (i32.add
                             (get_local $8)
                             (i32.const 16)
@@ -7287,31 +7287,31 @@
                     )
                     (if
                       (i32.lt_u
+                        (get_local $1)
                         (get_local $3)
-                        (get_local $9)
                       )
                       (call $qa)
                       (block
                         (i32.store offset=16
-                          (get_local $12)
-                          (get_local $3)
+                          (get_local $11)
+                          (get_local $1)
                         )
                         (i32.store offset=24
-                          (get_local $3)
-                          (get_local $12)
+                          (get_local $1)
+                          (get_local $11)
                         )
                       )
                     )
                   )
                   (if
-                    (tee_local $3
+                    (tee_local $1
                       (i32.load offset=4
-                        (get_local $6)
+                        (get_local $7)
                       )
                     )
                     (if
                       (i32.lt_u
-                        (get_local $3)
+                        (get_local $1)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7319,12 +7319,12 @@
                       (call $qa)
                       (block
                         (i32.store offset=20
-                          (get_local $12)
-                          (get_local $3)
+                          (get_local $11)
+                          (get_local $1)
                         )
                         (i32.store offset=24
-                          (get_local $3)
-                          (get_local $12)
+                          (get_local $1)
+                          (get_local $11)
                         )
                       )
                     )
@@ -7337,16 +7337,16 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $4)
+            (get_local $5)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $4)
+            (get_local $5)
           )
-          (get_local $4)
+          (get_local $5)
         )
         (if
           (i32.eq
@@ -7358,17 +7358,17 @@
           (block
             (i32.store
               (i32.const 1216)
-              (get_local $4)
+              (get_local $5)
             )
             (return)
           )
           (set_local $0
-            (get_local $4)
+            (get_local $5)
           )
         )
       )
     )
-    (set_local $5
+    (set_local $6
       (i32.shr_u
         (get_local $0)
         (i32.const 3)
@@ -7385,7 +7385,7 @@
             (i32.const 1248)
             (i32.shl
               (i32.shl
-                (get_local $5)
+                (get_local $6)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -7394,23 +7394,23 @@
         )
         (if
           (i32.and
-            (tee_local $6
+            (tee_local $7
               (i32.load
                 (i32.const 1208)
               )
             )
-            (tee_local $4
+            (tee_local $5
               (i32.shl
                 (i32.const 1)
-                (get_local $5)
+                (get_local $6)
               )
             )
           )
           (if
             (i32.lt_u
-              (tee_local $6
+              (tee_local $7
                 (i32.load
-                  (tee_local $4
+                  (tee_local $5
                     (i32.add
                       (get_local $1)
                       (i32.const 8)
@@ -7425,10 +7425,10 @@
             (call $qa)
             (block
               (set_local $15
-                (get_local $4)
+                (get_local $5)
               )
               (set_local $13
-                (get_local $6)
+                (get_local $7)
               )
             )
           )
@@ -7436,8 +7436,8 @@
             (i32.store
               (i32.const 1208)
               (i32.or
-                (get_local $6)
-                (get_local $4)
+                (get_local $7)
+                (get_local $5)
               )
             )
             (set_local $15
@@ -7470,11 +7470,11 @@
         (return)
       )
     )
-    (set_local $4
+    (set_local $5
       (i32.add
         (i32.const 1512)
         (i32.shl
-          (tee_local $5
+          (tee_local $6
             (if i32
               (tee_local $1
                 (i32.shr_u
@@ -7493,7 +7493,7 @@
                     (i32.shr_u
                       (get_local $0)
                       (i32.add
-                        (tee_local $4
+                        (tee_local $5
                           (i32.add
                             (i32.sub
                               (i32.const 14)
@@ -7533,7 +7533,7 @@
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (tee_local $6
+                                        (tee_local $7
                                           (i32.shl
                                             (get_local $15)
                                             (get_local $1)
@@ -7550,7 +7550,7 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $6)
+                                (get_local $7)
                                 (get_local $15)
                               )
                               (i32.const 15)
@@ -7563,7 +7563,7 @@
                     (i32.const 1)
                   )
                   (i32.shl
-                    (get_local $4)
+                    (get_local $5)
                     (i32.const 1)
                   )
                 )
@@ -7577,7 +7577,7 @@
     )
     (i32.store offset=28
       (get_local $2)
-      (get_local $5)
+      (get_local $6)
     )
     (i32.store offset=20
       (get_local $2)
@@ -7594,10 +7594,10 @@
             (i32.const 1212)
           )
         )
-        (tee_local $6
+        (tee_local $7
           (i32.shl
             (i32.const 1)
-            (get_local $5)
+            (get_local $6)
           )
         )
       )
@@ -7610,12 +7610,12 @@
               (i32.sub
                 (i32.const 25)
                 (i32.shr_u
-                  (get_local $5)
+                  (get_local $6)
                   (i32.const 1)
                 )
               )
               (i32.eq
-                (get_local $5)
+                (get_local $6)
                 (i32.const 31)
               )
             )
@@ -7623,7 +7623,7 @@
         )
         (set_local $1
           (i32.load
-            (get_local $4)
+            (get_local $5)
           )
         )
         (loop $while-in15
@@ -7649,9 +7649,9 @@
               )
             )
             (if
-              (tee_local $12
+              (tee_local $11
                 (i32.load
-                  (tee_local $5
+                  (tee_local $6
                     (i32.add
                       (i32.add
                         (get_local $1)
@@ -7676,13 +7676,13 @@
                   )
                 )
                 (set_local $1
-                  (get_local $12)
+                  (get_local $11)
                 )
                 (br $while-in15)
               )
               (block
                 (set_local $18
-                  (get_local $5)
+                  (get_local $6)
                 )
                 (set_local $19
                   (get_local $1)
@@ -7744,7 +7744,7 @@
                       )
                     )
                   )
-                  (tee_local $6
+                  (tee_local $7
                     (i32.load
                       (i32.const 1224)
                     )
@@ -7752,7 +7752,7 @@
                 )
                 (i32.ge_u
                   (get_local $16)
-                  (get_local $6)
+                  (get_local $7)
                 )
               )
               (block
@@ -7787,16 +7787,16 @@
           (i32.const 1212)
           (i32.or
             (get_local $15)
-            (get_local $6)
+            (get_local $7)
           )
         )
         (i32.store
-          (get_local $4)
+          (get_local $5)
           (get_local $2)
         )
         (i32.store offset=24
           (get_local $2)
-          (get_local $4)
+          (get_local $5)
         )
         (i32.store offset=12
           (get_local $2)

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -145,7 +145,7 @@
         (i32.const 16)
       )
     )
-    (set_local $13
+    (set_local $12
       (get_local $25)
     )
     (block $do-once
@@ -157,16 +157,16 @@
         (block
           (if
             (i32.and
-              (tee_local $1
+              (tee_local $4
                 (i32.shr_u
                   (tee_local $5
                     (i32.load
                       (i32.const 1208)
                     )
                   )
-                  (tee_local $0
+                  (tee_local $2
                     (i32.shr_u
-                      (tee_local $2
+                      (tee_local $0
                         (select
                           (i32.const 16)
                           (i32.and
@@ -190,13 +190,13 @@
               (i32.const 3)
             )
             (block
-              (set_local $0
+              (set_local $2
                 (i32.load
-                  (tee_local $1
+                  (tee_local $0
                     (i32.add
-                      (tee_local $2
+                      (tee_local $4
                         (i32.load
-                          (tee_local $11
+                          (tee_local $16
                             (i32.add
                               (tee_local $7
                                 (i32.add
@@ -207,12 +207,12 @@
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $1)
+                                              (get_local $4)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $0)
+                                          (get_local $2)
                                         )
                                       )
                                       (i32.const 1)
@@ -234,7 +234,7 @@
               (if
                 (i32.eq
                   (get_local $7)
-                  (get_local $0)
+                  (get_local $2)
                 )
                 (i32.store
                   (i32.const 1208)
@@ -252,7 +252,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $0)
+                      (get_local $2)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -262,23 +262,23 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $17
+                        (tee_local $8
                           (i32.add
-                            (get_local $0)
+                            (get_local $2)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $2)
+                      (get_local $4)
                     )
                     (block
                       (i32.store
-                        (get_local $17)
+                        (get_local $8)
                         (get_local $7)
                       )
                       (i32.store
-                        (get_local $11)
-                        (get_local $0)
+                        (get_local $16)
+                        (get_local $2)
                       )
                     )
                     (call $qa)
@@ -286,9 +286,9 @@
                 )
               )
               (i32.store offset=4
-                (get_local $2)
+                (get_local $4)
                 (i32.or
-                  (tee_local $0
+                  (tee_local $2
                     (i32.shl
                       (get_local $6)
                       (i32.const 3)
@@ -298,18 +298,18 @@
                 )
               )
               (i32.store
-                (tee_local $11
+                (tee_local $16
                   (i32.add
                     (i32.add
+                      (get_local $4)
                       (get_local $2)
-                      (get_local $0)
                     )
                     (i32.const 4)
                   )
                 )
                 (i32.or
                   (i32.load
-                    (get_local $11)
+                    (get_local $16)
                   )
                   (i32.const 1)
                 )
@@ -318,14 +318,14 @@
                 (get_local $25)
               )
               (return
-                (get_local $1)
+                (get_local $0)
               )
             )
           )
           (if
             (i32.gt_u
-              (get_local $2)
-              (tee_local $11
+              (get_local $0)
+              (tee_local $16
                 (i32.load
                   (i32.const 1216)
                 )
@@ -333,30 +333,30 @@
             )
             (block
               (if
-                (get_local $1)
+                (get_local $4)
                 (block
                   (set_local $7
                     (i32.and
                       (i32.shr_u
-                        (tee_local $0
+                        (tee_local $2
                           (i32.add
                             (i32.and
                               (tee_local $7
                                 (i32.and
                                   (i32.shl
-                                    (get_local $1)
-                                    (get_local $0)
+                                    (get_local $4)
+                                    (get_local $2)
                                   )
                                   (i32.or
-                                    (tee_local $0
+                                    (tee_local $2
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $0)
+                                        (get_local $2)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $0)
+                                      (get_local $2)
                                     )
                                   )
                                 )
@@ -376,29 +376,29 @@
                   )
                   (set_local $7
                     (i32.load
-                      (tee_local $17
+                      (tee_local $8
                         (i32.add
                           (tee_local $9
                             (i32.load
                               (tee_local $15
                                 (i32.add
-                                  (tee_local $4
+                                  (tee_local $1
                                     (i32.add
                                       (i32.const 1248)
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $8
+                                          (tee_local $14
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $0
+                                                      (tee_local $2
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $17
+                                                            (tee_local $8
                                                               (i32.shr_u
-                                                                (get_local $0)
+                                                                (get_local $2)
                                                                 (get_local $7)
                                                               )
                                                             )
@@ -409,13 +409,13 @@
                                                       )
                                                       (get_local $7)
                                                     )
-                                                    (tee_local $17
+                                                    (tee_local $8
                                                       (i32.and
                                                         (i32.shr_u
                                                           (tee_local $9
                                                             (i32.shr_u
-                                                              (get_local $17)
-                                                              (get_local $0)
+                                                              (get_local $8)
+                                                              (get_local $2)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -427,10 +427,10 @@
                                                   (tee_local $9
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (tee_local $4
+                                                        (tee_local $1
                                                           (i32.shr_u
                                                             (get_local $9)
-                                                            (get_local $17)
+                                                            (get_local $8)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -439,12 +439,12 @@
                                                     )
                                                   )
                                                 )
-                                                (tee_local $4
+                                                (tee_local $1
                                                   (i32.and
                                                     (i32.shr_u
                                                       (tee_local $15
                                                         (i32.shr_u
-                                                          (get_local $4)
+                                                          (get_local $1)
                                                           (get_local $9)
                                                         )
                                                       )
@@ -456,7 +456,7 @@
                                               )
                                               (i32.shr_u
                                                 (get_local $15)
-                                                (get_local $4)
+                                                (get_local $1)
                                               )
                                             )
                                           )
@@ -478,7 +478,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $4)
+                      (get_local $1)
                       (get_local $7)
                     )
                     (block
@@ -489,14 +489,14 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $8)
+                              (get_local $14)
                             )
                             (i32.const -1)
                           )
                         )
                       )
                       (set_local $33
-                        (get_local $11)
+                        (get_local $16)
                       )
                     )
                     (block
@@ -512,7 +512,7 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $0
+                            (tee_local $2
                               (i32.add
                                 (get_local $7)
                                 (i32.const 12)
@@ -523,8 +523,8 @@
                         )
                         (block
                           (i32.store
-                            (get_local $0)
-                            (get_local $4)
+                            (get_local $2)
+                            (get_local $1)
                           )
                           (i32.store
                             (get_local $15)
@@ -543,7 +543,7 @@
                   (i32.store offset=4
                     (get_local $9)
                     (i32.or
-                      (get_local $2)
+                      (get_local $0)
                       (i32.const 3)
                     )
                   )
@@ -551,17 +551,17 @@
                     (tee_local $15
                       (i32.add
                         (get_local $9)
-                        (get_local $2)
+                        (get_local $0)
                       )
                     )
                     (i32.or
                       (tee_local $7
                         (i32.sub
                           (i32.shl
-                            (get_local $8)
+                            (get_local $14)
                             (i32.const 3)
                           )
-                          (get_local $2)
+                          (get_local $0)
                         )
                       )
                       (i32.const 1)
@@ -577,7 +577,7 @@
                   (if
                     (get_local $33)
                     (block
-                      (set_local $4
+                      (set_local $1
                         (i32.load
                           (i32.const 1228)
                         )
@@ -587,7 +587,7 @@
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (tee_local $11
+                              (tee_local $16
                                 (i32.shr_u
                                   (get_local $33)
                                   (i32.const 3)
@@ -601,23 +601,23 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $0
+                          (tee_local $2
                             (i32.load
                               (i32.const 1208)
                             )
                           )
-                          (tee_local $1
+                          (tee_local $4
                             (i32.shl
                               (i32.const 1)
-                              (get_local $11)
+                              (get_local $16)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $0
+                            (tee_local $2
                               (i32.load
-                                (tee_local $1
+                                (tee_local $4
                                   (i32.add
                                     (get_local $5)
                                     (i32.const 8)
@@ -632,10 +632,10 @@
                           (call $qa)
                           (block
                             (set_local $41
-                              (get_local $1)
+                              (get_local $4)
                             )
                             (set_local $34
-                              (get_local $0)
+                              (get_local $2)
                             )
                           )
                         )
@@ -643,8 +643,8 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $0)
-                              (get_local $1)
+                              (get_local $2)
+                              (get_local $4)
                             )
                           )
                           (set_local $41
@@ -660,18 +660,18 @@
                       )
                       (i32.store
                         (get_local $41)
-                        (get_local $4)
+                        (get_local $1)
                       )
                       (i32.store offset=12
                         (get_local $34)
-                        (get_local $4)
+                        (get_local $1)
                       )
                       (i32.store offset=8
-                        (get_local $4)
+                        (get_local $1)
                         (get_local $34)
                       )
                       (i32.store offset=12
-                        (get_local $4)
+                        (get_local $1)
                         (get_local $5)
                       )
                     )
@@ -688,7 +688,7 @@
                     (get_local $25)
                   )
                   (return
-                    (get_local $17)
+                    (get_local $8)
                   )
                 )
               )
@@ -719,11 +719,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $0
+                  (set_local $2
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (tee_local $11
+                          (tee_local $16
                             (i32.load
                               (i32.add
                                 (i32.shl
@@ -751,7 +751,7 @@
                                           (tee_local $5
                                             (i32.and
                                               (i32.shr_u
-                                                (tee_local $4
+                                                (tee_local $1
                                                   (i32.shr_u
                                                     (get_local $5)
                                                     (get_local $7)
@@ -763,12 +763,12 @@
                                             )
                                           )
                                         )
-                                        (tee_local $4
+                                        (tee_local $1
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $0
+                                              (tee_local $2
                                                 (i32.shr_u
-                                                  (get_local $4)
+                                                  (get_local $1)
                                                   (get_local $5)
                                                 )
                                               )
@@ -778,13 +778,13 @@
                                           )
                                         )
                                       )
-                                      (tee_local $0
+                                      (tee_local $2
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $1
+                                            (tee_local $4
                                               (i32.shr_u
-                                                (get_local $0)
-                                                (get_local $4)
+                                                (get_local $2)
+                                                (get_local $1)
                                               )
                                             )
                                             (i32.const 1)
@@ -794,8 +794,8 @@
                                       )
                                     )
                                     (i32.shr_u
-                                      (get_local $1)
-                                      (get_local $0)
+                                      (get_local $4)
+                                      (get_local $2)
                                     )
                                   )
                                   (i32.const 2)
@@ -807,41 +807,41 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $2)
+                      (get_local $0)
                     )
                   )
-                  (set_local $1
-                    (get_local $11)
-                  )
                   (set_local $4
-                    (get_local $11)
+                    (get_local $16)
+                  )
+                  (set_local $1
+                    (get_local $16)
                   )
                   (loop $while-in
                     (block $while-out
                       (if
-                        (tee_local $11
+                        (tee_local $16
                           (i32.load offset=16
-                            (get_local $1)
+                            (get_local $4)
                           )
                         )
                         (set_local $6
-                          (get_local $11)
+                          (get_local $16)
                         )
                         (if
                           (tee_local $5
                             (i32.load offset=20
-                              (get_local $1)
+                              (get_local $4)
                             )
                           )
                           (set_local $6
                             (get_local $5)
                           )
                           (block
-                            (set_local $3
-                              (get_local $0)
+                            (set_local $7
+                              (get_local $2)
                             )
                             (set_local $6
-                              (get_local $4)
+                              (get_local $1)
                             )
                             (br $while-out)
                           )
@@ -849,7 +849,7 @@
                       )
                       (set_local $5
                         (i32.lt_u
-                          (tee_local $11
+                          (tee_local $16
                             (i32.sub
                               (i32.and
                                 (i32.load offset=4
@@ -857,26 +857,26 @@
                                 )
                                 (i32.const -8)
                               )
-                              (get_local $2)
+                              (get_local $0)
                             )
                           )
-                          (get_local $0)
+                          (get_local $2)
                         )
                       )
-                      (set_local $0
+                      (set_local $2
                         (select
-                          (get_local $11)
-                          (get_local $0)
+                          (get_local $16)
+                          (get_local $2)
                           (get_local $5)
                         )
                       )
-                      (set_local $1
+                      (set_local $4
                         (get_local $6)
                       )
-                      (set_local $4
+                      (set_local $1
                         (select
                           (get_local $6)
-                          (get_local $4)
+                          (get_local $1)
                           (get_local $5)
                         )
                       )
@@ -886,7 +886,7 @@
                   (if
                     (i32.lt_u
                       (get_local $6)
-                      (tee_local $4
+                      (tee_local $1
                         (i32.load
                           (i32.const 1224)
                         )
@@ -897,16 +897,16 @@
                   (if
                     (i32.ge_u
                       (get_local $6)
-                      (tee_local $1
+                      (tee_local $4
                         (i32.add
                           (get_local $6)
-                          (get_local $2)
+                          (get_local $0)
                         )
                       )
                     )
                     (call $qa)
                   )
-                  (set_local $0
+                  (set_local $2
                     (i32.load offset=24
                       (get_local $6)
                     )
@@ -914,7 +914,7 @@
                   (block $do-once4
                     (if
                       (i32.eq
-                        (tee_local $17
+                        (tee_local $8
                           (i32.load offset=12
                             (get_local $6)
                           )
@@ -923,7 +923,7 @@
                       )
                       (block
                         (if
-                          (tee_local $8
+                          (tee_local $14
                             (i32.load
                               (tee_local $9
                                 (i32.add
@@ -934,8 +934,8 @@
                             )
                           )
                           (block
-                            (set_local $11
-                              (get_local $8)
+                            (set_local $16
+                              (get_local $14)
                             )
                             (set_local $5
                               (get_local $9)
@@ -943,7 +943,7 @@
                           )
                           (if
                             (i32.eqz
-                              (tee_local $11
+                              (tee_local $16
                                 (i32.load
                                   (tee_local $5
                                     (i32.add
@@ -964,19 +964,19 @@
                         )
                         (loop $while-in7
                           (if
-                            (tee_local $8
+                            (tee_local $14
                               (i32.load
                                 (tee_local $9
                                   (i32.add
-                                    (get_local $11)
+                                    (get_local $16)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $11
-                                (get_local $8)
+                              (set_local $16
+                                (get_local $14)
                               )
                               (set_local $5
                                 (get_local $9)
@@ -985,19 +985,19 @@
                             )
                           )
                           (if
-                            (tee_local $8
+                            (tee_local $14
                               (i32.load
                                 (tee_local $9
                                   (i32.add
-                                    (get_local $11)
+                                    (get_local $16)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $11
-                                (get_local $8)
+                              (set_local $16
+                                (get_local $14)
                               )
                               (set_local $5
                                 (get_local $9)
@@ -1009,7 +1009,7 @@
                         (if
                           (i32.lt_u
                             (get_local $5)
-                            (get_local $4)
+                            (get_local $1)
                           )
                           (call $qa)
                           (block
@@ -1018,7 +1018,7 @@
                               (i32.const 0)
                             )
                             (set_local $21
-                              (get_local $11)
+                              (get_local $16)
                             )
                           )
                         )
@@ -1031,14 +1031,14 @@
                                 (get_local $6)
                               )
                             )
-                            (get_local $4)
+                            (get_local $1)
                           )
                           (call $qa)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (tee_local $8
+                              (tee_local $14
                                 (i32.add
                                   (get_local $9)
                                   (i32.const 12)
@@ -1054,7 +1054,7 @@
                             (i32.load
                               (tee_local $5
                                 (i32.add
-                                  (get_local $17)
+                                  (get_local $8)
                                   (i32.const 8)
                                 )
                               )
@@ -1063,15 +1063,15 @@
                           )
                           (block
                             (i32.store
+                              (get_local $14)
                               (get_local $8)
-                              (get_local $17)
                             )
                             (i32.store
                               (get_local $5)
                               (get_local $9)
                             )
                             (set_local $21
-                              (get_local $17)
+                              (get_local $8)
                             )
                           )
                           (call $qa)
@@ -1081,17 +1081,17 @@
                   )
                   (block $do-once8
                     (if
-                      (get_local $0)
+                      (get_local $2)
                       (block
                         (if
                           (i32.eq
                             (get_local $6)
                             (i32.load
-                              (tee_local $4
+                              (tee_local $1
                                 (i32.add
                                   (i32.const 1512)
                                   (i32.shl
-                                    (tee_local $17
+                                    (tee_local $8
                                       (i32.load offset=28
                                         (get_local $6)
                                       )
@@ -1104,7 +1104,7 @@
                           )
                           (block
                             (i32.store
-                              (get_local $4)
+                              (get_local $1)
                               (get_local $21)
                             )
                             (if
@@ -1121,7 +1121,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $17)
+                                        (get_local $8)
                                       )
                                       (i32.const -1)
                                     )
@@ -1134,7 +1134,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $0)
+                                (get_local $2)
                                 (i32.load
                                   (i32.const 1224)
                                 )
@@ -1144,9 +1144,9 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $17
+                                  (tee_local $8
                                     (i32.add
-                                      (get_local $0)
+                                      (get_local $2)
                                       (i32.const 16)
                                     )
                                   )
@@ -1154,11 +1154,11 @@
                                 (get_local $6)
                               )
                               (i32.store
-                                (get_local $17)
+                                (get_local $8)
                                 (get_local $21)
                               )
                               (i32.store offset=20
-                                (get_local $0)
+                                (get_local $2)
                                 (get_local $21)
                               )
                             )
@@ -1172,7 +1172,7 @@
                         (if
                           (i32.lt_u
                             (get_local $21)
-                            (tee_local $17
+                            (tee_local $8
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1182,41 +1182,41 @@
                         )
                         (i32.store offset=24
                           (get_local $21)
-                          (get_local $0)
+                          (get_local $2)
                         )
                         (if
-                          (tee_local $4
+                          (tee_local $1
                             (i32.load offset=16
                               (get_local $6)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $4)
-                              (get_local $17)
+                              (get_local $1)
+                              (get_local $8)
                             )
                             (call $qa)
                             (block
                               (i32.store offset=16
                                 (get_local $21)
-                                (get_local $4)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $4)
+                                (get_local $1)
                                 (get_local $21)
                               )
                             )
                           )
                         )
                         (if
-                          (tee_local $4
+                          (tee_local $1
                             (i32.load offset=20
                               (get_local $6)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $4)
+                              (get_local $1)
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1225,10 +1225,10 @@
                             (block
                               (i32.store offset=20
                                 (get_local $21)
-                                (get_local $4)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $4)
+                                (get_local $1)
                                 (get_local $21)
                               )
                             )
@@ -1239,35 +1239,35 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $3)
+                      (get_local $7)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
                         (get_local $6)
                         (i32.or
-                          (tee_local $0
+                          (tee_local $2
                             (i32.add
-                              (get_local $3)
-                              (get_local $2)
+                              (get_local $7)
+                              (get_local $0)
                             )
                           )
                           (i32.const 3)
                         )
                       )
                       (i32.store
-                        (tee_local $4
+                        (tee_local $1
                           (i32.add
                             (i32.add
                               (get_local $6)
-                              (get_local $0)
+                              (get_local $2)
                             )
                             (i32.const 4)
                           )
                         )
                         (i32.or
                           (i32.load
-                            (get_local $4)
+                            (get_local $1)
                           )
                           (i32.const 1)
                         )
@@ -1277,44 +1277,44 @@
                       (i32.store offset=4
                         (get_local $6)
                         (i32.or
-                          (get_local $2)
+                          (get_local $0)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $4)
                         (i32.or
-                          (get_local $3)
+                          (get_local $7)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $1)
-                          (get_local $3)
+                          (get_local $4)
+                          (get_local $7)
                         )
-                        (get_local $3)
+                        (get_local $7)
                       )
                       (if
-                        (tee_local $4
+                        (tee_local $1
                           (i32.load
                             (i32.const 1216)
                           )
                         )
                         (block
-                          (set_local $0
+                          (set_local $2
                             (i32.load
                               (i32.const 1228)
                             )
                           )
-                          (set_local $4
+                          (set_local $1
                             (i32.add
                               (i32.const 1248)
                               (i32.shl
                                 (i32.shl
-                                  (tee_local $17
+                                  (tee_local $8
                                     (i32.shr_u
-                                      (get_local $4)
+                                      (get_local $1)
                                       (i32.const 3)
                                     )
                                   )
@@ -1334,7 +1334,7 @@
                               (tee_local $5
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $17)
+                                  (get_local $8)
                                 )
                               )
                             )
@@ -1344,7 +1344,7 @@
                                   (i32.load
                                     (tee_local $5
                                       (i32.add
-                                        (get_local $4)
+                                        (get_local $1)
                                         (i32.const 8)
                                       )
                                     )
@@ -1374,40 +1374,40 @@
                               )
                               (set_local $42
                                 (i32.add
-                                  (get_local $4)
+                                  (get_local $1)
                                   (i32.const 8)
                                 )
                               )
                               (set_local $35
-                                (get_local $4)
+                                (get_local $1)
                               )
                             )
                           )
                           (i32.store
                             (get_local $42)
-                            (get_local $0)
+                            (get_local $2)
                           )
                           (i32.store offset=12
                             (get_local $35)
-                            (get_local $0)
+                            (get_local $2)
                           )
                           (i32.store offset=8
-                            (get_local $0)
+                            (get_local $2)
                             (get_local $35)
                           )
                           (i32.store offset=12
-                            (get_local $0)
-                            (get_local $4)
+                            (get_local $2)
+                            (get_local $1)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 1216)
-                        (get_local $3)
+                        (get_local $7)
                       )
                       (i32.store
                         (i32.const 1228)
-                        (get_local $1)
+                        (get_local $4)
                       )
                     )
                   )
@@ -1422,12 +1422,12 @@
                   )
                 )
                 (set_local $4
-                  (get_local $2)
+                  (get_local $0)
                 )
               )
             )
             (set_local $4
-              (get_local $2)
+              (get_local $0)
             )
           )
         )
@@ -1440,9 +1440,9 @@
             (i32.const -1)
           )
           (block
-            (set_local $0
+            (set_local $2
               (i32.and
-                (tee_local $4
+                (tee_local $1
                   (i32.add
                     (get_local $0)
                     (i32.const 11)
@@ -1461,7 +1461,7 @@
                 (set_local $5
                   (i32.sub
                     (i32.const 0)
-                    (get_local $0)
+                    (get_local $2)
                   )
                 )
                 (block $label$break$a
@@ -1472,22 +1472,22 @@
                           (i32.shl
                             (tee_local $21
                               (if i32
-                                (tee_local $17
+                                (tee_local $8
                                   (i32.shr_u
-                                    (get_local $4)
+                                    (get_local $1)
                                     (i32.const 8)
                                   )
                                 )
                                 (if i32
                                   (i32.gt_u
-                                    (get_local $0)
+                                    (get_local $2)
                                     (i32.const 16777215)
                                   )
                                   (i32.const 31)
                                   (i32.or
                                     (i32.and
                                       (i32.shr_u
-                                        (get_local $0)
+                                        (get_local $2)
                                         (i32.add
                                           (tee_local $15
                                             (i32.add
@@ -1495,18 +1495,18 @@
                                                 (i32.const 14)
                                                 (i32.or
                                                   (i32.or
-                                                    (tee_local $17
+                                                    (tee_local $8
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (tee_local $8
+                                                            (tee_local $14
                                                               (i32.shl
-                                                                (get_local $17)
-                                                                (tee_local $4
+                                                                (get_local $8)
+                                                                (tee_local $1
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
-                                                                        (get_local $17)
+                                                                        (get_local $8)
                                                                         (i32.const 1048320)
                                                                       )
                                                                       (i32.const 16)
@@ -1523,16 +1523,16 @@
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
-                                                  (tee_local $8
+                                                  (tee_local $14
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $11
+                                                          (tee_local $16
                                                             (i32.shl
+                                                              (get_local $14)
                                                               (get_local $8)
-                                                              (get_local $17)
                                                             )
                                                           )
                                                           (i32.const 245760)
@@ -1546,8 +1546,8 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $11)
-                                                  (get_local $8)
+                                                  (get_local $16)
+                                                  (get_local $14)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -1574,15 +1574,15 @@
                       )
                     )
                     (block
-                      (set_local $8
+                      (set_local $14
                         (get_local $5)
                       )
-                      (set_local $11
+                      (set_local $16
                         (i32.const 0)
                       )
-                      (set_local $4
+                      (set_local $1
                         (i32.shl
-                          (get_local $0)
+                          (get_local $2)
                           (select
                             (i32.const 0)
                             (i32.sub
@@ -1599,7 +1599,7 @@
                           )
                         )
                       )
-                      (set_local $17
+                      (set_local $8
                         (get_local $15)
                       )
                       (set_local $7
@@ -1608,35 +1608,35 @@
                       (loop $while-in14
                         (if
                           (i32.lt_u
-                            (tee_local $2
+                            (tee_local $4
                               (i32.sub
-                                (tee_local $1
+                                (tee_local $0
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $17)
+                                      (get_local $8)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $0)
+                                (get_local $2)
                               )
                             )
-                            (get_local $8)
+                            (get_local $14)
                           )
                           (if
                             (i32.eq
-                              (get_local $1)
                               (get_local $0)
+                              (get_local $2)
                             )
                             (block
                               (set_local $28
-                                (get_local $2)
+                                (get_local $4)
                               )
                               (set_local $27
-                                (get_local $17)
+                                (get_local $8)
                               )
                               (set_local $31
-                                (get_local $17)
+                                (get_local $8)
                               )
                               (set_local $8
                                 (i32.const 90)
@@ -1644,39 +1644,39 @@
                               (br $label$break$a)
                             )
                             (block
-                              (set_local $8
-                                (get_local $2)
+                              (set_local $14
+                                (get_local $4)
                               )
                               (set_local $7
-                                (get_local $17)
+                                (get_local $8)
                               )
                             )
                           )
                         )
-                        (set_local $1
+                        (set_local $0
                           (select
-                            (get_local $11)
-                            (tee_local $2
+                            (get_local $16)
+                            (tee_local $4
                               (i32.load offset=20
-                                (get_local $17)
+                                (get_local $8)
                               )
                             )
                             (i32.or
                               (i32.eqz
-                                (get_local $2)
+                                (get_local $4)
                               )
                               (i32.eq
-                                (get_local $2)
-                                (tee_local $17
+                                (get_local $4)
+                                (tee_local $8
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $17)
+                                        (get_local $8)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $4)
+                                          (get_local $1)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -1689,17 +1689,17 @@
                           )
                         )
                         (if
-                          (tee_local $2
+                          (tee_local $4
                             (i32.eqz
-                              (get_local $17)
+                              (get_local $8)
                             )
                           )
                           (block
                             (set_local $36
-                              (get_local $8)
+                              (get_local $14)
                             )
                             (set_local $37
-                              (get_local $1)
+                              (get_local $0)
                             )
                             (set_local $32
                               (get_local $7)
@@ -1709,15 +1709,15 @@
                             )
                           )
                           (block
-                            (set_local $11
-                              (get_local $1)
+                            (set_local $16
+                              (get_local $0)
                             )
-                            (set_local $4
+                            (set_local $1
                               (i32.shl
-                                (get_local $4)
+                                (get_local $1)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $2)
+                                    (get_local $4)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
@@ -1751,7 +1751,7 @@
                     (i32.const 86)
                   )
                   (if
-                    (tee_local $2
+                    (tee_local $0
                       (if i32
                         (i32.and
                           (i32.eqz
@@ -1784,7 +1784,7 @@
                             )
                             (block
                               (set_local $4
-                                (get_local $0)
+                                (get_local $2)
                               )
                               (br $do-once)
                             )
@@ -1820,7 +1820,7 @@
                                           (tee_local $15
                                             (i32.and
                                               (i32.shr_u
-                                                (tee_local $2
+                                                (tee_local $0
                                                   (i32.shr_u
                                                     (get_local $15)
                                                     (get_local $5)
@@ -1833,12 +1833,12 @@
                                           )
                                           (get_local $5)
                                         )
-                                        (tee_local $2
+                                        (tee_local $0
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $1
+                                              (tee_local $4
                                                 (i32.shr_u
-                                                  (get_local $2)
+                                                  (get_local $0)
                                                   (get_local $15)
                                                 )
                                               )
@@ -1848,13 +1848,13 @@
                                           )
                                         )
                                       )
-                                      (tee_local $1
+                                      (tee_local $4
                                         (i32.and
                                           (i32.shr_u
                                             (tee_local $7
                                               (i32.shr_u
-                                                (get_local $1)
-                                                (get_local $2)
+                                                (get_local $4)
+                                                (get_local $0)
                                               )
                                             )
                                             (i32.const 1)
@@ -1866,10 +1866,10 @@
                                     (tee_local $7
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $4
+                                          (tee_local $1
                                             (i32.shr_u
                                               (get_local $7)
-                                              (get_local $1)
+                                              (get_local $4)
                                             )
                                           )
                                           (i32.const 1)
@@ -1879,7 +1879,7 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $4)
+                                    (get_local $1)
                                     (get_local $7)
                                   )
                                 )
@@ -1897,7 +1897,7 @@
                         (get_local $36)
                       )
                       (set_local $27
-                        (get_local $2)
+                        (get_local $0)
                       )
                       (set_local $31
                         (get_local $32)
@@ -1907,7 +1907,7 @@
                       )
                     )
                     (block
-                      (set_local $16
+                      (set_local $18
                         (get_local $36)
                       )
                       (set_local $10
@@ -1925,7 +1925,7 @@
                     (set_local $8
                       (i32.const 0)
                     )
-                    (set_local $4
+                    (set_local $1
                       (i32.lt_u
                         (tee_local $7
                           (i32.sub
@@ -1935,38 +1935,38 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $0)
+                            (get_local $2)
                           )
                         )
                         (get_local $28)
                       )
                     )
-                    (set_local $1
+                    (set_local $4
                       (select
                         (get_local $7)
                         (get_local $28)
-                        (get_local $4)
+                        (get_local $1)
                       )
                     )
                     (set_local $7
                       (select
                         (get_local $27)
                         (get_local $31)
-                        (get_local $4)
+                        (get_local $1)
                       )
                     )
                     (if
-                      (tee_local $4
+                      (tee_local $1
                         (i32.load offset=16
                           (get_local $27)
                         )
                       )
                       (block
                         (set_local $28
-                          (get_local $1)
+                          (get_local $4)
                         )
                         (set_local $27
-                          (get_local $4)
+                          (get_local $1)
                         )
                         (set_local $31
                           (get_local $7)
@@ -1982,7 +1982,7 @@
                       )
                       (block
                         (set_local $28
-                          (get_local $1)
+                          (get_local $4)
                         )
                         (set_local $31
                           (get_local $7)
@@ -1990,8 +1990,8 @@
                         (br $while-in16)
                       )
                       (block
-                        (set_local $16
-                          (get_local $1)
+                        (set_local $18
+                          (get_local $4)
                         )
                         (set_local $10
                           (get_local $7)
@@ -2004,12 +2004,12 @@
                   (get_local $10)
                   (if
                     (i32.lt_u
-                      (get_local $16)
+                      (get_local $18)
                       (i32.sub
                         (i32.load
                           (i32.const 1216)
                         )
-                        (get_local $0)
+                        (get_local $2)
                       )
                     )
                     (block
@@ -2030,13 +2030,13 @@
                           (tee_local $7
                             (i32.add
                               (get_local $10)
-                              (get_local $0)
+                              (get_local $2)
                             )
                           )
                         )
                         (call $qa)
                       )
-                      (set_local $1
+                      (set_local $4
                         (i32.load offset=24
                           (get_local $10)
                         )
@@ -2044,7 +2044,7 @@
                       (block $do-once17
                         (if
                           (i32.eq
-                            (tee_local $4
+                            (tee_local $1
                               (i32.load offset=12
                                 (get_local $10)
                               )
@@ -2055,7 +2055,7 @@
                             (if
                               (tee_local $5
                                 (i32.load
-                                  (tee_local $2
+                                  (tee_local $0
                                     (i32.add
                                       (get_local $10)
                                       (i32.const 20)
@@ -2064,15 +2064,15 @@
                                 )
                               )
                               (block
-                                (set_local $11
+                                (set_local $16
                                   (get_local $5)
                                 )
-                                (set_local $3
-                                  (get_local $2)
+                                (set_local $1
+                                  (get_local $0)
                                 )
                               )
                               (if
-                                (tee_local $11
+                                (tee_local $16
                                   (i32.load
                                     (tee_local $15
                                       (i32.add
@@ -2082,7 +2082,7 @@
                                     )
                                   )
                                 )
-                                (set_local $3
+                                (set_local $1
                                   (get_local $15)
                                 )
                                 (block
@@ -2097,20 +2097,20 @@
                               (if
                                 (tee_local $5
                                   (i32.load
-                                    (tee_local $2
+                                    (tee_local $0
                                       (i32.add
-                                        (get_local $11)
+                                        (get_local $16)
                                         (i32.const 20)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $11
+                                  (set_local $16
                                     (get_local $5)
                                   )
-                                  (set_local $3
-                                    (get_local $2)
+                                  (set_local $1
+                                    (get_local $0)
                                   )
                                   (br $while-in20)
                                 )
@@ -2118,20 +2118,20 @@
                               (if
                                 (tee_local $5
                                   (i32.load
-                                    (tee_local $2
+                                    (tee_local $0
                                       (i32.add
-                                        (get_local $11)
+                                        (get_local $16)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $11
+                                  (set_local $16
                                     (get_local $5)
                                   )
-                                  (set_local $3
-                                    (get_local $2)
+                                  (set_local $1
+                                    (get_local $0)
                                   )
                                   (br $while-in20)
                                 )
@@ -2139,17 +2139,17 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $3)
+                                (get_local $1)
                                 (get_local $9)
                               )
                               (call $qa)
                               (block
                                 (i32.store
-                                  (get_local $3)
+                                  (get_local $1)
                                   (i32.const 0)
                                 )
                                 (set_local $23
-                                  (get_local $11)
+                                  (get_local $16)
                                 )
                               )
                             )
@@ -2157,7 +2157,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (tee_local $2
+                                (tee_local $0
                                   (i32.load offset=8
                                     (get_local $10)
                                   )
@@ -2171,7 +2171,7 @@
                                 (i32.load
                                   (tee_local $5
                                     (i32.add
-                                      (get_local $2)
+                                      (get_local $0)
                                       (i32.const 12)
                                     )
                                   )
@@ -2185,7 +2185,7 @@
                                 (i32.load
                                   (tee_local $15
                                     (i32.add
-                                      (get_local $4)
+                                      (get_local $1)
                                       (i32.const 8)
                                     )
                                   )
@@ -2195,14 +2195,14 @@
                               (block
                                 (i32.store
                                   (get_local $5)
-                                  (get_local $4)
+                                  (get_local $1)
                                 )
                                 (i32.store
                                   (get_local $15)
-                                  (get_local $2)
+                                  (get_local $0)
                                 )
                                 (set_local $23
-                                  (get_local $4)
+                                  (get_local $1)
                                 )
                               )
                               (call $qa)
@@ -2212,7 +2212,7 @@
                       )
                       (block $do-once21
                         (if
-                          (get_local $1)
+                          (get_local $4)
                           (block
                             (if
                               (i32.eq
@@ -2222,7 +2222,7 @@
                                     (i32.add
                                       (i32.const 1512)
                                       (i32.shl
-                                        (tee_local $4
+                                        (tee_local $1
                                           (i32.load offset=28
                                             (get_local $10)
                                           )
@@ -2252,7 +2252,7 @@
                                         (i32.xor
                                           (i32.shl
                                             (i32.const 1)
-                                            (get_local $4)
+                                            (get_local $1)
                                           )
                                           (i32.const -1)
                                         )
@@ -2265,7 +2265,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $1)
+                                    (get_local $4)
                                     (i32.load
                                       (i32.const 1224)
                                     )
@@ -2275,9 +2275,9 @@
                                 (if
                                   (i32.eq
                                     (i32.load
-                                      (tee_local $4
+                                      (tee_local $1
                                         (i32.add
-                                          (get_local $1)
+                                          (get_local $4)
                                           (i32.const 16)
                                         )
                                       )
@@ -2285,11 +2285,11 @@
                                     (get_local $10)
                                   )
                                   (i32.store
-                                    (get_local $4)
+                                    (get_local $1)
                                     (get_local $23)
                                   )
                                   (i32.store offset=20
-                                    (get_local $1)
+                                    (get_local $4)
                                     (get_local $23)
                                   )
                                 )
@@ -2303,7 +2303,7 @@
                             (if
                               (i32.lt_u
                                 (get_local $23)
-                                (tee_local $4
+                                (tee_local $1
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2313,7 +2313,7 @@
                             )
                             (i32.store offset=24
                               (get_local $23)
-                              (get_local $1)
+                              (get_local $4)
                             )
                             (if
                               (tee_local $9
@@ -2324,7 +2324,7 @@
                               (if
                                 (i32.lt_u
                                   (get_local $9)
-                                  (get_local $4)
+                                  (get_local $1)
                                 )
                                 (call $qa)
                                 (block
@@ -2371,17 +2371,17 @@
                       (block $do-once25
                         (if
                           (i32.lt_u
-                            (get_local $16)
+                            (get_local $18)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
                               (get_local $10)
                               (i32.or
-                                (tee_local $1
+                                (tee_local $4
                                   (i32.add
-                                    (get_local $16)
-                                    (get_local $0)
+                                    (get_local $18)
+                                    (get_local $2)
                                   )
                                 )
                                 (i32.const 3)
@@ -2392,7 +2392,7 @@
                                 (i32.add
                                   (i32.add
                                     (get_local $10)
-                                    (get_local $1)
+                                    (get_local $4)
                                   )
                                   (i32.const 4)
                                 )
@@ -2409,37 +2409,37 @@
                             (i32.store offset=4
                               (get_local $10)
                               (i32.or
-                                (get_local $0)
+                                (get_local $2)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
                               (get_local $7)
                               (i32.or
-                                (get_local $16)
+                                (get_local $18)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
                                 (get_local $7)
-                                (get_local $16)
+                                (get_local $18)
                               )
-                              (get_local $16)
+                              (get_local $18)
                             )
                             (set_local $9
                               (i32.shr_u
-                                (get_local $16)
+                                (get_local $18)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $16)
+                                (get_local $18)
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $1
+                                (set_local $4
                                   (i32.add
                                     (i32.const 1248)
                                     (i32.shl
@@ -2453,12 +2453,12 @@
                                 )
                                 (if
                                   (i32.and
-                                    (tee_local $4
+                                    (tee_local $1
                                       (i32.load
                                         (i32.const 1208)
                                       )
                                     )
-                                    (tee_local $2
+                                    (tee_local $0
                                       (i32.shl
                                         (i32.const 1)
                                         (get_local $9)
@@ -2467,11 +2467,11 @@
                                   )
                                   (if
                                     (i32.lt_u
-                                      (tee_local $4
+                                      (tee_local $1
                                         (i32.load
-                                          (tee_local $2
+                                          (tee_local $0
                                             (i32.add
-                                              (get_local $1)
+                                              (get_local $4)
                                               (i32.const 8)
                                             )
                                           )
@@ -2484,10 +2484,10 @@
                                     (call $qa)
                                     (block
                                       (set_local $19
-                                        (get_local $2)
+                                        (get_local $0)
                                       )
                                       (set_local $6
-                                        (get_local $4)
+                                        (get_local $1)
                                       )
                                     )
                                   )
@@ -2495,18 +2495,18 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $4)
-                                        (get_local $2)
+                                        (get_local $1)
+                                        (get_local $0)
                                       )
                                     )
                                     (set_local $19
                                       (i32.add
-                                        (get_local $1)
+                                        (get_local $4)
                                         (i32.const 8)
                                       )
                                     )
                                     (set_local $6
-                                      (get_local $1)
+                                      (get_local $4)
                                     )
                                   )
                                 )
@@ -2524,7 +2524,7 @@
                                 )
                                 (i32.store offset=12
                                   (get_local $7)
-                                  (get_local $1)
+                                  (get_local $4)
                                 )
                                 (br $do-once25)
                               )
@@ -2533,24 +2533,24 @@
                               (i32.add
                                 (i32.const 1512)
                                 (i32.shl
-                                  (tee_local $11
+                                  (tee_local $14
                                     (if i32
-                                      (tee_local $1
+                                      (tee_local $4
                                         (i32.shr_u
-                                          (get_local $16)
+                                          (get_local $18)
                                           (i32.const 8)
                                         )
                                       )
                                       (if i32
                                         (i32.gt_u
-                                          (get_local $16)
+                                          (get_local $18)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $16)
+                                              (get_local $18)
                                               (i32.add
                                                 (tee_local $15
                                                   (i32.add
@@ -2558,18 +2558,18 @@
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (tee_local $1
+                                                          (tee_local $4
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (tee_local $2
+                                                                  (tee_local $0
                                                                     (i32.shl
-                                                                      (get_local $1)
-                                                                      (tee_local $4
+                                                                      (get_local $4)
+                                                                      (tee_local $1
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $1)
+                                                                              (get_local $4)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -2586,16 +2586,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $4)
+                                                          (get_local $1)
                                                         )
-                                                        (tee_local $2
+                                                        (tee_local $0
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
                                                                 (tee_local $9
                                                                   (i32.shl
-                                                                    (get_local $2)
-                                                                    (get_local $1)
+                                                                    (get_local $0)
+                                                                    (get_local $4)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -2610,7 +2610,7 @@
                                                     (i32.shr_u
                                                       (i32.shl
                                                         (get_local $9)
-                                                        (get_local $2)
+                                                        (get_local $0)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -2636,10 +2636,10 @@
                             )
                             (i32.store offset=28
                               (get_local $7)
-                              (get_local $11)
+                              (get_local $14)
                             )
                             (i32.store offset=4
-                              (tee_local $2
+                              (tee_local $0
                                 (i32.add
                                   (get_local $7)
                                   (i32.const 16)
@@ -2648,13 +2648,13 @@
                               (i32.const 0)
                             )
                             (i32.store
-                              (get_local $2)
+                              (get_local $0)
                               (i32.const 0)
                             )
                             (if
                               (i32.eqz
                                 (i32.and
-                                  (tee_local $2
+                                  (tee_local $0
                                     (i32.load
                                       (i32.const 1212)
                                     )
@@ -2662,7 +2662,7 @@
                                   (tee_local $9
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $11)
+                                      (get_local $14)
                                     )
                                   )
                                 )
@@ -2671,7 +2671,7 @@
                                 (i32.store
                                   (i32.const 1212)
                                   (i32.or
-                                    (get_local $2)
+                                    (get_local $0)
                                     (get_local $9)
                                   )
                                 )
@@ -2696,24 +2696,24 @@
                             )
                             (set_local $9
                               (i32.shl
-                                (get_local $16)
+                                (get_local $18)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $11)
+                                      (get_local $14)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $11)
+                                    (get_local $14)
                                     (i32.const 31)
                                   )
                                 )
                               )
                             )
-                            (set_local $2
+                            (set_local $0
                               (i32.load
                                 (get_local $15)
                               )
@@ -2724,15 +2724,15 @@
                                   (i32.eq
                                     (i32.and
                                       (i32.load offset=4
-                                        (get_local $2)
+                                        (get_local $0)
                                       )
                                       (i32.const -8)
                                     )
-                                    (get_local $16)
+                                    (get_local $18)
                                   )
                                   (block
-                                    (set_local $18
-                                      (get_local $2)
+                                    (set_local $17
+                                      (get_local $0)
                                     )
                                     (set_local $8
                                       (i32.const 148)
@@ -2741,12 +2741,12 @@
                                   )
                                 )
                                 (if
-                                  (tee_local $4
+                                  (tee_local $1
                                     (i32.load
                                       (tee_local $15
                                         (i32.add
                                           (i32.add
-                                            (get_local $2)
+                                            (get_local $0)
                                             (i32.const 16)
                                           )
                                           (i32.shl
@@ -2767,8 +2767,8 @@
                                         (i32.const 1)
                                       )
                                     )
-                                    (set_local $2
-                                      (get_local $4)
+                                    (set_local $0
+                                      (get_local $1)
                                     )
                                     (br $while-in28)
                                   )
@@ -2776,8 +2776,8 @@
                                     (set_local $22
                                       (get_local $15)
                                     )
-                                    (set_local $14
-                                      (get_local $2)
+                                    (set_local $13
+                                      (get_local $0)
                                     )
                                     (set_local $8
                                       (i32.const 145)
@@ -2806,7 +2806,7 @@
                                   )
                                   (i32.store offset=24
                                     (get_local $7)
-                                    (get_local $14)
+                                    (get_local $13)
                                   )
                                   (i32.store offset=12
                                     (get_local $7)
@@ -2828,23 +2828,23 @@
                                     (i32.ge_u
                                       (tee_local $9
                                         (i32.load
-                                          (tee_local $2
+                                          (tee_local $0
                                             (i32.add
-                                              (get_local $18)
+                                              (get_local $17)
                                               (i32.const 8)
                                             )
                                           )
                                         )
                                       )
-                                      (tee_local $4
+                                      (tee_local $1
                                         (i32.load
                                           (i32.const 1224)
                                         )
                                       )
                                     )
                                     (i32.ge_u
-                                      (get_local $18)
-                                      (get_local $4)
+                                      (get_local $17)
+                                      (get_local $1)
                                     )
                                   )
                                   (block
@@ -2853,7 +2853,7 @@
                                       (get_local $7)
                                     )
                                     (i32.store
-                                      (get_local $2)
+                                      (get_local $0)
                                       (get_local $7)
                                     )
                                     (i32.store offset=8
@@ -2862,7 +2862,7 @@
                                     )
                                     (i32.store offset=12
                                       (get_local $7)
-                                      (get_local $18)
+                                      (get_local $17)
                                     )
                                     (i32.store offset=24
                                       (get_local $7)
@@ -2887,16 +2887,16 @@
                       )
                     )
                     (set_local $4
-                      (get_local $0)
+                      (get_local $2)
                     )
                   )
                   (set_local $4
-                    (get_local $0)
+                    (get_local $2)
                   )
                 )
               )
               (set_local $4
-                (get_local $0)
+                (get_local $2)
               )
             )
           )
@@ -2913,14 +2913,14 @@
         (get_local $4)
       )
       (block
-        (set_local $14
+        (set_local $13
           (i32.load
             (i32.const 1228)
           )
         )
         (if
           (i32.gt_u
-            (tee_local $18
+            (tee_local $17
               (i32.sub
                 (get_local $10)
                 (get_local $4)
@@ -2933,31 +2933,31 @@
               (i32.const 1228)
               (tee_local $22
                 (i32.add
-                  (get_local $14)
+                  (get_local $13)
                   (get_local $4)
                 )
               )
             )
             (i32.store
               (i32.const 1216)
-              (get_local $18)
+              (get_local $17)
             )
             (i32.store offset=4
               (get_local $22)
               (i32.or
-                (get_local $18)
+                (get_local $17)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $22)
-                (get_local $18)
+                (get_local $17)
               )
-              (get_local $18)
+              (get_local $17)
             )
             (i32.store offset=4
-              (get_local $14)
+              (get_local $13)
               (i32.or
                 (get_local $4)
                 (i32.const 3)
@@ -2974,17 +2974,17 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $14)
+              (get_local $13)
               (i32.or
                 (get_local $10)
                 (i32.const 3)
               )
             )
             (i32.store
-              (tee_local $18
+              (tee_local $17
                 (i32.add
                   (i32.add
-                    (get_local $14)
+                    (get_local $13)
                     (get_local $10)
                   )
                   (i32.const 4)
@@ -2992,7 +2992,7 @@
               )
               (i32.or
                 (i32.load
-                  (get_local $18)
+                  (get_local $17)
                 )
                 (i32.const 1)
               )
@@ -3004,7 +3004,7 @@
         )
         (return
           (i32.add
-            (get_local $14)
+            (get_local $13)
             (i32.const 8)
           )
         )
@@ -3012,7 +3012,7 @@
     )
     (if
       (i32.gt_u
-        (tee_local $14
+        (tee_local $13
           (i32.load
             (i32.const 1220)
           )
@@ -3022,9 +3022,9 @@
       (block
         (i32.store
           (i32.const 1220)
-          (tee_local $18
+          (tee_local $17
             (i32.sub
-              (get_local $14)
+              (get_local $13)
               (get_local $4)
             )
           )
@@ -3033,7 +3033,7 @@
           (i32.const 1232)
           (tee_local $10
             (i32.add
-              (tee_local $14
+              (tee_local $13
                 (i32.load
                   (i32.const 1232)
                 )
@@ -3045,12 +3045,12 @@
         (i32.store offset=4
           (get_local $10)
           (i32.or
-            (get_local $18)
+            (get_local $17)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $14)
+          (get_local $13)
           (i32.or
             (get_local $4)
             (i32.const 3)
@@ -3061,7 +3061,7 @@
         )
         (return
           (i32.add
-            (get_local $14)
+            (get_local $13)
             (i32.const 8)
           )
         )
@@ -3099,11 +3099,11 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $13)
-          (tee_local $14
+          (get_local $12)
+          (tee_local $13
             (i32.xor
               (i32.and
-                (get_local $13)
+                (get_local $12)
                 (i32.const -16)
               )
               (i32.const 1431655768)
@@ -3112,11 +3112,11 @@
         )
         (i32.store
           (i32.const 1680)
-          (get_local $14)
+          (get_local $13)
         )
       )
     )
-    (set_local $14
+    (set_local $13
       (i32.add
         (get_local $4)
         (i32.const 48)
@@ -3124,16 +3124,16 @@
     )
     (if
       (i32.le_u
-        (tee_local $13
+        (tee_local $12
           (i32.and
             (tee_local $10
               (i32.add
-                (tee_local $13
+                (tee_local $12
                   (i32.load
                     (i32.const 1688)
                   )
                 )
-                (tee_local $18
+                (tee_local $17
                   (i32.add
                     (get_local $4)
                     (i32.const 47)
@@ -3144,7 +3144,7 @@
             (tee_local $22
               (i32.sub
                 (i32.const 0)
-                (get_local $13)
+                (get_local $12)
               )
             )
           )
@@ -3161,7 +3161,7 @@
       )
     )
     (if
-      (tee_local $16
+      (tee_local $18
         (i32.load
           (i32.const 1648)
         )
@@ -3171,19 +3171,19 @@
           (i32.le_u
             (tee_local $6
               (i32.add
-                (tee_local $11
+                (tee_local $14
                   (i32.load
                     (i32.const 1640)
                   )
                 )
-                (get_local $13)
+                (get_local $12)
               )
             )
-            (get_local $11)
+            (get_local $14)
           )
           (i32.gt_u
             (get_local $6)
-            (get_local $16)
+            (get_local $18)
           )
         )
         (block
@@ -3211,7 +3211,7 @@
               (block i32
                 (block $label$break$c
                   (if
-                    (tee_local $16
+                    (tee_local $18
                       (i32.load
                         (i32.const 1232)
                       )
@@ -3224,17 +3224,17 @@
                         (block $while-out31
                           (if
                             (i32.le_u
-                              (tee_local $11
+                              (tee_local $14
                                 (i32.load
                                   (get_local $6)
                                 )
                               )
-                              (get_local $16)
+                              (get_local $18)
                             )
                             (if
                               (i32.gt_u
                                 (i32.add
-                                  (get_local $11)
+                                  (get_local $14)
                                   (i32.load
                                     (tee_local $19
                                       (i32.add
@@ -3244,10 +3244,10 @@
                                     )
                                   )
                                 )
-                                (get_local $16)
+                                (get_local $18)
                               )
                               (block
-                                (set_local $0
+                                (set_local $2
                                   (get_local $6)
                                 )
                                 (set_local $5
@@ -3294,7 +3294,7 @@
                             )
                             (i32.add
                               (i32.load
-                                (get_local $0)
+                                (get_local $2)
                               )
                               (i32.load
                                 (get_local $5)
@@ -3319,7 +3319,7 @@
                             )
                           )
                           (block
-                            (set_local $12
+                            (set_local $11
                               (get_local $19)
                             )
                             (set_local $3
@@ -3345,7 +3345,7 @@
                     )
                     (if
                       (i32.ne
-                        (tee_local $16
+                        (tee_local $18
                           (call $ta
                             (i32.const 0)
                           )
@@ -3353,7 +3353,7 @@
                         (i32.const -1)
                       )
                       (block
-                        (set_local $2
+                        (set_local $0
                           (if i32
                             (i32.and
                               (tee_local $19
@@ -3366,19 +3366,19 @@
                                   (i32.const -1)
                                 )
                               )
-                              (tee_local $0
-                                (get_local $16)
+                              (tee_local $2
+                                (get_local $18)
                               )
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $13)
-                                (get_local $0)
+                                (get_local $12)
+                                (get_local $2)
                               )
                               (i32.and
                                 (i32.add
                                   (get_local $19)
-                                  (get_local $0)
+                                  (get_local $2)
                                 )
                                 (i32.sub
                                   (i32.const 0)
@@ -3386,27 +3386,27 @@
                                 )
                               )
                             )
-                            (get_local $13)
+                            (get_local $12)
                           )
                         )
-                        (set_local $0
+                        (set_local $2
                           (i32.add
                             (tee_local $6
                               (i32.load
                                 (i32.const 1640)
                               )
                             )
-                            (get_local $2)
+                            (get_local $0)
                           )
                         )
                         (if
                           (i32.and
                             (i32.gt_u
-                              (get_local $2)
+                              (get_local $0)
                               (get_local $4)
                             )
                             (i32.lt_u
-                              (get_local $2)
+                              (get_local $0)
                               (i32.const 2147483647)
                             )
                           )
@@ -3420,11 +3420,11 @@
                               (br_if $do-once33
                                 (i32.or
                                   (i32.le_u
-                                    (get_local $0)
+                                    (get_local $2)
                                     (get_local $6)
                                   )
                                   (i32.gt_u
-                                    (get_local $0)
+                                    (get_local $2)
                                     (get_local $19)
                                   )
                                 )
@@ -3434,28 +3434,28 @@
                               (i32.eq
                                 (tee_local $19
                                   (call $ta
-                                    (get_local $2)
+                                    (get_local $0)
                                   )
                                 )
-                                (get_local $16)
+                                (get_local $18)
                               )
                               (block
                                 (set_local $20
-                                  (get_local $16)
+                                  (get_local $18)
                                 )
                                 (set_local $26
-                                  (get_local $2)
+                                  (get_local $0)
                                 )
                                 (br $label$break$b
                                   (i32.const 191)
                                 )
                               )
                               (block
-                                (set_local $12
+                                (set_local $11
                                   (get_local $19)
                                 )
                                 (set_local $3
-                                  (get_local $2)
+                                  (get_local $0)
                                 )
                                 (set_local $8
                                   (i32.const 181)
@@ -3484,7 +3484,7 @@
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $14)
+                            (get_local $13)
                             (get_local $3)
                           )
                           (i32.and
@@ -3493,21 +3493,21 @@
                               (i32.const 2147483647)
                             )
                             (i32.ne
-                              (get_local $12)
+                              (get_local $11)
                               (i32.const -1)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $0
+                            (tee_local $2
                               (i32.and
                                 (i32.add
                                   (i32.sub
-                                    (get_local $18)
+                                    (get_local $17)
                                     (get_local $3)
                                   )
-                                  (tee_local $16
+                                  (tee_local $18
                                     (i32.load
                                       (i32.const 1688)
                                     )
@@ -3515,7 +3515,7 @@
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $16)
+                                  (get_local $18)
                                 )
                               )
                             )
@@ -3524,7 +3524,7 @@
                           (if
                             (i32.eq
                               (call $ta
-                                (get_local $0)
+                                (get_local $2)
                               )
                               (i32.const -1)
                             )
@@ -3538,7 +3538,7 @@
                             )
                             (set_local $1
                               (i32.add
-                                (get_local $0)
+                                (get_local $2)
                                 (get_local $3)
                               )
                             )
@@ -3553,12 +3553,12 @@
                       )
                       (if
                         (i32.ne
-                          (get_local $12)
+                          (get_local $11)
                           (i32.const -1)
                         )
                         (block
                           (set_local $20
-                            (get_local $12)
+                            (get_local $11)
                           )
                           (set_local $26
                             (get_local $1)
@@ -3589,7 +3589,7 @@
       )
       (if
         (i32.lt_u
-          (get_local $13)
+          (get_local $12)
           (i32.const 2147483647)
         )
         (if
@@ -3597,10 +3597,10 @@
             (i32.lt_u
               (tee_local $1
                 (call $ta
-                  (get_local $13)
+                  (get_local $12)
                 )
               )
-              (tee_local $13
+              (tee_local $12
                 (call $ta
                   (i32.const 0)
                 )
@@ -3612,16 +3612,16 @@
                 (i32.const -1)
               )
               (i32.ne
-                (get_local $13)
+                (get_local $12)
                 (i32.const -1)
               )
             )
           )
           (if
             (i32.gt_u
-              (tee_local $12
+              (tee_local $11
                 (i32.sub
-                  (get_local $13)
+                  (get_local $12)
                   (get_local $1)
                 )
               )
@@ -3635,7 +3635,7 @@
                 (get_local $1)
               )
               (set_local $26
-                (get_local $12)
+                (get_local $11)
               )
               (set_local $8
                 (i32.const 191)
@@ -3653,7 +3653,7 @@
       (block
         (i32.store
           (i32.const 1640)
-          (tee_local $12
+          (tee_local $11
             (i32.add
               (i32.load
                 (i32.const 1640)
@@ -3664,19 +3664,19 @@
         )
         (if
           (i32.gt_u
-            (get_local $12)
+            (get_local $11)
             (i32.load
               (i32.const 1644)
             )
           )
           (i32.store
             (i32.const 1644)
-            (get_local $12)
+            (get_local $11)
           )
         )
         (block $do-once38
           (if
-            (tee_local $12
+            (tee_local $11
               (i32.load
                 (i32.const 1232)
               )
@@ -3696,9 +3696,9 @@
                             (get_local $3)
                           )
                         )
-                        (tee_local $18
+                        (tee_local $17
                           (i32.load
-                            (tee_local $13
+                            (tee_local $12
                               (i32.add
                                 (get_local $3)
                                 (i32.const 4)
@@ -3713,10 +3713,10 @@
                         (get_local $1)
                       )
                       (set_local $50
-                        (get_local $13)
+                        (get_local $12)
                       )
                       (set_local $51
-                        (get_local $18)
+                        (get_local $17)
                       )
                       (set_local $52
                         (get_local $3)
@@ -3756,11 +3756,11 @@
                   (if
                     (i32.and
                       (i32.lt_u
-                        (get_local $12)
+                        (get_local $11)
                         (get_local $20)
                       )
                       (i32.ge_u
-                        (get_local $12)
+                        (get_local $11)
                         (get_local $49)
                       )
                     )
@@ -3774,15 +3774,15 @@
                       )
                       (set_local $3
                         (i32.add
-                          (get_local $12)
-                          (tee_local $18
+                          (get_local $11)
+                          (tee_local $17
                             (select
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
                                   (tee_local $3
                                     (i32.add
-                                      (get_local $12)
+                                      (get_local $11)
                                       (i32.const 8)
                                     )
                                   )
@@ -3798,11 +3798,11 @@
                           )
                         )
                       )
-                      (set_local $13
+                      (set_local $12
                         (i32.add
                           (i32.sub
                             (get_local $26)
-                            (get_local $18)
+                            (get_local $17)
                           )
                           (i32.load
                             (i32.const 1220)
@@ -3815,19 +3815,19 @@
                       )
                       (i32.store
                         (i32.const 1220)
-                        (get_local $13)
+                        (get_local $12)
                       )
                       (i32.store offset=4
                         (get_local $3)
                         (i32.or
-                          (get_local $13)
+                          (get_local $12)
                           (i32.const 1)
                         )
                       )
                       (i32.store offset=4
                         (i32.add
                           (get_local $3)
-                          (get_local $13)
+                          (get_local $12)
                         )
                         (i32.const 40)
                       )
@@ -3846,7 +3846,7 @@
                 (if i32
                   (i32.lt_u
                     (get_local $20)
-                    (tee_local $13
+                    (tee_local $12
                       (i32.load
                         (i32.const 1224)
                       )
@@ -3859,10 +3859,10 @@
                     )
                     (get_local $20)
                   )
-                  (get_local $13)
+                  (get_local $12)
                 )
               )
-              (set_local $13
+              (set_local $12
                 (i32.add
                   (get_local $20)
                   (get_local $26)
@@ -3878,7 +3878,7 @@
                       (i32.load
                         (get_local $3)
                       )
-                      (get_local $13)
+                      (get_local $12)
                     )
                     (block
                       (set_local $53
@@ -3939,7 +3939,7 @@
                         (get_local $26)
                       )
                     )
-                    (set_local $18
+                    (set_local $17
                       (i32.add
                         (get_local $20)
                         (select
@@ -3965,14 +3965,14 @@
                     )
                     (set_local $1
                       (i32.add
-                        (get_local $13)
+                        (get_local $12)
                         (select
                           (i32.and
                             (i32.sub
                               (i32.const 0)
                               (tee_local $3
                                 (i32.add
-                                  (get_local $13)
+                                  (get_local $12)
                                   (i32.const 8)
                                 )
                               )
@@ -3989,21 +3989,21 @@
                     )
                     (set_local $3
                       (i32.add
-                        (get_local $18)
+                        (get_local $17)
                         (get_local $4)
                       )
                     )
-                    (set_local $14
+                    (set_local $13
                       (i32.sub
                         (i32.sub
                           (get_local $1)
-                          (get_local $18)
+                          (get_local $17)
                         )
                         (get_local $4)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $18)
+                      (get_local $17)
                       (i32.or
                         (get_local $4)
                         (i32.const 3)
@@ -4013,17 +4013,17 @@
                       (if
                         (i32.eq
                           (get_local $1)
-                          (get_local $12)
+                          (get_local $11)
                         )
                         (block
                           (i32.store
                             (i32.const 1220)
-                            (tee_local $2
+                            (tee_local $0
                               (i32.add
                                 (i32.load
                                   (i32.const 1220)
                                 )
-                                (get_local $14)
+                                (get_local $13)
                               )
                             )
                           )
@@ -4034,7 +4034,7 @@
                           (i32.store offset=4
                             (get_local $3)
                             (i32.or
-                              (get_local $2)
+                              (get_local $0)
                               (i32.const 1)
                             )
                           )
@@ -4050,12 +4050,12 @@
                             (block
                               (i32.store
                                 (i32.const 1216)
-                                (tee_local $2
+                                (tee_local $0
                                   (i32.add
                                     (i32.load
                                       (i32.const 1216)
                                     )
-                                    (get_local $14)
+                                    (get_local $13)
                                   )
                                 )
                               )
@@ -4066,27 +4066,27 @@
                               (i32.store offset=4
                                 (get_local $3)
                                 (i32.or
-                                  (get_local $2)
+                                  (get_local $0)
                                   (i32.const 1)
                                 )
                               )
                               (i32.store
                                 (i32.add
                                   (get_local $3)
-                                  (get_local $2)
+                                  (get_local $0)
                                 )
-                                (get_local $2)
+                                (get_local $0)
                               )
                               (br $do-once44)
                             )
                           )
                           (i32.store
-                            (tee_local $0
+                            (tee_local $2
                               (i32.add
                                 (if i32
                                   (i32.eq
                                     (i32.and
-                                      (tee_local $2
+                                      (tee_local $0
                                         (i32.load offset=4
                                           (get_local $1)
                                         )
@@ -4098,20 +4098,20 @@
                                   (block i32
                                     (set_local $5
                                       (i32.and
-                                        (get_local $2)
+                                        (get_local $0)
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $0
+                                    (set_local $2
                                       (i32.shr_u
-                                        (get_local $2)
+                                        (get_local $0)
                                         (i32.const 3)
                                       )
                                     )
                                     (block $label$break$e
                                       (if
                                         (i32.lt_u
-                                          (get_local $2)
+                                          (get_local $0)
                                           (i32.const 256)
                                         )
                                         (block
@@ -4133,7 +4133,7 @@
                                                     (i32.const 1248)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $0)
+                                                        (get_local $2)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4176,7 +4176,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $0)
+                                                      (get_local $2)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4208,7 +4208,7 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $0
+                                                      (tee_local $2
                                                         (i32.add
                                                           (get_local $10)
                                                           (i32.const 8)
@@ -4219,7 +4219,7 @@
                                                   )
                                                   (block
                                                     (set_local $44
-                                                      (get_local $0)
+                                                      (get_local $2)
                                                     )
                                                     (br $do-once49)
                                                   )
@@ -4246,7 +4246,7 @@
                                           (block $do-once51
                                             (if
                                               (i32.eq
-                                                (tee_local $0
+                                                (tee_local $2
                                                   (i32.load offset=12
                                                     (get_local $1)
                                                   )
@@ -4255,11 +4255,11 @@
                                               )
                                               (block
                                                 (if
-                                                  (tee_local $11
+                                                  (tee_local $14
                                                     (i32.load
                                                       (tee_local $6
                                                         (i32.add
-                                                          (tee_local $16
+                                                          (tee_local $18
                                                             (i32.add
                                                               (get_local $1)
                                                               (i32.const 16)
@@ -4272,20 +4272,25 @@
                                                   )
                                                   (block
                                                     (set_local $0
-                                                      (get_local $11)
+                                                      (get_local $14)
                                                     )
-                                                    (set_local $16
+                                                    (set_local $2
                                                       (get_local $6)
                                                     )
                                                   )
                                                   (if
                                                     (tee_local $23
                                                       (i32.load
-                                                        (get_local $16)
+                                                        (get_local $18)
                                                       )
                                                     )
-                                                    (set_local $0
-                                                      (get_local $23)
+                                                    (block
+                                                      (set_local $0
+                                                        (get_local $23)
+                                                      )
+                                                      (set_local $2
+                                                        (get_local $18)
+                                                      )
                                                     )
                                                     (block
                                                       (set_local $24
@@ -4297,7 +4302,7 @@
                                                 )
                                                 (loop $while-in54
                                                   (if
-                                                    (tee_local $11
+                                                    (tee_local $14
                                                       (i32.load
                                                         (tee_local $6
                                                           (i32.add
@@ -4309,16 +4314,16 @@
                                                     )
                                                     (block
                                                       (set_local $0
-                                                        (get_local $11)
+                                                        (get_local $14)
                                                       )
-                                                      (set_local $16
+                                                      (set_local $2
                                                         (get_local $6)
                                                       )
                                                       (br $while-in54)
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $11
+                                                    (tee_local $14
                                                       (i32.load
                                                         (tee_local $6
                                                           (i32.add
@@ -4330,9 +4335,9 @@
                                                     )
                                                     (block
                                                       (set_local $0
-                                                        (get_local $11)
+                                                        (get_local $14)
                                                       )
-                                                      (set_local $16
+                                                      (set_local $2
                                                         (get_local $6)
                                                       )
                                                       (br $while-in54)
@@ -4341,13 +4346,13 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $16)
+                                                    (get_local $2)
                                                     (get_local $7)
                                                   )
                                                   (call $qa)
                                                   (block
                                                     (i32.store
-                                                      (get_local $16)
+                                                      (get_local $2)
                                                       (i32.const 0)
                                                     )
                                                     (set_local $24
@@ -4371,7 +4376,7 @@
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (tee_local $11
+                                                      (tee_local $14
                                                         (i32.add
                                                           (get_local $6)
                                                           (i32.const 12)
@@ -4385,9 +4390,9 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $16
+                                                      (tee_local $18
                                                         (i32.add
-                                                          (get_local $0)
+                                                          (get_local $2)
                                                           (i32.const 8)
                                                         )
                                                       )
@@ -4396,15 +4401,15 @@
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $11)
-                                                      (get_local $0)
+                                                      (get_local $14)
+                                                      (get_local $2)
                                                     )
                                                     (i32.store
-                                                      (get_local $16)
+                                                      (get_local $18)
                                                       (get_local $6)
                                                     )
                                                     (set_local $24
-                                                      (get_local $0)
+                                                      (get_local $2)
                                                     )
                                                   )
                                                   (call $qa)
@@ -4426,7 +4431,7 @@
                                                     (i32.add
                                                       (i32.const 1512)
                                                       (i32.shl
-                                                        (tee_local $0
+                                                        (tee_local $2
                                                           (i32.load offset=28
                                                             (get_local $1)
                                                           )
@@ -4454,7 +4459,7 @@
                                                     (i32.xor
                                                       (i32.shl
                                                         (i32.const 1)
-                                                        (get_local $0)
+                                                        (get_local $2)
                                                       )
                                                       (i32.const -1)
                                                     )
@@ -4504,7 +4509,7 @@
                                           (if
                                             (i32.lt_u
                                               (get_local $24)
-                                              (tee_local $0
+                                              (tee_local $2
                                                 (i32.load
                                                   (i32.const 1224)
                                                 )
@@ -4530,7 +4535,7 @@
                                             (if
                                               (i32.lt_u
                                                 (get_local $10)
-                                                (get_local $0)
+                                                (get_local $2)
                                               )
                                               (call $qa)
                                               (block
@@ -4576,10 +4581,10 @@
                                         )
                                       )
                                     )
-                                    (set_local $14
+                                    (set_local $13
                                       (i32.add
                                         (get_local $5)
-                                        (get_local $14)
+                                        (get_local $13)
                                       )
                                     )
                                     (i32.add
@@ -4594,7 +4599,7 @@
                             )
                             (i32.and
                               (i32.load
-                                (get_local $0)
+                                (get_local $2)
                               )
                               (i32.const -2)
                             )
@@ -4602,35 +4607,35 @@
                           (i32.store offset=4
                             (get_local $3)
                             (i32.or
-                              (get_local $14)
+                              (get_local $13)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
                               (get_local $3)
-                              (get_local $14)
+                              (get_local $13)
                             )
-                            (get_local $14)
+                            (get_local $13)
                           )
-                          (set_local $0
+                          (set_local $2
                             (i32.shr_u
-                              (get_local $14)
+                              (get_local $13)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $14)
+                              (get_local $13)
                               (i32.const 256)
                             )
                             (block
-                              (set_local $2
+                              (set_local $0
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $0)
+                                      (get_local $2)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4645,10 +4650,10 @@
                                         (i32.const 1208)
                                       )
                                     )
-                                    (tee_local $0
+                                    (tee_local $2
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $0)
+                                        (get_local $2)
                                       )
                                     )
                                   )
@@ -4657,9 +4662,9 @@
                                       (i32.ge_u
                                         (tee_local $19
                                           (i32.load
-                                            (tee_local $0
+                                            (tee_local $2
                                               (i32.add
-                                                (get_local $2)
+                                                (get_local $0)
                                                 (i32.const 8)
                                               )
                                             )
@@ -4671,7 +4676,7 @@
                                       )
                                       (block
                                         (set_local $45
-                                          (get_local $0)
+                                          (get_local $2)
                                         )
                                         (set_local $38
                                           (get_local $19)
@@ -4686,17 +4691,17 @@
                                       (i32.const 1208)
                                       (i32.or
                                         (get_local $10)
-                                        (get_local $0)
+                                        (get_local $2)
                                       )
                                     )
                                     (set_local $45
                                       (i32.add
-                                        (get_local $2)
+                                        (get_local $0)
                                         (i32.const 8)
                                       )
                                     )
                                     (set_local $38
-                                      (get_local $2)
+                                      (get_local $0)
                                     )
                                   )
                                 )
@@ -4715,21 +4720,21 @@
                               )
                               (i32.store offset=12
                                 (get_local $3)
-                                (get_local $2)
+                                (get_local $0)
                               )
                               (br $do-once44)
                             )
                           )
-                          (set_local $0
+                          (set_local $2
                             (i32.add
                               (i32.const 1512)
                               (i32.shl
                                 (tee_local $5
                                   (block $do-once61 i32
                                     (if i32
-                                      (tee_local $0
+                                      (tee_local $2
                                         (i32.shr_u
-                                          (get_local $14)
+                                          (get_local $13)
                                           (i32.const 8)
                                         )
                                       )
@@ -4738,7 +4743,7 @@
                                           (br_if $do-once61
                                             (i32.const 31)
                                             (i32.gt_u
-                                              (get_local $14)
+                                              (get_local $13)
                                               (i32.const 16777215)
                                             )
                                           )
@@ -4746,7 +4751,7 @@
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $14)
+                                              (get_local $13)
                                               (i32.add
                                                 (tee_local $6
                                                   (i32.add
@@ -4760,12 +4765,12 @@
                                                                 (i32.add
                                                                   (tee_local $5
                                                                     (i32.shl
-                                                                      (get_local $0)
+                                                                      (get_local $2)
                                                                       (tee_local $10
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $0)
+                                                                              (get_local $2)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -4788,7 +4793,7 @@
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $0
+                                                                (tee_local $2
                                                                   (i32.shl
                                                                     (get_local $5)
                                                                     (get_local $19)
@@ -4805,7 +4810,7 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $0)
+                                                        (get_local $2)
                                                         (get_local $5)
                                                       )
                                                       (i32.const 15)
@@ -4836,7 +4841,7 @@
                             (get_local $5)
                           )
                           (i32.store offset=4
-                            (tee_local $2
+                            (tee_local $0
                               (i32.add
                                 (get_local $3)
                                 (i32.const 16)
@@ -4845,13 +4850,13 @@
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $2)
+                            (get_local $0)
                             (i32.const 0)
                           )
                           (if
                             (i32.eqz
                               (i32.and
-                                (tee_local $2
+                                (tee_local $0
                                   (i32.load
                                     (i32.const 1212)
                                   )
@@ -4868,17 +4873,17 @@
                               (i32.store
                                 (i32.const 1212)
                                 (i32.or
-                                  (get_local $2)
+                                  (get_local $0)
                                   (get_local $6)
                                 )
                               )
                               (i32.store
-                                (get_local $0)
+                                (get_local $2)
                                 (get_local $3)
                               )
                               (i32.store offset=24
                                 (get_local $3)
-                                (get_local $0)
+                                (get_local $2)
                               )
                               (i32.store offset=12
                                 (get_local $3)
@@ -4893,7 +4898,7 @@
                           )
                           (set_local $6
                             (i32.shl
-                              (get_local $14)
+                              (get_local $13)
                               (select
                                 (i32.const 0)
                                 (i32.sub
@@ -4910,9 +4915,9 @@
                               )
                             )
                           )
-                          (set_local $2
+                          (set_local $0
                             (i32.load
-                              (get_local $0)
+                              (get_local $2)
                             )
                           )
                           (loop $while-in64
@@ -4921,15 +4926,15 @@
                                 (i32.eq
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $2)
+                                      (get_local $0)
                                     )
                                     (i32.const -8)
                                   )
-                                  (get_local $14)
+                                  (get_local $13)
                                 )
                                 (block
                                   (set_local $39
-                                    (get_local $2)
+                                    (get_local $0)
                                   )
                                   (set_local $8
                                     (i32.const 279)
@@ -4940,10 +4945,10 @@
                               (if
                                 (tee_local $5
                                   (i32.load
-                                    (tee_local $0
+                                    (tee_local $2
                                       (i32.add
                                         (i32.add
-                                          (get_local $2)
+                                          (get_local $0)
                                           (i32.const 16)
                                         )
                                         (i32.shl
@@ -4964,17 +4969,17 @@
                                       (i32.const 1)
                                     )
                                   )
-                                  (set_local $2
+                                  (set_local $0
                                     (get_local $5)
                                   )
                                   (br $while-in64)
                                 )
                                 (block
                                   (set_local $46
-                                    (get_local $0)
+                                    (get_local $2)
                                   )
                                   (set_local $54
-                                    (get_local $2)
+                                    (get_local $0)
                                   )
                                   (set_local $8
                                     (i32.const 276)
@@ -5025,7 +5030,7 @@
                                   (i32.ge_u
                                     (tee_local $6
                                       (i32.load
-                                        (tee_local $2
+                                        (tee_local $0
                                           (i32.add
                                             (get_local $39)
                                             (i32.const 8)
@@ -5050,7 +5055,7 @@
                                     (get_local $3)
                                   )
                                   (i32.store
-                                    (get_local $2)
+                                    (get_local $0)
                                     (get_local $3)
                                   )
                                   (i32.store offset=8
@@ -5078,7 +5083,7 @@
                     )
                     (return
                       (i32.add
-                        (get_local $18)
+                        (get_local $17)
                         (i32.const 8)
                       )
                     )
@@ -5094,11 +5099,11 @@
                           (get_local $29)
                         )
                       )
-                      (get_local $12)
+                      (get_local $11)
                     )
                     (if
                       (i32.gt_u
-                        (tee_local $14
+                        (tee_local $13
                           (i32.add
                             (get_local $3)
                             (i32.load offset=4
@@ -5106,11 +5111,11 @@
                             )
                           )
                         )
-                        (get_local $12)
+                        (get_local $11)
                       )
                       (block
                         (set_local $0
-                          (get_local $14)
+                          (get_local $13)
                         )
                         (br $while-out65)
                       )
@@ -5124,9 +5129,9 @@
                   (br $while-in66)
                 )
               )
-              (set_local $14
+              (set_local $13
                 (i32.add
-                  (tee_local $18
+                  (tee_local $17
                     (i32.add
                       (get_local $0)
                       (i32.const -47)
@@ -5137,23 +5142,23 @@
               )
               (set_local $3
                 (i32.add
-                  (tee_local $18
+                  (tee_local $17
                     (select
-                      (get_local $12)
+                      (get_local $11)
                       (tee_local $3
                         (i32.add
-                          (get_local $18)
+                          (get_local $17)
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $14)
+                                (get_local $13)
                               )
                               (i32.const 7)
                             )
                             (i32.const 0)
                             (i32.and
-                              (get_local $14)
+                              (get_local $13)
                               (i32.const 7)
                             )
                           )
@@ -5161,9 +5166,9 @@
                       )
                       (i32.lt_u
                         (get_local $3)
-                        (tee_local $14
+                        (tee_local $13
                           (i32.add
-                            (get_local $12)
+                            (get_local $11)
                             (i32.const 16)
                           )
                         )
@@ -5178,7 +5183,7 @@
                 (tee_local $1
                   (i32.add
                     (get_local $20)
-                    (tee_local $13
+                    (tee_local $12
                       (select
                         (i32.and
                           (i32.sub
@@ -5210,7 +5215,7 @@
                       (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $13)
+                    (get_local $12)
                   )
                 )
               )
@@ -5237,7 +5242,7 @@
               (i32.store
                 (tee_local $6
                   (i32.add
-                    (get_local $18)
+                    (get_local $17)
                     (i32.const 4)
                   )
                 )
@@ -5285,7 +5290,7 @@
               )
               (set_local $3
                 (i32.add
-                  (get_local $18)
+                  (get_local $17)
                   (i32.const 24)
                 )
               )
@@ -5311,8 +5316,8 @@
               )
               (if
                 (i32.ne
-                  (get_local $18)
-                  (get_local $12)
+                  (get_local $17)
+                  (get_local $11)
                 )
                 (block
                   (i32.store
@@ -5325,19 +5330,19 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $12)
+                    (get_local $11)
                     (i32.or
                       (tee_local $3
                         (i32.sub
-                          (get_local $18)
-                          (get_local $12)
+                          (get_local $17)
+                          (get_local $11)
                         )
                       )
                       (i32.const 1)
                     )
                   )
                   (i32.store
-                    (get_local $18)
+                    (get_local $17)
                     (get_local $3)
                   )
                   (set_local $1
@@ -5352,7 +5357,7 @@
                       (i32.const 256)
                     )
                     (block
-                      (set_local $13
+                      (set_local $12
                         (i32.add
                           (i32.const 1248)
                           (i32.shl
@@ -5366,7 +5371,7 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $2
+                          (tee_local $0
                             (i32.load
                               (i32.const 1208)
                             )
@@ -5380,11 +5385,11 @@
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $2
+                            (tee_local $0
                               (i32.load
                                 (tee_local $5
                                   (i32.add
-                                    (get_local $13)
+                                    (get_local $12)
                                     (i32.const 8)
                                   )
                                 )
@@ -5400,7 +5405,7 @@
                               (get_local $5)
                             )
                             (set_local $40
-                              (get_local $2)
+                              (get_local $0)
                             )
                           )
                         )
@@ -5408,47 +5413,47 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $2)
+                              (get_local $0)
                               (get_local $5)
                             )
                           )
                           (set_local $47
                             (i32.add
-                              (get_local $13)
+                              (get_local $12)
                               (i32.const 8)
                             )
                           )
                           (set_local $40
-                            (get_local $13)
+                            (get_local $12)
                           )
                         )
                       )
                       (i32.store
                         (get_local $47)
-                        (get_local $12)
+                        (get_local $11)
                       )
                       (i32.store offset=12
                         (get_local $40)
-                        (get_local $12)
+                        (get_local $11)
                       )
                       (i32.store offset=8
-                        (get_local $12)
+                        (get_local $11)
                         (get_local $40)
                       )
                       (i32.store offset=12
+                        (get_local $11)
                         (get_local $12)
-                        (get_local $13)
                       )
                       (br $do-once38)
                     )
                   )
-                  (set_local $0
+                  (set_local $2
                     (i32.add
                       (i32.const 1512)
                       (i32.shl
-                        (tee_local $2
+                        (tee_local $0
                           (if i32
-                            (tee_local $13
+                            (tee_local $12
                               (i32.shr_u
                                 (get_local $3)
                                 (i32.const 8)
@@ -5465,24 +5470,24 @@
                                   (i32.shr_u
                                     (get_local $3)
                                     (i32.add
-                                      (tee_local $0
+                                      (tee_local $2
                                         (i32.add
                                           (i32.sub
                                             (i32.const 14)
                                             (i32.or
                                               (i32.or
-                                                (tee_local $13
+                                                (tee_local $12
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
                                                         (tee_local $5
                                                           (i32.shl
-                                                            (get_local $13)
-                                                            (tee_local $2
+                                                            (get_local $12)
+                                                            (tee_local $0
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
-                                                                    (get_local $13)
+                                                                    (get_local $12)
                                                                     (i32.const 1048320)
                                                                   )
                                                                   (i32.const 16)
@@ -5499,7 +5504,7 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $2)
+                                                (get_local $0)
                                               )
                                               (tee_local $5
                                                 (i32.and
@@ -5508,7 +5513,7 @@
                                                       (tee_local $1
                                                         (i32.shl
                                                           (get_local $5)
-                                                          (get_local $13)
+                                                          (get_local $12)
                                                         )
                                                       )
                                                       (i32.const 245760)
@@ -5535,7 +5540,7 @@
                                   (i32.const 1)
                                 )
                                 (i32.shl
-                                  (get_local $0)
+                                  (get_local $2)
                                   (i32.const 1)
                                 )
                               )
@@ -5548,15 +5553,15 @@
                     )
                   )
                   (i32.store offset=28
-                    (get_local $12)
-                    (get_local $2)
+                    (get_local $11)
+                    (get_local $0)
                   )
                   (i32.store offset=20
-                    (get_local $12)
+                    (get_local $11)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $14)
+                    (get_local $13)
                     (i32.const 0)
                   )
                   (if
@@ -5570,7 +5575,7 @@
                         (tee_local $1
                           (i32.shl
                             (i32.const 1)
-                            (get_local $2)
+                            (get_local $0)
                           )
                         )
                       )
@@ -5584,20 +5589,20 @@
                         )
                       )
                       (i32.store
-                        (get_local $0)
-                        (get_local $12)
+                        (get_local $2)
+                        (get_local $11)
                       )
                       (i32.store offset=24
-                        (get_local $12)
-                        (get_local $0)
+                        (get_local $11)
+                        (get_local $2)
                       )
                       (i32.store offset=12
-                        (get_local $12)
-                        (get_local $12)
+                        (get_local $11)
+                        (get_local $11)
                       )
                       (i32.store offset=8
-                        (get_local $12)
-                        (get_local $12)
+                        (get_local $11)
+                        (get_local $11)
                       )
                       (br $do-once38)
                     )
@@ -5610,12 +5615,12 @@
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $2)
+                            (get_local $0)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $2)
+                          (get_local $0)
                           (i32.const 31)
                         )
                       )
@@ -5623,7 +5628,7 @@
                   )
                   (set_local $5
                     (i32.load
-                      (get_local $0)
+                      (get_local $2)
                     )
                   )
                   (loop $while-in70
@@ -5649,9 +5654,9 @@
                         )
                       )
                       (if
-                        (tee_local $2
+                        (tee_local $0
                           (i32.load
-                            (tee_local $0
+                            (tee_local $2
                               (i32.add
                                 (i32.add
                                   (get_local $5)
@@ -5676,13 +5681,13 @@
                             )
                           )
                           (set_local $5
-                            (get_local $2)
+                            (get_local $0)
                           )
                           (br $while-in70)
                         )
                         (block
                           (set_local $48
-                            (get_local $0)
+                            (get_local $2)
                           )
                           (set_local $55
                             (get_local $5)
@@ -5710,19 +5715,19 @@
                       (block
                         (i32.store
                           (get_local $48)
-                          (get_local $12)
+                          (get_local $11)
                         )
                         (i32.store offset=24
-                          (get_local $12)
+                          (get_local $11)
                           (get_local $55)
                         )
                         (i32.store offset=12
-                          (get_local $12)
-                          (get_local $12)
+                          (get_local $11)
+                          (get_local $11)
                         )
                         (i32.store offset=8
-                          (get_local $12)
-                          (get_local $12)
+                          (get_local $11)
+                          (get_local $11)
                         )
                       )
                     )
@@ -5758,22 +5763,22 @@
                         (block
                           (i32.store offset=12
                             (get_local $1)
-                            (get_local $12)
+                            (get_local $11)
                           )
                           (i32.store
                             (get_local $5)
-                            (get_local $12)
+                            (get_local $11)
                           )
                           (i32.store offset=8
-                            (get_local $12)
+                            (get_local $11)
                             (get_local $1)
                           )
                           (i32.store offset=12
-                            (get_local $12)
+                            (get_local $11)
                             (get_local $30)
                           )
                           (i32.store offset=24
-                            (get_local $12)
+                            (get_local $11)
                             (i32.const 0)
                           )
                         )
@@ -5831,7 +5836,7 @@
               )
               (loop $do-in
                 (i32.store offset=12
-                  (tee_local $13
+                  (tee_local $12
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
@@ -5843,11 +5848,11 @@
                       )
                     )
                   )
-                  (get_local $13)
+                  (get_local $12)
                 )
                 (i32.store offset=8
-                  (get_local $13)
-                  (get_local $13)
+                  (get_local $12)
+                  (get_local $12)
                 )
                 (br_if $do-in
                   (i32.ne
@@ -5866,7 +5871,7 @@
                 (tee_local $1
                   (i32.add
                     (get_local $20)
-                    (tee_local $13
+                    (tee_local $12
                       (select
                         (i32.and
                           (i32.sub
@@ -5898,7 +5903,7 @@
                       (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $13)
+                    (get_local $12)
                   )
                 )
               )
@@ -5927,7 +5932,7 @@
         )
         (if
           (i32.gt_u
-            (tee_local $12
+            (tee_local $11
               (i32.load
                 (i32.const 1220)
               )
@@ -5939,7 +5944,7 @@
               (i32.const 1220)
               (tee_local $30
                 (i32.sub
-                  (get_local $12)
+                  (get_local $11)
                   (get_local $4)
                 )
               )
@@ -5948,7 +5953,7 @@
               (i32.const 1232)
               (tee_local $8
                 (i32.add
-                  (tee_local $12
+                  (tee_local $11
                     (i32.load
                       (i32.const 1232)
                     )
@@ -5965,7 +5970,7 @@
               )
             )
             (i32.store offset=4
-              (get_local $12)
+              (get_local $11)
               (i32.or
                 (get_local $4)
                 (i32.const 3)
@@ -5976,7 +5981,7 @@
             )
             (return
               (i32.add
-                (get_local $12)
+                (get_local $11)
                 (i32.const 8)
               )
             )
@@ -6039,7 +6044,7 @@
       (i32.eq
         (tee_local $0
           (i32.and
-            (tee_local $4
+            (tee_local $3
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -6059,7 +6064,7 @@
         (get_local $1)
         (tee_local $6
           (i32.and
-            (get_local $4)
+            (get_local $3)
             (i32.const -8)
           )
         )
@@ -6068,19 +6073,19 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $4)
+          (get_local $3)
           (i32.const 1)
         )
         (block
           (set_local $2
             (get_local $1)
           )
-          (set_local $7
+          (set_local $5
             (get_local $6)
           )
         )
         (block
-          (set_local $10
+          (set_local $11
             (i32.load
               (get_local $1)
             )
@@ -6093,18 +6098,18 @@
           )
           (set_local $6
             (i32.add
-              (get_local $10)
+              (get_local $11)
               (get_local $6)
             )
           )
           (if
             (i32.lt_u
-              (tee_local $0
+              (tee_local $3
                 (i32.add
                   (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $10)
+                    (get_local $11)
                   )
                 )
               )
@@ -6114,7 +6119,7 @@
           )
           (if
             (i32.eq
-              (get_local $0)
+              (get_local $3)
               (i32.load
                 (i32.const 1228)
               )
@@ -6123,9 +6128,9 @@
               (if
                 (i32.ne
                   (i32.and
-                    (tee_local $3
+                    (tee_local $7
                       (i32.load
-                        (tee_local $1
+                        (tee_local $0
                           (i32.add
                             (get_local $8)
                             (i32.const 4)
@@ -6139,9 +6144,9 @@
                 )
                 (block
                   (set_local $2
-                    (get_local $0)
+                    (get_local $3)
                   )
-                  (set_local $7
+                  (set_local $5
                     (get_local $6)
                   )
                   (br $do-once)
@@ -6152,14 +6157,14 @@
                 (get_local $6)
               )
               (i32.store
-                (get_local $1)
+                (get_local $0)
                 (i32.and
-                  (get_local $3)
+                  (get_local $7)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $0)
+                (get_local $3)
                 (i32.or
                   (get_local $6)
                   (i32.const 1)
@@ -6167,7 +6172,7 @@
               )
               (i32.store
                 (i32.add
-                  (get_local $0)
+                  (get_local $3)
                   (get_local $6)
                 )
                 (get_local $6)
@@ -6175,36 +6180,36 @@
               (return)
             )
           )
-          (set_local $3
+          (set_local $7
             (i32.shr_u
-              (get_local $10)
+              (get_local $11)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $10)
+              (get_local $11)
               (i32.const 256)
             )
             (block
-              (set_local $1
+              (set_local $0
                 (i32.load offset=12
-                  (get_local $0)
+                  (get_local $3)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $10
+                  (tee_local $11
                     (i32.load offset=8
-                      (get_local $0)
+                      (get_local $3)
                     )
                   )
-                  (tee_local $4
+                  (tee_local $1
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $3)
+                          (get_local $7)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6215,7 +6220,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $10)
+                      (get_local $11)
                       (get_local $14)
                     )
                     (call $qa)
@@ -6223,9 +6228,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $10)
+                        (get_local $11)
                       )
-                      (get_local $0)
+                      (get_local $3)
                     )
                     (call $qa)
                   )
@@ -6233,8 +6238,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $1)
-                  (get_local $10)
+                  (get_local $0)
+                  (get_local $11)
                 )
                 (block
                   (i32.store
@@ -6246,16 +6251,16 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $3)
+                          (get_local $7)
                         )
                         (i32.const -1)
                       )
                     )
                   )
                   (set_local $2
-                    (get_local $0)
+                    (get_local $3)
                   )
-                  (set_local $7
+                  (set_local $5
                     (get_local $6)
                   )
                   (br $do-once)
@@ -6263,19 +6268,19 @@
               )
               (if
                 (i32.eq
+                  (get_local $0)
                   (get_local $1)
-                  (get_local $4)
                 )
-                (set_local $9
+                (set_local $10
                   (i32.add
-                    (get_local $1)
+                    (get_local $0)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $0)
                       (get_local $14)
                     )
                     (call $qa)
@@ -6283,63 +6288,63 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $4
+                        (tee_local $1
                           (i32.add
-                            (get_local $1)
+                            (get_local $0)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $0)
+                      (get_local $3)
                     )
-                    (set_local $9
-                      (get_local $4)
+                    (set_local $10
+                      (get_local $1)
                     )
                     (call $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $10)
-                (get_local $1)
-              )
-              (i32.store
-                (get_local $9)
-                (get_local $10)
-              )
-              (set_local $2
+                (get_local $11)
                 (get_local $0)
               )
-              (set_local $7
+              (i32.store
+                (get_local $10)
+                (get_local $11)
+              )
+              (set_local $2
+                (get_local $3)
+              )
+              (set_local $5
                 (get_local $6)
               )
               (br $do-once)
             )
           )
-          (set_local $10
+          (set_local $11
             (i32.load offset=24
-              (get_local $0)
+              (get_local $3)
             )
           )
           (block $do-once0
             (if
               (i32.eq
-                (tee_local $1
+                (tee_local $0
                   (i32.load offset=12
-                    (get_local $0)
+                    (get_local $3)
                   )
                 )
-                (get_local $0)
+                (get_local $3)
               )
               (block
                 (if
-                  (tee_local $9
+                  (tee_local $10
                     (i32.load
-                      (tee_local $3
+                      (tee_local $7
                         (i32.add
-                          (tee_local $4
+                          (tee_local $1
                             (i32.add
-                              (get_local $0)
+                              (get_local $3)
                               (i32.const 16)
                             )
                           )
@@ -6349,23 +6354,23 @@
                     )
                   )
                   (block
-                    (set_local $1
-                      (get_local $9)
+                    (set_local $0
+                      (get_local $10)
                     )
-                    (set_local $4
-                      (get_local $3)
+                    (set_local $1
+                      (get_local $7)
                     )
                   )
                   (if
                     (i32.eqz
-                      (tee_local $1
+                      (tee_local $0
                         (i32.load
-                          (get_local $4)
+                          (get_local $1)
                         )
                       )
                     )
                     (block
-                      (set_local $5
+                      (set_local $4
                         (i32.const 0)
                       )
                       (br $do-once0)
@@ -6374,69 +6379,69 @@
                 )
                 (loop $while-in
                   (if
-                    (tee_local $9
+                    (tee_local $10
                       (i32.load
-                        (tee_local $3
+                        (tee_local $7
                           (i32.add
-                            (get_local $1)
+                            (get_local $0)
                             (i32.const 20)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $1
-                        (get_local $9)
+                      (set_local $0
+                        (get_local $10)
                       )
-                      (set_local $4
-                        (get_local $3)
+                      (set_local $1
+                        (get_local $7)
                       )
                       (br $while-in)
                     )
                   )
                   (if
-                    (tee_local $9
+                    (tee_local $10
                       (i32.load
-                        (tee_local $3
+                        (tee_local $7
                           (i32.add
-                            (get_local $1)
+                            (get_local $0)
                             (i32.const 16)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $1
-                        (get_local $9)
+                      (set_local $0
+                        (get_local $10)
                       )
-                      (set_local $4
-                        (get_local $3)
+                      (set_local $1
+                        (get_local $7)
                       )
                       (br $while-in)
                     )
                     (block
-                      (set_local $12
-                        (get_local $1)
+                      (set_local $7
+                        (get_local $0)
                       )
-                      (set_local $3
-                        (get_local $4)
+                      (set_local $9
+                        (get_local $1)
                       )
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $3)
+                    (get_local $9)
                     (get_local $14)
                   )
                   (call $qa)
                   (block
                     (i32.store
-                      (get_local $3)
+                      (get_local $9)
                       (i32.const 0)
                     )
-                    (set_local $5
-                      (get_local $12)
+                    (set_local $4
+                      (get_local $7)
                     )
                   )
                 )
@@ -6444,9 +6449,9 @@
               (block
                 (if
                   (i32.lt_u
-                    (tee_local $3
+                    (tee_local $7
                       (i32.load offset=8
-                        (get_local $0)
+                        (get_local $3)
                       )
                     )
                     (get_local $14)
@@ -6456,40 +6461,40 @@
                 (if
                   (i32.ne
                     (i32.load
-                      (tee_local $9
+                      (tee_local $10
                         (i32.add
-                          (get_local $3)
+                          (get_local $7)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $3)
                   )
                   (call $qa)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $4
+                      (tee_local $1
                         (i32.add
-                          (get_local $1)
+                          (get_local $0)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $3)
                   )
                   (block
                     (i32.store
-                      (get_local $9)
-                      (get_local $1)
+                      (get_local $10)
+                      (get_local $0)
                     )
                     (i32.store
-                      (get_local $4)
-                      (get_local $3)
-                    )
-                    (set_local $5
                       (get_local $1)
+                      (get_local $7)
+                    )
+                    (set_local $4
+                      (get_local $0)
                     )
                   )
                   (call $qa)
@@ -6498,19 +6503,19 @@
             )
           )
           (if
-            (get_local $10)
+            (get_local $11)
             (block
               (if
                 (i32.eq
-                  (get_local $0)
+                  (get_local $3)
                   (i32.load
-                    (tee_local $3
+                    (tee_local $7
                       (i32.add
                         (i32.const 1512)
                         (i32.shl
-                          (tee_local $1
+                          (tee_local $0
                             (i32.load offset=28
-                              (get_local $0)
+                              (get_local $3)
                             )
                           )
                           (i32.const 2)
@@ -6521,12 +6526,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $3)
-                    (get_local $5)
+                    (get_local $7)
+                    (get_local $4)
                   )
                   (if
                     (i32.eqz
-                      (get_local $5)
+                      (get_local $4)
                     )
                     (block
                       (i32.store
@@ -6538,16 +6543,16 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $1)
+                              (get_local $0)
                             )
                             (i32.const -1)
                           )
                         )
                       )
                       (set_local $2
-                        (get_local $0)
+                        (get_local $3)
                       )
-                      (set_local $7
+                      (set_local $5
                         (get_local $6)
                       )
                       (br $do-once)
@@ -6557,7 +6562,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $10)
+                      (get_local $11)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6567,33 +6572,33 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $1
+                        (tee_local $0
                           (i32.add
-                            (get_local $10)
+                            (get_local $11)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $0)
+                      (get_local $3)
                     )
                     (i32.store
-                      (get_local $1)
-                      (get_local $5)
+                      (get_local $0)
+                      (get_local $4)
                     )
                     (i32.store offset=20
-                      (get_local $10)
-                      (get_local $5)
+                      (get_local $11)
+                      (get_local $4)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $5)
+                      (get_local $4)
                     )
                     (block
                       (set_local $2
-                        (get_local $0)
+                        (get_local $3)
                       )
-                      (set_local $7
+                      (set_local $5
                         (get_local $6)
                       )
                       (br $do-once)
@@ -6603,8 +6608,8 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $5)
-                  (tee_local $1
+                  (get_local $4)
+                  (tee_local $0
                     (i32.load
                       (i32.const 1224)
                     )
@@ -6613,15 +6618,15 @@
                 (call $qa)
               )
               (i32.store offset=24
-                (get_local $5)
-                (get_local $10)
+                (get_local $4)
+                (get_local $11)
               )
               (if
-                (tee_local $4
+                (tee_local $1
                   (i32.load
-                    (tee_local $3
+                    (tee_local $7
                       (i32.add
-                        (get_local $0)
+                        (get_local $3)
                         (i32.const 16)
                       )
                     )
@@ -6629,31 +6634,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $4)
                     (get_local $1)
+                    (get_local $0)
                   )
                   (call $qa)
                   (block
                     (i32.store offset=16
-                      (get_local $5)
                       (get_local $4)
+                      (get_local $1)
                     )
                     (i32.store offset=24
+                      (get_local $1)
                       (get_local $4)
-                      (get_local $5)
                     )
                   )
                 )
               )
               (if
-                (tee_local $4
+                (tee_local $1
                   (i32.load offset=4
-                    (get_local $3)
+                    (get_local $7)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $4)
+                    (get_local $1)
                     (i32.load
                       (i32.const 1224)
                     )
@@ -6661,26 +6666,26 @@
                   (call $qa)
                   (block
                     (i32.store offset=20
-                      (get_local $5)
                       (get_local $4)
+                      (get_local $1)
                     )
                     (i32.store offset=24
+                      (get_local $1)
                       (get_local $4)
-                      (get_local $5)
                     )
                     (set_local $2
-                      (get_local $0)
+                      (get_local $3)
                     )
-                    (set_local $7
+                    (set_local $5
                       (get_local $6)
                     )
                   )
                 )
                 (block
                   (set_local $2
-                    (get_local $0)
+                    (get_local $3)
                   )
-                  (set_local $7
+                  (set_local $5
                     (get_local $6)
                   )
                 )
@@ -6688,9 +6693,9 @@
             )
             (block
               (set_local $2
-                (get_local $0)
+                (get_local $3)
               )
-              (set_local $7
+              (set_local $5
                 (get_local $6)
               )
             )
@@ -6739,19 +6744,19 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $7)
+            (get_local $5)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $7)
+            (get_local $5)
           )
-          (get_local $7)
+          (get_local $5)
         )
         (set_local $0
-          (get_local $7)
+          (get_local $5)
         )
       )
       (block
@@ -6765,12 +6770,12 @@
           (block
             (i32.store
               (i32.const 1220)
-              (tee_local $5
+              (tee_local $4
                 (i32.add
                   (i32.load
                     (i32.const 1220)
                   )
-                  (get_local $7)
+                  (get_local $5)
                 )
               )
             )
@@ -6781,7 +6786,7 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $5)
+                (get_local $4)
                 (i32.const 1)
               )
             )
@@ -6815,12 +6820,12 @@
           (block
             (i32.store
               (i32.const 1216)
-              (tee_local $5
+              (tee_local $4
                 (i32.add
                   (i32.load
                     (i32.const 1216)
                   )
-                  (get_local $7)
+                  (get_local $5)
                 )
               )
             )
@@ -6831,27 +6836,27 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $5)
+                (get_local $4)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $2)
-                (get_local $5)
+                (get_local $4)
               )
-              (get_local $5)
+              (get_local $4)
             )
             (return)
           )
         )
-        (set_local $5
+        (set_local $4
           (i32.add
             (i32.and
               (get_local $1)
               (i32.const -8)
             )
-            (get_local $7)
+            (get_local $5)
           )
         )
         (set_local $14
@@ -6867,19 +6872,19 @@
               (i32.const 256)
             )
             (block
-              (set_local $3
+              (set_local $9
                 (i32.load offset=12
                   (get_local $8)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $12
+                  (tee_local $7
                     (i32.load offset=8
                       (get_local $8)
                     )
                   )
-                  (tee_local $4
+                  (tee_local $1
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
@@ -6895,7 +6900,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $12)
+                      (get_local $7)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6905,7 +6910,7 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $12)
+                        (get_local $7)
                       )
                       (get_local $8)
                     )
@@ -6915,8 +6920,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $3)
-                  (get_local $12)
+                  (get_local $9)
+                  (get_local $7)
                 )
                 (block
                   (i32.store
@@ -6939,19 +6944,19 @@
               )
               (if
                 (i32.eq
-                  (get_local $3)
-                  (get_local $4)
+                  (get_local $9)
+                  (get_local $1)
                 )
                 (set_local $17
                   (i32.add
-                    (get_local $3)
+                    (get_local $9)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $3)
+                      (get_local $9)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6961,9 +6966,9 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $4
+                        (tee_local $1
                           (i32.add
-                            (get_local $3)
+                            (get_local $9)
                             (i32.const 8)
                           )
                         )
@@ -6971,23 +6976,23 @@
                       (get_local $8)
                     )
                     (set_local $17
-                      (get_local $4)
+                      (get_local $1)
                     )
                     (call $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $12)
-                (get_local $3)
+                (get_local $7)
+                (get_local $9)
               )
               (i32.store
                 (get_local $17)
-                (get_local $12)
+                (get_local $7)
               )
             )
             (block
-              (set_local $12
+              (set_local $7
                 (i32.load offset=24
                   (get_local $8)
                 )
@@ -6995,7 +7000,7 @@
               (block $do-once6
                 (if
                   (i32.eq
-                    (tee_local $3
+                    (tee_local $9
                       (i32.load offset=12
                         (get_local $8)
                       )
@@ -7004,11 +7009,11 @@
                   )
                   (block
                     (if
-                      (tee_local $9
+                      (tee_local $10
                         (i32.load
-                          (tee_local $1
+                          (tee_local $0
                             (i32.add
-                              (tee_local $4
+                              (tee_local $1
                                 (i32.add
                                   (get_local $8)
                                   (i32.const 16)
@@ -7020,23 +7025,24 @@
                         )
                       )
                       (block
-                        (set_local $0
-                          (get_local $9)
+                        (set_local $5
+                          (get_local $10)
                         )
-                        (set_local $4
-                          (get_local $1)
+                        (set_local $1
+                          (get_local $0)
                         )
                       )
                       (if
-                        (i32.eqz
-                          (tee_local $0
-                            (i32.load
-                              (get_local $4)
-                            )
+                        (tee_local $0
+                          (i32.load
+                            (get_local $1)
                           )
                         )
+                        (set_local $5
+                          (get_local $0)
+                        )
                         (block
-                          (set_local $11
+                          (set_local $12
                             (i32.const 0)
                           )
                           (br $do-once6)
@@ -7045,43 +7051,43 @@
                     )
                     (loop $while-in9
                       (if
-                        (tee_local $9
+                        (tee_local $10
                           (i32.load
-                            (tee_local $1
+                            (tee_local $0
                               (i32.add
-                                (get_local $0)
+                                (get_local $5)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $0
-                            (get_local $9)
+                          (set_local $5
+                            (get_local $10)
                           )
-                          (set_local $4
-                            (get_local $1)
+                          (set_local $1
+                            (get_local $0)
                           )
                           (br $while-in9)
                         )
                       )
                       (if
-                        (tee_local $9
+                        (tee_local $10
                           (i32.load
-                            (tee_local $1
+                            (tee_local $0
                               (i32.add
-                                (get_local $0)
+                                (get_local $5)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $0
-                            (get_local $9)
+                          (set_local $5
+                            (get_local $10)
                           )
-                          (set_local $4
-                            (get_local $1)
+                          (set_local $1
+                            (get_local $0)
                           )
                           (br $while-in9)
                         )
@@ -7089,7 +7095,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $4)
+                        (get_local $1)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7097,11 +7103,11 @@
                       (call $qa)
                       (block
                         (i32.store
-                          (get_local $4)
+                          (get_local $1)
                           (i32.const 0)
                         )
-                        (set_local $11
-                          (get_local $0)
+                        (set_local $12
+                          (get_local $5)
                         )
                       )
                     )
@@ -7109,7 +7115,7 @@
                   (block
                     (if
                       (i32.lt_u
-                        (tee_local $1
+                        (tee_local $0
                           (i32.load offset=8
                             (get_local $8)
                           )
@@ -7123,9 +7129,9 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (tee_local $9
+                          (tee_local $10
                             (i32.add
-                              (get_local $1)
+                              (get_local $0)
                               (i32.const 12)
                             )
                           )
@@ -7137,9 +7143,9 @@
                     (if
                       (i32.eq
                         (i32.load
-                          (tee_local $4
+                          (tee_local $1
                             (i32.add
-                              (get_local $3)
+                              (get_local $9)
                               (i32.const 8)
                             )
                           )
@@ -7148,15 +7154,15 @@
                       )
                       (block
                         (i32.store
+                          (get_local $10)
                           (get_local $9)
-                          (get_local $3)
                         )
                         (i32.store
-                          (get_local $4)
                           (get_local $1)
+                          (get_local $0)
                         )
-                        (set_local $11
-                          (get_local $3)
+                        (set_local $12
+                          (get_local $9)
                         )
                       )
                       (call $qa)
@@ -7165,7 +7171,7 @@
                 )
               )
               (if
-                (get_local $12)
+                (get_local $7)
                 (block
                   (if
                     (i32.eq
@@ -7175,7 +7181,7 @@
                           (i32.add
                             (i32.const 1512)
                             (i32.shl
-                              (tee_local $3
+                              (tee_local $9
                                 (i32.load offset=28
                                   (get_local $8)
                                 )
@@ -7189,11 +7195,11 @@
                     (block
                       (i32.store
                         (get_local $6)
-                        (get_local $11)
+                        (get_local $12)
                       )
                       (if
                         (i32.eqz
-                          (get_local $11)
+                          (get_local $12)
                         )
                         (block
                           (i32.store
@@ -7205,7 +7211,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $3)
+                                  (get_local $9)
                                 )
                                 (i32.const -1)
                               )
@@ -7218,7 +7224,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $12)
+                          (get_local $7)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -7228,9 +7234,9 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $3
+                            (tee_local $9
                               (i32.add
-                                (get_local $12)
+                                (get_local $7)
                                 (i32.const 16)
                               )
                             )
@@ -7238,25 +7244,25 @@
                           (get_local $8)
                         )
                         (i32.store
-                          (get_local $3)
-                          (get_local $11)
+                          (get_local $9)
+                          (get_local $12)
                         )
                         (i32.store offset=20
+                          (get_local $7)
                           (get_local $12)
-                          (get_local $11)
                         )
                       )
                       (br_if $do-once4
                         (i32.eqz
-                          (get_local $11)
+                          (get_local $12)
                         )
                       )
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $11)
-                      (tee_local $3
+                      (get_local $12)
+                      (tee_local $9
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7265,11 +7271,11 @@
                     (call $qa)
                   )
                   (i32.store offset=24
-                    (get_local $11)
                     (get_local $12)
+                    (get_local $7)
                   )
                   (if
-                    (tee_local $0
+                    (tee_local $3
                       (i32.load
                         (tee_local $6
                           (i32.add
@@ -7281,31 +7287,31 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $0)
                         (get_local $3)
+                        (get_local $9)
                       )
                       (call $qa)
                       (block
                         (i32.store offset=16
-                          (get_local $11)
-                          (get_local $0)
+                          (get_local $12)
+                          (get_local $3)
                         )
                         (i32.store offset=24
-                          (get_local $0)
-                          (get_local $11)
+                          (get_local $3)
+                          (get_local $12)
                         )
                       )
                     )
                   )
                   (if
-                    (tee_local $0
+                    (tee_local $3
                       (i32.load offset=4
                         (get_local $6)
                       )
                     )
                     (if
                       (i32.lt_u
-                        (get_local $0)
+                        (get_local $3)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7313,12 +7319,12 @@
                       (call $qa)
                       (block
                         (i32.store offset=20
-                          (get_local $11)
-                          (get_local $0)
+                          (get_local $12)
+                          (get_local $3)
                         )
                         (i32.store offset=24
-                          (get_local $0)
-                          (get_local $11)
+                          (get_local $3)
+                          (get_local $12)
                         )
                       )
                     )
@@ -7331,16 +7337,16 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $5)
+            (get_local $4)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $5)
+            (get_local $4)
           )
-          (get_local $5)
+          (get_local $4)
         )
         (if
           (i32.eq
@@ -7352,17 +7358,17 @@
           (block
             (i32.store
               (i32.const 1216)
-              (get_local $5)
+              (get_local $4)
             )
             (return)
           )
           (set_local $0
-            (get_local $5)
+            (get_local $4)
           )
         )
       )
     )
-    (set_local $7
+    (set_local $5
       (i32.shr_u
         (get_local $0)
         (i32.const 3)
@@ -7379,7 +7385,7 @@
             (i32.const 1248)
             (i32.shl
               (i32.shl
-                (get_local $7)
+                (get_local $5)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -7393,10 +7399,10 @@
                 (i32.const 1208)
               )
             )
-            (tee_local $5
+            (tee_local $4
               (i32.shl
                 (i32.const 1)
-                (get_local $7)
+                (get_local $5)
               )
             )
           )
@@ -7404,7 +7410,7 @@
             (i32.lt_u
               (tee_local $6
                 (i32.load
-                  (tee_local $5
+                  (tee_local $4
                     (i32.add
                       (get_local $1)
                       (i32.const 8)
@@ -7419,7 +7425,7 @@
             (call $qa)
             (block
               (set_local $15
-                (get_local $5)
+                (get_local $4)
               )
               (set_local $13
                 (get_local $6)
@@ -7431,7 +7437,7 @@
               (i32.const 1208)
               (i32.or
                 (get_local $6)
-                (get_local $5)
+                (get_local $4)
               )
             )
             (set_local $15
@@ -7464,11 +7470,11 @@
         (return)
       )
     )
-    (set_local $5
+    (set_local $4
       (i32.add
         (i32.const 1512)
         (i32.shl
-          (tee_local $7
+          (tee_local $5
             (if i32
               (tee_local $1
                 (i32.shr_u
@@ -7487,7 +7493,7 @@
                     (i32.shr_u
                       (get_local $0)
                       (i32.add
-                        (tee_local $5
+                        (tee_local $4
                           (i32.add
                             (i32.sub
                               (i32.const 14)
@@ -7557,7 +7563,7 @@
                     (i32.const 1)
                   )
                   (i32.shl
-                    (get_local $5)
+                    (get_local $4)
                     (i32.const 1)
                   )
                 )
@@ -7571,7 +7577,7 @@
     )
     (i32.store offset=28
       (get_local $2)
-      (get_local $7)
+      (get_local $5)
     )
     (i32.store offset=20
       (get_local $2)
@@ -7591,7 +7597,7 @@
         (tee_local $6
           (i32.shl
             (i32.const 1)
-            (get_local $7)
+            (get_local $5)
           )
         )
       )
@@ -7604,12 +7610,12 @@
               (i32.sub
                 (i32.const 25)
                 (i32.shr_u
-                  (get_local $7)
+                  (get_local $5)
                   (i32.const 1)
                 )
               )
               (i32.eq
-                (get_local $7)
+                (get_local $5)
                 (i32.const 31)
               )
             )
@@ -7617,7 +7623,7 @@
         )
         (set_local $1
           (i32.load
-            (get_local $5)
+            (get_local $4)
           )
         )
         (loop $while-in15
@@ -7643,9 +7649,9 @@
               )
             )
             (if
-              (tee_local $11
+              (tee_local $12
                 (i32.load
-                  (tee_local $7
+                  (tee_local $5
                     (i32.add
                       (i32.add
                         (get_local $1)
@@ -7670,13 +7676,13 @@
                   )
                 )
                 (set_local $1
-                  (get_local $11)
+                  (get_local $12)
                 )
                 (br $while-in15)
               )
               (block
                 (set_local $18
-                  (get_local $7)
+                  (get_local $5)
                 )
                 (set_local $19
                   (get_local $1)
@@ -7785,12 +7791,12 @@
           )
         )
         (i32.store
-          (get_local $5)
+          (get_local $4)
           (get_local $2)
         )
         (i32.store offset=24
           (get_local $2)
-          (get_local $5)
+          (get_local $4)
         )
         (i32.store offset=12
           (get_local $2)

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -162,9 +162,9 @@
                       (i32.const 1208)
                     )
                   )
-                  (tee_local $2
+                  (tee_local $0
                     (i32.shr_u
-                      (tee_local $0
+                      (tee_local $3
                         (select
                           (i32.const 16)
                           (i32.and
@@ -188,20 +188,20 @@
               (i32.const 3)
             )
             (block
-              (set_local $2
+              (set_local $6
                 (i32.load
-                  (tee_local $0
+                  (tee_local $3
                     (i32.add
                       (tee_local $4
                         (i32.load
-                          (tee_local $16
+                          (tee_local $13
                             (i32.add
-                              (tee_local $7
+                              (tee_local $8
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
                                     (i32.shl
-                                      (tee_local $6
+                                      (tee_local $0
                                         (i32.add
                                           (i32.xor
                                             (i32.and
@@ -210,7 +210,7 @@
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $2)
+                                          (get_local $0)
                                         )
                                       )
                                       (i32.const 1)
@@ -231,8 +231,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $7)
-                  (get_local $2)
+                  (get_local $8)
+                  (get_local $6)
                 )
                 (i32.store
                   (i32.const 1208)
@@ -241,7 +241,7 @@
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $6)
+                        (get_local $0)
                       )
                       (i32.const -1)
                     )
@@ -250,7 +250,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $2)
+                      (get_local $6)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -260,9 +260,9 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $8
+                        (tee_local $7
                           (i32.add
-                            (get_local $2)
+                            (get_local $6)
                             (i32.const 12)
                           )
                         )
@@ -271,12 +271,12 @@
                     )
                     (block
                       (i32.store
-                        (get_local $8)
                         (get_local $7)
+                        (get_local $8)
                       )
                       (i32.store
-                        (get_local $16)
-                        (get_local $2)
+                        (get_local $13)
+                        (get_local $6)
                       )
                     )
                     (call $qa)
@@ -286,9 +286,9 @@
               (i32.store offset=4
                 (get_local $4)
                 (i32.or
-                  (tee_local $2
+                  (tee_local $6
                     (i32.shl
-                      (get_local $6)
+                      (get_local $0)
                       (i32.const 3)
                     )
                   )
@@ -296,18 +296,18 @@
                 )
               )
               (i32.store
-                (tee_local $16
+                (tee_local $13
                   (i32.add
                     (i32.add
                       (get_local $4)
-                      (get_local $2)
+                      (get_local $6)
                     )
                     (i32.const 4)
                   )
                 )
                 (i32.or
                   (i32.load
-                    (get_local $16)
+                    (get_local $13)
                   )
                   (i32.const 1)
                 )
@@ -316,14 +316,14 @@
                 (get_local $25)
               )
               (return
-                (get_local $0)
+                (get_local $3)
               )
             )
           )
           (if
             (i32.gt_u
-              (get_local $0)
-              (tee_local $16
+              (get_local $3)
+              (tee_local $13
                 (i32.load
                   (i32.const 1216)
                 )
@@ -333,35 +333,35 @@
               (if
                 (get_local $4)
                 (block
-                  (set_local $7
+                  (set_local $8
                     (i32.and
                       (i32.shr_u
-                        (tee_local $2
+                        (tee_local $6
                           (i32.add
                             (i32.and
-                              (tee_local $7
+                              (tee_local $8
                                 (i32.and
                                   (i32.shl
                                     (get_local $4)
-                                    (get_local $2)
+                                    (get_local $0)
                                   )
                                   (i32.or
-                                    (tee_local $2
+                                    (tee_local $6
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $2)
+                                        (get_local $0)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $2)
+                                      (get_local $6)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $7)
+                                (get_local $8)
                               )
                             )
                             (i32.const -1)
@@ -372,32 +372,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $7
+                  (set_local $8
                     (i32.load
-                      (tee_local $8
+                      (tee_local $7
                         (i32.add
                           (tee_local $9
                             (i32.load
-                              (tee_local $15
+                              (tee_local $16
                                 (i32.add
                                   (tee_local $1
                                     (i32.add
                                       (i32.const 1248)
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $14
+                                          (tee_local $15
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $2
+                                                      (tee_local $6
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $8
+                                                            (tee_local $7
                                                               (i32.shr_u
-                                                                (get_local $2)
-                                                                (get_local $7)
+                                                                (get_local $6)
+                                                                (get_local $8)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -405,15 +405,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $7)
+                                                      (get_local $8)
                                                     )
-                                                    (tee_local $8
+                                                    (tee_local $7
                                                       (i32.and
                                                         (i32.shr_u
                                                           (tee_local $9
                                                             (i32.shr_u
-                                                              (get_local $8)
-                                                              (get_local $2)
+                                                              (get_local $7)
+                                                              (get_local $6)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -428,7 +428,7 @@
                                                         (tee_local $1
                                                           (i32.shr_u
                                                             (get_local $9)
-                                                            (get_local $8)
+                                                            (get_local $7)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -440,7 +440,7 @@
                                                 (tee_local $1
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (tee_local $15
+                                                      (tee_local $16
                                                         (i32.shr_u
                                                           (get_local $1)
                                                           (get_local $9)
@@ -453,7 +453,7 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $15)
+                                                (get_local $16)
                                                 (get_local $1)
                                               )
                                             )
@@ -477,7 +477,7 @@
                   (if
                     (i32.eq
                       (get_local $1)
-                      (get_local $7)
+                      (get_local $8)
                     )
                     (block
                       (i32.store
@@ -487,20 +487,20 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $14)
+                              (get_local $15)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $33
-                        (get_local $16)
+                      (set_local $34
+                        (get_local $13)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $7)
+                          (get_local $8)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -510,9 +510,9 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $2
+                            (tee_local $6
                               (i32.add
-                                (get_local $7)
+                                (get_local $8)
                                 (i32.const 12)
                               )
                             )
@@ -521,14 +521,14 @@
                         )
                         (block
                           (i32.store
-                            (get_local $2)
+                            (get_local $6)
                             (get_local $1)
                           )
                           (i32.store
-                            (get_local $15)
-                            (get_local $7)
+                            (get_local $16)
+                            (get_local $8)
                           )
-                          (set_local $33
+                          (set_local $34
                             (i32.load
                               (i32.const 1216)
                             )
@@ -541,25 +541,25 @@
                   (i32.store offset=4
                     (get_local $9)
                     (i32.or
-                      (get_local $0)
+                      (get_local $3)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $15
+                    (tee_local $16
                       (i32.add
                         (get_local $9)
-                        (get_local $0)
+                        (get_local $3)
                       )
                     )
                     (i32.or
-                      (tee_local $7
+                      (tee_local $8
                         (i32.sub
                           (i32.shl
-                            (get_local $14)
+                            (get_local $15)
                             (i32.const 3)
                           )
-                          (get_local $0)
+                          (get_local $3)
                         )
                       )
                       (i32.const 1)
@@ -567,13 +567,13 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $15)
-                      (get_local $7)
+                      (get_local $16)
+                      (get_local $8)
                     )
-                    (get_local $7)
+                    (get_local $8)
                   )
                   (if
-                    (get_local $33)
+                    (get_local $34)
                     (block
                       (set_local $1
                         (i32.load
@@ -585,9 +585,9 @@
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (tee_local $16
+                              (tee_local $13
                                 (i32.shr_u
-                                  (get_local $33)
+                                  (get_local $34)
                                   (i32.const 3)
                                 )
                               )
@@ -599,7 +599,7 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $2
+                          (tee_local $0
                             (i32.load
                               (i32.const 1208)
                             )
@@ -607,13 +607,13 @@
                           (tee_local $4
                             (i32.shl
                               (i32.const 1)
-                              (get_local $16)
+                              (get_local $13)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $2
+                            (tee_local $0
                               (i32.load
                                 (tee_local $4
                                   (i32.add
@@ -632,8 +632,8 @@
                             (set_local $41
                               (get_local $4)
                             )
-                            (set_local $34
-                              (get_local $2)
+                            (set_local $35
+                              (get_local $0)
                             )
                           )
                         )
@@ -641,7 +641,7 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $2)
+                              (get_local $0)
                               (get_local $4)
                             )
                           )
@@ -651,7 +651,7 @@
                               (i32.const 8)
                             )
                           )
-                          (set_local $34
+                          (set_local $35
                             (get_local $5)
                           )
                         )
@@ -661,12 +661,12 @@
                         (get_local $1)
                       )
                       (i32.store offset=12
-                        (get_local $34)
+                        (get_local $35)
                         (get_local $1)
                       )
                       (i32.store offset=8
                         (get_local $1)
-                        (get_local $34)
+                        (get_local $35)
                       )
                       (i32.store offset=12
                         (get_local $1)
@@ -676,37 +676,37 @@
                   )
                   (i32.store
                     (i32.const 1216)
-                    (get_local $7)
+                    (get_local $8)
                   )
                   (i32.store
                     (i32.const 1228)
-                    (get_local $15)
+                    (get_local $16)
                   )
                   (set_global $r
                     (get_local $25)
                   )
                   (return
-                    (get_local $8)
+                    (get_local $7)
                   )
                 )
               )
               (if
-                (tee_local $15
+                (tee_local $16
                   (i32.load
                     (i32.const 1212)
                   )
                 )
                 (block
-                  (set_local $15
+                  (set_local $16
                     (i32.and
                       (i32.shr_u
-                        (tee_local $7
+                        (tee_local $8
                           (i32.add
                             (i32.and
-                              (get_local $15)
+                              (get_local $16)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $15)
+                                (get_local $16)
                               )
                             )
                             (i32.const -1)
@@ -717,11 +717,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $2
+                  (set_local $0
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (tee_local $16
+                          (tee_local $13
                             (i32.load
                               (i32.add
                                 (i32.shl
@@ -730,13 +730,13 @@
                                       (i32.or
                                         (i32.or
                                           (i32.or
-                                            (tee_local $7
+                                            (tee_local $8
                                               (i32.and
                                                 (i32.shr_u
                                                   (tee_local $5
                                                     (i32.shr_u
-                                                      (get_local $7)
-                                                      (get_local $15)
+                                                      (get_local $8)
+                                                      (get_local $16)
                                                     )
                                                   )
                                                   (i32.const 5)
@@ -744,7 +744,7 @@
                                                 (i32.const 8)
                                               )
                                             )
-                                            (get_local $15)
+                                            (get_local $16)
                                           )
                                           (tee_local $5
                                             (i32.and
@@ -752,7 +752,7 @@
                                                 (tee_local $1
                                                   (i32.shr_u
                                                     (get_local $5)
-                                                    (get_local $7)
+                                                    (get_local $8)
                                                   )
                                                 )
                                                 (i32.const 2)
@@ -764,7 +764,7 @@
                                         (tee_local $1
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $2
+                                              (tee_local $0
                                                 (i32.shr_u
                                                   (get_local $1)
                                                   (get_local $5)
@@ -776,12 +776,12 @@
                                           )
                                         )
                                       )
-                                      (tee_local $2
+                                      (tee_local $0
                                         (i32.and
                                           (i32.shr_u
                                             (tee_local $4
                                               (i32.shr_u
-                                                (get_local $2)
+                                                (get_local $0)
                                                 (get_local $1)
                                               )
                                             )
@@ -793,7 +793,7 @@
                                     )
                                     (i32.shr_u
                                       (get_local $4)
-                                      (get_local $2)
+                                      (get_local $0)
                                     )
                                   )
                                   (i32.const 2)
@@ -805,25 +805,25 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $0)
+                      (get_local $3)
                     )
                   )
                   (set_local $4
-                    (get_local $16)
+                    (get_local $13)
                   )
                   (set_local $1
-                    (get_local $16)
+                    (get_local $13)
                   )
                   (loop $while-in
                     (block $while-out
                       (if
-                        (tee_local $16
+                        (tee_local $13
                           (i32.load offset=16
                             (get_local $4)
                           )
                         )
                         (set_local $6
-                          (get_local $16)
+                          (get_local $13)
                         )
                         (if
                           (tee_local $5
@@ -835,10 +835,10 @@
                             (get_local $5)
                           )
                           (block
-                            (set_local $7
-                              (get_local $2)
-                            )
                             (set_local $6
+                              (get_local $0)
+                            )
+                            (set_local $2
                               (get_local $1)
                             )
                             (br $while-out)
@@ -847,7 +847,7 @@
                       )
                       (set_local $5
                         (i32.lt_u
-                          (tee_local $16
+                          (tee_local $13
                             (i32.sub
                               (i32.and
                                 (i32.load offset=4
@@ -855,16 +855,16 @@
                                 )
                                 (i32.const -8)
                               )
-                              (get_local $0)
+                              (get_local $3)
                             )
                           )
-                          (get_local $2)
+                          (get_local $0)
                         )
                       )
-                      (set_local $2
+                      (set_local $0
                         (select
-                          (get_local $16)
-                          (get_local $2)
+                          (get_local $13)
+                          (get_local $0)
                           (get_local $5)
                         )
                       )
@@ -883,7 +883,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $6)
+                      (get_local $2)
                       (tee_local $1
                         (i32.load
                           (i32.const 1224)
@@ -894,46 +894,46 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $6)
+                      (get_local $2)
                       (tee_local $4
                         (i32.add
-                          (get_local $6)
-                          (get_local $0)
+                          (get_local $2)
+                          (get_local $3)
                         )
                       )
                     )
                     (call $qa)
                   )
-                  (set_local $2
+                  (set_local $0
                     (i32.load offset=24
-                      (get_local $6)
+                      (get_local $2)
                     )
                   )
                   (block $do-once4
                     (if
                       (i32.eq
-                        (tee_local $8
+                        (tee_local $7
                           (i32.load offset=12
-                            (get_local $6)
+                            (get_local $2)
                           )
                         )
-                        (get_local $6)
+                        (get_local $2)
                       )
                       (block
                         (if
-                          (tee_local $14
+                          (tee_local $15
                             (i32.load
                               (tee_local $9
                                 (i32.add
-                                  (get_local $6)
+                                  (get_local $2)
                                   (i32.const 20)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $16
-                              (get_local $14)
+                            (set_local $13
+                              (get_local $15)
                             )
                             (set_local $5
                               (get_local $9)
@@ -941,11 +941,11 @@
                           )
                           (if
                             (i32.eqz
-                              (tee_local $16
+                              (tee_local $13
                                 (i32.load
                                   (tee_local $5
                                     (i32.add
-                                      (get_local $6)
+                                      (get_local $2)
                                       (i32.const 16)
                                     )
                                   )
@@ -953,7 +953,7 @@
                               )
                             )
                             (block
-                              (set_local $21
+                              (set_local $23
                                 (i32.const 0)
                               )
                               (br $do-once4)
@@ -962,19 +962,19 @@
                         )
                         (loop $while-in7
                           (if
-                            (tee_local $14
+                            (tee_local $15
                               (i32.load
                                 (tee_local $9
                                   (i32.add
-                                    (get_local $16)
+                                    (get_local $13)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $16
-                                (get_local $14)
+                              (set_local $13
+                                (get_local $15)
                               )
                               (set_local $5
                                 (get_local $9)
@@ -983,19 +983,19 @@
                             )
                           )
                           (if
-                            (tee_local $14
+                            (tee_local $15
                               (i32.load
                                 (tee_local $9
                                   (i32.add
-                                    (get_local $16)
+                                    (get_local $13)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $16
-                                (get_local $14)
+                              (set_local $13
+                                (get_local $15)
                               )
                               (set_local $5
                                 (get_local $9)
@@ -1015,8 +1015,8 @@
                               (get_local $5)
                               (i32.const 0)
                             )
-                            (set_local $21
-                              (get_local $16)
+                            (set_local $23
+                              (get_local $13)
                             )
                           )
                         )
@@ -1026,7 +1026,7 @@
                           (i32.lt_u
                             (tee_local $9
                               (i32.load offset=8
-                                (get_local $6)
+                                (get_local $2)
                               )
                             )
                             (get_local $1)
@@ -1036,14 +1036,14 @@
                         (if
                           (i32.ne
                             (i32.load
-                              (tee_local $14
+                              (tee_local $15
                                 (i32.add
                                   (get_local $9)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $6)
+                            (get_local $2)
                           )
                           (call $qa)
                         )
@@ -1052,24 +1052,24 @@
                             (i32.load
                               (tee_local $5
                                 (i32.add
-                                  (get_local $8)
+                                  (get_local $7)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $6)
+                            (get_local $2)
                           )
                           (block
                             (i32.store
-                              (get_local $14)
-                              (get_local $8)
+                              (get_local $15)
+                              (get_local $7)
                             )
                             (i32.store
                               (get_local $5)
                               (get_local $9)
                             )
-                            (set_local $21
-                              (get_local $8)
+                            (set_local $23
+                              (get_local $7)
                             )
                           )
                           (call $qa)
@@ -1079,19 +1079,19 @@
                   )
                   (block $do-once8
                     (if
-                      (get_local $2)
+                      (get_local $0)
                       (block
                         (if
                           (i32.eq
-                            (get_local $6)
+                            (get_local $2)
                             (i32.load
                               (tee_local $1
                                 (i32.add
                                   (i32.const 1512)
                                   (i32.shl
-                                    (tee_local $8
+                                    (tee_local $7
                                       (i32.load offset=28
-                                        (get_local $6)
+                                        (get_local $2)
                                       )
                                     )
                                     (i32.const 2)
@@ -1103,11 +1103,11 @@
                           (block
                             (i32.store
                               (get_local $1)
-                              (get_local $21)
+                              (get_local $23)
                             )
                             (if
                               (i32.eqz
-                                (get_local $21)
+                                (get_local $23)
                               )
                               (block
                                 (i32.store
@@ -1119,7 +1119,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $8)
+                                        (get_local $7)
                                       )
                                       (i32.const -1)
                                     )
@@ -1132,7 +1132,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $2)
+                                (get_local $0)
                                 (i32.load
                                   (i32.const 1224)
                                 )
@@ -1142,35 +1142,35 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $8
+                                  (tee_local $7
                                     (i32.add
-                                      (get_local $2)
+                                      (get_local $0)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $2)
                               )
                               (i32.store
-                                (get_local $8)
-                                (get_local $21)
+                                (get_local $7)
+                                (get_local $23)
                               )
                               (i32.store offset=20
-                                (get_local $2)
-                                (get_local $21)
+                                (get_local $0)
+                                (get_local $23)
                               )
                             )
                             (br_if $do-once8
                               (i32.eqz
-                                (get_local $21)
+                                (get_local $23)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $21)
-                            (tee_local $8
+                            (get_local $23)
+                            (tee_local $7
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1179,29 +1179,29 @@
                           (call $qa)
                         )
                         (i32.store offset=24
-                          (get_local $21)
-                          (get_local $2)
+                          (get_local $23)
+                          (get_local $0)
                         )
                         (if
                           (tee_local $1
                             (i32.load offset=16
-                              (get_local $6)
+                              (get_local $2)
                             )
                           )
                           (if
                             (i32.lt_u
                               (get_local $1)
-                              (get_local $8)
+                              (get_local $7)
                             )
                             (call $qa)
                             (block
                               (i32.store offset=16
-                                (get_local $21)
+                                (get_local $23)
                                 (get_local $1)
                               )
                               (i32.store offset=24
                                 (get_local $1)
-                                (get_local $21)
+                                (get_local $23)
                               )
                             )
                           )
@@ -1209,7 +1209,7 @@
                         (if
                           (tee_local $1
                             (i32.load offset=20
-                              (get_local $6)
+                              (get_local $2)
                             )
                           )
                           (if
@@ -1222,12 +1222,12 @@
                             (call $qa)
                             (block
                               (i32.store offset=20
-                                (get_local $21)
+                                (get_local $23)
                                 (get_local $1)
                               )
                               (i32.store offset=24
                                 (get_local $1)
-                                (get_local $21)
+                                (get_local $23)
                               )
                             )
                           )
@@ -1237,17 +1237,17 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $6)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $6)
+                        (get_local $2)
                         (i32.or
-                          (tee_local $2
+                          (tee_local $0
                             (i32.add
-                              (get_local $7)
-                              (get_local $0)
+                              (get_local $6)
+                              (get_local $3)
                             )
                           )
                           (i32.const 3)
@@ -1257,8 +1257,8 @@
                         (tee_local $1
                           (i32.add
                             (i32.add
-                              (get_local $6)
                               (get_local $2)
+                              (get_local $0)
                             )
                             (i32.const 4)
                           )
@@ -1273,25 +1273,25 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $6)
+                        (get_local $2)
                         (i32.or
-                          (get_local $0)
+                          (get_local $3)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
                         (get_local $4)
                         (i32.or
-                          (get_local $7)
+                          (get_local $6)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
                           (get_local $4)
-                          (get_local $7)
+                          (get_local $6)
                         )
-                        (get_local $7)
+                        (get_local $6)
                       )
                       (if
                         (tee_local $1
@@ -1300,7 +1300,7 @@
                           )
                         )
                         (block
-                          (set_local $2
+                          (set_local $0
                             (i32.load
                               (i32.const 1228)
                             )
@@ -1310,7 +1310,7 @@
                               (i32.const 1248)
                               (i32.shl
                                 (i32.shl
-                                  (tee_local $8
+                                  (tee_local $7
                                     (i32.shr_u
                                       (get_local $1)
                                       (i32.const 3)
@@ -1332,7 +1332,7 @@
                               (tee_local $5
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $8)
+                                  (get_local $7)
                                 )
                               )
                             )
@@ -1357,7 +1357,7 @@
                                 (set_local $42
                                   (get_local $5)
                                 )
-                                (set_local $35
+                                (set_local $27
                                   (get_local $9)
                                 )
                               )
@@ -1376,32 +1376,32 @@
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $35
+                              (set_local $27
                                 (get_local $1)
                               )
                             )
                           )
                           (i32.store
                             (get_local $42)
-                            (get_local $2)
+                            (get_local $0)
                           )
                           (i32.store offset=12
-                            (get_local $35)
-                            (get_local $2)
+                            (get_local $27)
+                            (get_local $0)
                           )
                           (i32.store offset=8
-                            (get_local $2)
-                            (get_local $35)
+                            (get_local $0)
+                            (get_local $27)
                           )
                           (i32.store offset=12
-                            (get_local $2)
+                            (get_local $0)
                             (get_local $1)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 1216)
-                        (get_local $7)
+                        (get_local $6)
                       )
                       (i32.store
                         (i32.const 1228)
@@ -1414,18 +1414,18 @@
                   )
                   (return
                     (i32.add
-                      (get_local $6)
+                      (get_local $2)
                       (i32.const 8)
                     )
                   )
                 )
                 (set_local $4
-                  (get_local $0)
+                  (get_local $3)
                 )
               )
             )
             (set_local $4
-              (get_local $0)
+              (get_local $3)
             )
           )
         )
@@ -1438,7 +1438,7 @@
             (i32.const -1)
           )
           (block
-            (set_local $2
+            (set_local $0
               (i32.and
                 (tee_local $1
                   (i32.add
@@ -1459,18 +1459,18 @@
                 (set_local $5
                   (i32.sub
                     (i32.const 0)
-                    (get_local $2)
+                    (get_local $0)
                   )
                 )
                 (block $label$break$a
                   (if
-                    (tee_local $15
+                    (tee_local $16
                       (i32.load
                         (i32.add
                           (i32.shl
-                            (tee_local $21
+                            (tee_local $27
                               (if i32
-                                (tee_local $8
+                                (tee_local $7
                                   (i32.shr_u
                                     (get_local $1)
                                     (i32.const 8)
@@ -1478,33 +1478,33 @@
                                 )
                                 (if i32
                                   (i32.gt_u
-                                    (get_local $2)
+                                    (get_local $0)
                                     (i32.const 16777215)
                                   )
                                   (i32.const 31)
                                   (i32.or
                                     (i32.and
                                       (i32.shr_u
-                                        (get_local $2)
+                                        (get_local $0)
                                         (i32.add
-                                          (tee_local $15
+                                          (tee_local $16
                                             (i32.add
                                               (i32.sub
                                                 (i32.const 14)
                                                 (i32.or
                                                   (i32.or
-                                                    (tee_local $8
+                                                    (tee_local $7
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (tee_local $14
+                                                            (tee_local $15
                                                               (i32.shl
-                                                                (get_local $8)
+                                                                (get_local $7)
                                                                 (tee_local $1
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
-                                                                        (get_local $8)
+                                                                        (get_local $7)
                                                                         (i32.const 1048320)
                                                                       )
                                                                       (i32.const 16)
@@ -1523,14 +1523,14 @@
                                                     )
                                                     (get_local $1)
                                                   )
-                                                  (tee_local $14
+                                                  (tee_local $15
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $16
+                                                          (tee_local $13
                                                             (i32.shl
-                                                              (get_local $14)
-                                                              (get_local $8)
+                                                              (get_local $15)
+                                                              (get_local $7)
                                                             )
                                                           )
                                                           (i32.const 245760)
@@ -1544,8 +1544,8 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $16)
-                                                  (get_local $14)
+                                                  (get_local $13)
+                                                  (get_local $15)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -1557,7 +1557,7 @@
                                       (i32.const 1)
                                     )
                                     (i32.shl
-                                      (get_local $15)
+                                      (get_local $16)
                                       (i32.const 1)
                                     )
                                   )
@@ -1572,35 +1572,35 @@
                       )
                     )
                     (block
-                      (set_local $14
+                      (set_local $15
                         (get_local $5)
                       )
-                      (set_local $16
+                      (set_local $13
                         (i32.const 0)
                       )
                       (set_local $1
                         (i32.shl
-                          (get_local $2)
+                          (get_local $0)
                           (select
                             (i32.const 0)
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $21)
+                                (get_local $27)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $21)
+                              (get_local $27)
                               (i32.const 31)
                             )
                           )
                         )
                       )
-                      (set_local $8
-                        (get_local $15)
-                      )
                       (set_local $7
+                        (get_local $16)
+                      )
+                      (set_local $8
                         (i32.const 0)
                       )
                       (loop $while-in14
@@ -1608,55 +1608,55 @@
                           (i32.lt_u
                             (tee_local $4
                               (i32.sub
-                                (tee_local $0
+                                (tee_local $3
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $8)
+                                      (get_local $7)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $2)
+                                (get_local $0)
                               )
                             )
-                            (get_local $14)
+                            (get_local $15)
                           )
                           (if
                             (i32.eq
+                              (get_local $3)
                               (get_local $0)
-                              (get_local $2)
                             )
                             (block
-                              (set_local $28
+                              (set_local $29
                                 (get_local $4)
                               )
-                              (set_local $27
-                                (get_local $8)
+                              (set_local $28
+                                (get_local $7)
                               )
-                              (set_local $31
-                                (get_local $8)
+                              (set_local $32
+                                (get_local $7)
                               )
-                              (set_local $8
+                              (set_local $7
                                 (i32.const 90)
                               )
                               (br $label$break$a)
                             )
                             (block
-                              (set_local $14
+                              (set_local $15
                                 (get_local $4)
                               )
-                              (set_local $7
-                                (get_local $8)
+                              (set_local $8
+                                (get_local $7)
                               )
                             )
                           )
                         )
-                        (set_local $0
+                        (set_local $3
                           (select
-                            (get_local $16)
+                            (get_local $13)
                             (tee_local $4
                               (i32.load offset=20
-                                (get_local $8)
+                                (get_local $7)
                               )
                             )
                             (i32.or
@@ -1665,11 +1665,11 @@
                               )
                               (i32.eq
                                 (get_local $4)
-                                (tee_local $8
+                                (tee_local $7
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $8)
+                                        (get_local $7)
                                         (i32.const 16)
                                       )
                                       (i32.shl
@@ -1689,26 +1689,26 @@
                         (if
                           (tee_local $4
                             (i32.eqz
-                              (get_local $8)
+                              (get_local $7)
                             )
                           )
                           (block
                             (set_local $36
-                              (get_local $14)
+                              (get_local $15)
                             )
                             (set_local $37
-                              (get_local $0)
+                              (get_local $3)
                             )
-                            (set_local $32
-                              (get_local $7)
+                            (set_local $33
+                              (get_local $8)
                             )
-                            (set_local $8
+                            (set_local $7
                               (i32.const 86)
                             )
                           )
                           (block
-                            (set_local $16
-                              (get_local $0)
+                            (set_local $13
+                              (get_local $3)
                             )
                             (set_local $1
                               (i32.shl
@@ -1734,10 +1734,10 @@
                       (set_local $37
                         (i32.const 0)
                       )
-                      (set_local $32
+                      (set_local $33
                         (i32.const 0)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 86)
                       )
                     )
@@ -1745,18 +1745,18 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $7)
                     (i32.const 86)
                   )
                   (if
-                    (tee_local $0
+                    (tee_local $3
                       (if i32
                         (i32.and
                           (i32.eqz
                             (get_local $37)
                           )
                           (i32.eqz
-                            (get_local $32)
+                            (get_local $33)
                           )
                         )
                         (block i32
@@ -1766,15 +1766,15 @@
                                 (i32.and
                                   (get_local $9)
                                   (i32.or
-                                    (tee_local $15
+                                    (tee_local $16
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $21)
+                                        (get_local $27)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $15)
+                                      (get_local $16)
                                     )
                                   )
                                 )
@@ -1782,7 +1782,7 @@
                             )
                             (block
                               (set_local $4
-                                (get_local $2)
+                                (get_local $0)
                               )
                               (br $do-once)
                             )
@@ -1790,7 +1790,7 @@
                           (set_local $5
                             (i32.and
                               (i32.shr_u
-                                (tee_local $15
+                                (tee_local $16
                                   (i32.add
                                     (i32.and
                                       (get_local $5)
@@ -1815,12 +1815,12 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (tee_local $15
+                                          (tee_local $16
                                             (i32.and
                                               (i32.shr_u
-                                                (tee_local $0
+                                                (tee_local $3
                                                   (i32.shr_u
-                                                    (get_local $15)
+                                                    (get_local $16)
                                                     (get_local $5)
                                                   )
                                                 )
@@ -1831,13 +1831,13 @@
                                           )
                                           (get_local $5)
                                         )
-                                        (tee_local $0
+                                        (tee_local $3
                                           (i32.and
                                             (i32.shr_u
                                               (tee_local $4
                                                 (i32.shr_u
-                                                  (get_local $0)
-                                                  (get_local $15)
+                                                  (get_local $3)
+                                                  (get_local $16)
                                                 )
                                               )
                                               (i32.const 2)
@@ -1849,10 +1849,10 @@
                                       (tee_local $4
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $7
+                                            (tee_local $8
                                               (i32.shr_u
                                                 (get_local $4)
-                                                (get_local $0)
+                                                (get_local $3)
                                               )
                                             )
                                             (i32.const 1)
@@ -1861,12 +1861,12 @@
                                         )
                                       )
                                     )
-                                    (tee_local $7
+                                    (tee_local $8
                                       (i32.and
                                         (i32.shr_u
                                           (tee_local $1
                                             (i32.shr_u
-                                              (get_local $7)
+                                              (get_local $8)
                                               (get_local $4)
                                             )
                                           )
@@ -1878,7 +1878,7 @@
                                   )
                                   (i32.shr_u
                                     (get_local $1)
-                                    (get_local $7)
+                                    (get_local $8)
                                   )
                                 )
                                 (i32.const 2)
@@ -1891,16 +1891,16 @@
                       )
                     )
                     (block
-                      (set_local $28
+                      (set_local $29
                         (get_local $36)
                       )
-                      (set_local $27
-                        (get_local $0)
+                      (set_local $28
+                        (get_local $3)
                       )
-                      (set_local $31
-                        (get_local $32)
+                      (set_local $32
+                        (get_local $33)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 90)
                       )
                     )
@@ -1909,81 +1909,81 @@
                         (get_local $36)
                       )
                       (set_local $10
-                        (get_local $32)
+                        (get_local $33)
                       )
                     )
                   )
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $7)
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $8
+                    (set_local $7
                       (i32.const 0)
                     )
                     (set_local $1
                       (i32.lt_u
-                        (tee_local $7
+                        (tee_local $8
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $27)
+                                (get_local $28)
                               )
                               (i32.const -8)
                             )
-                            (get_local $2)
+                            (get_local $0)
                           )
                         )
-                        (get_local $28)
+                        (get_local $29)
                       )
                     )
                     (set_local $4
                       (select
-                        (get_local $7)
-                        (get_local $28)
+                        (get_local $8)
+                        (get_local $29)
                         (get_local $1)
                       )
                     )
-                    (set_local $7
+                    (set_local $8
                       (select
-                        (get_local $27)
-                        (get_local $31)
+                        (get_local $28)
+                        (get_local $32)
                         (get_local $1)
                       )
                     )
                     (if
                       (tee_local $1
                         (i32.load offset=16
-                          (get_local $27)
+                          (get_local $28)
                         )
                       )
                       (block
-                        (set_local $28
+                        (set_local $29
                           (get_local $4)
                         )
-                        (set_local $27
+                        (set_local $28
                           (get_local $1)
                         )
-                        (set_local $31
-                          (get_local $7)
+                        (set_local $32
+                          (get_local $8)
                         )
                         (br $while-in16)
                       )
                     )
                     (if
-                      (tee_local $27
+                      (tee_local $28
                         (i32.load offset=20
-                          (get_local $27)
+                          (get_local $28)
                         )
                       )
                       (block
-                        (set_local $28
+                        (set_local $29
                           (get_local $4)
                         )
-                        (set_local $31
-                          (get_local $7)
+                        (set_local $32
+                          (get_local $8)
                         )
                         (br $while-in16)
                       )
@@ -1992,7 +1992,7 @@
                           (get_local $4)
                         )
                         (set_local $10
-                          (get_local $7)
+                          (get_local $8)
                         )
                       )
                     )
@@ -2007,7 +2007,7 @@
                         (i32.load
                           (i32.const 1216)
                         )
-                        (get_local $2)
+                        (get_local $0)
                       )
                     )
                     (block
@@ -2025,10 +2025,10 @@
                       (if
                         (i32.ge_u
                           (get_local $10)
-                          (tee_local $7
+                          (tee_local $8
                             (i32.add
                               (get_local $10)
-                              (get_local $2)
+                              (get_local $0)
                             )
                           )
                         )
@@ -2053,7 +2053,7 @@
                             (if
                               (tee_local $5
                                 (i32.load
-                                  (tee_local $0
+                                  (tee_local $3
                                     (i32.add
                                       (get_local $10)
                                       (i32.const 20)
@@ -2062,17 +2062,17 @@
                                 )
                               )
                               (block
-                                (set_local $16
+                                (set_local $13
                                   (get_local $5)
                                 )
                                 (set_local $1
-                                  (get_local $0)
+                                  (get_local $3)
                                 )
                               )
                               (if
-                                (tee_local $16
+                                (tee_local $13
                                   (i32.load
-                                    (tee_local $15
+                                    (tee_local $16
                                       (i32.add
                                         (get_local $10)
                                         (i32.const 16)
@@ -2081,10 +2081,10 @@
                                   )
                                 )
                                 (set_local $1
-                                  (get_local $15)
+                                  (get_local $16)
                                 )
                                 (block
-                                  (set_local $23
+                                  (set_local $22
                                     (i32.const 0)
                                   )
                                   (br $do-once17)
@@ -2095,20 +2095,20 @@
                               (if
                                 (tee_local $5
                                   (i32.load
-                                    (tee_local $0
+                                    (tee_local $3
                                       (i32.add
-                                        (get_local $16)
+                                        (get_local $13)
                                         (i32.const 20)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $16
+                                  (set_local $13
                                     (get_local $5)
                                   )
                                   (set_local $1
-                                    (get_local $0)
+                                    (get_local $3)
                                   )
                                   (br $while-in20)
                                 )
@@ -2116,20 +2116,20 @@
                               (if
                                 (tee_local $5
                                   (i32.load
-                                    (tee_local $0
+                                    (tee_local $3
                                       (i32.add
-                                        (get_local $16)
+                                        (get_local $13)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $16
+                                  (set_local $13
                                     (get_local $5)
                                   )
                                   (set_local $1
-                                    (get_local $0)
+                                    (get_local $3)
                                   )
                                   (br $while-in20)
                                 )
@@ -2146,8 +2146,8 @@
                                   (get_local $1)
                                   (i32.const 0)
                                 )
-                                (set_local $23
-                                  (get_local $16)
+                                (set_local $22
+                                  (get_local $13)
                                 )
                               )
                             )
@@ -2155,7 +2155,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (tee_local $0
+                                (tee_local $3
                                   (i32.load offset=8
                                     (get_local $10)
                                   )
@@ -2169,7 +2169,7 @@
                                 (i32.load
                                   (tee_local $5
                                     (i32.add
-                                      (get_local $0)
+                                      (get_local $3)
                                       (i32.const 12)
                                     )
                                   )
@@ -2181,7 +2181,7 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $15
+                                  (tee_local $16
                                     (i32.add
                                       (get_local $1)
                                       (i32.const 8)
@@ -2196,10 +2196,10 @@
                                   (get_local $1)
                                 )
                                 (i32.store
-                                  (get_local $15)
-                                  (get_local $0)
+                                  (get_local $16)
+                                  (get_local $3)
                                 )
-                                (set_local $23
+                                (set_local $22
                                   (get_local $1)
                                 )
                               )
@@ -2234,11 +2234,11 @@
                               (block
                                 (i32.store
                                   (get_local $9)
-                                  (get_local $23)
+                                  (get_local $22)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $23)
+                                    (get_local $22)
                                   )
                                   (block
                                     (i32.store
@@ -2284,23 +2284,23 @@
                                   )
                                   (i32.store
                                     (get_local $1)
-                                    (get_local $23)
+                                    (get_local $22)
                                   )
                                   (i32.store offset=20
                                     (get_local $4)
-                                    (get_local $23)
+                                    (get_local $22)
                                   )
                                 )
                                 (br_if $do-once21
                                   (i32.eqz
-                                    (get_local $23)
+                                    (get_local $22)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $23)
+                                (get_local $22)
                                 (tee_local $1
                                   (i32.load
                                     (i32.const 1224)
@@ -2310,7 +2310,7 @@
                               (call $qa)
                             )
                             (i32.store offset=24
-                              (get_local $23)
+                              (get_local $22)
                               (get_local $4)
                             )
                             (if
@@ -2327,12 +2327,12 @@
                                 (call $qa)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $23)
+                                    (get_local $22)
                                     (get_local $9)
                                   )
                                   (i32.store offset=24
                                     (get_local $9)
-                                    (get_local $23)
+                                    (get_local $22)
                                   )
                                 )
                               )
@@ -2353,12 +2353,12 @@
                                 (call $qa)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $23)
+                                    (get_local $22)
                                     (get_local $9)
                                   )
                                   (i32.store offset=24
                                     (get_local $9)
-                                    (get_local $23)
+                                    (get_local $22)
                                   )
                                 )
                               )
@@ -2379,7 +2379,7 @@
                                 (tee_local $4
                                   (i32.add
                                     (get_local $18)
-                                    (get_local $2)
+                                    (get_local $0)
                                   )
                                 )
                                 (i32.const 3)
@@ -2407,12 +2407,12 @@
                             (i32.store offset=4
                               (get_local $10)
                               (i32.or
-                                (get_local $2)
+                                (get_local $0)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
-                              (get_local $7)
+                              (get_local $8)
                               (i32.or
                                 (get_local $18)
                                 (i32.const 1)
@@ -2420,7 +2420,7 @@
                             )
                             (i32.store
                               (i32.add
-                                (get_local $7)
+                                (get_local $8)
                                 (get_local $18)
                               )
                               (get_local $18)
@@ -2456,7 +2456,7 @@
                                         (i32.const 1208)
                                       )
                                     )
-                                    (tee_local $0
+                                    (tee_local $3
                                       (i32.shl
                                         (i32.const 1)
                                         (get_local $9)
@@ -2467,7 +2467,7 @@
                                     (i32.lt_u
                                       (tee_local $1
                                         (i32.load
-                                          (tee_local $0
+                                          (tee_local $3
                                             (i32.add
                                               (get_local $4)
                                               (i32.const 8)
@@ -2482,7 +2482,7 @@
                                     (call $qa)
                                     (block
                                       (set_local $19
-                                        (get_local $0)
+                                        (get_local $3)
                                       )
                                       (set_local $6
                                         (get_local $1)
@@ -2494,7 +2494,7 @@
                                       (i32.const 1208)
                                       (i32.or
                                         (get_local $1)
-                                        (get_local $0)
+                                        (get_local $3)
                                       )
                                     )
                                     (set_local $19
@@ -2510,28 +2510,28 @@
                                 )
                                 (i32.store
                                   (get_local $19)
-                                  (get_local $7)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=12
                                   (get_local $6)
-                                  (get_local $7)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=8
-                                  (get_local $7)
+                                  (get_local $8)
                                   (get_local $6)
                                 )
                                 (i32.store offset=12
-                                  (get_local $7)
+                                  (get_local $8)
                                   (get_local $4)
                                 )
                                 (br $do-once25)
                               )
                             )
-                            (set_local $15
+                            (set_local $16
                               (i32.add
                                 (i32.const 1512)
                                 (i32.shl
-                                  (tee_local $14
+                                  (tee_local $15
                                     (if i32
                                       (tee_local $4
                                         (i32.shr_u
@@ -2550,7 +2550,7 @@
                                             (i32.shr_u
                                               (get_local $18)
                                               (i32.add
-                                                (tee_local $15
+                                                (tee_local $16
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
@@ -2560,7 +2560,7 @@
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (tee_local $0
+                                                                  (tee_local $3
                                                                     (i32.shl
                                                                       (get_local $4)
                                                                       (tee_local $1
@@ -2586,13 +2586,13 @@
                                                           )
                                                           (get_local $1)
                                                         )
-                                                        (tee_local $0
+                                                        (tee_local $3
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
                                                                 (tee_local $9
                                                                   (i32.shl
-                                                                    (get_local $0)
+                                                                    (get_local $3)
                                                                     (get_local $4)
                                                                   )
                                                                 )
@@ -2608,7 +2608,7 @@
                                                     (i32.shr_u
                                                       (i32.shl
                                                         (get_local $9)
-                                                        (get_local $0)
+                                                        (get_local $3)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -2620,7 +2620,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $15)
+                                            (get_local $16)
                                             (i32.const 1)
                                           )
                                         )
@@ -2633,26 +2633,26 @@
                               )
                             )
                             (i32.store offset=28
-                              (get_local $7)
-                              (get_local $14)
+                              (get_local $8)
+                              (get_local $15)
                             )
                             (i32.store offset=4
-                              (tee_local $0
+                              (tee_local $3
                                 (i32.add
-                                  (get_local $7)
+                                  (get_local $8)
                                   (i32.const 16)
                                 )
                               )
                               (i32.const 0)
                             )
                             (i32.store
-                              (get_local $0)
+                              (get_local $3)
                               (i32.const 0)
                             )
                             (if
                               (i32.eqz
                                 (i32.and
-                                  (tee_local $0
+                                  (tee_local $3
                                     (i32.load
                                       (i32.const 1212)
                                     )
@@ -2660,7 +2660,7 @@
                                   (tee_local $9
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $14)
+                                      (get_local $15)
                                     )
                                   )
                                 )
@@ -2669,25 +2669,25 @@
                                 (i32.store
                                   (i32.const 1212)
                                   (i32.or
-                                    (get_local $0)
+                                    (get_local $3)
                                     (get_local $9)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $15)
-                                  (get_local $7)
+                                  (get_local $16)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=24
-                                  (get_local $7)
-                                  (get_local $15)
+                                  (get_local $8)
+                                  (get_local $16)
                                 )
                                 (i32.store offset=12
-                                  (get_local $7)
-                                  (get_local $7)
+                                  (get_local $8)
+                                  (get_local $8)
                                 )
                                 (i32.store offset=8
-                                  (get_local $7)
-                                  (get_local $7)
+                                  (get_local $8)
+                                  (get_local $8)
                                 )
                                 (br $do-once25)
                               )
@@ -2700,20 +2700,20 @@
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $14)
+                                      (get_local $15)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $14)
+                                    (get_local $15)
                                     (i32.const 31)
                                   )
                                 )
                               )
                             )
-                            (set_local $0
+                            (set_local $3
                               (i32.load
-                                (get_local $15)
+                                (get_local $16)
                               )
                             )
                             (loop $while-in28
@@ -2722,7 +2722,7 @@
                                   (i32.eq
                                     (i32.and
                                       (i32.load offset=4
-                                        (get_local $0)
+                                        (get_local $3)
                                       )
                                       (i32.const -8)
                                     )
@@ -2730,9 +2730,9 @@
                                   )
                                   (block
                                     (set_local $17
-                                      (get_local $0)
+                                      (get_local $3)
                                     )
-                                    (set_local $8
+                                    (set_local $7
                                       (i32.const 148)
                                     )
                                     (br $while-out27)
@@ -2741,10 +2741,10 @@
                                 (if
                                   (tee_local $1
                                     (i32.load
-                                      (tee_local $15
+                                      (tee_local $16
                                         (i32.add
                                           (i32.add
-                                            (get_local $0)
+                                            (get_local $3)
                                             (i32.const 16)
                                           )
                                           (i32.shl
@@ -2765,19 +2765,19 @@
                                         (i32.const 1)
                                       )
                                     )
-                                    (set_local $0
+                                    (set_local $3
                                       (get_local $1)
                                     )
                                     (br $while-in28)
                                   )
                                   (block
-                                    (set_local $22
-                                      (get_local $15)
+                                    (set_local $21
+                                      (get_local $16)
                                     )
-                                    (set_local $13
-                                      (get_local $0)
+                                    (set_local $14
+                                      (get_local $3)
                                     )
-                                    (set_local $8
+                                    (set_local $7
                                       (i32.const 145)
                                     )
                                   )
@@ -2786,12 +2786,12 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.const 145)
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $22)
+                                  (get_local $21)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2799,26 +2799,26 @@
                                 (call $qa)
                                 (block
                                   (i32.store
-                                    (get_local $22)
-                                    (get_local $7)
+                                    (get_local $21)
+                                    (get_local $8)
                                   )
                                   (i32.store offset=24
-                                    (get_local $7)
-                                    (get_local $13)
+                                    (get_local $8)
+                                    (get_local $14)
                                   )
                                   (i32.store offset=12
-                                    (get_local $7)
-                                    (get_local $7)
+                                    (get_local $8)
+                                    (get_local $8)
                                   )
                                   (i32.store offset=8
-                                    (get_local $7)
-                                    (get_local $7)
+                                    (get_local $8)
+                                    (get_local $8)
                                   )
                                 )
                               )
                               (if
                                 (i32.eq
-                                  (get_local $8)
+                                  (get_local $7)
                                   (i32.const 148)
                                 )
                                 (if
@@ -2826,7 +2826,7 @@
                                     (i32.ge_u
                                       (tee_local $9
                                         (i32.load
-                                          (tee_local $0
+                                          (tee_local $3
                                             (i32.add
                                               (get_local $17)
                                               (i32.const 8)
@@ -2848,22 +2848,22 @@
                                   (block
                                     (i32.store offset=12
                                       (get_local $9)
-                                      (get_local $7)
+                                      (get_local $8)
                                     )
                                     (i32.store
-                                      (get_local $0)
-                                      (get_local $7)
+                                      (get_local $3)
+                                      (get_local $8)
                                     )
                                     (i32.store offset=8
-                                      (get_local $7)
+                                      (get_local $8)
                                       (get_local $9)
                                     )
                                     (i32.store offset=12
-                                      (get_local $7)
+                                      (get_local $8)
                                       (get_local $17)
                                     )
                                     (i32.store offset=24
-                                      (get_local $7)
+                                      (get_local $8)
                                       (i32.const 0)
                                     )
                                   )
@@ -2885,16 +2885,16 @@
                       )
                     )
                     (set_local $4
-                      (get_local $2)
+                      (get_local $0)
                     )
                   )
                   (set_local $4
-                    (get_local $2)
+                    (get_local $0)
                   )
                 )
               )
               (set_local $4
-                (get_local $2)
+                (get_local $0)
               )
             )
           )
@@ -2911,7 +2911,7 @@
         (get_local $4)
       )
       (block
-        (set_local $13
+        (set_local $14
           (i32.load
             (i32.const 1228)
           )
@@ -2929,9 +2929,9 @@
           (block
             (i32.store
               (i32.const 1228)
-              (tee_local $22
+              (tee_local $21
                 (i32.add
-                  (get_local $13)
+                  (get_local $14)
                   (get_local $4)
                 )
               )
@@ -2941,7 +2941,7 @@
               (get_local $17)
             )
             (i32.store offset=4
-              (get_local $22)
+              (get_local $21)
               (i32.or
                 (get_local $17)
                 (i32.const 1)
@@ -2949,13 +2949,13 @@
             )
             (i32.store
               (i32.add
-                (get_local $22)
+                (get_local $21)
                 (get_local $17)
               )
               (get_local $17)
             )
             (i32.store offset=4
-              (get_local $13)
+              (get_local $14)
               (i32.or
                 (get_local $4)
                 (i32.const 3)
@@ -2972,7 +2972,7 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $13)
+              (get_local $14)
               (i32.or
                 (get_local $10)
                 (i32.const 3)
@@ -2982,7 +2982,7 @@
               (tee_local $17
                 (i32.add
                   (i32.add
-                    (get_local $13)
+                    (get_local $14)
                     (get_local $10)
                   )
                   (i32.const 4)
@@ -3002,7 +3002,7 @@
         )
         (return
           (i32.add
-            (get_local $13)
+            (get_local $14)
             (i32.const 8)
           )
         )
@@ -3010,7 +3010,7 @@
     )
     (if
       (i32.gt_u
-        (tee_local $13
+        (tee_local $14
           (i32.load
             (i32.const 1220)
           )
@@ -3022,7 +3022,7 @@
           (i32.const 1220)
           (tee_local $17
             (i32.sub
-              (get_local $13)
+              (get_local $14)
               (get_local $4)
             )
           )
@@ -3031,7 +3031,7 @@
           (i32.const 1232)
           (tee_local $10
             (i32.add
-              (tee_local $13
+              (tee_local $14
                 (i32.load
                   (i32.const 1232)
                 )
@@ -3048,7 +3048,7 @@
           )
         )
         (i32.store offset=4
-          (get_local $13)
+          (get_local $14)
           (i32.or
             (get_local $4)
             (i32.const 3)
@@ -3059,7 +3059,7 @@
         )
         (return
           (i32.add
-            (get_local $13)
+            (get_local $14)
             (i32.const 8)
           )
         )
@@ -3098,7 +3098,7 @@
         )
         (i32.store
           (get_local $12)
-          (tee_local $13
+          (tee_local $14
             (i32.xor
               (i32.and
                 (get_local $12)
@@ -3110,11 +3110,11 @@
         )
         (i32.store
           (i32.const 1680)
-          (get_local $13)
+          (get_local $14)
         )
       )
     )
-    (set_local $13
+    (set_local $14
       (i32.add
         (get_local $4)
         (i32.const 48)
@@ -3139,7 +3139,7 @@
                 )
               )
             )
-            (tee_local $22
+            (tee_local $21
               (i32.sub
                 (i32.const 0)
                 (get_local $12)
@@ -3169,7 +3169,7 @@
           (i32.le_u
             (tee_local $6
               (i32.add
-                (tee_local $14
+                (tee_local $15
                   (i32.load
                     (i32.const 1640)
                   )
@@ -3177,7 +3177,7 @@
                 (get_local $12)
               )
             )
-            (get_local $14)
+            (get_local $15)
           )
           (i32.gt_u
             (get_local $6)
@@ -3196,7 +3196,7 @@
     )
     (if
       (i32.eq
-        (tee_local $8
+        (tee_local $7
           (block $label$break$b i32
             (if i32
               (i32.and
@@ -3222,7 +3222,7 @@
                         (block $while-out31
                           (if
                             (i32.le_u
-                              (tee_local $14
+                              (tee_local $15
                                 (i32.load
                                   (get_local $6)
                                 )
@@ -3232,7 +3232,7 @@
                             (if
                               (i32.gt_u
                                 (i32.add
-                                  (get_local $14)
+                                  (get_local $15)
                                   (i32.load
                                     (tee_local $19
                                       (i32.add
@@ -3245,7 +3245,7 @@
                                 (get_local $18)
                               )
                               (block
-                                (set_local $2
+                                (set_local $0
                                   (get_local $6)
                                 )
                                 (set_local $5
@@ -3262,7 +3262,7 @@
                               )
                             )
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.const 171)
                           )
                           (br $label$break$c)
@@ -3278,7 +3278,7 @@
                                   (i32.const 1220)
                                 )
                               )
-                              (get_local $22)
+                              (get_local $21)
                             )
                           )
                           (i32.const 2147483647)
@@ -3292,7 +3292,7 @@
                             )
                             (i32.add
                               (i32.load
-                                (get_local $2)
+                                (get_local $0)
                               )
                               (i32.load
                                 (get_local $5)
@@ -3320,17 +3320,17 @@
                             (set_local $11
                               (get_local $19)
                             )
-                            (set_local $3
+                            (set_local $2
                               (get_local $6)
                             )
-                            (set_local $8
+                            (set_local $7
                               (i32.const 181)
                             )
                           )
                         )
                       )
                     )
-                    (set_local $8
+                    (set_local $7
                       (i32.const 171)
                     )
                   )
@@ -3338,7 +3338,7 @@
                 (block $do-once33
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 171)
                     )
                     (if
@@ -3351,7 +3351,7 @@
                         (i32.const -1)
                       )
                       (block
-                        (set_local $0
+                        (set_local $3
                           (if i32
                             (i32.and
                               (tee_local $19
@@ -3364,19 +3364,19 @@
                                   (i32.const -1)
                                 )
                               )
-                              (tee_local $2
+                              (tee_local $0
                                 (get_local $18)
                               )
                             )
                             (i32.add
                               (i32.sub
                                 (get_local $12)
-                                (get_local $2)
+                                (get_local $0)
                               )
                               (i32.and
                                 (i32.add
                                   (get_local $19)
-                                  (get_local $2)
+                                  (get_local $0)
                                 )
                                 (i32.sub
                                   (i32.const 0)
@@ -3387,24 +3387,24 @@
                             (get_local $12)
                           )
                         )
-                        (set_local $2
+                        (set_local $0
                           (i32.add
                             (tee_local $6
                               (i32.load
                                 (i32.const 1640)
                               )
                             )
-                            (get_local $0)
+                            (get_local $3)
                           )
                         )
                         (if
                           (i32.and
                             (i32.gt_u
-                              (get_local $0)
+                              (get_local $3)
                               (get_local $4)
                             )
                             (i32.lt_u
-                              (get_local $0)
+                              (get_local $3)
                               (i32.const 2147483647)
                             )
                           )
@@ -3418,11 +3418,11 @@
                               (br_if $do-once33
                                 (i32.or
                                   (i32.le_u
-                                    (get_local $2)
+                                    (get_local $0)
                                     (get_local $6)
                                   )
                                   (i32.gt_u
-                                    (get_local $2)
+                                    (get_local $0)
                                     (get_local $19)
                                   )
                                 )
@@ -3432,7 +3432,7 @@
                               (i32.eq
                                 (tee_local $19
                                   (call $ta
-                                    (get_local $0)
+                                    (get_local $3)
                                   )
                                 )
                                 (get_local $18)
@@ -3442,7 +3442,7 @@
                                   (get_local $18)
                                 )
                                 (set_local $26
-                                  (get_local $0)
+                                  (get_local $3)
                                 )
                                 (br $label$break$b
                                   (i32.const 191)
@@ -3452,10 +3452,10 @@
                                 (set_local $11
                                   (get_local $19)
                                 )
-                                (set_local $3
-                                  (get_local $0)
+                                (set_local $2
+                                  (get_local $3)
                                 )
-                                (set_local $8
+                                (set_local $7
                                   (i32.const 181)
                                 )
                               )
@@ -3469,25 +3469,25 @@
                 (block $label$break$d
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 181)
                     )
                     (block
                       (set_local $19
                         (i32.sub
                           (i32.const 0)
-                          (get_local $3)
+                          (get_local $2)
                         )
                       )
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $13)
-                            (get_local $3)
+                            (get_local $14)
+                            (get_local $2)
                           )
                           (i32.and
                             (i32.lt_u
-                              (get_local $3)
+                              (get_local $2)
                               (i32.const 2147483647)
                             )
                             (i32.ne
@@ -3498,12 +3498,12 @@
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $2
+                            (tee_local $0
                               (i32.and
                                 (i32.add
                                   (i32.sub
                                     (get_local $17)
-                                    (get_local $3)
+                                    (get_local $2)
                                   )
                                   (tee_local $18
                                     (i32.load
@@ -3522,7 +3522,7 @@
                           (if
                             (i32.eq
                               (call $ta
-                                (get_local $2)
+                                (get_local $0)
                               )
                               (i32.const -1)
                             )
@@ -3536,17 +3536,17 @@
                             )
                             (set_local $1
                               (i32.add
+                                (get_local $0)
                                 (get_local $2)
-                                (get_local $3)
                               )
                             )
                           )
                           (set_local $1
-                            (get_local $3)
+                            (get_local $2)
                           )
                         )
                         (set_local $1
-                          (get_local $3)
+                          (get_local $2)
                         )
                       )
                       (if
@@ -3635,7 +3635,7 @@
               (set_local $26
                 (get_local $11)
               )
-              (set_local $8
+              (set_local $7
                 (i32.const 191)
               )
             )
@@ -3645,7 +3645,7 @@
     )
     (if
       (i32.eq
-        (get_local $8)
+        (get_local $7)
         (i32.const 191)
       )
       (block
@@ -3680,7 +3680,7 @@
               )
             )
             (block
-              (set_local $3
+              (set_local $2
                 (i32.const 1656)
               )
               (loop $do-in41
@@ -3691,14 +3691,14 @@
                       (i32.add
                         (tee_local $1
                           (i32.load
-                            (get_local $3)
+                            (get_local $2)
                           )
                         )
                         (tee_local $17
                           (i32.load
                             (tee_local $12
                               (i32.add
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 4)
                               )
                             )
@@ -3717,9 +3717,9 @@
                         (get_local $17)
                       )
                       (set_local $52
-                        (get_local $3)
+                        (get_local $2)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 201)
                       )
                       (br $do-out40)
@@ -3727,9 +3727,9 @@
                   )
                   (br_if $do-in41
                     (i32.ne
-                      (tee_local $3
+                      (tee_local $2
                         (i32.load offset=8
-                          (get_local $3)
+                          (get_local $2)
                         )
                       )
                       (i32.const 0)
@@ -3739,7 +3739,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $8)
+                  (get_local $7)
                   (i32.const 201)
                 )
                 (if
@@ -3770,7 +3770,7 @@
                           (get_local $26)
                         )
                       )
-                      (set_local $3
+                      (set_local $2
                         (i32.add
                           (get_local $11)
                           (tee_local $17
@@ -3778,7 +3778,7 @@
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (tee_local $3
+                                  (tee_local $2
                                     (i32.add
                                       (get_local $11)
                                       (i32.const 8)
@@ -3789,7 +3789,7 @@
                               )
                               (i32.const 0)
                               (i32.and
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 7)
                               )
                             )
@@ -3809,14 +3809,14 @@
                       )
                       (i32.store
                         (i32.const 1232)
-                        (get_local $3)
+                        (get_local $2)
                       )
                       (i32.store
                         (i32.const 1220)
                         (get_local $12)
                       )
                       (i32.store offset=4
-                        (get_local $3)
+                        (get_local $2)
                         (i32.or
                           (get_local $12)
                           (i32.const 1)
@@ -3824,7 +3824,7 @@
                       )
                       (i32.store offset=4
                         (i32.add
-                          (get_local $3)
+                          (get_local $2)
                           (get_local $12)
                         )
                         (i32.const 40)
@@ -3840,7 +3840,7 @@
                   )
                 )
               )
-              (set_local $7
+              (set_local $13
                 (if i32
                   (i32.lt_u
                     (get_local $20)
@@ -3866,7 +3866,7 @@
                   (get_local $26)
                 )
               )
-              (set_local $3
+              (set_local $2
                 (i32.const 1656)
               )
               (loop $while-in43
@@ -3874,38 +3874,38 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (get_local $3)
+                        (get_local $2)
                       )
                       (get_local $12)
                     )
                     (block
                       (set_local $53
-                        (get_local $3)
+                        (get_local $2)
                       )
                       (set_local $43
-                        (get_local $3)
+                        (get_local $2)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 209)
                       )
                       (br $while-out42)
                     )
                   )
                   (br_if $while-in43
-                    (tee_local $3
+                    (tee_local $2
                       (i32.load offset=8
-                        (get_local $3)
+                        (get_local $2)
                       )
                     )
                   )
-                  (set_local $29
+                  (set_local $30
                     (i32.const 1656)
                   )
                 )
               )
               (if
                 (i32.eq
-                  (get_local $8)
+                  (get_local $7)
                   (i32.const 209)
                 )
                 (if
@@ -3915,7 +3915,7 @@
                     )
                     (i32.const 8)
                   )
-                  (set_local $29
+                  (set_local $30
                     (i32.const 1656)
                   )
                   (block
@@ -3924,7 +3924,7 @@
                       (get_local $20)
                     )
                     (i32.store
-                      (tee_local $3
+                      (tee_local $2
                         (i32.add
                           (get_local $43)
                           (i32.const 4)
@@ -3932,7 +3932,7 @@
                       )
                       (i32.add
                         (i32.load
-                          (get_local $3)
+                          (get_local $2)
                         )
                         (get_local $26)
                       )
@@ -3944,7 +3944,7 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $3
+                              (tee_local $2
                                 (i32.add
                                   (get_local $20)
                                   (i32.const 8)
@@ -3955,7 +3955,7 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $3)
+                            (get_local $2)
                             (i32.const 7)
                           )
                         )
@@ -3968,7 +3968,7 @@
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (tee_local $3
+                              (tee_local $2
                                 (i32.add
                                   (get_local $12)
                                   (i32.const 8)
@@ -3979,19 +3979,19 @@
                           )
                           (i32.const 0)
                           (i32.and
-                            (get_local $3)
+                            (get_local $2)
                             (i32.const 7)
                           )
                         )
                       )
                     )
-                    (set_local $3
+                    (set_local $2
                       (i32.add
                         (get_local $17)
                         (get_local $4)
                       )
                     )
-                    (set_local $13
+                    (set_local $14
                       (i32.sub
                         (i32.sub
                           (get_local $1)
@@ -4016,23 +4016,23 @@
                         (block
                           (i32.store
                             (i32.const 1220)
-                            (tee_local $0
+                            (tee_local $3
                               (i32.add
                                 (i32.load
                                   (i32.const 1220)
                                 )
-                                (get_local $13)
+                                (get_local $14)
                               )
                             )
                           )
                           (i32.store
                             (i32.const 1232)
-                            (get_local $3)
+                            (get_local $2)
                           )
                           (i32.store offset=4
-                            (get_local $3)
+                            (get_local $2)
                             (i32.or
-                              (get_local $0)
+                              (get_local $3)
                               (i32.const 1)
                             )
                           )
@@ -4048,43 +4048,43 @@
                             (block
                               (i32.store
                                 (i32.const 1216)
-                                (tee_local $0
+                                (tee_local $3
                                   (i32.add
                                     (i32.load
                                       (i32.const 1216)
                                     )
-                                    (get_local $13)
+                                    (get_local $14)
                                   )
                                 )
                               )
                               (i32.store
                                 (i32.const 1228)
-                                (get_local $3)
+                                (get_local $2)
                               )
                               (i32.store offset=4
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.or
-                                  (get_local $0)
+                                  (get_local $3)
                                   (i32.const 1)
                                 )
                               )
                               (i32.store
                                 (i32.add
+                                  (get_local $2)
                                   (get_local $3)
-                                  (get_local $0)
                                 )
-                                (get_local $0)
+                                (get_local $3)
                               )
                               (br $do-once44)
                             )
                           )
                           (i32.store
-                            (tee_local $2
+                            (tee_local $0
                               (i32.add
                                 (if i32
                                   (i32.eq
                                     (i32.and
-                                      (tee_local $0
+                                      (tee_local $3
                                         (i32.load offset=4
                                           (get_local $1)
                                         )
@@ -4096,20 +4096,20 @@
                                   (block i32
                                     (set_local $5
                                       (i32.and
-                                        (get_local $0)
+                                        (get_local $3)
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $2
+                                    (set_local $0
                                       (i32.shr_u
-                                        (get_local $0)
+                                        (get_local $3)
                                         (i32.const 3)
                                       )
                                     )
                                     (block $label$break$e
                                       (if
                                         (i32.lt_u
-                                          (get_local $0)
+                                          (get_local $3)
                                           (i32.const 256)
                                         )
                                         (block
@@ -4121,7 +4121,7 @@
                                           (block $do-once47
                                             (if
                                               (i32.ne
-                                                (tee_local $22
+                                                (tee_local $21
                                                   (i32.load offset=8
                                                     (get_local $1)
                                                   )
@@ -4131,7 +4131,7 @@
                                                     (i32.const 1248)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $2)
+                                                        (get_local $0)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4142,15 +4142,15 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $22)
-                                                    (get_local $7)
+                                                    (get_local $21)
+                                                    (get_local $13)
                                                   )
                                                   (call $qa)
                                                 )
                                                 (br_if $do-once47
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $22)
+                                                      (get_local $21)
                                                     )
                                                     (get_local $1)
                                                   )
@@ -4162,7 +4162,7 @@
                                           (if
                                             (i32.eq
                                               (get_local $10)
-                                              (get_local $22)
+                                              (get_local $21)
                                             )
                                             (block
                                               (i32.store
@@ -4174,7 +4174,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $2)
+                                                      (get_local $0)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4199,14 +4199,14 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $10)
-                                                    (get_local $7)
+                                                    (get_local $13)
                                                   )
                                                   (call $qa)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $2
+                                                      (tee_local $0
                                                         (i32.add
                                                           (get_local $10)
                                                           (i32.const 8)
@@ -4217,7 +4217,7 @@
                                                   )
                                                   (block
                                                     (set_local $44
-                                                      (get_local $2)
+                                                      (get_local $0)
                                                     )
                                                     (br $do-once49)
                                                   )
@@ -4227,12 +4227,12 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $22)
+                                            (get_local $21)
                                             (get_local $10)
                                           )
                                           (i32.store
                                             (get_local $44)
-                                            (get_local $22)
+                                            (get_local $21)
                                           )
                                         )
                                         (block
@@ -4244,7 +4244,7 @@
                                           (block $do-once51
                                             (if
                                               (i32.eq
-                                                (tee_local $2
+                                                (tee_local $0
                                                   (i32.load offset=12
                                                     (get_local $1)
                                                   )
@@ -4253,7 +4253,7 @@
                                               )
                                               (block
                                                 (if
-                                                  (tee_local $14
+                                                  (tee_local $15
                                                     (i32.load
                                                       (tee_local $6
                                                         (i32.add
@@ -4269,24 +4269,24 @@
                                                     )
                                                   )
                                                   (block
-                                                    (set_local $0
-                                                      (get_local $14)
+                                                    (set_local $3
+                                                      (get_local $15)
                                                     )
-                                                    (set_local $2
+                                                    (set_local $0
                                                       (get_local $6)
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $23
+                                                    (tee_local $22
                                                       (i32.load
                                                         (get_local $18)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $0
-                                                        (get_local $23)
+                                                      (set_local $3
+                                                        (get_local $22)
                                                       )
-                                                      (set_local $2
+                                                      (set_local $0
                                                         (get_local $18)
                                                       )
                                                     )
@@ -4300,42 +4300,42 @@
                                                 )
                                                 (loop $while-in54
                                                   (if
-                                                    (tee_local $14
+                                                    (tee_local $15
                                                       (i32.load
                                                         (tee_local $6
                                                           (i32.add
-                                                            (get_local $0)
+                                                            (get_local $3)
                                                             (i32.const 20)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $0
-                                                        (get_local $14)
+                                                      (set_local $3
+                                                        (get_local $15)
                                                       )
-                                                      (set_local $2
+                                                      (set_local $0
                                                         (get_local $6)
                                                       )
                                                       (br $while-in54)
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $14
+                                                    (tee_local $15
                                                       (i32.load
                                                         (tee_local $6
                                                           (i32.add
-                                                            (get_local $0)
+                                                            (get_local $3)
                                                             (i32.const 16)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $0
-                                                        (get_local $14)
+                                                      (set_local $3
+                                                        (get_local $15)
                                                       )
-                                                      (set_local $2
+                                                      (set_local $0
                                                         (get_local $6)
                                                       )
                                                       (br $while-in54)
@@ -4344,17 +4344,17 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $2)
-                                                    (get_local $7)
+                                                    (get_local $0)
+                                                    (get_local $13)
                                                   )
                                                   (call $qa)
                                                   (block
                                                     (i32.store
-                                                      (get_local $2)
+                                                      (get_local $0)
                                                       (i32.const 0)
                                                     )
                                                     (set_local $24
-                                                      (get_local $0)
+                                                      (get_local $3)
                                                     )
                                                   )
                                                 )
@@ -4367,14 +4367,14 @@
                                                         (get_local $1)
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $13)
                                                   )
                                                   (call $qa)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (tee_local $14
+                                                      (tee_local $15
                                                         (i32.add
                                                           (get_local $6)
                                                           (i32.const 12)
@@ -4390,7 +4390,7 @@
                                                     (i32.load
                                                       (tee_local $18
                                                         (i32.add
-                                                          (get_local $2)
+                                                          (get_local $0)
                                                           (i32.const 8)
                                                         )
                                                       )
@@ -4399,15 +4399,15 @@
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $14)
-                                                      (get_local $2)
+                                                      (get_local $15)
+                                                      (get_local $0)
                                                     )
                                                     (i32.store
                                                       (get_local $18)
                                                       (get_local $6)
                                                     )
                                                     (set_local $24
-                                                      (get_local $2)
+                                                      (get_local $0)
                                                     )
                                                   )
                                                   (call $qa)
@@ -4425,11 +4425,11 @@
                                               (i32.eq
                                                 (get_local $1)
                                                 (i32.load
-                                                  (tee_local $22
+                                                  (tee_local $21
                                                     (i32.add
                                                       (i32.const 1512)
                                                       (i32.shl
-                                                        (tee_local $2
+                                                        (tee_local $0
                                                           (i32.load offset=28
                                                             (get_local $1)
                                                           )
@@ -4442,7 +4442,7 @@
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $22)
+                                                  (get_local $21)
                                                   (get_local $24)
                                                 )
                                                 (br_if $do-once55
@@ -4457,7 +4457,7 @@
                                                     (i32.xor
                                                       (i32.shl
                                                         (i32.const 1)
-                                                        (get_local $2)
+                                                        (get_local $0)
                                                       )
                                                       (i32.const -1)
                                                     )
@@ -4507,7 +4507,7 @@
                                           (if
                                             (i32.lt_u
                                               (get_local $24)
-                                              (tee_local $2
+                                              (tee_local $0
                                                 (i32.load
                                                   (i32.const 1224)
                                                 )
@@ -4522,7 +4522,7 @@
                                           (if
                                             (tee_local $10
                                               (i32.load
-                                                (tee_local $22
+                                                (tee_local $21
                                                   (i32.add
                                                     (get_local $1)
                                                     (i32.const 16)
@@ -4533,7 +4533,7 @@
                                             (if
                                               (i32.lt_u
                                                 (get_local $10)
-                                                (get_local $2)
+                                                (get_local $0)
                                               )
                                               (call $qa)
                                               (block
@@ -4552,7 +4552,7 @@
                                             (i32.eqz
                                               (tee_local $10
                                                 (i32.load offset=4
-                                                  (get_local $22)
+                                                  (get_local $21)
                                                 )
                                               )
                                             )
@@ -4579,10 +4579,10 @@
                                         )
                                       )
                                     )
-                                    (set_local $13
+                                    (set_local $14
                                       (i32.add
                                         (get_local $5)
-                                        (get_local $13)
+                                        (get_local $14)
                                       )
                                     )
                                     (i32.add
@@ -4597,43 +4597,43 @@
                             )
                             (i32.and
                               (i32.load
-                                (get_local $2)
+                                (get_local $0)
                               )
                               (i32.const -2)
                             )
                           )
                           (i32.store offset=4
-                            (get_local $3)
+                            (get_local $2)
                             (i32.or
-                              (get_local $13)
+                              (get_local $14)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $3)
-                              (get_local $13)
+                              (get_local $2)
+                              (get_local $14)
                             )
-                            (get_local $13)
+                            (get_local $14)
                           )
-                          (set_local $2
+                          (set_local $0
                             (i32.shr_u
-                              (get_local $13)
+                              (get_local $14)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $13)
+                              (get_local $14)
                               (i32.const 256)
                             )
                             (block
-                              (set_local $0
+                              (set_local $3
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $2)
+                                      (get_local $0)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4648,10 +4648,10 @@
                                         (i32.const 1208)
                                       )
                                     )
-                                    (tee_local $2
+                                    (tee_local $0
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $2)
+                                        (get_local $0)
                                       )
                                     )
                                   )
@@ -4660,9 +4660,9 @@
                                       (i32.ge_u
                                         (tee_local $19
                                           (i32.load
-                                            (tee_local $2
+                                            (tee_local $0
                                               (i32.add
-                                                (get_local $0)
+                                                (get_local $3)
                                                 (i32.const 8)
                                               )
                                             )
@@ -4674,7 +4674,7 @@
                                       )
                                       (block
                                         (set_local $45
-                                          (get_local $2)
+                                          (get_local $0)
                                         )
                                         (set_local $38
                                           (get_local $19)
@@ -4689,50 +4689,50 @@
                                       (i32.const 1208)
                                       (i32.or
                                         (get_local $10)
-                                        (get_local $2)
+                                        (get_local $0)
                                       )
                                     )
                                     (set_local $45
                                       (i32.add
-                                        (get_local $0)
+                                        (get_local $3)
                                         (i32.const 8)
                                       )
                                     )
                                     (set_local $38
-                                      (get_local $0)
+                                      (get_local $3)
                                     )
                                   )
                                 )
                               )
                               (i32.store
                                 (get_local $45)
-                                (get_local $3)
+                                (get_local $2)
                               )
                               (i32.store offset=12
                                 (get_local $38)
-                                (get_local $3)
+                                (get_local $2)
                               )
                               (i32.store offset=8
-                                (get_local $3)
+                                (get_local $2)
                                 (get_local $38)
                               )
                               (i32.store offset=12
+                                (get_local $2)
                                 (get_local $3)
-                                (get_local $0)
                               )
                               (br $do-once44)
                             )
                           )
-                          (set_local $2
+                          (set_local $0
                             (i32.add
                               (i32.const 1512)
                               (i32.shl
                                 (tee_local $5
                                   (block $do-once61 i32
                                     (if i32
-                                      (tee_local $2
+                                      (tee_local $0
                                         (i32.shr_u
-                                          (get_local $13)
+                                          (get_local $14)
                                           (i32.const 8)
                                         )
                                       )
@@ -4741,7 +4741,7 @@
                                           (br_if $do-once61
                                             (i32.const 31)
                                             (i32.gt_u
-                                              (get_local $13)
+                                              (get_local $14)
                                               (i32.const 16777215)
                                             )
                                           )
@@ -4749,7 +4749,7 @@
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $13)
+                                              (get_local $14)
                                               (i32.add
                                                 (tee_local $6
                                                   (i32.add
@@ -4763,12 +4763,12 @@
                                                                 (i32.add
                                                                   (tee_local $5
                                                                     (i32.shl
-                                                                      (get_local $2)
+                                                                      (get_local $0)
                                                                       (tee_local $10
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $2)
+                                                                              (get_local $0)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -4791,7 +4791,7 @@
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $2
+                                                                (tee_local $0
                                                                   (i32.shl
                                                                     (get_local $5)
                                                                     (get_local $19)
@@ -4808,7 +4808,7 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $2)
+                                                        (get_local $0)
                                                         (get_local $5)
                                                       )
                                                       (i32.const 15)
@@ -4835,26 +4835,26 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $3)
+                            (get_local $2)
                             (get_local $5)
                           )
                           (i32.store offset=4
-                            (tee_local $0
+                            (tee_local $3
                               (i32.add
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 16)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $0)
+                            (get_local $3)
                             (i32.const 0)
                           )
                           (if
                             (i32.eqz
                               (i32.and
-                                (tee_local $0
+                                (tee_local $3
                                   (i32.load
                                     (i32.const 1212)
                                   )
@@ -4871,32 +4871,32 @@
                               (i32.store
                                 (i32.const 1212)
                                 (i32.or
-                                  (get_local $0)
+                                  (get_local $3)
                                   (get_local $6)
                                 )
                               )
                               (i32.store
+                                (get_local $0)
                                 (get_local $2)
-                                (get_local $3)
                               )
                               (i32.store offset=24
-                                (get_local $3)
                                 (get_local $2)
+                                (get_local $0)
                               )
                               (i32.store offset=12
-                                (get_local $3)
-                                (get_local $3)
+                                (get_local $2)
+                                (get_local $2)
                               )
                               (i32.store offset=8
-                                (get_local $3)
-                                (get_local $3)
+                                (get_local $2)
+                                (get_local $2)
                               )
                               (br $do-once44)
                             )
                           )
                           (set_local $6
                             (i32.shl
-                              (get_local $13)
+                              (get_local $14)
                               (select
                                 (i32.const 0)
                                 (i32.sub
@@ -4913,9 +4913,9 @@
                               )
                             )
                           )
-                          (set_local $0
+                          (set_local $3
                             (i32.load
-                              (get_local $2)
+                              (get_local $0)
                             )
                           )
                           (loop $while-in64
@@ -4924,17 +4924,17 @@
                                 (i32.eq
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $0)
+                                      (get_local $3)
                                     )
                                     (i32.const -8)
                                   )
-                                  (get_local $13)
+                                  (get_local $14)
                                 )
                                 (block
                                   (set_local $39
-                                    (get_local $0)
+                                    (get_local $3)
                                   )
-                                  (set_local $8
+                                  (set_local $7
                                     (i32.const 279)
                                   )
                                   (br $while-out63)
@@ -4943,10 +4943,10 @@
                               (if
                                 (tee_local $5
                                   (i32.load
-                                    (tee_local $2
+                                    (tee_local $0
                                       (i32.add
                                         (i32.add
-                                          (get_local $0)
+                                          (get_local $3)
                                           (i32.const 16)
                                         )
                                         (i32.shl
@@ -4967,19 +4967,19 @@
                                       (i32.const 1)
                                     )
                                   )
-                                  (set_local $0
+                                  (set_local $3
                                     (get_local $5)
                                   )
                                   (br $while-in64)
                                 )
                                 (block
                                   (set_local $46
-                                    (get_local $2)
-                                  )
-                                  (set_local $54
                                     (get_local $0)
                                   )
-                                  (set_local $8
+                                  (set_local $54
+                                    (get_local $3)
+                                  )
+                                  (set_local $7
                                     (i32.const 276)
                                   )
                                 )
@@ -4988,7 +4988,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $8)
+                              (get_local $7)
                               (i32.const 276)
                             )
                             (if
@@ -5002,25 +5002,25 @@
                               (block
                                 (i32.store
                                   (get_local $46)
-                                  (get_local $3)
+                                  (get_local $2)
                                 )
                                 (i32.store offset=24
-                                  (get_local $3)
+                                  (get_local $2)
                                   (get_local $54)
                                 )
                                 (i32.store offset=12
-                                  (get_local $3)
-                                  (get_local $3)
+                                  (get_local $2)
+                                  (get_local $2)
                                 )
                                 (i32.store offset=8
-                                  (get_local $3)
-                                  (get_local $3)
+                                  (get_local $2)
+                                  (get_local $2)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.const 279)
                               )
                               (if
@@ -5028,7 +5028,7 @@
                                   (i32.ge_u
                                     (tee_local $6
                                       (i32.load
-                                        (tee_local $0
+                                        (tee_local $3
                                           (i32.add
                                             (get_local $39)
                                             (i32.const 8)
@@ -5050,22 +5050,22 @@
                                 (block
                                   (i32.store offset=12
                                     (get_local $6)
-                                    (get_local $3)
+                                    (get_local $2)
                                   )
                                   (i32.store
-                                    (get_local $0)
                                     (get_local $3)
+                                    (get_local $2)
                                   )
                                   (i32.store offset=8
-                                    (get_local $3)
+                                    (get_local $2)
                                     (get_local $6)
                                   )
                                   (i32.store offset=12
-                                    (get_local $3)
+                                    (get_local $2)
                                     (get_local $39)
                                   )
                                   (i32.store offset=24
-                                    (get_local $3)
+                                    (get_local $2)
                                     (i32.const 0)
                                   )
                                 )
@@ -5092,20 +5092,20 @@
                 (block $while-out65
                   (if
                     (i32.le_u
-                      (tee_local $3
+                      (tee_local $2
                         (i32.load
-                          (get_local $29)
+                          (get_local $30)
                         )
                       )
                       (get_local $11)
                     )
                     (if
                       (i32.gt_u
-                        (tee_local $13
+                        (tee_local $14
                           (i32.add
-                            (get_local $3)
+                            (get_local $2)
                             (i32.load offset=4
-                              (get_local $29)
+                              (get_local $30)
                             )
                           )
                         )
@@ -5113,21 +5113,21 @@
                       )
                       (block
                         (set_local $0
-                          (get_local $13)
+                          (get_local $14)
                         )
                         (br $while-out65)
                       )
                     )
                   )
-                  (set_local $29
+                  (set_local $30
                     (i32.load offset=8
-                      (get_local $29)
+                      (get_local $30)
                     )
                   )
                   (br $while-in66)
                 )
               )
-              (set_local $13
+              (set_local $14
                 (i32.add
                   (tee_local $17
                     (i32.add
@@ -5138,33 +5138,33 @@
                   (i32.const 8)
                 )
               )
-              (set_local $3
+              (set_local $2
                 (i32.add
                   (tee_local $17
                     (select
                       (get_local $11)
-                      (tee_local $3
+                      (tee_local $2
                         (i32.add
                           (get_local $17)
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $13)
+                                (get_local $14)
                               )
                               (i32.const 7)
                             )
                             (i32.const 0)
                             (i32.and
-                              (get_local $13)
+                              (get_local $14)
                               (i32.const 7)
                             )
                           )
                         )
                       )
                       (i32.lt_u
-                        (get_local $3)
-                        (tee_local $13
+                        (get_local $2)
+                        (tee_local $14
                           (i32.add
                             (get_local $11)
                             (i32.const 16)
@@ -5247,25 +5247,25 @@
                 (i32.const 27)
               )
               (i32.store
-                (get_local $3)
+                (get_local $2)
                 (i32.load
                   (i32.const 1656)
                 )
               )
               (i32.store offset=4
-                (get_local $3)
+                (get_local $2)
                 (i32.load
                   (i32.const 1660)
                 )
               )
               (i32.store offset=8
-                (get_local $3)
+                (get_local $2)
                 (i32.load
                   (i32.const 1664)
                 )
               )
               (i32.store offset=12
-                (get_local $3)
+                (get_local $2)
                 (i32.load
                   (i32.const 1668)
                 )
@@ -5284,9 +5284,9 @@
               )
               (i32.store
                 (i32.const 1664)
-                (get_local $3)
+                (get_local $2)
               )
-              (set_local $3
+              (set_local $2
                 (i32.add
                   (get_local $17)
                   (i32.const 24)
@@ -5294,9 +5294,9 @@
               )
               (loop $do-in68
                 (i32.store
-                  (tee_local $3
+                  (tee_local $2
                     (i32.add
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const 4)
                     )
                   )
@@ -5305,7 +5305,7 @@
                 (br_if $do-in68
                   (i32.lt_u
                     (i32.add
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const 4)
                     )
                     (get_local $0)
@@ -5330,7 +5330,7 @@
                   (i32.store offset=4
                     (get_local $11)
                     (i32.or
-                      (tee_local $3
+                      (tee_local $2
                         (i32.sub
                           (get_local $17)
                           (get_local $11)
@@ -5341,17 +5341,17 @@
                   )
                   (i32.store
                     (get_local $17)
-                    (get_local $3)
+                    (get_local $2)
                   )
                   (set_local $1
                     (i32.shr_u
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const 256)
                     )
                     (block
@@ -5369,7 +5369,7 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $0
+                          (tee_local $3
                             (i32.load
                               (i32.const 1208)
                             )
@@ -5383,7 +5383,7 @@
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $0
+                            (tee_local $3
                               (i32.load
                                 (tee_local $5
                                   (i32.add
@@ -5403,7 +5403,7 @@
                               (get_local $5)
                             )
                             (set_local $40
-                              (get_local $0)
+                              (get_local $3)
                             )
                           )
                         )
@@ -5411,7 +5411,7 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $0)
+                              (get_local $3)
                               (get_local $5)
                             )
                           )
@@ -5445,30 +5445,30 @@
                       (br $do-once38)
                     )
                   )
-                  (set_local $2
+                  (set_local $0
                     (i32.add
                       (i32.const 1512)
                       (i32.shl
-                        (tee_local $0
+                        (tee_local $3
                           (if i32
                             (tee_local $12
                               (i32.shr_u
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 8)
                               )
                             )
                             (if i32
                               (i32.gt_u
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $3)
+                                    (get_local $2)
                                     (i32.add
-                                      (tee_local $2
+                                      (tee_local $0
                                         (i32.add
                                           (i32.sub
                                             (i32.const 14)
@@ -5481,7 +5481,7 @@
                                                         (tee_local $5
                                                           (i32.shl
                                                             (get_local $12)
-                                                            (tee_local $0
+                                                            (tee_local $3
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
@@ -5502,7 +5502,7 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $0)
+                                                (get_local $3)
                                               )
                                               (tee_local $5
                                                 (i32.and
@@ -5538,7 +5538,7 @@
                                   (i32.const 1)
                                 )
                                 (i32.shl
-                                  (get_local $2)
+                                  (get_local $0)
                                   (i32.const 1)
                                 )
                               )
@@ -5552,14 +5552,14 @@
                   )
                   (i32.store offset=28
                     (get_local $11)
-                    (get_local $0)
+                    (get_local $3)
                   )
                   (i32.store offset=20
                     (get_local $11)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $13)
+                    (get_local $14)
                     (i32.const 0)
                   )
                   (if
@@ -5573,7 +5573,7 @@
                         (tee_local $1
                           (i32.shl
                             (i32.const 1)
-                            (get_local $0)
+                            (get_local $3)
                           )
                         )
                       )
@@ -5587,12 +5587,12 @@
                         )
                       )
                       (i32.store
-                        (get_local $2)
+                        (get_local $0)
                         (get_local $11)
                       )
                       (i32.store offset=24
                         (get_local $11)
-                        (get_local $2)
+                        (get_local $0)
                       )
                       (i32.store offset=12
                         (get_local $11)
@@ -5607,18 +5607,18 @@
                   )
                   (set_local $1
                     (i32.shl
-                      (get_local $3)
+                      (get_local $2)
                       (select
                         (i32.const 0)
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $0)
+                            (get_local $3)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $0)
+                          (get_local $3)
                           (i32.const 31)
                         )
                       )
@@ -5626,7 +5626,7 @@
                   )
                   (set_local $5
                     (i32.load
-                      (get_local $2)
+                      (get_local $0)
                     )
                   )
                   (loop $while-in70
@@ -5639,22 +5639,22 @@
                             )
                             (i32.const -8)
                           )
-                          (get_local $3)
+                          (get_local $2)
                         )
                         (block
-                          (set_local $30
+                          (set_local $31
                             (get_local $5)
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.const 305)
                           )
                           (br $while-out69)
                         )
                       )
                       (if
-                        (tee_local $0
+                        (tee_local $3
                           (i32.load
-                            (tee_local $2
+                            (tee_local $0
                               (i32.add
                                 (i32.add
                                   (get_local $5)
@@ -5679,18 +5679,18 @@
                             )
                           )
                           (set_local $5
-                            (get_local $0)
+                            (get_local $3)
                           )
                           (br $while-in70)
                         )
                         (block
                           (set_local $48
-                            (get_local $2)
+                            (get_local $0)
                           )
                           (set_local $55
                             (get_local $5)
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.const 302)
                           )
                         )
@@ -5699,7 +5699,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 302)
                     )
                     (if
@@ -5731,7 +5731,7 @@
                     )
                     (if
                       (i32.eq
-                        (get_local $8)
+                        (get_local $7)
                         (i32.const 305)
                       )
                       (if
@@ -5741,21 +5741,21 @@
                               (i32.load
                                 (tee_local $5
                                   (i32.add
-                                    (get_local $30)
+                                    (get_local $31)
                                     (i32.const 8)
                                   )
                                 )
                               )
                             )
-                            (tee_local $3
+                            (tee_local $2
                               (i32.load
                                 (i32.const 1224)
                               )
                             )
                           )
                           (i32.ge_u
-                            (get_local $30)
-                            (get_local $3)
+                            (get_local $31)
+                            (get_local $2)
                           )
                         )
                         (block
@@ -5773,7 +5773,7 @@
                           )
                           (i32.store offset=12
                             (get_local $11)
-                            (get_local $30)
+                            (get_local $31)
                           )
                           (i32.store offset=24
                             (get_local $11)
@@ -5895,7 +5895,7 @@
               )
               (i32.store
                 (i32.const 1220)
-                (tee_local $3
+                (tee_local $2
                   (i32.sub
                     (i32.add
                       (get_local $26)
@@ -5908,14 +5908,14 @@
               (i32.store offset=4
                 (get_local $1)
                 (i32.or
-                  (get_local $3)
+                  (get_local $2)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
                   (get_local $1)
-                  (get_local $3)
+                  (get_local $2)
                 )
                 (i32.const 40)
               )
@@ -5940,7 +5940,7 @@
           (block
             (i32.store
               (i32.const 1220)
-              (tee_local $30
+              (tee_local $31
                 (i32.sub
                   (get_local $11)
                   (get_local $4)
@@ -5949,7 +5949,7 @@
             )
             (i32.store
               (i32.const 1232)
-              (tee_local $8
+              (tee_local $7
                 (i32.add
                   (tee_local $11
                     (i32.load
@@ -5961,9 +5961,9 @@
               )
             )
             (i32.store offset=4
-              (get_local $8)
+              (get_local $7)
               (i32.or
-                (get_local $30)
+                (get_local $31)
                 (i32.const 1)
               )
             )
@@ -6042,7 +6042,7 @@
       (i32.eq
         (tee_local $0
           (i32.and
-            (tee_local $3
+            (tee_local $4
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -6060,9 +6060,9 @@
     (set_local $8
       (i32.add
         (get_local $1)
-        (tee_local $6
+        (tee_local $7
           (i32.and
-            (get_local $3)
+            (get_local $4)
             (i32.const -8)
           )
         )
@@ -6071,19 +6071,19 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $3)
+          (get_local $4)
           (i32.const 1)
         )
         (block
           (set_local $2
             (get_local $1)
           )
-          (set_local $5
-            (get_local $6)
+          (set_local $6
+            (get_local $7)
           )
         )
         (block
-          (set_local $11
+          (set_local $10
             (i32.load
               (get_local $1)
             )
@@ -6094,20 +6094,20 @@
             )
             (return)
           )
-          (set_local $6
+          (set_local $7
             (i32.add
-              (get_local $11)
-              (get_local $6)
+              (get_local $10)
+              (get_local $7)
             )
           )
           (if
             (i32.lt_u
-              (tee_local $3
+              (tee_local $1
                 (i32.add
                   (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $11)
+                    (get_local $10)
                   )
                 )
               )
@@ -6117,7 +6117,7 @@
           )
           (if
             (i32.eq
-              (get_local $3)
+              (get_local $1)
               (i32.load
                 (i32.const 1228)
               )
@@ -6126,7 +6126,7 @@
               (if
                 (i32.ne
                   (i32.and
-                    (tee_local $7
+                    (tee_local $3
                       (i32.load
                         (tee_local $0
                           (i32.add
@@ -6142,72 +6142,72 @@
                 )
                 (block
                   (set_local $2
-                    (get_local $3)
+                    (get_local $1)
                   )
-                  (set_local $5
-                    (get_local $6)
+                  (set_local $6
+                    (get_local $7)
                   )
                   (br $do-once)
                 )
               )
               (i32.store
                 (i32.const 1216)
-                (get_local $6)
+                (get_local $7)
               )
               (i32.store
                 (get_local $0)
                 (i32.and
-                  (get_local $7)
+                  (get_local $3)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $3)
+                (get_local $1)
                 (i32.or
-                  (get_local $6)
+                  (get_local $7)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
-                  (get_local $3)
-                  (get_local $6)
+                  (get_local $1)
+                  (get_local $7)
                 )
-                (get_local $6)
+                (get_local $7)
               )
               (return)
             )
           )
-          (set_local $7
+          (set_local $3
             (i32.shr_u
-              (get_local $11)
+              (get_local $10)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $11)
+              (get_local $10)
               (i32.const 256)
             )
             (block
               (set_local $0
                 (i32.load offset=12
-                  (get_local $3)
+                  (get_local $1)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $11
+                  (tee_local $10
                     (i32.load offset=8
-                      (get_local $3)
+                      (get_local $1)
                     )
                   )
-                  (tee_local $1
+                  (tee_local $4
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $7)
+                          (get_local $3)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6218,7 +6218,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $11)
+                      (get_local $10)
                       (get_local $14)
                     )
                     (call $qa)
@@ -6226,9 +6226,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $11)
+                        (get_local $10)
                       )
-                      (get_local $3)
+                      (get_local $1)
                     )
                     (call $qa)
                   )
@@ -6237,7 +6237,7 @@
               (if
                 (i32.eq
                   (get_local $0)
-                  (get_local $11)
+                  (get_local $10)
                 )
                 (block
                   (i32.store
@@ -6249,17 +6249,17 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $7)
+                          (get_local $3)
                         )
                         (i32.const -1)
                       )
                     )
                   )
                   (set_local $2
-                    (get_local $3)
+                    (get_local $1)
                   )
-                  (set_local $5
-                    (get_local $6)
+                  (set_local $6
+                    (get_local $7)
                   )
                   (br $do-once)
                 )
@@ -6267,9 +6267,9 @@
               (if
                 (i32.eq
                   (get_local $0)
-                  (get_local $1)
+                  (get_local $4)
                 )
-                (set_local $10
+                (set_local $9
                   (i32.add
                     (get_local $0)
                     (i32.const 8)
@@ -6286,42 +6286,42 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $1
+                        (tee_local $4
                           (i32.add
                             (get_local $0)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $3)
-                    )
-                    (set_local $10
                       (get_local $1)
+                    )
+                    (set_local $9
+                      (get_local $4)
                     )
                     (call $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $11)
+                (get_local $10)
                 (get_local $0)
               )
               (i32.store
+                (get_local $9)
                 (get_local $10)
-                (get_local $11)
               )
               (set_local $2
-                (get_local $3)
+                (get_local $1)
               )
-              (set_local $5
-                (get_local $6)
+              (set_local $6
+                (get_local $7)
               )
               (br $do-once)
             )
           )
-          (set_local $11
+          (set_local $10
             (i32.load offset=24
-              (get_local $3)
+              (get_local $1)
             )
           )
           (block $do-once0
@@ -6329,20 +6329,20 @@
               (i32.eq
                 (tee_local $0
                   (i32.load offset=12
-                    (get_local $3)
+                    (get_local $1)
                   )
                 )
-                (get_local $3)
+                (get_local $1)
               )
               (block
                 (if
-                  (tee_local $10
+                  (tee_local $9
                     (i32.load
-                      (tee_local $7
+                      (tee_local $3
                         (i32.add
-                          (tee_local $1
+                          (tee_local $4
                             (i32.add
-                              (get_local $3)
+                              (get_local $1)
                               (i32.const 16)
                             )
                           )
@@ -6353,22 +6353,22 @@
                   )
                   (block
                     (set_local $0
-                      (get_local $10)
+                      (get_local $9)
                     )
-                    (set_local $1
-                      (get_local $7)
+                    (set_local $4
+                      (get_local $3)
                     )
                   )
                   (if
                     (i32.eqz
                       (tee_local $0
                         (i32.load
-                          (get_local $1)
+                          (get_local $4)
                         )
                       )
                     )
                     (block
-                      (set_local $4
+                      (set_local $5
                         (i32.const 0)
                       )
                       (br $do-once0)
@@ -6377,9 +6377,9 @@
                 )
                 (loop $while-in
                   (if
-                    (tee_local $10
+                    (tee_local $9
                       (i32.load
-                        (tee_local $7
+                        (tee_local $3
                           (i32.add
                             (get_local $0)
                             (i32.const 20)
@@ -6389,18 +6389,18 @@
                     )
                     (block
                       (set_local $0
-                        (get_local $10)
+                        (get_local $9)
                       )
-                      (set_local $1
-                        (get_local $7)
+                      (set_local $4
+                        (get_local $3)
                       )
                       (br $while-in)
                     )
                   )
                   (if
-                    (tee_local $10
+                    (tee_local $9
                       (i32.load
-                        (tee_local $7
+                        (tee_local $3
                           (i32.add
                             (get_local $0)
                             (i32.const 16)
@@ -6410,36 +6410,36 @@
                     )
                     (block
                       (set_local $0
-                        (get_local $10)
+                        (get_local $9)
                       )
-                      (set_local $1
-                        (get_local $7)
+                      (set_local $4
+                        (get_local $3)
                       )
                       (br $while-in)
                     )
                     (block
-                      (set_local $7
+                      (set_local $12
                         (get_local $0)
                       )
-                      (set_local $9
-                        (get_local $1)
+                      (set_local $3
+                        (get_local $4)
                       )
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $9)
+                    (get_local $3)
                     (get_local $14)
                   )
                   (call $qa)
                   (block
                     (i32.store
-                      (get_local $9)
+                      (get_local $3)
                       (i32.const 0)
                     )
-                    (set_local $4
-                      (get_local $7)
+                    (set_local $5
+                      (get_local $12)
                     )
                   )
                 )
@@ -6447,9 +6447,9 @@
               (block
                 (if
                   (i32.lt_u
-                    (tee_local $7
+                    (tee_local $3
                       (i32.load offset=8
-                        (get_local $3)
+                        (get_local $1)
                       )
                     )
                     (get_local $14)
@@ -6459,39 +6459,39 @@
                 (if
                   (i32.ne
                     (i32.load
-                      (tee_local $10
+                      (tee_local $9
                         (i32.add
-                          (get_local $7)
+                          (get_local $3)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $3)
+                    (get_local $1)
                   )
                   (call $qa)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $1
+                      (tee_local $4
                         (i32.add
                           (get_local $0)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $3)
+                    (get_local $1)
                   )
                   (block
                     (i32.store
-                      (get_local $10)
+                      (get_local $9)
                       (get_local $0)
                     )
                     (i32.store
-                      (get_local $1)
-                      (get_local $7)
+                      (get_local $4)
+                      (get_local $3)
                     )
-                    (set_local $4
+                    (set_local $5
                       (get_local $0)
                     )
                   )
@@ -6501,19 +6501,19 @@
             )
           )
           (if
-            (get_local $11)
+            (get_local $10)
             (block
               (if
                 (i32.eq
-                  (get_local $3)
+                  (get_local $1)
                   (i32.load
-                    (tee_local $7
+                    (tee_local $3
                       (i32.add
                         (i32.const 1512)
                         (i32.shl
                           (tee_local $0
                             (i32.load offset=28
-                              (get_local $3)
+                              (get_local $1)
                             )
                           )
                           (i32.const 2)
@@ -6524,12 +6524,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $7)
-                    (get_local $4)
+                    (get_local $3)
+                    (get_local $5)
                   )
                   (if
                     (i32.eqz
-                      (get_local $4)
+                      (get_local $5)
                     )
                     (block
                       (i32.store
@@ -6548,10 +6548,10 @@
                         )
                       )
                       (set_local $2
-                        (get_local $3)
+                        (get_local $1)
                       )
-                      (set_local $5
-                        (get_local $6)
+                      (set_local $6
+                        (get_local $7)
                       )
                       (br $do-once)
                     )
@@ -6560,7 +6560,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $11)
+                      (get_local $10)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6572,32 +6572,32 @@
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $11)
+                            (get_local $10)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $3)
+                      (get_local $1)
                     )
                     (i32.store
                       (get_local $0)
-                      (get_local $4)
+                      (get_local $5)
                     )
                     (i32.store offset=20
-                      (get_local $11)
-                      (get_local $4)
+                      (get_local $10)
+                      (get_local $5)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $4)
+                      (get_local $5)
                     )
                     (block
                       (set_local $2
-                        (get_local $3)
+                        (get_local $1)
                       )
-                      (set_local $5
-                        (get_local $6)
+                      (set_local $6
+                        (get_local $7)
                       )
                       (br $do-once)
                     )
@@ -6606,7 +6606,7 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $4)
+                  (get_local $5)
                   (tee_local $0
                     (i32.load
                       (i32.const 1224)
@@ -6616,15 +6616,15 @@
                 (call $qa)
               )
               (i32.store offset=24
-                (get_local $4)
-                (get_local $11)
+                (get_local $5)
+                (get_local $10)
               )
               (if
-                (tee_local $1
+                (tee_local $4
                   (i32.load
-                    (tee_local $7
+                    (tee_local $3
                       (i32.add
-                        (get_local $3)
+                        (get_local $1)
                         (i32.const 16)
                       )
                     )
@@ -6632,31 +6632,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $1)
+                    (get_local $4)
                     (get_local $0)
                   )
                   (call $qa)
                   (block
                     (i32.store offset=16
+                      (get_local $5)
                       (get_local $4)
-                      (get_local $1)
                     )
                     (i32.store offset=24
-                      (get_local $1)
                       (get_local $4)
+                      (get_local $5)
                     )
                   )
                 )
               )
               (if
-                (tee_local $1
+                (tee_local $4
                   (i32.load offset=4
-                    (get_local $7)
+                    (get_local $3)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $1)
+                    (get_local $4)
                     (i32.load
                       (i32.const 1224)
                     )
@@ -6664,37 +6664,37 @@
                   (call $qa)
                   (block
                     (i32.store offset=20
+                      (get_local $5)
                       (get_local $4)
-                      (get_local $1)
                     )
                     (i32.store offset=24
-                      (get_local $1)
                       (get_local $4)
+                      (get_local $5)
                     )
                     (set_local $2
-                      (get_local $3)
+                      (get_local $1)
                     )
-                    (set_local $5
-                      (get_local $6)
+                    (set_local $6
+                      (get_local $7)
                     )
                   )
                 )
                 (block
                   (set_local $2
-                    (get_local $3)
+                    (get_local $1)
                   )
-                  (set_local $5
-                    (get_local $6)
+                  (set_local $6
+                    (get_local $7)
                   )
                 )
               )
             )
             (block
               (set_local $2
-                (get_local $3)
+                (get_local $1)
               )
-              (set_local $5
-                (get_local $6)
+              (set_local $6
+                (get_local $7)
               )
             )
           )
@@ -6713,7 +6713,7 @@
         (i32.and
           (tee_local $1
             (i32.load
-              (tee_local $6
+              (tee_local $7
                 (i32.add
                   (get_local $8)
                   (i32.const 4)
@@ -6733,7 +6733,7 @@
       )
       (block
         (i32.store
-          (get_local $6)
+          (get_local $7)
           (i32.and
             (get_local $1)
             (i32.const -2)
@@ -6742,19 +6742,19 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $5)
+            (get_local $6)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $5)
+            (get_local $6)
           )
-          (get_local $5)
+          (get_local $6)
         )
         (set_local $0
-          (get_local $5)
+          (get_local $6)
         )
       )
       (block
@@ -6768,12 +6768,12 @@
           (block
             (i32.store
               (i32.const 1220)
-              (tee_local $4
+              (tee_local $5
                 (i32.add
                   (i32.load
                     (i32.const 1220)
                   )
-                  (get_local $5)
+                  (get_local $6)
                 )
               )
             )
@@ -6784,7 +6784,7 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $4)
+                (get_local $5)
                 (i32.const 1)
               )
             )
@@ -6818,12 +6818,12 @@
           (block
             (i32.store
               (i32.const 1216)
-              (tee_local $4
+              (tee_local $5
                 (i32.add
                   (i32.load
                     (i32.const 1216)
                   )
-                  (get_local $5)
+                  (get_local $6)
                 )
               )
             )
@@ -6834,27 +6834,27 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $4)
+                (get_local $5)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $2)
-                (get_local $4)
+                (get_local $5)
               )
-              (get_local $4)
+              (get_local $5)
             )
             (return)
           )
         )
-        (set_local $4
+        (set_local $5
           (i32.add
             (i32.and
               (get_local $1)
               (i32.const -8)
             )
-            (get_local $5)
+            (get_local $6)
           )
         )
         (set_local $14
@@ -6870,19 +6870,19 @@
               (i32.const 256)
             )
             (block
-              (set_local $9
+              (set_local $3
                 (i32.load offset=12
                   (get_local $8)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $7
+                  (tee_local $12
                     (i32.load offset=8
                       (get_local $8)
                     )
                   )
-                  (tee_local $1
+                  (tee_local $4
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
@@ -6898,7 +6898,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $12)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6908,7 +6908,7 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $7)
+                        (get_local $12)
                       )
                       (get_local $8)
                     )
@@ -6918,8 +6918,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $9)
-                  (get_local $7)
+                  (get_local $3)
+                  (get_local $12)
                 )
                 (block
                   (i32.store
@@ -6942,19 +6942,19 @@
               )
               (if
                 (i32.eq
-                  (get_local $9)
-                  (get_local $1)
+                  (get_local $3)
+                  (get_local $4)
                 )
                 (set_local $17
                   (i32.add
-                    (get_local $9)
+                    (get_local $3)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $9)
+                      (get_local $3)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6964,9 +6964,9 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $1
+                        (tee_local $4
                           (i32.add
-                            (get_local $9)
+                            (get_local $3)
                             (i32.const 8)
                           )
                         )
@@ -6974,23 +6974,23 @@
                       (get_local $8)
                     )
                     (set_local $17
-                      (get_local $1)
+                      (get_local $4)
                     )
                     (call $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $7)
-                (get_local $9)
+                (get_local $12)
+                (get_local $3)
               )
               (i32.store
                 (get_local $17)
-                (get_local $7)
+                (get_local $12)
               )
             )
             (block
-              (set_local $7
+              (set_local $12
                 (i32.load offset=24
                   (get_local $8)
                 )
@@ -6998,7 +6998,7 @@
               (block $do-once6
                 (if
                   (i32.eq
-                    (tee_local $9
+                    (tee_local $3
                       (i32.load offset=12
                         (get_local $8)
                       )
@@ -7007,11 +7007,11 @@
                   )
                   (block
                     (if
-                      (tee_local $10
+                      (tee_local $9
                         (i32.load
                           (tee_local $0
                             (i32.add
-                              (tee_local $1
+                              (tee_local $4
                                 (i32.add
                                   (get_local $8)
                                   (i32.const 16)
@@ -7023,24 +7023,24 @@
                         )
                       )
                       (block
-                        (set_local $5
-                          (get_local $10)
+                        (set_local $6
+                          (get_local $9)
                         )
-                        (set_local $1
+                        (set_local $4
                           (get_local $0)
                         )
                       )
                       (if
                         (tee_local $0
                           (i32.load
-                            (get_local $1)
+                            (get_local $4)
                           )
                         )
-                        (set_local $5
+                        (set_local $6
                           (get_local $0)
                         )
                         (block
-                          (set_local $12
+                          (set_local $11
                             (i32.const 0)
                           )
                           (br $do-once6)
@@ -7049,42 +7049,42 @@
                     )
                     (loop $while-in9
                       (if
-                        (tee_local $10
+                        (tee_local $9
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $5)
+                                (get_local $6)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $5
-                            (get_local $10)
+                          (set_local $6
+                            (get_local $9)
                           )
-                          (set_local $1
+                          (set_local $4
                             (get_local $0)
                           )
                           (br $while-in9)
                         )
                       )
                       (if
-                        (tee_local $10
+                        (tee_local $9
                           (i32.load
                             (tee_local $0
                               (i32.add
-                                (get_local $5)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $5
-                            (get_local $10)
+                          (set_local $6
+                            (get_local $9)
                           )
-                          (set_local $1
+                          (set_local $4
                             (get_local $0)
                           )
                           (br $while-in9)
@@ -7093,7 +7093,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $4)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7101,11 +7101,11 @@
                       (call $qa)
                       (block
                         (i32.store
-                          (get_local $1)
+                          (get_local $4)
                           (i32.const 0)
                         )
-                        (set_local $12
-                          (get_local $5)
+                        (set_local $11
+                          (get_local $6)
                         )
                       )
                     )
@@ -7127,7 +7127,7 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (tee_local $10
+                          (tee_local $9
                             (i32.add
                               (get_local $0)
                               (i32.const 12)
@@ -7141,9 +7141,9 @@
                     (if
                       (i32.eq
                         (i32.load
-                          (tee_local $1
+                          (tee_local $4
                             (i32.add
-                              (get_local $9)
+                              (get_local $3)
                               (i32.const 8)
                             )
                           )
@@ -7152,15 +7152,15 @@
                       )
                       (block
                         (i32.store
-                          (get_local $10)
                           (get_local $9)
+                          (get_local $3)
                         )
                         (i32.store
-                          (get_local $1)
+                          (get_local $4)
                           (get_local $0)
                         )
-                        (set_local $12
-                          (get_local $9)
+                        (set_local $11
+                          (get_local $3)
                         )
                       )
                       (call $qa)
@@ -7169,17 +7169,17 @@
                 )
               )
               (if
-                (get_local $7)
+                (get_local $12)
                 (block
                   (if
                     (i32.eq
                       (get_local $8)
                       (i32.load
-                        (tee_local $6
+                        (tee_local $7
                           (i32.add
                             (i32.const 1512)
                             (i32.shl
-                              (tee_local $9
+                              (tee_local $3
                                 (i32.load offset=28
                                   (get_local $8)
                                 )
@@ -7192,12 +7192,12 @@
                     )
                     (block
                       (i32.store
-                        (get_local $6)
-                        (get_local $12)
+                        (get_local $7)
+                        (get_local $11)
                       )
                       (if
                         (i32.eqz
-                          (get_local $12)
+                          (get_local $11)
                         )
                         (block
                           (i32.store
@@ -7209,7 +7209,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $9)
+                                  (get_local $3)
                                 )
                                 (i32.const -1)
                               )
@@ -7222,7 +7222,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $7)
+                          (get_local $12)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -7232,9 +7232,9 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $9
+                            (tee_local $3
                               (i32.add
-                                (get_local $7)
+                                (get_local $12)
                                 (i32.const 16)
                               )
                             )
@@ -7242,25 +7242,25 @@
                           (get_local $8)
                         )
                         (i32.store
-                          (get_local $9)
-                          (get_local $12)
+                          (get_local $3)
+                          (get_local $11)
                         )
                         (i32.store offset=20
-                          (get_local $7)
                           (get_local $12)
+                          (get_local $11)
                         )
                       )
                       (br_if $do-once4
                         (i32.eqz
-                          (get_local $12)
+                          (get_local $11)
                         )
                       )
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $12)
-                      (tee_local $9
+                      (get_local $11)
+                      (tee_local $3
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7269,13 +7269,13 @@
                     (call $qa)
                   )
                   (i32.store offset=24
+                    (get_local $11)
                     (get_local $12)
-                    (get_local $7)
                   )
                   (if
-                    (tee_local $3
+                    (tee_local $1
                       (i32.load
-                        (tee_local $6
+                        (tee_local $7
                           (i32.add
                             (get_local $8)
                             (i32.const 16)
@@ -7285,31 +7285,31 @@
                     )
                     (if
                       (i32.lt_u
+                        (get_local $1)
                         (get_local $3)
-                        (get_local $9)
                       )
                       (call $qa)
                       (block
                         (i32.store offset=16
-                          (get_local $12)
-                          (get_local $3)
+                          (get_local $11)
+                          (get_local $1)
                         )
                         (i32.store offset=24
-                          (get_local $3)
-                          (get_local $12)
+                          (get_local $1)
+                          (get_local $11)
                         )
                       )
                     )
                   )
                   (if
-                    (tee_local $3
+                    (tee_local $1
                       (i32.load offset=4
-                        (get_local $6)
+                        (get_local $7)
                       )
                     )
                     (if
                       (i32.lt_u
-                        (get_local $3)
+                        (get_local $1)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7317,12 +7317,12 @@
                       (call $qa)
                       (block
                         (i32.store offset=20
-                          (get_local $12)
-                          (get_local $3)
+                          (get_local $11)
+                          (get_local $1)
                         )
                         (i32.store offset=24
-                          (get_local $3)
-                          (get_local $12)
+                          (get_local $1)
+                          (get_local $11)
                         )
                       )
                     )
@@ -7335,16 +7335,16 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $4)
+            (get_local $5)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $4)
+            (get_local $5)
           )
-          (get_local $4)
+          (get_local $5)
         )
         (if
           (i32.eq
@@ -7356,17 +7356,17 @@
           (block
             (i32.store
               (i32.const 1216)
-              (get_local $4)
+              (get_local $5)
             )
             (return)
           )
           (set_local $0
-            (get_local $4)
+            (get_local $5)
           )
         )
       )
     )
-    (set_local $5
+    (set_local $6
       (i32.shr_u
         (get_local $0)
         (i32.const 3)
@@ -7383,7 +7383,7 @@
             (i32.const 1248)
             (i32.shl
               (i32.shl
-                (get_local $5)
+                (get_local $6)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -7392,23 +7392,23 @@
         )
         (if
           (i32.and
-            (tee_local $6
+            (tee_local $7
               (i32.load
                 (i32.const 1208)
               )
             )
-            (tee_local $4
+            (tee_local $5
               (i32.shl
                 (i32.const 1)
-                (get_local $5)
+                (get_local $6)
               )
             )
           )
           (if
             (i32.lt_u
-              (tee_local $6
+              (tee_local $7
                 (i32.load
-                  (tee_local $4
+                  (tee_local $5
                     (i32.add
                       (get_local $1)
                       (i32.const 8)
@@ -7423,10 +7423,10 @@
             (call $qa)
             (block
               (set_local $15
-                (get_local $4)
+                (get_local $5)
               )
               (set_local $13
-                (get_local $6)
+                (get_local $7)
               )
             )
           )
@@ -7434,8 +7434,8 @@
             (i32.store
               (i32.const 1208)
               (i32.or
-                (get_local $6)
-                (get_local $4)
+                (get_local $7)
+                (get_local $5)
               )
             )
             (set_local $15
@@ -7468,11 +7468,11 @@
         (return)
       )
     )
-    (set_local $4
+    (set_local $5
       (i32.add
         (i32.const 1512)
         (i32.shl
-          (tee_local $5
+          (tee_local $6
             (if i32
               (tee_local $1
                 (i32.shr_u
@@ -7491,7 +7491,7 @@
                     (i32.shr_u
                       (get_local $0)
                       (i32.add
-                        (tee_local $4
+                        (tee_local $5
                           (i32.add
                             (i32.sub
                               (i32.const 14)
@@ -7531,7 +7531,7 @@
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (tee_local $6
+                                        (tee_local $7
                                           (i32.shl
                                             (get_local $15)
                                             (get_local $1)
@@ -7548,7 +7548,7 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $6)
+                                (get_local $7)
                                 (get_local $15)
                               )
                               (i32.const 15)
@@ -7561,7 +7561,7 @@
                     (i32.const 1)
                   )
                   (i32.shl
-                    (get_local $4)
+                    (get_local $5)
                     (i32.const 1)
                   )
                 )
@@ -7575,7 +7575,7 @@
     )
     (i32.store offset=28
       (get_local $2)
-      (get_local $5)
+      (get_local $6)
     )
     (i32.store offset=20
       (get_local $2)
@@ -7592,10 +7592,10 @@
             (i32.const 1212)
           )
         )
-        (tee_local $6
+        (tee_local $7
           (i32.shl
             (i32.const 1)
-            (get_local $5)
+            (get_local $6)
           )
         )
       )
@@ -7608,12 +7608,12 @@
               (i32.sub
                 (i32.const 25)
                 (i32.shr_u
-                  (get_local $5)
+                  (get_local $6)
                   (i32.const 1)
                 )
               )
               (i32.eq
-                (get_local $5)
+                (get_local $6)
                 (i32.const 31)
               )
             )
@@ -7621,7 +7621,7 @@
         )
         (set_local $1
           (i32.load
-            (get_local $4)
+            (get_local $5)
           )
         )
         (loop $while-in15
@@ -7647,9 +7647,9 @@
               )
             )
             (if
-              (tee_local $12
+              (tee_local $11
                 (i32.load
-                  (tee_local $5
+                  (tee_local $6
                     (i32.add
                       (i32.add
                         (get_local $1)
@@ -7674,13 +7674,13 @@
                   )
                 )
                 (set_local $1
-                  (get_local $12)
+                  (get_local $11)
                 )
                 (br $while-in15)
               )
               (block
                 (set_local $18
-                  (get_local $5)
+                  (get_local $6)
                 )
                 (set_local $19
                   (get_local $1)
@@ -7742,7 +7742,7 @@
                       )
                     )
                   )
-                  (tee_local $6
+                  (tee_local $7
                     (i32.load
                       (i32.const 1224)
                     )
@@ -7750,7 +7750,7 @@
                 )
                 (i32.ge_u
                   (get_local $16)
-                  (get_local $6)
+                  (get_local $7)
                 )
               )
               (block
@@ -7785,16 +7785,16 @@
           (i32.const 1212)
           (i32.or
             (get_local $15)
-            (get_local $6)
+            (get_local $7)
           )
         )
         (i32.store
-          (get_local $4)
+          (get_local $5)
           (get_local $2)
         )
         (i32.store offset=24
           (get_local $2)
-          (get_local $4)
+          (get_local $5)
         )
         (i32.store offset=12
           (get_local $2)

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -143,7 +143,7 @@
         (i32.const 16)
       )
     )
-    (set_local $13
+    (set_local $12
       (get_local $25)
     )
     (block $do-once
@@ -155,16 +155,16 @@
         (block
           (if
             (i32.and
-              (tee_local $1
+              (tee_local $4
                 (i32.shr_u
                   (tee_local $5
                     (i32.load
                       (i32.const 1208)
                     )
                   )
-                  (tee_local $0
+                  (tee_local $2
                     (i32.shr_u
-                      (tee_local $2
+                      (tee_local $0
                         (select
                           (i32.const 16)
                           (i32.and
@@ -188,13 +188,13 @@
               (i32.const 3)
             )
             (block
-              (set_local $0
+              (set_local $2
                 (i32.load
-                  (tee_local $1
+                  (tee_local $0
                     (i32.add
-                      (tee_local $2
+                      (tee_local $4
                         (i32.load
-                          (tee_local $11
+                          (tee_local $16
                             (i32.add
                               (tee_local $7
                                 (i32.add
@@ -205,12 +205,12 @@
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $1)
+                                              (get_local $4)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $0)
+                                          (get_local $2)
                                         )
                                       )
                                       (i32.const 1)
@@ -232,7 +232,7 @@
               (if
                 (i32.eq
                   (get_local $7)
-                  (get_local $0)
+                  (get_local $2)
                 )
                 (i32.store
                   (i32.const 1208)
@@ -250,7 +250,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $0)
+                      (get_local $2)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -260,23 +260,23 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $17
+                        (tee_local $8
                           (i32.add
-                            (get_local $0)
+                            (get_local $2)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $2)
+                      (get_local $4)
                     )
                     (block
                       (i32.store
-                        (get_local $17)
+                        (get_local $8)
                         (get_local $7)
                       )
                       (i32.store
-                        (get_local $11)
-                        (get_local $0)
+                        (get_local $16)
+                        (get_local $2)
                       )
                     )
                     (call $qa)
@@ -284,9 +284,9 @@
                 )
               )
               (i32.store offset=4
-                (get_local $2)
+                (get_local $4)
                 (i32.or
-                  (tee_local $0
+                  (tee_local $2
                     (i32.shl
                       (get_local $6)
                       (i32.const 3)
@@ -296,18 +296,18 @@
                 )
               )
               (i32.store
-                (tee_local $11
+                (tee_local $16
                   (i32.add
                     (i32.add
+                      (get_local $4)
                       (get_local $2)
-                      (get_local $0)
                     )
                     (i32.const 4)
                   )
                 )
                 (i32.or
                   (i32.load
-                    (get_local $11)
+                    (get_local $16)
                   )
                   (i32.const 1)
                 )
@@ -316,14 +316,14 @@
                 (get_local $25)
               )
               (return
-                (get_local $1)
+                (get_local $0)
               )
             )
           )
           (if
             (i32.gt_u
-              (get_local $2)
-              (tee_local $11
+              (get_local $0)
+              (tee_local $16
                 (i32.load
                   (i32.const 1216)
                 )
@@ -331,30 +331,30 @@
             )
             (block
               (if
-                (get_local $1)
+                (get_local $4)
                 (block
                   (set_local $7
                     (i32.and
                       (i32.shr_u
-                        (tee_local $0
+                        (tee_local $2
                           (i32.add
                             (i32.and
                               (tee_local $7
                                 (i32.and
                                   (i32.shl
-                                    (get_local $1)
-                                    (get_local $0)
+                                    (get_local $4)
+                                    (get_local $2)
                                   )
                                   (i32.or
-                                    (tee_local $0
+                                    (tee_local $2
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $0)
+                                        (get_local $2)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $0)
+                                      (get_local $2)
                                     )
                                   )
                                 )
@@ -374,29 +374,29 @@
                   )
                   (set_local $7
                     (i32.load
-                      (tee_local $17
+                      (tee_local $8
                         (i32.add
                           (tee_local $9
                             (i32.load
                               (tee_local $15
                                 (i32.add
-                                  (tee_local $4
+                                  (tee_local $1
                                     (i32.add
                                       (i32.const 1248)
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $8
+                                          (tee_local $14
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (tee_local $0
+                                                      (tee_local $2
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $17
+                                                            (tee_local $8
                                                               (i32.shr_u
-                                                                (get_local $0)
+                                                                (get_local $2)
                                                                 (get_local $7)
                                                               )
                                                             )
@@ -407,13 +407,13 @@
                                                       )
                                                       (get_local $7)
                                                     )
-                                                    (tee_local $17
+                                                    (tee_local $8
                                                       (i32.and
                                                         (i32.shr_u
                                                           (tee_local $9
                                                             (i32.shr_u
-                                                              (get_local $17)
-                                                              (get_local $0)
+                                                              (get_local $8)
+                                                              (get_local $2)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -425,10 +425,10 @@
                                                   (tee_local $9
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (tee_local $4
+                                                        (tee_local $1
                                                           (i32.shr_u
                                                             (get_local $9)
-                                                            (get_local $17)
+                                                            (get_local $8)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -437,12 +437,12 @@
                                                     )
                                                   )
                                                 )
-                                                (tee_local $4
+                                                (tee_local $1
                                                   (i32.and
                                                     (i32.shr_u
                                                       (tee_local $15
                                                         (i32.shr_u
-                                                          (get_local $4)
+                                                          (get_local $1)
                                                           (get_local $9)
                                                         )
                                                       )
@@ -454,7 +454,7 @@
                                               )
                                               (i32.shr_u
                                                 (get_local $15)
-                                                (get_local $4)
+                                                (get_local $1)
                                               )
                                             )
                                           )
@@ -476,7 +476,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $4)
+                      (get_local $1)
                       (get_local $7)
                     )
                     (block
@@ -487,14 +487,14 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $8)
+                              (get_local $14)
                             )
                             (i32.const -1)
                           )
                         )
                       )
                       (set_local $33
-                        (get_local $11)
+                        (get_local $16)
                       )
                     )
                     (block
@@ -510,7 +510,7 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $0
+                            (tee_local $2
                               (i32.add
                                 (get_local $7)
                                 (i32.const 12)
@@ -521,8 +521,8 @@
                         )
                         (block
                           (i32.store
-                            (get_local $0)
-                            (get_local $4)
+                            (get_local $2)
+                            (get_local $1)
                           )
                           (i32.store
                             (get_local $15)
@@ -541,7 +541,7 @@
                   (i32.store offset=4
                     (get_local $9)
                     (i32.or
-                      (get_local $2)
+                      (get_local $0)
                       (i32.const 3)
                     )
                   )
@@ -549,17 +549,17 @@
                     (tee_local $15
                       (i32.add
                         (get_local $9)
-                        (get_local $2)
+                        (get_local $0)
                       )
                     )
                     (i32.or
                       (tee_local $7
                         (i32.sub
                           (i32.shl
-                            (get_local $8)
+                            (get_local $14)
                             (i32.const 3)
                           )
-                          (get_local $2)
+                          (get_local $0)
                         )
                       )
                       (i32.const 1)
@@ -575,7 +575,7 @@
                   (if
                     (get_local $33)
                     (block
-                      (set_local $4
+                      (set_local $1
                         (i32.load
                           (i32.const 1228)
                         )
@@ -585,7 +585,7 @@
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (tee_local $11
+                              (tee_local $16
                                 (i32.shr_u
                                   (get_local $33)
                                   (i32.const 3)
@@ -599,23 +599,23 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $0
+                          (tee_local $2
                             (i32.load
                               (i32.const 1208)
                             )
                           )
-                          (tee_local $1
+                          (tee_local $4
                             (i32.shl
                               (i32.const 1)
-                              (get_local $11)
+                              (get_local $16)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $0
+                            (tee_local $2
                               (i32.load
-                                (tee_local $1
+                                (tee_local $4
                                   (i32.add
                                     (get_local $5)
                                     (i32.const 8)
@@ -630,10 +630,10 @@
                           (call $qa)
                           (block
                             (set_local $41
-                              (get_local $1)
+                              (get_local $4)
                             )
                             (set_local $34
-                              (get_local $0)
+                              (get_local $2)
                             )
                           )
                         )
@@ -641,8 +641,8 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $0)
-                              (get_local $1)
+                              (get_local $2)
+                              (get_local $4)
                             )
                           )
                           (set_local $41
@@ -658,18 +658,18 @@
                       )
                       (i32.store
                         (get_local $41)
-                        (get_local $4)
+                        (get_local $1)
                       )
                       (i32.store offset=12
                         (get_local $34)
-                        (get_local $4)
+                        (get_local $1)
                       )
                       (i32.store offset=8
-                        (get_local $4)
+                        (get_local $1)
                         (get_local $34)
                       )
                       (i32.store offset=12
-                        (get_local $4)
+                        (get_local $1)
                         (get_local $5)
                       )
                     )
@@ -686,7 +686,7 @@
                     (get_local $25)
                   )
                   (return
-                    (get_local $17)
+                    (get_local $8)
                   )
                 )
               )
@@ -717,11 +717,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $0
+                  (set_local $2
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (tee_local $11
+                          (tee_local $16
                             (i32.load
                               (i32.add
                                 (i32.shl
@@ -749,7 +749,7 @@
                                           (tee_local $5
                                             (i32.and
                                               (i32.shr_u
-                                                (tee_local $4
+                                                (tee_local $1
                                                   (i32.shr_u
                                                     (get_local $5)
                                                     (get_local $7)
@@ -761,12 +761,12 @@
                                             )
                                           )
                                         )
-                                        (tee_local $4
+                                        (tee_local $1
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $0
+                                              (tee_local $2
                                                 (i32.shr_u
-                                                  (get_local $4)
+                                                  (get_local $1)
                                                   (get_local $5)
                                                 )
                                               )
@@ -776,13 +776,13 @@
                                           )
                                         )
                                       )
-                                      (tee_local $0
+                                      (tee_local $2
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $1
+                                            (tee_local $4
                                               (i32.shr_u
-                                                (get_local $0)
-                                                (get_local $4)
+                                                (get_local $2)
+                                                (get_local $1)
                                               )
                                             )
                                             (i32.const 1)
@@ -792,8 +792,8 @@
                                       )
                                     )
                                     (i32.shr_u
-                                      (get_local $1)
-                                      (get_local $0)
+                                      (get_local $4)
+                                      (get_local $2)
                                     )
                                   )
                                   (i32.const 2)
@@ -805,41 +805,41 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $2)
+                      (get_local $0)
                     )
                   )
-                  (set_local $1
-                    (get_local $11)
-                  )
                   (set_local $4
-                    (get_local $11)
+                    (get_local $16)
+                  )
+                  (set_local $1
+                    (get_local $16)
                   )
                   (loop $while-in
                     (block $while-out
                       (if
-                        (tee_local $11
+                        (tee_local $16
                           (i32.load offset=16
-                            (get_local $1)
+                            (get_local $4)
                           )
                         )
                         (set_local $6
-                          (get_local $11)
+                          (get_local $16)
                         )
                         (if
                           (tee_local $5
                             (i32.load offset=20
-                              (get_local $1)
+                              (get_local $4)
                             )
                           )
                           (set_local $6
                             (get_local $5)
                           )
                           (block
-                            (set_local $3
-                              (get_local $0)
+                            (set_local $7
+                              (get_local $2)
                             )
                             (set_local $6
-                              (get_local $4)
+                              (get_local $1)
                             )
                             (br $while-out)
                           )
@@ -847,7 +847,7 @@
                       )
                       (set_local $5
                         (i32.lt_u
-                          (tee_local $11
+                          (tee_local $16
                             (i32.sub
                               (i32.and
                                 (i32.load offset=4
@@ -855,26 +855,26 @@
                                 )
                                 (i32.const -8)
                               )
-                              (get_local $2)
+                              (get_local $0)
                             )
                           )
-                          (get_local $0)
+                          (get_local $2)
                         )
                       )
-                      (set_local $0
+                      (set_local $2
                         (select
-                          (get_local $11)
-                          (get_local $0)
+                          (get_local $16)
+                          (get_local $2)
                           (get_local $5)
                         )
                       )
-                      (set_local $1
+                      (set_local $4
                         (get_local $6)
                       )
-                      (set_local $4
+                      (set_local $1
                         (select
                           (get_local $6)
-                          (get_local $4)
+                          (get_local $1)
                           (get_local $5)
                         )
                       )
@@ -884,7 +884,7 @@
                   (if
                     (i32.lt_u
                       (get_local $6)
-                      (tee_local $4
+                      (tee_local $1
                         (i32.load
                           (i32.const 1224)
                         )
@@ -895,16 +895,16 @@
                   (if
                     (i32.ge_u
                       (get_local $6)
-                      (tee_local $1
+                      (tee_local $4
                         (i32.add
                           (get_local $6)
-                          (get_local $2)
+                          (get_local $0)
                         )
                       )
                     )
                     (call $qa)
                   )
-                  (set_local $0
+                  (set_local $2
                     (i32.load offset=24
                       (get_local $6)
                     )
@@ -912,7 +912,7 @@
                   (block $do-once4
                     (if
                       (i32.eq
-                        (tee_local $17
+                        (tee_local $8
                           (i32.load offset=12
                             (get_local $6)
                           )
@@ -921,7 +921,7 @@
                       )
                       (block
                         (if
-                          (tee_local $8
+                          (tee_local $14
                             (i32.load
                               (tee_local $9
                                 (i32.add
@@ -932,8 +932,8 @@
                             )
                           )
                           (block
-                            (set_local $11
-                              (get_local $8)
+                            (set_local $16
+                              (get_local $14)
                             )
                             (set_local $5
                               (get_local $9)
@@ -941,7 +941,7 @@
                           )
                           (if
                             (i32.eqz
-                              (tee_local $11
+                              (tee_local $16
                                 (i32.load
                                   (tee_local $5
                                     (i32.add
@@ -962,19 +962,19 @@
                         )
                         (loop $while-in7
                           (if
-                            (tee_local $8
+                            (tee_local $14
                               (i32.load
                                 (tee_local $9
                                   (i32.add
-                                    (get_local $11)
+                                    (get_local $16)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $11
-                                (get_local $8)
+                              (set_local $16
+                                (get_local $14)
                               )
                               (set_local $5
                                 (get_local $9)
@@ -983,19 +983,19 @@
                             )
                           )
                           (if
-                            (tee_local $8
+                            (tee_local $14
                               (i32.load
                                 (tee_local $9
                                   (i32.add
-                                    (get_local $11)
+                                    (get_local $16)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $11
-                                (get_local $8)
+                              (set_local $16
+                                (get_local $14)
                               )
                               (set_local $5
                                 (get_local $9)
@@ -1007,7 +1007,7 @@
                         (if
                           (i32.lt_u
                             (get_local $5)
-                            (get_local $4)
+                            (get_local $1)
                           )
                           (call $qa)
                           (block
@@ -1016,7 +1016,7 @@
                               (i32.const 0)
                             )
                             (set_local $21
-                              (get_local $11)
+                              (get_local $16)
                             )
                           )
                         )
@@ -1029,14 +1029,14 @@
                                 (get_local $6)
                               )
                             )
-                            (get_local $4)
+                            (get_local $1)
                           )
                           (call $qa)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (tee_local $8
+                              (tee_local $14
                                 (i32.add
                                   (get_local $9)
                                   (i32.const 12)
@@ -1052,7 +1052,7 @@
                             (i32.load
                               (tee_local $5
                                 (i32.add
-                                  (get_local $17)
+                                  (get_local $8)
                                   (i32.const 8)
                                 )
                               )
@@ -1061,15 +1061,15 @@
                           )
                           (block
                             (i32.store
+                              (get_local $14)
                               (get_local $8)
-                              (get_local $17)
                             )
                             (i32.store
                               (get_local $5)
                               (get_local $9)
                             )
                             (set_local $21
-                              (get_local $17)
+                              (get_local $8)
                             )
                           )
                           (call $qa)
@@ -1079,17 +1079,17 @@
                   )
                   (block $do-once8
                     (if
-                      (get_local $0)
+                      (get_local $2)
                       (block
                         (if
                           (i32.eq
                             (get_local $6)
                             (i32.load
-                              (tee_local $4
+                              (tee_local $1
                                 (i32.add
                                   (i32.const 1512)
                                   (i32.shl
-                                    (tee_local $17
+                                    (tee_local $8
                                       (i32.load offset=28
                                         (get_local $6)
                                       )
@@ -1102,7 +1102,7 @@
                           )
                           (block
                             (i32.store
-                              (get_local $4)
+                              (get_local $1)
                               (get_local $21)
                             )
                             (if
@@ -1119,7 +1119,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $17)
+                                        (get_local $8)
                                       )
                                       (i32.const -1)
                                     )
@@ -1132,7 +1132,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $0)
+                                (get_local $2)
                                 (i32.load
                                   (i32.const 1224)
                                 )
@@ -1142,9 +1142,9 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $17
+                                  (tee_local $8
                                     (i32.add
-                                      (get_local $0)
+                                      (get_local $2)
                                       (i32.const 16)
                                     )
                                   )
@@ -1152,11 +1152,11 @@
                                 (get_local $6)
                               )
                               (i32.store
-                                (get_local $17)
+                                (get_local $8)
                                 (get_local $21)
                               )
                               (i32.store offset=20
-                                (get_local $0)
+                                (get_local $2)
                                 (get_local $21)
                               )
                             )
@@ -1170,7 +1170,7 @@
                         (if
                           (i32.lt_u
                             (get_local $21)
-                            (tee_local $17
+                            (tee_local $8
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1180,41 +1180,41 @@
                         )
                         (i32.store offset=24
                           (get_local $21)
-                          (get_local $0)
+                          (get_local $2)
                         )
                         (if
-                          (tee_local $4
+                          (tee_local $1
                             (i32.load offset=16
                               (get_local $6)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $4)
-                              (get_local $17)
+                              (get_local $1)
+                              (get_local $8)
                             )
                             (call $qa)
                             (block
                               (i32.store offset=16
                                 (get_local $21)
-                                (get_local $4)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $4)
+                                (get_local $1)
                                 (get_local $21)
                               )
                             )
                           )
                         )
                         (if
-                          (tee_local $4
+                          (tee_local $1
                             (i32.load offset=20
                               (get_local $6)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $4)
+                              (get_local $1)
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1223,10 +1223,10 @@
                             (block
                               (i32.store offset=20
                                 (get_local $21)
-                                (get_local $4)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $4)
+                                (get_local $1)
                                 (get_local $21)
                               )
                             )
@@ -1237,35 +1237,35 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $3)
+                      (get_local $7)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
                         (get_local $6)
                         (i32.or
-                          (tee_local $0
+                          (tee_local $2
                             (i32.add
-                              (get_local $3)
-                              (get_local $2)
+                              (get_local $7)
+                              (get_local $0)
                             )
                           )
                           (i32.const 3)
                         )
                       )
                       (i32.store
-                        (tee_local $4
+                        (tee_local $1
                           (i32.add
                             (i32.add
                               (get_local $6)
-                              (get_local $0)
+                              (get_local $2)
                             )
                             (i32.const 4)
                           )
                         )
                         (i32.or
                           (i32.load
-                            (get_local $4)
+                            (get_local $1)
                           )
                           (i32.const 1)
                         )
@@ -1275,44 +1275,44 @@
                       (i32.store offset=4
                         (get_local $6)
                         (i32.or
-                          (get_local $2)
+                          (get_local $0)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $4)
                         (i32.or
-                          (get_local $3)
+                          (get_local $7)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $1)
-                          (get_local $3)
+                          (get_local $4)
+                          (get_local $7)
                         )
-                        (get_local $3)
+                        (get_local $7)
                       )
                       (if
-                        (tee_local $4
+                        (tee_local $1
                           (i32.load
                             (i32.const 1216)
                           )
                         )
                         (block
-                          (set_local $0
+                          (set_local $2
                             (i32.load
                               (i32.const 1228)
                             )
                           )
-                          (set_local $4
+                          (set_local $1
                             (i32.add
                               (i32.const 1248)
                               (i32.shl
                                 (i32.shl
-                                  (tee_local $17
+                                  (tee_local $8
                                     (i32.shr_u
-                                      (get_local $4)
+                                      (get_local $1)
                                       (i32.const 3)
                                     )
                                   )
@@ -1332,7 +1332,7 @@
                               (tee_local $5
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $17)
+                                  (get_local $8)
                                 )
                               )
                             )
@@ -1342,7 +1342,7 @@
                                   (i32.load
                                     (tee_local $5
                                       (i32.add
-                                        (get_local $4)
+                                        (get_local $1)
                                         (i32.const 8)
                                       )
                                     )
@@ -1372,40 +1372,40 @@
                               )
                               (set_local $42
                                 (i32.add
-                                  (get_local $4)
+                                  (get_local $1)
                                   (i32.const 8)
                                 )
                               )
                               (set_local $35
-                                (get_local $4)
+                                (get_local $1)
                               )
                             )
                           )
                           (i32.store
                             (get_local $42)
-                            (get_local $0)
+                            (get_local $2)
                           )
                           (i32.store offset=12
                             (get_local $35)
-                            (get_local $0)
+                            (get_local $2)
                           )
                           (i32.store offset=8
-                            (get_local $0)
+                            (get_local $2)
                             (get_local $35)
                           )
                           (i32.store offset=12
-                            (get_local $0)
-                            (get_local $4)
+                            (get_local $2)
+                            (get_local $1)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 1216)
-                        (get_local $3)
+                        (get_local $7)
                       )
                       (i32.store
                         (i32.const 1228)
-                        (get_local $1)
+                        (get_local $4)
                       )
                     )
                   )
@@ -1420,12 +1420,12 @@
                   )
                 )
                 (set_local $4
-                  (get_local $2)
+                  (get_local $0)
                 )
               )
             )
             (set_local $4
-              (get_local $2)
+              (get_local $0)
             )
           )
         )
@@ -1438,9 +1438,9 @@
             (i32.const -1)
           )
           (block
-            (set_local $0
+            (set_local $2
               (i32.and
-                (tee_local $4
+                (tee_local $1
                   (i32.add
                     (get_local $0)
                     (i32.const 11)
@@ -1459,7 +1459,7 @@
                 (set_local $5
                   (i32.sub
                     (i32.const 0)
-                    (get_local $0)
+                    (get_local $2)
                   )
                 )
                 (block $label$break$a
@@ -1470,22 +1470,22 @@
                           (i32.shl
                             (tee_local $21
                               (if i32
-                                (tee_local $17
+                                (tee_local $8
                                   (i32.shr_u
-                                    (get_local $4)
+                                    (get_local $1)
                                     (i32.const 8)
                                   )
                                 )
                                 (if i32
                                   (i32.gt_u
-                                    (get_local $0)
+                                    (get_local $2)
                                     (i32.const 16777215)
                                   )
                                   (i32.const 31)
                                   (i32.or
                                     (i32.and
                                       (i32.shr_u
-                                        (get_local $0)
+                                        (get_local $2)
                                         (i32.add
                                           (tee_local $15
                                             (i32.add
@@ -1493,18 +1493,18 @@
                                                 (i32.const 14)
                                                 (i32.or
                                                   (i32.or
-                                                    (tee_local $17
+                                                    (tee_local $8
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (tee_local $8
+                                                            (tee_local $14
                                                               (i32.shl
-                                                                (get_local $17)
-                                                                (tee_local $4
+                                                                (get_local $8)
+                                                                (tee_local $1
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
-                                                                        (get_local $17)
+                                                                        (get_local $8)
                                                                         (i32.const 1048320)
                                                                       )
                                                                       (i32.const 16)
@@ -1521,16 +1521,16 @@
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $4)
+                                                    (get_local $1)
                                                   )
-                                                  (tee_local $8
+                                                  (tee_local $14
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $11
+                                                          (tee_local $16
                                                             (i32.shl
+                                                              (get_local $14)
                                                               (get_local $8)
-                                                              (get_local $17)
                                                             )
                                                           )
                                                           (i32.const 245760)
@@ -1544,8 +1544,8 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $11)
-                                                  (get_local $8)
+                                                  (get_local $16)
+                                                  (get_local $14)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -1572,15 +1572,15 @@
                       )
                     )
                     (block
-                      (set_local $8
+                      (set_local $14
                         (get_local $5)
                       )
-                      (set_local $11
+                      (set_local $16
                         (i32.const 0)
                       )
-                      (set_local $4
+                      (set_local $1
                         (i32.shl
-                          (get_local $0)
+                          (get_local $2)
                           (select
                             (i32.const 0)
                             (i32.sub
@@ -1597,7 +1597,7 @@
                           )
                         )
                       )
-                      (set_local $17
+                      (set_local $8
                         (get_local $15)
                       )
                       (set_local $7
@@ -1606,35 +1606,35 @@
                       (loop $while-in14
                         (if
                           (i32.lt_u
-                            (tee_local $2
+                            (tee_local $4
                               (i32.sub
-                                (tee_local $1
+                                (tee_local $0
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $17)
+                                      (get_local $8)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $0)
+                                (get_local $2)
                               )
                             )
-                            (get_local $8)
+                            (get_local $14)
                           )
                           (if
                             (i32.eq
-                              (get_local $1)
                               (get_local $0)
+                              (get_local $2)
                             )
                             (block
                               (set_local $28
-                                (get_local $2)
+                                (get_local $4)
                               )
                               (set_local $27
-                                (get_local $17)
+                                (get_local $8)
                               )
                               (set_local $31
-                                (get_local $17)
+                                (get_local $8)
                               )
                               (set_local $8
                                 (i32.const 90)
@@ -1642,39 +1642,39 @@
                               (br $label$break$a)
                             )
                             (block
-                              (set_local $8
-                                (get_local $2)
+                              (set_local $14
+                                (get_local $4)
                               )
                               (set_local $7
-                                (get_local $17)
+                                (get_local $8)
                               )
                             )
                           )
                         )
-                        (set_local $1
+                        (set_local $0
                           (select
-                            (get_local $11)
-                            (tee_local $2
+                            (get_local $16)
+                            (tee_local $4
                               (i32.load offset=20
-                                (get_local $17)
+                                (get_local $8)
                               )
                             )
                             (i32.or
                               (i32.eqz
-                                (get_local $2)
+                                (get_local $4)
                               )
                               (i32.eq
-                                (get_local $2)
-                                (tee_local $17
+                                (get_local $4)
+                                (tee_local $8
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $17)
+                                        (get_local $8)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $4)
+                                          (get_local $1)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -1687,17 +1687,17 @@
                           )
                         )
                         (if
-                          (tee_local $2
+                          (tee_local $4
                             (i32.eqz
-                              (get_local $17)
+                              (get_local $8)
                             )
                           )
                           (block
                             (set_local $36
-                              (get_local $8)
+                              (get_local $14)
                             )
                             (set_local $37
-                              (get_local $1)
+                              (get_local $0)
                             )
                             (set_local $32
                               (get_local $7)
@@ -1707,15 +1707,15 @@
                             )
                           )
                           (block
-                            (set_local $11
-                              (get_local $1)
+                            (set_local $16
+                              (get_local $0)
                             )
-                            (set_local $4
+                            (set_local $1
                               (i32.shl
-                                (get_local $4)
+                                (get_local $1)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $2)
+                                    (get_local $4)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
@@ -1749,7 +1749,7 @@
                     (i32.const 86)
                   )
                   (if
-                    (tee_local $2
+                    (tee_local $0
                       (if i32
                         (i32.and
                           (i32.eqz
@@ -1782,7 +1782,7 @@
                             )
                             (block
                               (set_local $4
-                                (get_local $0)
+                                (get_local $2)
                               )
                               (br $do-once)
                             )
@@ -1818,7 +1818,7 @@
                                           (tee_local $15
                                             (i32.and
                                               (i32.shr_u
-                                                (tee_local $2
+                                                (tee_local $0
                                                   (i32.shr_u
                                                     (get_local $15)
                                                     (get_local $5)
@@ -1831,12 +1831,12 @@
                                           )
                                           (get_local $5)
                                         )
-                                        (tee_local $2
+                                        (tee_local $0
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $1
+                                              (tee_local $4
                                                 (i32.shr_u
-                                                  (get_local $2)
+                                                  (get_local $0)
                                                   (get_local $15)
                                                 )
                                               )
@@ -1846,13 +1846,13 @@
                                           )
                                         )
                                       )
-                                      (tee_local $1
+                                      (tee_local $4
                                         (i32.and
                                           (i32.shr_u
                                             (tee_local $7
                                               (i32.shr_u
-                                                (get_local $1)
-                                                (get_local $2)
+                                                (get_local $4)
+                                                (get_local $0)
                                               )
                                             )
                                             (i32.const 1)
@@ -1864,10 +1864,10 @@
                                     (tee_local $7
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $4
+                                          (tee_local $1
                                             (i32.shr_u
                                               (get_local $7)
-                                              (get_local $1)
+                                              (get_local $4)
                                             )
                                           )
                                           (i32.const 1)
@@ -1877,7 +1877,7 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $4)
+                                    (get_local $1)
                                     (get_local $7)
                                   )
                                 )
@@ -1895,7 +1895,7 @@
                         (get_local $36)
                       )
                       (set_local $27
-                        (get_local $2)
+                        (get_local $0)
                       )
                       (set_local $31
                         (get_local $32)
@@ -1905,7 +1905,7 @@
                       )
                     )
                     (block
-                      (set_local $16
+                      (set_local $18
                         (get_local $36)
                       )
                       (set_local $10
@@ -1923,7 +1923,7 @@
                     (set_local $8
                       (i32.const 0)
                     )
-                    (set_local $4
+                    (set_local $1
                       (i32.lt_u
                         (tee_local $7
                           (i32.sub
@@ -1933,38 +1933,38 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $0)
+                            (get_local $2)
                           )
                         )
                         (get_local $28)
                       )
                     )
-                    (set_local $1
+                    (set_local $4
                       (select
                         (get_local $7)
                         (get_local $28)
-                        (get_local $4)
+                        (get_local $1)
                       )
                     )
                     (set_local $7
                       (select
                         (get_local $27)
                         (get_local $31)
-                        (get_local $4)
+                        (get_local $1)
                       )
                     )
                     (if
-                      (tee_local $4
+                      (tee_local $1
                         (i32.load offset=16
                           (get_local $27)
                         )
                       )
                       (block
                         (set_local $28
-                          (get_local $1)
+                          (get_local $4)
                         )
                         (set_local $27
-                          (get_local $4)
+                          (get_local $1)
                         )
                         (set_local $31
                           (get_local $7)
@@ -1980,7 +1980,7 @@
                       )
                       (block
                         (set_local $28
-                          (get_local $1)
+                          (get_local $4)
                         )
                         (set_local $31
                           (get_local $7)
@@ -1988,8 +1988,8 @@
                         (br $while-in16)
                       )
                       (block
-                        (set_local $16
-                          (get_local $1)
+                        (set_local $18
+                          (get_local $4)
                         )
                         (set_local $10
                           (get_local $7)
@@ -2002,12 +2002,12 @@
                   (get_local $10)
                   (if
                     (i32.lt_u
-                      (get_local $16)
+                      (get_local $18)
                       (i32.sub
                         (i32.load
                           (i32.const 1216)
                         )
-                        (get_local $0)
+                        (get_local $2)
                       )
                     )
                     (block
@@ -2028,13 +2028,13 @@
                           (tee_local $7
                             (i32.add
                               (get_local $10)
-                              (get_local $0)
+                              (get_local $2)
                             )
                           )
                         )
                         (call $qa)
                       )
-                      (set_local $1
+                      (set_local $4
                         (i32.load offset=24
                           (get_local $10)
                         )
@@ -2042,7 +2042,7 @@
                       (block $do-once17
                         (if
                           (i32.eq
-                            (tee_local $4
+                            (tee_local $1
                               (i32.load offset=12
                                 (get_local $10)
                               )
@@ -2053,7 +2053,7 @@
                             (if
                               (tee_local $5
                                 (i32.load
-                                  (tee_local $2
+                                  (tee_local $0
                                     (i32.add
                                       (get_local $10)
                                       (i32.const 20)
@@ -2062,15 +2062,15 @@
                                 )
                               )
                               (block
-                                (set_local $11
+                                (set_local $16
                                   (get_local $5)
                                 )
-                                (set_local $3
-                                  (get_local $2)
+                                (set_local $1
+                                  (get_local $0)
                                 )
                               )
                               (if
-                                (tee_local $11
+                                (tee_local $16
                                   (i32.load
                                     (tee_local $15
                                       (i32.add
@@ -2080,7 +2080,7 @@
                                     )
                                   )
                                 )
-                                (set_local $3
+                                (set_local $1
                                   (get_local $15)
                                 )
                                 (block
@@ -2095,20 +2095,20 @@
                               (if
                                 (tee_local $5
                                   (i32.load
-                                    (tee_local $2
+                                    (tee_local $0
                                       (i32.add
-                                        (get_local $11)
+                                        (get_local $16)
                                         (i32.const 20)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $11
+                                  (set_local $16
                                     (get_local $5)
                                   )
-                                  (set_local $3
-                                    (get_local $2)
+                                  (set_local $1
+                                    (get_local $0)
                                   )
                                   (br $while-in20)
                                 )
@@ -2116,20 +2116,20 @@
                               (if
                                 (tee_local $5
                                   (i32.load
-                                    (tee_local $2
+                                    (tee_local $0
                                       (i32.add
-                                        (get_local $11)
+                                        (get_local $16)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $11
+                                  (set_local $16
                                     (get_local $5)
                                   )
-                                  (set_local $3
-                                    (get_local $2)
+                                  (set_local $1
+                                    (get_local $0)
                                   )
                                   (br $while-in20)
                                 )
@@ -2137,17 +2137,17 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $3)
+                                (get_local $1)
                                 (get_local $9)
                               )
                               (call $qa)
                               (block
                                 (i32.store
-                                  (get_local $3)
+                                  (get_local $1)
                                   (i32.const 0)
                                 )
                                 (set_local $23
-                                  (get_local $11)
+                                  (get_local $16)
                                 )
                               )
                             )
@@ -2155,7 +2155,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (tee_local $2
+                                (tee_local $0
                                   (i32.load offset=8
                                     (get_local $10)
                                   )
@@ -2169,7 +2169,7 @@
                                 (i32.load
                                   (tee_local $5
                                     (i32.add
-                                      (get_local $2)
+                                      (get_local $0)
                                       (i32.const 12)
                                     )
                                   )
@@ -2183,7 +2183,7 @@
                                 (i32.load
                                   (tee_local $15
                                     (i32.add
-                                      (get_local $4)
+                                      (get_local $1)
                                       (i32.const 8)
                                     )
                                   )
@@ -2193,14 +2193,14 @@
                               (block
                                 (i32.store
                                   (get_local $5)
-                                  (get_local $4)
+                                  (get_local $1)
                                 )
                                 (i32.store
                                   (get_local $15)
-                                  (get_local $2)
+                                  (get_local $0)
                                 )
                                 (set_local $23
-                                  (get_local $4)
+                                  (get_local $1)
                                 )
                               )
                               (call $qa)
@@ -2210,7 +2210,7 @@
                       )
                       (block $do-once21
                         (if
-                          (get_local $1)
+                          (get_local $4)
                           (block
                             (if
                               (i32.eq
@@ -2220,7 +2220,7 @@
                                     (i32.add
                                       (i32.const 1512)
                                       (i32.shl
-                                        (tee_local $4
+                                        (tee_local $1
                                           (i32.load offset=28
                                             (get_local $10)
                                           )
@@ -2250,7 +2250,7 @@
                                         (i32.xor
                                           (i32.shl
                                             (i32.const 1)
-                                            (get_local $4)
+                                            (get_local $1)
                                           )
                                           (i32.const -1)
                                         )
@@ -2263,7 +2263,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $1)
+                                    (get_local $4)
                                     (i32.load
                                       (i32.const 1224)
                                     )
@@ -2273,9 +2273,9 @@
                                 (if
                                   (i32.eq
                                     (i32.load
-                                      (tee_local $4
+                                      (tee_local $1
                                         (i32.add
-                                          (get_local $1)
+                                          (get_local $4)
                                           (i32.const 16)
                                         )
                                       )
@@ -2283,11 +2283,11 @@
                                     (get_local $10)
                                   )
                                   (i32.store
-                                    (get_local $4)
+                                    (get_local $1)
                                     (get_local $23)
                                   )
                                   (i32.store offset=20
-                                    (get_local $1)
+                                    (get_local $4)
                                     (get_local $23)
                                   )
                                 )
@@ -2301,7 +2301,7 @@
                             (if
                               (i32.lt_u
                                 (get_local $23)
-                                (tee_local $4
+                                (tee_local $1
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2311,7 +2311,7 @@
                             )
                             (i32.store offset=24
                               (get_local $23)
-                              (get_local $1)
+                              (get_local $4)
                             )
                             (if
                               (tee_local $9
@@ -2322,7 +2322,7 @@
                               (if
                                 (i32.lt_u
                                   (get_local $9)
-                                  (get_local $4)
+                                  (get_local $1)
                                 )
                                 (call $qa)
                                 (block
@@ -2369,17 +2369,17 @@
                       (block $do-once25
                         (if
                           (i32.lt_u
-                            (get_local $16)
+                            (get_local $18)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
                               (get_local $10)
                               (i32.or
-                                (tee_local $1
+                                (tee_local $4
                                   (i32.add
-                                    (get_local $16)
-                                    (get_local $0)
+                                    (get_local $18)
+                                    (get_local $2)
                                   )
                                 )
                                 (i32.const 3)
@@ -2390,7 +2390,7 @@
                                 (i32.add
                                   (i32.add
                                     (get_local $10)
-                                    (get_local $1)
+                                    (get_local $4)
                                   )
                                   (i32.const 4)
                                 )
@@ -2407,37 +2407,37 @@
                             (i32.store offset=4
                               (get_local $10)
                               (i32.or
-                                (get_local $0)
+                                (get_local $2)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
                               (get_local $7)
                               (i32.or
-                                (get_local $16)
+                                (get_local $18)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
                                 (get_local $7)
-                                (get_local $16)
+                                (get_local $18)
                               )
-                              (get_local $16)
+                              (get_local $18)
                             )
                             (set_local $9
                               (i32.shr_u
-                                (get_local $16)
+                                (get_local $18)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $16)
+                                (get_local $18)
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $1
+                                (set_local $4
                                   (i32.add
                                     (i32.const 1248)
                                     (i32.shl
@@ -2451,12 +2451,12 @@
                                 )
                                 (if
                                   (i32.and
-                                    (tee_local $4
+                                    (tee_local $1
                                       (i32.load
                                         (i32.const 1208)
                                       )
                                     )
-                                    (tee_local $2
+                                    (tee_local $0
                                       (i32.shl
                                         (i32.const 1)
                                         (get_local $9)
@@ -2465,11 +2465,11 @@
                                   )
                                   (if
                                     (i32.lt_u
-                                      (tee_local $4
+                                      (tee_local $1
                                         (i32.load
-                                          (tee_local $2
+                                          (tee_local $0
                                             (i32.add
-                                              (get_local $1)
+                                              (get_local $4)
                                               (i32.const 8)
                                             )
                                           )
@@ -2482,10 +2482,10 @@
                                     (call $qa)
                                     (block
                                       (set_local $19
-                                        (get_local $2)
+                                        (get_local $0)
                                       )
                                       (set_local $6
-                                        (get_local $4)
+                                        (get_local $1)
                                       )
                                     )
                                   )
@@ -2493,18 +2493,18 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $4)
-                                        (get_local $2)
+                                        (get_local $1)
+                                        (get_local $0)
                                       )
                                     )
                                     (set_local $19
                                       (i32.add
-                                        (get_local $1)
+                                        (get_local $4)
                                         (i32.const 8)
                                       )
                                     )
                                     (set_local $6
-                                      (get_local $1)
+                                      (get_local $4)
                                     )
                                   )
                                 )
@@ -2522,7 +2522,7 @@
                                 )
                                 (i32.store offset=12
                                   (get_local $7)
-                                  (get_local $1)
+                                  (get_local $4)
                                 )
                                 (br $do-once25)
                               )
@@ -2531,24 +2531,24 @@
                               (i32.add
                                 (i32.const 1512)
                                 (i32.shl
-                                  (tee_local $11
+                                  (tee_local $14
                                     (if i32
-                                      (tee_local $1
+                                      (tee_local $4
                                         (i32.shr_u
-                                          (get_local $16)
+                                          (get_local $18)
                                           (i32.const 8)
                                         )
                                       )
                                       (if i32
                                         (i32.gt_u
-                                          (get_local $16)
+                                          (get_local $18)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $16)
+                                              (get_local $18)
                                               (i32.add
                                                 (tee_local $15
                                                   (i32.add
@@ -2556,18 +2556,18 @@
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (tee_local $1
+                                                          (tee_local $4
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (tee_local $2
+                                                                  (tee_local $0
                                                                     (i32.shl
-                                                                      (get_local $1)
-                                                                      (tee_local $4
+                                                                      (get_local $4)
+                                                                      (tee_local $1
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $1)
+                                                                              (get_local $4)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -2584,16 +2584,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $4)
+                                                          (get_local $1)
                                                         )
-                                                        (tee_local $2
+                                                        (tee_local $0
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
                                                                 (tee_local $9
                                                                   (i32.shl
-                                                                    (get_local $2)
-                                                                    (get_local $1)
+                                                                    (get_local $0)
+                                                                    (get_local $4)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -2608,7 +2608,7 @@
                                                     (i32.shr_u
                                                       (i32.shl
                                                         (get_local $9)
-                                                        (get_local $2)
+                                                        (get_local $0)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -2634,10 +2634,10 @@
                             )
                             (i32.store offset=28
                               (get_local $7)
-                              (get_local $11)
+                              (get_local $14)
                             )
                             (i32.store offset=4
-                              (tee_local $2
+                              (tee_local $0
                                 (i32.add
                                   (get_local $7)
                                   (i32.const 16)
@@ -2646,13 +2646,13 @@
                               (i32.const 0)
                             )
                             (i32.store
-                              (get_local $2)
+                              (get_local $0)
                               (i32.const 0)
                             )
                             (if
                               (i32.eqz
                                 (i32.and
-                                  (tee_local $2
+                                  (tee_local $0
                                     (i32.load
                                       (i32.const 1212)
                                     )
@@ -2660,7 +2660,7 @@
                                   (tee_local $9
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $11)
+                                      (get_local $14)
                                     )
                                   )
                                 )
@@ -2669,7 +2669,7 @@
                                 (i32.store
                                   (i32.const 1212)
                                   (i32.or
-                                    (get_local $2)
+                                    (get_local $0)
                                     (get_local $9)
                                   )
                                 )
@@ -2694,24 +2694,24 @@
                             )
                             (set_local $9
                               (i32.shl
-                                (get_local $16)
+                                (get_local $18)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $11)
+                                      (get_local $14)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $11)
+                                    (get_local $14)
                                     (i32.const 31)
                                   )
                                 )
                               )
                             )
-                            (set_local $2
+                            (set_local $0
                               (i32.load
                                 (get_local $15)
                               )
@@ -2722,15 +2722,15 @@
                                   (i32.eq
                                     (i32.and
                                       (i32.load offset=4
-                                        (get_local $2)
+                                        (get_local $0)
                                       )
                                       (i32.const -8)
                                     )
-                                    (get_local $16)
+                                    (get_local $18)
                                   )
                                   (block
-                                    (set_local $18
-                                      (get_local $2)
+                                    (set_local $17
+                                      (get_local $0)
                                     )
                                     (set_local $8
                                       (i32.const 148)
@@ -2739,12 +2739,12 @@
                                   )
                                 )
                                 (if
-                                  (tee_local $4
+                                  (tee_local $1
                                     (i32.load
                                       (tee_local $15
                                         (i32.add
                                           (i32.add
-                                            (get_local $2)
+                                            (get_local $0)
                                             (i32.const 16)
                                           )
                                           (i32.shl
@@ -2765,8 +2765,8 @@
                                         (i32.const 1)
                                       )
                                     )
-                                    (set_local $2
-                                      (get_local $4)
+                                    (set_local $0
+                                      (get_local $1)
                                     )
                                     (br $while-in28)
                                   )
@@ -2774,8 +2774,8 @@
                                     (set_local $22
                                       (get_local $15)
                                     )
-                                    (set_local $14
-                                      (get_local $2)
+                                    (set_local $13
+                                      (get_local $0)
                                     )
                                     (set_local $8
                                       (i32.const 145)
@@ -2804,7 +2804,7 @@
                                   )
                                   (i32.store offset=24
                                     (get_local $7)
-                                    (get_local $14)
+                                    (get_local $13)
                                   )
                                   (i32.store offset=12
                                     (get_local $7)
@@ -2826,23 +2826,23 @@
                                     (i32.ge_u
                                       (tee_local $9
                                         (i32.load
-                                          (tee_local $2
+                                          (tee_local $0
                                             (i32.add
-                                              (get_local $18)
+                                              (get_local $17)
                                               (i32.const 8)
                                             )
                                           )
                                         )
                                       )
-                                      (tee_local $4
+                                      (tee_local $1
                                         (i32.load
                                           (i32.const 1224)
                                         )
                                       )
                                     )
                                     (i32.ge_u
-                                      (get_local $18)
-                                      (get_local $4)
+                                      (get_local $17)
+                                      (get_local $1)
                                     )
                                   )
                                   (block
@@ -2851,7 +2851,7 @@
                                       (get_local $7)
                                     )
                                     (i32.store
-                                      (get_local $2)
+                                      (get_local $0)
                                       (get_local $7)
                                     )
                                     (i32.store offset=8
@@ -2860,7 +2860,7 @@
                                     )
                                     (i32.store offset=12
                                       (get_local $7)
-                                      (get_local $18)
+                                      (get_local $17)
                                     )
                                     (i32.store offset=24
                                       (get_local $7)
@@ -2885,16 +2885,16 @@
                       )
                     )
                     (set_local $4
-                      (get_local $0)
+                      (get_local $2)
                     )
                   )
                   (set_local $4
-                    (get_local $0)
+                    (get_local $2)
                   )
                 )
               )
               (set_local $4
-                (get_local $0)
+                (get_local $2)
               )
             )
           )
@@ -2911,14 +2911,14 @@
         (get_local $4)
       )
       (block
-        (set_local $14
+        (set_local $13
           (i32.load
             (i32.const 1228)
           )
         )
         (if
           (i32.gt_u
-            (tee_local $18
+            (tee_local $17
               (i32.sub
                 (get_local $10)
                 (get_local $4)
@@ -2931,31 +2931,31 @@
               (i32.const 1228)
               (tee_local $22
                 (i32.add
-                  (get_local $14)
+                  (get_local $13)
                   (get_local $4)
                 )
               )
             )
             (i32.store
               (i32.const 1216)
-              (get_local $18)
+              (get_local $17)
             )
             (i32.store offset=4
               (get_local $22)
               (i32.or
-                (get_local $18)
+                (get_local $17)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $22)
-                (get_local $18)
+                (get_local $17)
               )
-              (get_local $18)
+              (get_local $17)
             )
             (i32.store offset=4
-              (get_local $14)
+              (get_local $13)
               (i32.or
                 (get_local $4)
                 (i32.const 3)
@@ -2972,17 +2972,17 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $14)
+              (get_local $13)
               (i32.or
                 (get_local $10)
                 (i32.const 3)
               )
             )
             (i32.store
-              (tee_local $18
+              (tee_local $17
                 (i32.add
                   (i32.add
-                    (get_local $14)
+                    (get_local $13)
                     (get_local $10)
                   )
                   (i32.const 4)
@@ -2990,7 +2990,7 @@
               )
               (i32.or
                 (i32.load
-                  (get_local $18)
+                  (get_local $17)
                 )
                 (i32.const 1)
               )
@@ -3002,7 +3002,7 @@
         )
         (return
           (i32.add
-            (get_local $14)
+            (get_local $13)
             (i32.const 8)
           )
         )
@@ -3010,7 +3010,7 @@
     )
     (if
       (i32.gt_u
-        (tee_local $14
+        (tee_local $13
           (i32.load
             (i32.const 1220)
           )
@@ -3020,9 +3020,9 @@
       (block
         (i32.store
           (i32.const 1220)
-          (tee_local $18
+          (tee_local $17
             (i32.sub
-              (get_local $14)
+              (get_local $13)
               (get_local $4)
             )
           )
@@ -3031,7 +3031,7 @@
           (i32.const 1232)
           (tee_local $10
             (i32.add
-              (tee_local $14
+              (tee_local $13
                 (i32.load
                   (i32.const 1232)
                 )
@@ -3043,12 +3043,12 @@
         (i32.store offset=4
           (get_local $10)
           (i32.or
-            (get_local $18)
+            (get_local $17)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $14)
+          (get_local $13)
           (i32.or
             (get_local $4)
             (i32.const 3)
@@ -3059,7 +3059,7 @@
         )
         (return
           (i32.add
-            (get_local $14)
+            (get_local $13)
             (i32.const 8)
           )
         )
@@ -3097,11 +3097,11 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $13)
-          (tee_local $14
+          (get_local $12)
+          (tee_local $13
             (i32.xor
               (i32.and
-                (get_local $13)
+                (get_local $12)
                 (i32.const -16)
               )
               (i32.const 1431655768)
@@ -3110,11 +3110,11 @@
         )
         (i32.store
           (i32.const 1680)
-          (get_local $14)
+          (get_local $13)
         )
       )
     )
-    (set_local $14
+    (set_local $13
       (i32.add
         (get_local $4)
         (i32.const 48)
@@ -3122,16 +3122,16 @@
     )
     (if
       (i32.le_u
-        (tee_local $13
+        (tee_local $12
           (i32.and
             (tee_local $10
               (i32.add
-                (tee_local $13
+                (tee_local $12
                   (i32.load
                     (i32.const 1688)
                   )
                 )
-                (tee_local $18
+                (tee_local $17
                   (i32.add
                     (get_local $4)
                     (i32.const 47)
@@ -3142,7 +3142,7 @@
             (tee_local $22
               (i32.sub
                 (i32.const 0)
-                (get_local $13)
+                (get_local $12)
               )
             )
           )
@@ -3159,7 +3159,7 @@
       )
     )
     (if
-      (tee_local $16
+      (tee_local $18
         (i32.load
           (i32.const 1648)
         )
@@ -3169,19 +3169,19 @@
           (i32.le_u
             (tee_local $6
               (i32.add
-                (tee_local $11
+                (tee_local $14
                   (i32.load
                     (i32.const 1640)
                   )
                 )
-                (get_local $13)
+                (get_local $12)
               )
             )
-            (get_local $11)
+            (get_local $14)
           )
           (i32.gt_u
             (get_local $6)
-            (get_local $16)
+            (get_local $18)
           )
         )
         (block
@@ -3209,7 +3209,7 @@
               (block i32
                 (block $label$break$c
                   (if
-                    (tee_local $16
+                    (tee_local $18
                       (i32.load
                         (i32.const 1232)
                       )
@@ -3222,17 +3222,17 @@
                         (block $while-out31
                           (if
                             (i32.le_u
-                              (tee_local $11
+                              (tee_local $14
                                 (i32.load
                                   (get_local $6)
                                 )
                               )
-                              (get_local $16)
+                              (get_local $18)
                             )
                             (if
                               (i32.gt_u
                                 (i32.add
-                                  (get_local $11)
+                                  (get_local $14)
                                   (i32.load
                                     (tee_local $19
                                       (i32.add
@@ -3242,10 +3242,10 @@
                                     )
                                   )
                                 )
-                                (get_local $16)
+                                (get_local $18)
                               )
                               (block
-                                (set_local $0
+                                (set_local $2
                                   (get_local $6)
                                 )
                                 (set_local $5
@@ -3292,7 +3292,7 @@
                             )
                             (i32.add
                               (i32.load
-                                (get_local $0)
+                                (get_local $2)
                               )
                               (i32.load
                                 (get_local $5)
@@ -3317,7 +3317,7 @@
                             )
                           )
                           (block
-                            (set_local $12
+                            (set_local $11
                               (get_local $19)
                             )
                             (set_local $3
@@ -3343,7 +3343,7 @@
                     )
                     (if
                       (i32.ne
-                        (tee_local $16
+                        (tee_local $18
                           (call $ta
                             (i32.const 0)
                           )
@@ -3351,7 +3351,7 @@
                         (i32.const -1)
                       )
                       (block
-                        (set_local $2
+                        (set_local $0
                           (if i32
                             (i32.and
                               (tee_local $19
@@ -3364,19 +3364,19 @@
                                   (i32.const -1)
                                 )
                               )
-                              (tee_local $0
-                                (get_local $16)
+                              (tee_local $2
+                                (get_local $18)
                               )
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $13)
-                                (get_local $0)
+                                (get_local $12)
+                                (get_local $2)
                               )
                               (i32.and
                                 (i32.add
                                   (get_local $19)
-                                  (get_local $0)
+                                  (get_local $2)
                                 )
                                 (i32.sub
                                   (i32.const 0)
@@ -3384,27 +3384,27 @@
                                 )
                               )
                             )
-                            (get_local $13)
+                            (get_local $12)
                           )
                         )
-                        (set_local $0
+                        (set_local $2
                           (i32.add
                             (tee_local $6
                               (i32.load
                                 (i32.const 1640)
                               )
                             )
-                            (get_local $2)
+                            (get_local $0)
                           )
                         )
                         (if
                           (i32.and
                             (i32.gt_u
-                              (get_local $2)
+                              (get_local $0)
                               (get_local $4)
                             )
                             (i32.lt_u
-                              (get_local $2)
+                              (get_local $0)
                               (i32.const 2147483647)
                             )
                           )
@@ -3418,11 +3418,11 @@
                               (br_if $do-once33
                                 (i32.or
                                   (i32.le_u
-                                    (get_local $0)
+                                    (get_local $2)
                                     (get_local $6)
                                   )
                                   (i32.gt_u
-                                    (get_local $0)
+                                    (get_local $2)
                                     (get_local $19)
                                   )
                                 )
@@ -3432,28 +3432,28 @@
                               (i32.eq
                                 (tee_local $19
                                   (call $ta
-                                    (get_local $2)
+                                    (get_local $0)
                                   )
                                 )
-                                (get_local $16)
+                                (get_local $18)
                               )
                               (block
                                 (set_local $20
-                                  (get_local $16)
+                                  (get_local $18)
                                 )
                                 (set_local $26
-                                  (get_local $2)
+                                  (get_local $0)
                                 )
                                 (br $label$break$b
                                   (i32.const 191)
                                 )
                               )
                               (block
-                                (set_local $12
+                                (set_local $11
                                   (get_local $19)
                                 )
                                 (set_local $3
-                                  (get_local $2)
+                                  (get_local $0)
                                 )
                                 (set_local $8
                                   (i32.const 181)
@@ -3482,7 +3482,7 @@
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $14)
+                            (get_local $13)
                             (get_local $3)
                           )
                           (i32.and
@@ -3491,21 +3491,21 @@
                               (i32.const 2147483647)
                             )
                             (i32.ne
-                              (get_local $12)
+                              (get_local $11)
                               (i32.const -1)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $0
+                            (tee_local $2
                               (i32.and
                                 (i32.add
                                   (i32.sub
-                                    (get_local $18)
+                                    (get_local $17)
                                     (get_local $3)
                                   )
-                                  (tee_local $16
+                                  (tee_local $18
                                     (i32.load
                                       (i32.const 1688)
                                     )
@@ -3513,7 +3513,7 @@
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $16)
+                                  (get_local $18)
                                 )
                               )
                             )
@@ -3522,7 +3522,7 @@
                           (if
                             (i32.eq
                               (call $ta
-                                (get_local $0)
+                                (get_local $2)
                               )
                               (i32.const -1)
                             )
@@ -3536,7 +3536,7 @@
                             )
                             (set_local $1
                               (i32.add
-                                (get_local $0)
+                                (get_local $2)
                                 (get_local $3)
                               )
                             )
@@ -3551,12 +3551,12 @@
                       )
                       (if
                         (i32.ne
-                          (get_local $12)
+                          (get_local $11)
                           (i32.const -1)
                         )
                         (block
                           (set_local $20
-                            (get_local $12)
+                            (get_local $11)
                           )
                           (set_local $26
                             (get_local $1)
@@ -3587,7 +3587,7 @@
       )
       (if
         (i32.lt_u
-          (get_local $13)
+          (get_local $12)
           (i32.const 2147483647)
         )
         (if
@@ -3595,10 +3595,10 @@
             (i32.lt_u
               (tee_local $1
                 (call $ta
-                  (get_local $13)
+                  (get_local $12)
                 )
               )
-              (tee_local $13
+              (tee_local $12
                 (call $ta
                   (i32.const 0)
                 )
@@ -3610,16 +3610,16 @@
                 (i32.const -1)
               )
               (i32.ne
-                (get_local $13)
+                (get_local $12)
                 (i32.const -1)
               )
             )
           )
           (if
             (i32.gt_u
-              (tee_local $12
+              (tee_local $11
                 (i32.sub
-                  (get_local $13)
+                  (get_local $12)
                   (get_local $1)
                 )
               )
@@ -3633,7 +3633,7 @@
                 (get_local $1)
               )
               (set_local $26
-                (get_local $12)
+                (get_local $11)
               )
               (set_local $8
                 (i32.const 191)
@@ -3651,7 +3651,7 @@
       (block
         (i32.store
           (i32.const 1640)
-          (tee_local $12
+          (tee_local $11
             (i32.add
               (i32.load
                 (i32.const 1640)
@@ -3662,19 +3662,19 @@
         )
         (if
           (i32.gt_u
-            (get_local $12)
+            (get_local $11)
             (i32.load
               (i32.const 1644)
             )
           )
           (i32.store
             (i32.const 1644)
-            (get_local $12)
+            (get_local $11)
           )
         )
         (block $do-once38
           (if
-            (tee_local $12
+            (tee_local $11
               (i32.load
                 (i32.const 1232)
               )
@@ -3694,9 +3694,9 @@
                             (get_local $3)
                           )
                         )
-                        (tee_local $18
+                        (tee_local $17
                           (i32.load
-                            (tee_local $13
+                            (tee_local $12
                               (i32.add
                                 (get_local $3)
                                 (i32.const 4)
@@ -3711,10 +3711,10 @@
                         (get_local $1)
                       )
                       (set_local $50
-                        (get_local $13)
+                        (get_local $12)
                       )
                       (set_local $51
-                        (get_local $18)
+                        (get_local $17)
                       )
                       (set_local $52
                         (get_local $3)
@@ -3754,11 +3754,11 @@
                   (if
                     (i32.and
                       (i32.lt_u
-                        (get_local $12)
+                        (get_local $11)
                         (get_local $20)
                       )
                       (i32.ge_u
-                        (get_local $12)
+                        (get_local $11)
                         (get_local $49)
                       )
                     )
@@ -3772,15 +3772,15 @@
                       )
                       (set_local $3
                         (i32.add
-                          (get_local $12)
-                          (tee_local $18
+                          (get_local $11)
+                          (tee_local $17
                             (select
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
                                   (tee_local $3
                                     (i32.add
-                                      (get_local $12)
+                                      (get_local $11)
                                       (i32.const 8)
                                     )
                                   )
@@ -3796,11 +3796,11 @@
                           )
                         )
                       )
-                      (set_local $13
+                      (set_local $12
                         (i32.add
                           (i32.sub
                             (get_local $26)
-                            (get_local $18)
+                            (get_local $17)
                           )
                           (i32.load
                             (i32.const 1220)
@@ -3813,19 +3813,19 @@
                       )
                       (i32.store
                         (i32.const 1220)
-                        (get_local $13)
+                        (get_local $12)
                       )
                       (i32.store offset=4
                         (get_local $3)
                         (i32.or
-                          (get_local $13)
+                          (get_local $12)
                           (i32.const 1)
                         )
                       )
                       (i32.store offset=4
                         (i32.add
                           (get_local $3)
-                          (get_local $13)
+                          (get_local $12)
                         )
                         (i32.const 40)
                       )
@@ -3844,7 +3844,7 @@
                 (if i32
                   (i32.lt_u
                     (get_local $20)
-                    (tee_local $13
+                    (tee_local $12
                       (i32.load
                         (i32.const 1224)
                       )
@@ -3857,10 +3857,10 @@
                     )
                     (get_local $20)
                   )
-                  (get_local $13)
+                  (get_local $12)
                 )
               )
-              (set_local $13
+              (set_local $12
                 (i32.add
                   (get_local $20)
                   (get_local $26)
@@ -3876,7 +3876,7 @@
                       (i32.load
                         (get_local $3)
                       )
-                      (get_local $13)
+                      (get_local $12)
                     )
                     (block
                       (set_local $53
@@ -3937,7 +3937,7 @@
                         (get_local $26)
                       )
                     )
-                    (set_local $18
+                    (set_local $17
                       (i32.add
                         (get_local $20)
                         (select
@@ -3963,14 +3963,14 @@
                     )
                     (set_local $1
                       (i32.add
-                        (get_local $13)
+                        (get_local $12)
                         (select
                           (i32.and
                             (i32.sub
                               (i32.const 0)
                               (tee_local $3
                                 (i32.add
-                                  (get_local $13)
+                                  (get_local $12)
                                   (i32.const 8)
                                 )
                               )
@@ -3987,21 +3987,21 @@
                     )
                     (set_local $3
                       (i32.add
-                        (get_local $18)
+                        (get_local $17)
                         (get_local $4)
                       )
                     )
-                    (set_local $14
+                    (set_local $13
                       (i32.sub
                         (i32.sub
                           (get_local $1)
-                          (get_local $18)
+                          (get_local $17)
                         )
                         (get_local $4)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $18)
+                      (get_local $17)
                       (i32.or
                         (get_local $4)
                         (i32.const 3)
@@ -4011,17 +4011,17 @@
                       (if
                         (i32.eq
                           (get_local $1)
-                          (get_local $12)
+                          (get_local $11)
                         )
                         (block
                           (i32.store
                             (i32.const 1220)
-                            (tee_local $2
+                            (tee_local $0
                               (i32.add
                                 (i32.load
                                   (i32.const 1220)
                                 )
-                                (get_local $14)
+                                (get_local $13)
                               )
                             )
                           )
@@ -4032,7 +4032,7 @@
                           (i32.store offset=4
                             (get_local $3)
                             (i32.or
-                              (get_local $2)
+                              (get_local $0)
                               (i32.const 1)
                             )
                           )
@@ -4048,12 +4048,12 @@
                             (block
                               (i32.store
                                 (i32.const 1216)
-                                (tee_local $2
+                                (tee_local $0
                                   (i32.add
                                     (i32.load
                                       (i32.const 1216)
                                     )
-                                    (get_local $14)
+                                    (get_local $13)
                                   )
                                 )
                               )
@@ -4064,27 +4064,27 @@
                               (i32.store offset=4
                                 (get_local $3)
                                 (i32.or
-                                  (get_local $2)
+                                  (get_local $0)
                                   (i32.const 1)
                                 )
                               )
                               (i32.store
                                 (i32.add
                                   (get_local $3)
-                                  (get_local $2)
+                                  (get_local $0)
                                 )
-                                (get_local $2)
+                                (get_local $0)
                               )
                               (br $do-once44)
                             )
                           )
                           (i32.store
-                            (tee_local $0
+                            (tee_local $2
                               (i32.add
                                 (if i32
                                   (i32.eq
                                     (i32.and
-                                      (tee_local $2
+                                      (tee_local $0
                                         (i32.load offset=4
                                           (get_local $1)
                                         )
@@ -4096,20 +4096,20 @@
                                   (block i32
                                     (set_local $5
                                       (i32.and
-                                        (get_local $2)
+                                        (get_local $0)
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $0
+                                    (set_local $2
                                       (i32.shr_u
-                                        (get_local $2)
+                                        (get_local $0)
                                         (i32.const 3)
                                       )
                                     )
                                     (block $label$break$e
                                       (if
                                         (i32.lt_u
-                                          (get_local $2)
+                                          (get_local $0)
                                           (i32.const 256)
                                         )
                                         (block
@@ -4131,7 +4131,7 @@
                                                     (i32.const 1248)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $0)
+                                                        (get_local $2)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4174,7 +4174,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $0)
+                                                      (get_local $2)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4206,7 +4206,7 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $0
+                                                      (tee_local $2
                                                         (i32.add
                                                           (get_local $10)
                                                           (i32.const 8)
@@ -4217,7 +4217,7 @@
                                                   )
                                                   (block
                                                     (set_local $44
-                                                      (get_local $0)
+                                                      (get_local $2)
                                                     )
                                                     (br $do-once49)
                                                   )
@@ -4244,7 +4244,7 @@
                                           (block $do-once51
                                             (if
                                               (i32.eq
-                                                (tee_local $0
+                                                (tee_local $2
                                                   (i32.load offset=12
                                                     (get_local $1)
                                                   )
@@ -4253,11 +4253,11 @@
                                               )
                                               (block
                                                 (if
-                                                  (tee_local $11
+                                                  (tee_local $14
                                                     (i32.load
                                                       (tee_local $6
                                                         (i32.add
-                                                          (tee_local $16
+                                                          (tee_local $18
                                                             (i32.add
                                                               (get_local $1)
                                                               (i32.const 16)
@@ -4270,20 +4270,25 @@
                                                   )
                                                   (block
                                                     (set_local $0
-                                                      (get_local $11)
+                                                      (get_local $14)
                                                     )
-                                                    (set_local $16
+                                                    (set_local $2
                                                       (get_local $6)
                                                     )
                                                   )
                                                   (if
                                                     (tee_local $23
                                                       (i32.load
-                                                        (get_local $16)
+                                                        (get_local $18)
                                                       )
                                                     )
-                                                    (set_local $0
-                                                      (get_local $23)
+                                                    (block
+                                                      (set_local $0
+                                                        (get_local $23)
+                                                      )
+                                                      (set_local $2
+                                                        (get_local $18)
+                                                      )
                                                     )
                                                     (block
                                                       (set_local $24
@@ -4295,7 +4300,7 @@
                                                 )
                                                 (loop $while-in54
                                                   (if
-                                                    (tee_local $11
+                                                    (tee_local $14
                                                       (i32.load
                                                         (tee_local $6
                                                           (i32.add
@@ -4307,16 +4312,16 @@
                                                     )
                                                     (block
                                                       (set_local $0
-                                                        (get_local $11)
+                                                        (get_local $14)
                                                       )
-                                                      (set_local $16
+                                                      (set_local $2
                                                         (get_local $6)
                                                       )
                                                       (br $while-in54)
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $11
+                                                    (tee_local $14
                                                       (i32.load
                                                         (tee_local $6
                                                           (i32.add
@@ -4328,9 +4333,9 @@
                                                     )
                                                     (block
                                                       (set_local $0
-                                                        (get_local $11)
+                                                        (get_local $14)
                                                       )
-                                                      (set_local $16
+                                                      (set_local $2
                                                         (get_local $6)
                                                       )
                                                       (br $while-in54)
@@ -4339,13 +4344,13 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $16)
+                                                    (get_local $2)
                                                     (get_local $7)
                                                   )
                                                   (call $qa)
                                                   (block
                                                     (i32.store
-                                                      (get_local $16)
+                                                      (get_local $2)
                                                       (i32.const 0)
                                                     )
                                                     (set_local $24
@@ -4369,7 +4374,7 @@
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (tee_local $11
+                                                      (tee_local $14
                                                         (i32.add
                                                           (get_local $6)
                                                           (i32.const 12)
@@ -4383,9 +4388,9 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (tee_local $16
+                                                      (tee_local $18
                                                         (i32.add
-                                                          (get_local $0)
+                                                          (get_local $2)
                                                           (i32.const 8)
                                                         )
                                                       )
@@ -4394,15 +4399,15 @@
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $11)
-                                                      (get_local $0)
+                                                      (get_local $14)
+                                                      (get_local $2)
                                                     )
                                                     (i32.store
-                                                      (get_local $16)
+                                                      (get_local $18)
                                                       (get_local $6)
                                                     )
                                                     (set_local $24
-                                                      (get_local $0)
+                                                      (get_local $2)
                                                     )
                                                   )
                                                   (call $qa)
@@ -4424,7 +4429,7 @@
                                                     (i32.add
                                                       (i32.const 1512)
                                                       (i32.shl
-                                                        (tee_local $0
+                                                        (tee_local $2
                                                           (i32.load offset=28
                                                             (get_local $1)
                                                           )
@@ -4452,7 +4457,7 @@
                                                     (i32.xor
                                                       (i32.shl
                                                         (i32.const 1)
-                                                        (get_local $0)
+                                                        (get_local $2)
                                                       )
                                                       (i32.const -1)
                                                     )
@@ -4502,7 +4507,7 @@
                                           (if
                                             (i32.lt_u
                                               (get_local $24)
-                                              (tee_local $0
+                                              (tee_local $2
                                                 (i32.load
                                                   (i32.const 1224)
                                                 )
@@ -4528,7 +4533,7 @@
                                             (if
                                               (i32.lt_u
                                                 (get_local $10)
-                                                (get_local $0)
+                                                (get_local $2)
                                               )
                                               (call $qa)
                                               (block
@@ -4574,10 +4579,10 @@
                                         )
                                       )
                                     )
-                                    (set_local $14
+                                    (set_local $13
                                       (i32.add
                                         (get_local $5)
-                                        (get_local $14)
+                                        (get_local $13)
                                       )
                                     )
                                     (i32.add
@@ -4592,7 +4597,7 @@
                             )
                             (i32.and
                               (i32.load
-                                (get_local $0)
+                                (get_local $2)
                               )
                               (i32.const -2)
                             )
@@ -4600,35 +4605,35 @@
                           (i32.store offset=4
                             (get_local $3)
                             (i32.or
-                              (get_local $14)
+                              (get_local $13)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
                               (get_local $3)
-                              (get_local $14)
+                              (get_local $13)
                             )
-                            (get_local $14)
+                            (get_local $13)
                           )
-                          (set_local $0
+                          (set_local $2
                             (i32.shr_u
-                              (get_local $14)
+                              (get_local $13)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $14)
+                              (get_local $13)
                               (i32.const 256)
                             )
                             (block
-                              (set_local $2
+                              (set_local $0
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $0)
+                                      (get_local $2)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4643,10 +4648,10 @@
                                         (i32.const 1208)
                                       )
                                     )
-                                    (tee_local $0
+                                    (tee_local $2
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $0)
+                                        (get_local $2)
                                       )
                                     )
                                   )
@@ -4655,9 +4660,9 @@
                                       (i32.ge_u
                                         (tee_local $19
                                           (i32.load
-                                            (tee_local $0
+                                            (tee_local $2
                                               (i32.add
-                                                (get_local $2)
+                                                (get_local $0)
                                                 (i32.const 8)
                                               )
                                             )
@@ -4669,7 +4674,7 @@
                                       )
                                       (block
                                         (set_local $45
-                                          (get_local $0)
+                                          (get_local $2)
                                         )
                                         (set_local $38
                                           (get_local $19)
@@ -4684,17 +4689,17 @@
                                       (i32.const 1208)
                                       (i32.or
                                         (get_local $10)
-                                        (get_local $0)
+                                        (get_local $2)
                                       )
                                     )
                                     (set_local $45
                                       (i32.add
-                                        (get_local $2)
+                                        (get_local $0)
                                         (i32.const 8)
                                       )
                                     )
                                     (set_local $38
-                                      (get_local $2)
+                                      (get_local $0)
                                     )
                                   )
                                 )
@@ -4713,21 +4718,21 @@
                               )
                               (i32.store offset=12
                                 (get_local $3)
-                                (get_local $2)
+                                (get_local $0)
                               )
                               (br $do-once44)
                             )
                           )
-                          (set_local $0
+                          (set_local $2
                             (i32.add
                               (i32.const 1512)
                               (i32.shl
                                 (tee_local $5
                                   (block $do-once61 i32
                                     (if i32
-                                      (tee_local $0
+                                      (tee_local $2
                                         (i32.shr_u
-                                          (get_local $14)
+                                          (get_local $13)
                                           (i32.const 8)
                                         )
                                       )
@@ -4736,7 +4741,7 @@
                                           (br_if $do-once61
                                             (i32.const 31)
                                             (i32.gt_u
-                                              (get_local $14)
+                                              (get_local $13)
                                               (i32.const 16777215)
                                             )
                                           )
@@ -4744,7 +4749,7 @@
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $14)
+                                              (get_local $13)
                                               (i32.add
                                                 (tee_local $6
                                                   (i32.add
@@ -4758,12 +4763,12 @@
                                                                 (i32.add
                                                                   (tee_local $5
                                                                     (i32.shl
-                                                                      (get_local $0)
+                                                                      (get_local $2)
                                                                       (tee_local $10
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $0)
+                                                                              (get_local $2)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -4786,7 +4791,7 @@
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $0
+                                                                (tee_local $2
                                                                   (i32.shl
                                                                     (get_local $5)
                                                                     (get_local $19)
@@ -4803,7 +4808,7 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $0)
+                                                        (get_local $2)
                                                         (get_local $5)
                                                       )
                                                       (i32.const 15)
@@ -4834,7 +4839,7 @@
                             (get_local $5)
                           )
                           (i32.store offset=4
-                            (tee_local $2
+                            (tee_local $0
                               (i32.add
                                 (get_local $3)
                                 (i32.const 16)
@@ -4843,13 +4848,13 @@
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $2)
+                            (get_local $0)
                             (i32.const 0)
                           )
                           (if
                             (i32.eqz
                               (i32.and
-                                (tee_local $2
+                                (tee_local $0
                                   (i32.load
                                     (i32.const 1212)
                                   )
@@ -4866,17 +4871,17 @@
                               (i32.store
                                 (i32.const 1212)
                                 (i32.or
-                                  (get_local $2)
+                                  (get_local $0)
                                   (get_local $6)
                                 )
                               )
                               (i32.store
-                                (get_local $0)
+                                (get_local $2)
                                 (get_local $3)
                               )
                               (i32.store offset=24
                                 (get_local $3)
-                                (get_local $0)
+                                (get_local $2)
                               )
                               (i32.store offset=12
                                 (get_local $3)
@@ -4891,7 +4896,7 @@
                           )
                           (set_local $6
                             (i32.shl
-                              (get_local $14)
+                              (get_local $13)
                               (select
                                 (i32.const 0)
                                 (i32.sub
@@ -4908,9 +4913,9 @@
                               )
                             )
                           )
-                          (set_local $2
+                          (set_local $0
                             (i32.load
-                              (get_local $0)
+                              (get_local $2)
                             )
                           )
                           (loop $while-in64
@@ -4919,15 +4924,15 @@
                                 (i32.eq
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $2)
+                                      (get_local $0)
                                     )
                                     (i32.const -8)
                                   )
-                                  (get_local $14)
+                                  (get_local $13)
                                 )
                                 (block
                                   (set_local $39
-                                    (get_local $2)
+                                    (get_local $0)
                                   )
                                   (set_local $8
                                     (i32.const 279)
@@ -4938,10 +4943,10 @@
                               (if
                                 (tee_local $5
                                   (i32.load
-                                    (tee_local $0
+                                    (tee_local $2
                                       (i32.add
                                         (i32.add
-                                          (get_local $2)
+                                          (get_local $0)
                                           (i32.const 16)
                                         )
                                         (i32.shl
@@ -4962,17 +4967,17 @@
                                       (i32.const 1)
                                     )
                                   )
-                                  (set_local $2
+                                  (set_local $0
                                     (get_local $5)
                                   )
                                   (br $while-in64)
                                 )
                                 (block
                                   (set_local $46
-                                    (get_local $0)
+                                    (get_local $2)
                                   )
                                   (set_local $54
-                                    (get_local $2)
+                                    (get_local $0)
                                   )
                                   (set_local $8
                                     (i32.const 276)
@@ -5023,7 +5028,7 @@
                                   (i32.ge_u
                                     (tee_local $6
                                       (i32.load
-                                        (tee_local $2
+                                        (tee_local $0
                                           (i32.add
                                             (get_local $39)
                                             (i32.const 8)
@@ -5048,7 +5053,7 @@
                                     (get_local $3)
                                   )
                                   (i32.store
-                                    (get_local $2)
+                                    (get_local $0)
                                     (get_local $3)
                                   )
                                   (i32.store offset=8
@@ -5076,7 +5081,7 @@
                     )
                     (return
                       (i32.add
-                        (get_local $18)
+                        (get_local $17)
                         (i32.const 8)
                       )
                     )
@@ -5092,11 +5097,11 @@
                           (get_local $29)
                         )
                       )
-                      (get_local $12)
+                      (get_local $11)
                     )
                     (if
                       (i32.gt_u
-                        (tee_local $14
+                        (tee_local $13
                           (i32.add
                             (get_local $3)
                             (i32.load offset=4
@@ -5104,11 +5109,11 @@
                             )
                           )
                         )
-                        (get_local $12)
+                        (get_local $11)
                       )
                       (block
                         (set_local $0
-                          (get_local $14)
+                          (get_local $13)
                         )
                         (br $while-out65)
                       )
@@ -5122,9 +5127,9 @@
                   (br $while-in66)
                 )
               )
-              (set_local $14
+              (set_local $13
                 (i32.add
-                  (tee_local $18
+                  (tee_local $17
                     (i32.add
                       (get_local $0)
                       (i32.const -47)
@@ -5135,23 +5140,23 @@
               )
               (set_local $3
                 (i32.add
-                  (tee_local $18
+                  (tee_local $17
                     (select
-                      (get_local $12)
+                      (get_local $11)
                       (tee_local $3
                         (i32.add
-                          (get_local $18)
+                          (get_local $17)
                           (select
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $14)
+                                (get_local $13)
                               )
                               (i32.const 7)
                             )
                             (i32.const 0)
                             (i32.and
-                              (get_local $14)
+                              (get_local $13)
                               (i32.const 7)
                             )
                           )
@@ -5159,9 +5164,9 @@
                       )
                       (i32.lt_u
                         (get_local $3)
-                        (tee_local $14
+                        (tee_local $13
                           (i32.add
-                            (get_local $12)
+                            (get_local $11)
                             (i32.const 16)
                           )
                         )
@@ -5176,7 +5181,7 @@
                 (tee_local $1
                   (i32.add
                     (get_local $20)
-                    (tee_local $13
+                    (tee_local $12
                       (select
                         (i32.and
                           (i32.sub
@@ -5208,7 +5213,7 @@
                       (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $13)
+                    (get_local $12)
                   )
                 )
               )
@@ -5235,7 +5240,7 @@
               (i32.store
                 (tee_local $6
                   (i32.add
-                    (get_local $18)
+                    (get_local $17)
                     (i32.const 4)
                   )
                 )
@@ -5283,7 +5288,7 @@
               )
               (set_local $3
                 (i32.add
-                  (get_local $18)
+                  (get_local $17)
                   (i32.const 24)
                 )
               )
@@ -5309,8 +5314,8 @@
               )
               (if
                 (i32.ne
-                  (get_local $18)
-                  (get_local $12)
+                  (get_local $17)
+                  (get_local $11)
                 )
                 (block
                   (i32.store
@@ -5323,19 +5328,19 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $12)
+                    (get_local $11)
                     (i32.or
                       (tee_local $3
                         (i32.sub
-                          (get_local $18)
-                          (get_local $12)
+                          (get_local $17)
+                          (get_local $11)
                         )
                       )
                       (i32.const 1)
                     )
                   )
                   (i32.store
-                    (get_local $18)
+                    (get_local $17)
                     (get_local $3)
                   )
                   (set_local $1
@@ -5350,7 +5355,7 @@
                       (i32.const 256)
                     )
                     (block
-                      (set_local $13
+                      (set_local $12
                         (i32.add
                           (i32.const 1248)
                           (i32.shl
@@ -5364,7 +5369,7 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $2
+                          (tee_local $0
                             (i32.load
                               (i32.const 1208)
                             )
@@ -5378,11 +5383,11 @@
                         )
                         (if
                           (i32.lt_u
-                            (tee_local $2
+                            (tee_local $0
                               (i32.load
                                 (tee_local $5
                                   (i32.add
-                                    (get_local $13)
+                                    (get_local $12)
                                     (i32.const 8)
                                   )
                                 )
@@ -5398,7 +5403,7 @@
                               (get_local $5)
                             )
                             (set_local $40
-                              (get_local $2)
+                              (get_local $0)
                             )
                           )
                         )
@@ -5406,47 +5411,47 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $2)
+                              (get_local $0)
                               (get_local $5)
                             )
                           )
                           (set_local $47
                             (i32.add
-                              (get_local $13)
+                              (get_local $12)
                               (i32.const 8)
                             )
                           )
                           (set_local $40
-                            (get_local $13)
+                            (get_local $12)
                           )
                         )
                       )
                       (i32.store
                         (get_local $47)
-                        (get_local $12)
+                        (get_local $11)
                       )
                       (i32.store offset=12
                         (get_local $40)
-                        (get_local $12)
+                        (get_local $11)
                       )
                       (i32.store offset=8
-                        (get_local $12)
+                        (get_local $11)
                         (get_local $40)
                       )
                       (i32.store offset=12
+                        (get_local $11)
                         (get_local $12)
-                        (get_local $13)
                       )
                       (br $do-once38)
                     )
                   )
-                  (set_local $0
+                  (set_local $2
                     (i32.add
                       (i32.const 1512)
                       (i32.shl
-                        (tee_local $2
+                        (tee_local $0
                           (if i32
-                            (tee_local $13
+                            (tee_local $12
                               (i32.shr_u
                                 (get_local $3)
                                 (i32.const 8)
@@ -5463,24 +5468,24 @@
                                   (i32.shr_u
                                     (get_local $3)
                                     (i32.add
-                                      (tee_local $0
+                                      (tee_local $2
                                         (i32.add
                                           (i32.sub
                                             (i32.const 14)
                                             (i32.or
                                               (i32.or
-                                                (tee_local $13
+                                                (tee_local $12
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
                                                         (tee_local $5
                                                           (i32.shl
-                                                            (get_local $13)
-                                                            (tee_local $2
+                                                            (get_local $12)
+                                                            (tee_local $0
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
-                                                                    (get_local $13)
+                                                                    (get_local $12)
                                                                     (i32.const 1048320)
                                                                   )
                                                                   (i32.const 16)
@@ -5497,7 +5502,7 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $2)
+                                                (get_local $0)
                                               )
                                               (tee_local $5
                                                 (i32.and
@@ -5506,7 +5511,7 @@
                                                       (tee_local $1
                                                         (i32.shl
                                                           (get_local $5)
-                                                          (get_local $13)
+                                                          (get_local $12)
                                                         )
                                                       )
                                                       (i32.const 245760)
@@ -5533,7 +5538,7 @@
                                   (i32.const 1)
                                 )
                                 (i32.shl
-                                  (get_local $0)
+                                  (get_local $2)
                                   (i32.const 1)
                                 )
                               )
@@ -5546,15 +5551,15 @@
                     )
                   )
                   (i32.store offset=28
-                    (get_local $12)
-                    (get_local $2)
+                    (get_local $11)
+                    (get_local $0)
                   )
                   (i32.store offset=20
-                    (get_local $12)
+                    (get_local $11)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $14)
+                    (get_local $13)
                     (i32.const 0)
                   )
                   (if
@@ -5568,7 +5573,7 @@
                         (tee_local $1
                           (i32.shl
                             (i32.const 1)
-                            (get_local $2)
+                            (get_local $0)
                           )
                         )
                       )
@@ -5582,20 +5587,20 @@
                         )
                       )
                       (i32.store
-                        (get_local $0)
-                        (get_local $12)
+                        (get_local $2)
+                        (get_local $11)
                       )
                       (i32.store offset=24
-                        (get_local $12)
-                        (get_local $0)
+                        (get_local $11)
+                        (get_local $2)
                       )
                       (i32.store offset=12
-                        (get_local $12)
-                        (get_local $12)
+                        (get_local $11)
+                        (get_local $11)
                       )
                       (i32.store offset=8
-                        (get_local $12)
-                        (get_local $12)
+                        (get_local $11)
+                        (get_local $11)
                       )
                       (br $do-once38)
                     )
@@ -5608,12 +5613,12 @@
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $2)
+                            (get_local $0)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $2)
+                          (get_local $0)
                           (i32.const 31)
                         )
                       )
@@ -5621,7 +5626,7 @@
                   )
                   (set_local $5
                     (i32.load
-                      (get_local $0)
+                      (get_local $2)
                     )
                   )
                   (loop $while-in70
@@ -5647,9 +5652,9 @@
                         )
                       )
                       (if
-                        (tee_local $2
+                        (tee_local $0
                           (i32.load
-                            (tee_local $0
+                            (tee_local $2
                               (i32.add
                                 (i32.add
                                   (get_local $5)
@@ -5674,13 +5679,13 @@
                             )
                           )
                           (set_local $5
-                            (get_local $2)
+                            (get_local $0)
                           )
                           (br $while-in70)
                         )
                         (block
                           (set_local $48
-                            (get_local $0)
+                            (get_local $2)
                           )
                           (set_local $55
                             (get_local $5)
@@ -5708,19 +5713,19 @@
                       (block
                         (i32.store
                           (get_local $48)
-                          (get_local $12)
+                          (get_local $11)
                         )
                         (i32.store offset=24
-                          (get_local $12)
+                          (get_local $11)
                           (get_local $55)
                         )
                         (i32.store offset=12
-                          (get_local $12)
-                          (get_local $12)
+                          (get_local $11)
+                          (get_local $11)
                         )
                         (i32.store offset=8
-                          (get_local $12)
-                          (get_local $12)
+                          (get_local $11)
+                          (get_local $11)
                         )
                       )
                     )
@@ -5756,22 +5761,22 @@
                         (block
                           (i32.store offset=12
                             (get_local $1)
-                            (get_local $12)
+                            (get_local $11)
                           )
                           (i32.store
                             (get_local $5)
-                            (get_local $12)
+                            (get_local $11)
                           )
                           (i32.store offset=8
-                            (get_local $12)
+                            (get_local $11)
                             (get_local $1)
                           )
                           (i32.store offset=12
-                            (get_local $12)
+                            (get_local $11)
                             (get_local $30)
                           )
                           (i32.store offset=24
-                            (get_local $12)
+                            (get_local $11)
                             (i32.const 0)
                           )
                         )
@@ -5829,7 +5834,7 @@
               )
               (loop $do-in
                 (i32.store offset=12
-                  (tee_local $13
+                  (tee_local $12
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
@@ -5841,11 +5846,11 @@
                       )
                     )
                   )
-                  (get_local $13)
+                  (get_local $12)
                 )
                 (i32.store offset=8
-                  (get_local $13)
-                  (get_local $13)
+                  (get_local $12)
+                  (get_local $12)
                 )
                 (br_if $do-in
                   (i32.ne
@@ -5864,7 +5869,7 @@
                 (tee_local $1
                   (i32.add
                     (get_local $20)
-                    (tee_local $13
+                    (tee_local $12
                       (select
                         (i32.and
                           (i32.sub
@@ -5896,7 +5901,7 @@
                       (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $13)
+                    (get_local $12)
                   )
                 )
               )
@@ -5925,7 +5930,7 @@
         )
         (if
           (i32.gt_u
-            (tee_local $12
+            (tee_local $11
               (i32.load
                 (i32.const 1220)
               )
@@ -5937,7 +5942,7 @@
               (i32.const 1220)
               (tee_local $30
                 (i32.sub
-                  (get_local $12)
+                  (get_local $11)
                   (get_local $4)
                 )
               )
@@ -5946,7 +5951,7 @@
               (i32.const 1232)
               (tee_local $8
                 (i32.add
-                  (tee_local $12
+                  (tee_local $11
                     (i32.load
                       (i32.const 1232)
                     )
@@ -5963,7 +5968,7 @@
               )
             )
             (i32.store offset=4
-              (get_local $12)
+              (get_local $11)
               (i32.or
                 (get_local $4)
                 (i32.const 3)
@@ -5974,7 +5979,7 @@
             )
             (return
               (i32.add
-                (get_local $12)
+                (get_local $11)
                 (i32.const 8)
               )
             )
@@ -6037,7 +6042,7 @@
       (i32.eq
         (tee_local $0
           (i32.and
-            (tee_local $4
+            (tee_local $3
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -6057,7 +6062,7 @@
         (get_local $1)
         (tee_local $6
           (i32.and
-            (get_local $4)
+            (get_local $3)
             (i32.const -8)
           )
         )
@@ -6066,19 +6071,19 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $4)
+          (get_local $3)
           (i32.const 1)
         )
         (block
           (set_local $2
             (get_local $1)
           )
-          (set_local $7
+          (set_local $5
             (get_local $6)
           )
         )
         (block
-          (set_local $10
+          (set_local $11
             (i32.load
               (get_local $1)
             )
@@ -6091,18 +6096,18 @@
           )
           (set_local $6
             (i32.add
-              (get_local $10)
+              (get_local $11)
               (get_local $6)
             )
           )
           (if
             (i32.lt_u
-              (tee_local $0
+              (tee_local $3
                 (i32.add
                   (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $10)
+                    (get_local $11)
                   )
                 )
               )
@@ -6112,7 +6117,7 @@
           )
           (if
             (i32.eq
-              (get_local $0)
+              (get_local $3)
               (i32.load
                 (i32.const 1228)
               )
@@ -6121,9 +6126,9 @@
               (if
                 (i32.ne
                   (i32.and
-                    (tee_local $3
+                    (tee_local $7
                       (i32.load
-                        (tee_local $1
+                        (tee_local $0
                           (i32.add
                             (get_local $8)
                             (i32.const 4)
@@ -6137,9 +6142,9 @@
                 )
                 (block
                   (set_local $2
-                    (get_local $0)
+                    (get_local $3)
                   )
-                  (set_local $7
+                  (set_local $5
                     (get_local $6)
                   )
                   (br $do-once)
@@ -6150,14 +6155,14 @@
                 (get_local $6)
               )
               (i32.store
-                (get_local $1)
+                (get_local $0)
                 (i32.and
-                  (get_local $3)
+                  (get_local $7)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $0)
+                (get_local $3)
                 (i32.or
                   (get_local $6)
                   (i32.const 1)
@@ -6165,7 +6170,7 @@
               )
               (i32.store
                 (i32.add
-                  (get_local $0)
+                  (get_local $3)
                   (get_local $6)
                 )
                 (get_local $6)
@@ -6173,36 +6178,36 @@
               (return)
             )
           )
-          (set_local $3
+          (set_local $7
             (i32.shr_u
-              (get_local $10)
+              (get_local $11)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $10)
+              (get_local $11)
               (i32.const 256)
             )
             (block
-              (set_local $1
+              (set_local $0
                 (i32.load offset=12
-                  (get_local $0)
+                  (get_local $3)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $10
+                  (tee_local $11
                     (i32.load offset=8
-                      (get_local $0)
+                      (get_local $3)
                     )
                   )
-                  (tee_local $4
+                  (tee_local $1
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $3)
+                          (get_local $7)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6213,7 +6218,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $10)
+                      (get_local $11)
                       (get_local $14)
                     )
                     (call $qa)
@@ -6221,9 +6226,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $10)
+                        (get_local $11)
                       )
-                      (get_local $0)
+                      (get_local $3)
                     )
                     (call $qa)
                   )
@@ -6231,8 +6236,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $1)
-                  (get_local $10)
+                  (get_local $0)
+                  (get_local $11)
                 )
                 (block
                   (i32.store
@@ -6244,16 +6249,16 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $3)
+                          (get_local $7)
                         )
                         (i32.const -1)
                       )
                     )
                   )
                   (set_local $2
-                    (get_local $0)
+                    (get_local $3)
                   )
-                  (set_local $7
+                  (set_local $5
                     (get_local $6)
                   )
                   (br $do-once)
@@ -6261,19 +6266,19 @@
               )
               (if
                 (i32.eq
+                  (get_local $0)
                   (get_local $1)
-                  (get_local $4)
                 )
-                (set_local $9
+                (set_local $10
                   (i32.add
-                    (get_local $1)
+                    (get_local $0)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $1)
+                      (get_local $0)
                       (get_local $14)
                     )
                     (call $qa)
@@ -6281,63 +6286,63 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $4
+                        (tee_local $1
                           (i32.add
-                            (get_local $1)
+                            (get_local $0)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $0)
+                      (get_local $3)
                     )
-                    (set_local $9
-                      (get_local $4)
+                    (set_local $10
+                      (get_local $1)
                     )
                     (call $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $10)
-                (get_local $1)
-              )
-              (i32.store
-                (get_local $9)
-                (get_local $10)
-              )
-              (set_local $2
+                (get_local $11)
                 (get_local $0)
               )
-              (set_local $7
+              (i32.store
+                (get_local $10)
+                (get_local $11)
+              )
+              (set_local $2
+                (get_local $3)
+              )
+              (set_local $5
                 (get_local $6)
               )
               (br $do-once)
             )
           )
-          (set_local $10
+          (set_local $11
             (i32.load offset=24
-              (get_local $0)
+              (get_local $3)
             )
           )
           (block $do-once0
             (if
               (i32.eq
-                (tee_local $1
+                (tee_local $0
                   (i32.load offset=12
-                    (get_local $0)
+                    (get_local $3)
                   )
                 )
-                (get_local $0)
+                (get_local $3)
               )
               (block
                 (if
-                  (tee_local $9
+                  (tee_local $10
                     (i32.load
-                      (tee_local $3
+                      (tee_local $7
                         (i32.add
-                          (tee_local $4
+                          (tee_local $1
                             (i32.add
-                              (get_local $0)
+                              (get_local $3)
                               (i32.const 16)
                             )
                           )
@@ -6347,23 +6352,23 @@
                     )
                   )
                   (block
-                    (set_local $1
-                      (get_local $9)
+                    (set_local $0
+                      (get_local $10)
                     )
-                    (set_local $4
-                      (get_local $3)
+                    (set_local $1
+                      (get_local $7)
                     )
                   )
                   (if
                     (i32.eqz
-                      (tee_local $1
+                      (tee_local $0
                         (i32.load
-                          (get_local $4)
+                          (get_local $1)
                         )
                       )
                     )
                     (block
-                      (set_local $5
+                      (set_local $4
                         (i32.const 0)
                       )
                       (br $do-once0)
@@ -6372,69 +6377,69 @@
                 )
                 (loop $while-in
                   (if
-                    (tee_local $9
+                    (tee_local $10
                       (i32.load
-                        (tee_local $3
+                        (tee_local $7
                           (i32.add
-                            (get_local $1)
+                            (get_local $0)
                             (i32.const 20)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $1
-                        (get_local $9)
+                      (set_local $0
+                        (get_local $10)
                       )
-                      (set_local $4
-                        (get_local $3)
+                      (set_local $1
+                        (get_local $7)
                       )
                       (br $while-in)
                     )
                   )
                   (if
-                    (tee_local $9
+                    (tee_local $10
                       (i32.load
-                        (tee_local $3
+                        (tee_local $7
                           (i32.add
-                            (get_local $1)
+                            (get_local $0)
                             (i32.const 16)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $1
-                        (get_local $9)
+                      (set_local $0
+                        (get_local $10)
                       )
-                      (set_local $4
-                        (get_local $3)
+                      (set_local $1
+                        (get_local $7)
                       )
                       (br $while-in)
                     )
                     (block
-                      (set_local $12
-                        (get_local $1)
+                      (set_local $7
+                        (get_local $0)
                       )
-                      (set_local $3
-                        (get_local $4)
+                      (set_local $9
+                        (get_local $1)
                       )
                     )
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $3)
+                    (get_local $9)
                     (get_local $14)
                   )
                   (call $qa)
                   (block
                     (i32.store
-                      (get_local $3)
+                      (get_local $9)
                       (i32.const 0)
                     )
-                    (set_local $5
-                      (get_local $12)
+                    (set_local $4
+                      (get_local $7)
                     )
                   )
                 )
@@ -6442,9 +6447,9 @@
               (block
                 (if
                   (i32.lt_u
-                    (tee_local $3
+                    (tee_local $7
                       (i32.load offset=8
-                        (get_local $0)
+                        (get_local $3)
                       )
                     )
                     (get_local $14)
@@ -6454,40 +6459,40 @@
                 (if
                   (i32.ne
                     (i32.load
-                      (tee_local $9
+                      (tee_local $10
                         (i32.add
-                          (get_local $3)
+                          (get_local $7)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $3)
                   )
                   (call $qa)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (tee_local $4
+                      (tee_local $1
                         (i32.add
-                          (get_local $1)
+                          (get_local $0)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $0)
+                    (get_local $3)
                   )
                   (block
                     (i32.store
-                      (get_local $9)
-                      (get_local $1)
+                      (get_local $10)
+                      (get_local $0)
                     )
                     (i32.store
-                      (get_local $4)
-                      (get_local $3)
-                    )
-                    (set_local $5
                       (get_local $1)
+                      (get_local $7)
+                    )
+                    (set_local $4
+                      (get_local $0)
                     )
                   )
                   (call $qa)
@@ -6496,19 +6501,19 @@
             )
           )
           (if
-            (get_local $10)
+            (get_local $11)
             (block
               (if
                 (i32.eq
-                  (get_local $0)
+                  (get_local $3)
                   (i32.load
-                    (tee_local $3
+                    (tee_local $7
                       (i32.add
                         (i32.const 1512)
                         (i32.shl
-                          (tee_local $1
+                          (tee_local $0
                             (i32.load offset=28
-                              (get_local $0)
+                              (get_local $3)
                             )
                           )
                           (i32.const 2)
@@ -6519,12 +6524,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $3)
-                    (get_local $5)
+                    (get_local $7)
+                    (get_local $4)
                   )
                   (if
                     (i32.eqz
-                      (get_local $5)
+                      (get_local $4)
                     )
                     (block
                       (i32.store
@@ -6536,16 +6541,16 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $1)
+                              (get_local $0)
                             )
                             (i32.const -1)
                           )
                         )
                       )
                       (set_local $2
-                        (get_local $0)
+                        (get_local $3)
                       )
-                      (set_local $7
+                      (set_local $5
                         (get_local $6)
                       )
                       (br $do-once)
@@ -6555,7 +6560,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $10)
+                      (get_local $11)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6565,33 +6570,33 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $1
+                        (tee_local $0
                           (i32.add
-                            (get_local $10)
+                            (get_local $11)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $0)
+                      (get_local $3)
                     )
                     (i32.store
-                      (get_local $1)
-                      (get_local $5)
+                      (get_local $0)
+                      (get_local $4)
                     )
                     (i32.store offset=20
-                      (get_local $10)
-                      (get_local $5)
+                      (get_local $11)
+                      (get_local $4)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $5)
+                      (get_local $4)
                     )
                     (block
                       (set_local $2
-                        (get_local $0)
+                        (get_local $3)
                       )
-                      (set_local $7
+                      (set_local $5
                         (get_local $6)
                       )
                       (br $do-once)
@@ -6601,8 +6606,8 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $5)
-                  (tee_local $1
+                  (get_local $4)
+                  (tee_local $0
                     (i32.load
                       (i32.const 1224)
                     )
@@ -6611,15 +6616,15 @@
                 (call $qa)
               )
               (i32.store offset=24
-                (get_local $5)
-                (get_local $10)
+                (get_local $4)
+                (get_local $11)
               )
               (if
-                (tee_local $4
+                (tee_local $1
                   (i32.load
-                    (tee_local $3
+                    (tee_local $7
                       (i32.add
-                        (get_local $0)
+                        (get_local $3)
                         (i32.const 16)
                       )
                     )
@@ -6627,31 +6632,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $4)
                     (get_local $1)
+                    (get_local $0)
                   )
                   (call $qa)
                   (block
                     (i32.store offset=16
-                      (get_local $5)
                       (get_local $4)
+                      (get_local $1)
                     )
                     (i32.store offset=24
+                      (get_local $1)
                       (get_local $4)
-                      (get_local $5)
                     )
                   )
                 )
               )
               (if
-                (tee_local $4
+                (tee_local $1
                   (i32.load offset=4
-                    (get_local $3)
+                    (get_local $7)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $4)
+                    (get_local $1)
                     (i32.load
                       (i32.const 1224)
                     )
@@ -6659,26 +6664,26 @@
                   (call $qa)
                   (block
                     (i32.store offset=20
-                      (get_local $5)
                       (get_local $4)
+                      (get_local $1)
                     )
                     (i32.store offset=24
+                      (get_local $1)
                       (get_local $4)
-                      (get_local $5)
                     )
                     (set_local $2
-                      (get_local $0)
+                      (get_local $3)
                     )
-                    (set_local $7
+                    (set_local $5
                       (get_local $6)
                     )
                   )
                 )
                 (block
                   (set_local $2
-                    (get_local $0)
+                    (get_local $3)
                   )
-                  (set_local $7
+                  (set_local $5
                     (get_local $6)
                   )
                 )
@@ -6686,9 +6691,9 @@
             )
             (block
               (set_local $2
-                (get_local $0)
+                (get_local $3)
               )
-              (set_local $7
+              (set_local $5
                 (get_local $6)
               )
             )
@@ -6737,19 +6742,19 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $7)
+            (get_local $5)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $7)
+            (get_local $5)
           )
-          (get_local $7)
+          (get_local $5)
         )
         (set_local $0
-          (get_local $7)
+          (get_local $5)
         )
       )
       (block
@@ -6763,12 +6768,12 @@
           (block
             (i32.store
               (i32.const 1220)
-              (tee_local $5
+              (tee_local $4
                 (i32.add
                   (i32.load
                     (i32.const 1220)
                   )
-                  (get_local $7)
+                  (get_local $5)
                 )
               )
             )
@@ -6779,7 +6784,7 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $5)
+                (get_local $4)
                 (i32.const 1)
               )
             )
@@ -6813,12 +6818,12 @@
           (block
             (i32.store
               (i32.const 1216)
-              (tee_local $5
+              (tee_local $4
                 (i32.add
                   (i32.load
                     (i32.const 1216)
                   )
-                  (get_local $7)
+                  (get_local $5)
                 )
               )
             )
@@ -6829,27 +6834,27 @@
             (i32.store offset=4
               (get_local $2)
               (i32.or
-                (get_local $5)
+                (get_local $4)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $2)
-                (get_local $5)
+                (get_local $4)
               )
-              (get_local $5)
+              (get_local $4)
             )
             (return)
           )
         )
-        (set_local $5
+        (set_local $4
           (i32.add
             (i32.and
               (get_local $1)
               (i32.const -8)
             )
-            (get_local $7)
+            (get_local $5)
           )
         )
         (set_local $14
@@ -6865,19 +6870,19 @@
               (i32.const 256)
             )
             (block
-              (set_local $3
+              (set_local $9
                 (i32.load offset=12
                   (get_local $8)
                 )
               )
               (if
                 (i32.ne
-                  (tee_local $12
+                  (tee_local $7
                     (i32.load offset=8
                       (get_local $8)
                     )
                   )
-                  (tee_local $4
+                  (tee_local $1
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
@@ -6893,7 +6898,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $12)
+                      (get_local $7)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6903,7 +6908,7 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $12)
+                        (get_local $7)
                       )
                       (get_local $8)
                     )
@@ -6913,8 +6918,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $3)
-                  (get_local $12)
+                  (get_local $9)
+                  (get_local $7)
                 )
                 (block
                   (i32.store
@@ -6937,19 +6942,19 @@
               )
               (if
                 (i32.eq
-                  (get_local $3)
-                  (get_local $4)
+                  (get_local $9)
+                  (get_local $1)
                 )
                 (set_local $17
                   (i32.add
-                    (get_local $3)
+                    (get_local $9)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $3)
+                      (get_local $9)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6959,9 +6964,9 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $4
+                        (tee_local $1
                           (i32.add
-                            (get_local $3)
+                            (get_local $9)
                             (i32.const 8)
                           )
                         )
@@ -6969,23 +6974,23 @@
                       (get_local $8)
                     )
                     (set_local $17
-                      (get_local $4)
+                      (get_local $1)
                     )
                     (call $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $12)
-                (get_local $3)
+                (get_local $7)
+                (get_local $9)
               )
               (i32.store
                 (get_local $17)
-                (get_local $12)
+                (get_local $7)
               )
             )
             (block
-              (set_local $12
+              (set_local $7
                 (i32.load offset=24
                   (get_local $8)
                 )
@@ -6993,7 +6998,7 @@
               (block $do-once6
                 (if
                   (i32.eq
-                    (tee_local $3
+                    (tee_local $9
                       (i32.load offset=12
                         (get_local $8)
                       )
@@ -7002,11 +7007,11 @@
                   )
                   (block
                     (if
-                      (tee_local $9
+                      (tee_local $10
                         (i32.load
-                          (tee_local $1
+                          (tee_local $0
                             (i32.add
-                              (tee_local $4
+                              (tee_local $1
                                 (i32.add
                                   (get_local $8)
                                   (i32.const 16)
@@ -7018,23 +7023,24 @@
                         )
                       )
                       (block
-                        (set_local $0
-                          (get_local $9)
+                        (set_local $5
+                          (get_local $10)
                         )
-                        (set_local $4
-                          (get_local $1)
+                        (set_local $1
+                          (get_local $0)
                         )
                       )
                       (if
-                        (i32.eqz
-                          (tee_local $0
-                            (i32.load
-                              (get_local $4)
-                            )
+                        (tee_local $0
+                          (i32.load
+                            (get_local $1)
                           )
                         )
+                        (set_local $5
+                          (get_local $0)
+                        )
                         (block
-                          (set_local $11
+                          (set_local $12
                             (i32.const 0)
                           )
                           (br $do-once6)
@@ -7043,43 +7049,43 @@
                     )
                     (loop $while-in9
                       (if
-                        (tee_local $9
+                        (tee_local $10
                           (i32.load
-                            (tee_local $1
+                            (tee_local $0
                               (i32.add
-                                (get_local $0)
+                                (get_local $5)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $0
-                            (get_local $9)
+                          (set_local $5
+                            (get_local $10)
                           )
-                          (set_local $4
-                            (get_local $1)
+                          (set_local $1
+                            (get_local $0)
                           )
                           (br $while-in9)
                         )
                       )
                       (if
-                        (tee_local $9
+                        (tee_local $10
                           (i32.load
-                            (tee_local $1
+                            (tee_local $0
                               (i32.add
-                                (get_local $0)
+                                (get_local $5)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $0
-                            (get_local $9)
+                          (set_local $5
+                            (get_local $10)
                           )
-                          (set_local $4
-                            (get_local $1)
+                          (set_local $1
+                            (get_local $0)
                           )
                           (br $while-in9)
                         )
@@ -7087,7 +7093,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $4)
+                        (get_local $1)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7095,11 +7101,11 @@
                       (call $qa)
                       (block
                         (i32.store
-                          (get_local $4)
+                          (get_local $1)
                           (i32.const 0)
                         )
-                        (set_local $11
-                          (get_local $0)
+                        (set_local $12
+                          (get_local $5)
                         )
                       )
                     )
@@ -7107,7 +7113,7 @@
                   (block
                     (if
                       (i32.lt_u
-                        (tee_local $1
+                        (tee_local $0
                           (i32.load offset=8
                             (get_local $8)
                           )
@@ -7121,9 +7127,9 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (tee_local $9
+                          (tee_local $10
                             (i32.add
-                              (get_local $1)
+                              (get_local $0)
                               (i32.const 12)
                             )
                           )
@@ -7135,9 +7141,9 @@
                     (if
                       (i32.eq
                         (i32.load
-                          (tee_local $4
+                          (tee_local $1
                             (i32.add
-                              (get_local $3)
+                              (get_local $9)
                               (i32.const 8)
                             )
                           )
@@ -7146,15 +7152,15 @@
                       )
                       (block
                         (i32.store
+                          (get_local $10)
                           (get_local $9)
-                          (get_local $3)
                         )
                         (i32.store
-                          (get_local $4)
                           (get_local $1)
+                          (get_local $0)
                         )
-                        (set_local $11
-                          (get_local $3)
+                        (set_local $12
+                          (get_local $9)
                         )
                       )
                       (call $qa)
@@ -7163,7 +7169,7 @@
                 )
               )
               (if
-                (get_local $12)
+                (get_local $7)
                 (block
                   (if
                     (i32.eq
@@ -7173,7 +7179,7 @@
                           (i32.add
                             (i32.const 1512)
                             (i32.shl
-                              (tee_local $3
+                              (tee_local $9
                                 (i32.load offset=28
                                   (get_local $8)
                                 )
@@ -7187,11 +7193,11 @@
                     (block
                       (i32.store
                         (get_local $6)
-                        (get_local $11)
+                        (get_local $12)
                       )
                       (if
                         (i32.eqz
-                          (get_local $11)
+                          (get_local $12)
                         )
                         (block
                           (i32.store
@@ -7203,7 +7209,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $3)
+                                  (get_local $9)
                                 )
                                 (i32.const -1)
                               )
@@ -7216,7 +7222,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $12)
+                          (get_local $7)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -7226,9 +7232,9 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (tee_local $3
+                            (tee_local $9
                               (i32.add
-                                (get_local $12)
+                                (get_local $7)
                                 (i32.const 16)
                               )
                             )
@@ -7236,25 +7242,25 @@
                           (get_local $8)
                         )
                         (i32.store
-                          (get_local $3)
-                          (get_local $11)
+                          (get_local $9)
+                          (get_local $12)
                         )
                         (i32.store offset=20
+                          (get_local $7)
                           (get_local $12)
-                          (get_local $11)
                         )
                       )
                       (br_if $do-once4
                         (i32.eqz
-                          (get_local $11)
+                          (get_local $12)
                         )
                       )
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $11)
-                      (tee_local $3
+                      (get_local $12)
+                      (tee_local $9
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7263,11 +7269,11 @@
                     (call $qa)
                   )
                   (i32.store offset=24
-                    (get_local $11)
                     (get_local $12)
+                    (get_local $7)
                   )
                   (if
-                    (tee_local $0
+                    (tee_local $3
                       (i32.load
                         (tee_local $6
                           (i32.add
@@ -7279,31 +7285,31 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $0)
                         (get_local $3)
+                        (get_local $9)
                       )
                       (call $qa)
                       (block
                         (i32.store offset=16
-                          (get_local $11)
-                          (get_local $0)
+                          (get_local $12)
+                          (get_local $3)
                         )
                         (i32.store offset=24
-                          (get_local $0)
-                          (get_local $11)
+                          (get_local $3)
+                          (get_local $12)
                         )
                       )
                     )
                   )
                   (if
-                    (tee_local $0
+                    (tee_local $3
                       (i32.load offset=4
                         (get_local $6)
                       )
                     )
                     (if
                       (i32.lt_u
-                        (get_local $0)
+                        (get_local $3)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7311,12 +7317,12 @@
                       (call $qa)
                       (block
                         (i32.store offset=20
-                          (get_local $11)
-                          (get_local $0)
+                          (get_local $12)
+                          (get_local $3)
                         )
                         (i32.store offset=24
-                          (get_local $0)
-                          (get_local $11)
+                          (get_local $3)
+                          (get_local $12)
                         )
                       )
                     )
@@ -7329,16 +7335,16 @@
         (i32.store offset=4
           (get_local $2)
           (i32.or
-            (get_local $5)
+            (get_local $4)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $2)
-            (get_local $5)
+            (get_local $4)
           )
-          (get_local $5)
+          (get_local $4)
         )
         (if
           (i32.eq
@@ -7350,17 +7356,17 @@
           (block
             (i32.store
               (i32.const 1216)
-              (get_local $5)
+              (get_local $4)
             )
             (return)
           )
           (set_local $0
-            (get_local $5)
+            (get_local $4)
           )
         )
       )
     )
-    (set_local $7
+    (set_local $5
       (i32.shr_u
         (get_local $0)
         (i32.const 3)
@@ -7377,7 +7383,7 @@
             (i32.const 1248)
             (i32.shl
               (i32.shl
-                (get_local $7)
+                (get_local $5)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -7391,10 +7397,10 @@
                 (i32.const 1208)
               )
             )
-            (tee_local $5
+            (tee_local $4
               (i32.shl
                 (i32.const 1)
-                (get_local $7)
+                (get_local $5)
               )
             )
           )
@@ -7402,7 +7408,7 @@
             (i32.lt_u
               (tee_local $6
                 (i32.load
-                  (tee_local $5
+                  (tee_local $4
                     (i32.add
                       (get_local $1)
                       (i32.const 8)
@@ -7417,7 +7423,7 @@
             (call $qa)
             (block
               (set_local $15
-                (get_local $5)
+                (get_local $4)
               )
               (set_local $13
                 (get_local $6)
@@ -7429,7 +7435,7 @@
               (i32.const 1208)
               (i32.or
                 (get_local $6)
-                (get_local $5)
+                (get_local $4)
               )
             )
             (set_local $15
@@ -7462,11 +7468,11 @@
         (return)
       )
     )
-    (set_local $5
+    (set_local $4
       (i32.add
         (i32.const 1512)
         (i32.shl
-          (tee_local $7
+          (tee_local $5
             (if i32
               (tee_local $1
                 (i32.shr_u
@@ -7485,7 +7491,7 @@
                     (i32.shr_u
                       (get_local $0)
                       (i32.add
-                        (tee_local $5
+                        (tee_local $4
                           (i32.add
                             (i32.sub
                               (i32.const 14)
@@ -7555,7 +7561,7 @@
                     (i32.const 1)
                   )
                   (i32.shl
-                    (get_local $5)
+                    (get_local $4)
                     (i32.const 1)
                   )
                 )
@@ -7569,7 +7575,7 @@
     )
     (i32.store offset=28
       (get_local $2)
-      (get_local $7)
+      (get_local $5)
     )
     (i32.store offset=20
       (get_local $2)
@@ -7589,7 +7595,7 @@
         (tee_local $6
           (i32.shl
             (i32.const 1)
-            (get_local $7)
+            (get_local $5)
           )
         )
       )
@@ -7602,12 +7608,12 @@
               (i32.sub
                 (i32.const 25)
                 (i32.shr_u
-                  (get_local $7)
+                  (get_local $5)
                   (i32.const 1)
                 )
               )
               (i32.eq
-                (get_local $7)
+                (get_local $5)
                 (i32.const 31)
               )
             )
@@ -7615,7 +7621,7 @@
         )
         (set_local $1
           (i32.load
-            (get_local $5)
+            (get_local $4)
           )
         )
         (loop $while-in15
@@ -7641,9 +7647,9 @@
               )
             )
             (if
-              (tee_local $11
+              (tee_local $12
                 (i32.load
-                  (tee_local $7
+                  (tee_local $5
                     (i32.add
                       (i32.add
                         (get_local $1)
@@ -7668,13 +7674,13 @@
                   )
                 )
                 (set_local $1
-                  (get_local $11)
+                  (get_local $12)
                 )
                 (br $while-in15)
               )
               (block
                 (set_local $18
-                  (get_local $7)
+                  (get_local $5)
                 )
                 (set_local $19
                   (get_local $1)
@@ -7783,12 +7789,12 @@
           )
         )
         (i32.store
-          (get_local $5)
+          (get_local $4)
           (get_local $2)
         )
         (i32.store offset=24
           (get_local $2)
-          (get_local $5)
+          (get_local $4)
         )
         (i32.store offset=12
           (get_local $2)

--- a/test/passes/coalesce-locals.txt
+++ b/test/passes/coalesce-locals.txt
@@ -4,7 +4,9 @@
   (type $2 (func))
   (type $3 (func (param i32 f32)))
   (type $4 (func (param i32)))
+  (type $FUNCSIG$i (func (result i32)))
   (import "env" "_emscripten_autodebug_i32" (func $_emscripten_autodebug_i32 (param i32 i32) (result i32)))
+  (import "env" "get" (func $get (result i32)))
   (memory $0 10)
   (func $nothing-to-do (type $2)
     (local $0 i32)
@@ -938,6 +940,40 @@
       (i32.store
         (unreachable)
         (unreachable)
+      )
+    )
+  )
+  (func $loop-backedge (type $2)
+    (local $0 i32)
+    (local $1 i32)
+    (set_local $1
+      (i32.const 2)
+    )
+    (block $out
+      (loop $while-in7
+        (set_local $0
+          (i32.add
+            (get_local $1)
+            (i32.const 1)
+          )
+        )
+        (br_if $out
+          (i32.eqz
+            (i32.rem_s
+              (i32.const 1000)
+              (get_local $1)
+            )
+          )
+        )
+        (br_if $out
+          (i32.eqz
+            (get_local $0)
+          )
+        )
+        (set_local $1
+          (get_local $0)
+        )
+        (br $while-in7)
       )
     )
   )

--- a/test/passes/coalesce-locals.txt
+++ b/test/passes/coalesce-locals.txt
@@ -970,28 +970,9 @@
           (set_local $1
             (get_local $0)
           )
-          (if
-            (call $get)
-            (set_local $1
-              (get_local $0)
-            )
-            (set_local $1
-              (get_local $0)
-            )
-          )
         )
         (br_if $out
           (get_local $1)
-        )
-        (if
-          (call $get)
-          (block $block
-            (set_local $0
-              (i32.const 200)
-            )
-            (nop)
-            (br $while-in7)
-          )
         )
         (set_local $0
           (i32.const 100)

--- a/test/passes/coalesce-locals.txt
+++ b/test/passes/coalesce-locals.txt
@@ -5,8 +5,10 @@
   (type $3 (func (param i32 f32)))
   (type $4 (func (param i32)))
   (type $FUNCSIG$i (func (result i32)))
+  (type $FUNCSIG$vi (func (param i32)))
   (import "env" "_emscripten_autodebug_i32" (func $_emscripten_autodebug_i32 (param i32 i32) (result i32)))
   (import "env" "get" (func $get (result i32)))
+  (import "env" "set" (func $set (param i32)))
   (memory $0 10)
   (func $nothing-to-do (type $2)
     (local $0 i32)
@@ -946,33 +948,55 @@
   (func $loop-backedge (type $2)
     (local $0 i32)
     (local $1 i32)
-    (set_local $1
+    (set_local $0
       (i32.const 2)
     )
     (block $out
       (loop $while-in7
+        (set_local $1
+          (i32.const 0)
+        )
+        (call $set
+          (get_local $1)
+        )
         (set_local $0
           (i32.add
-            (get_local $1)
+            (get_local $0)
             (i32.const 1)
           )
         )
-        (br_if $out
-          (i32.eqz
-            (i32.rem_s
-              (i32.const 1000)
-              (get_local $1)
+        (if
+          (call $get)
+          (set_local $1
+            (get_local $0)
+          )
+          (if
+            (call $get)
+            (set_local $1
+              (get_local $0)
+            )
+            (set_local $1
+              (get_local $0)
             )
           )
         )
         (br_if $out
-          (i32.eqz
-            (get_local $0)
+          (get_local $1)
+        )
+        (if
+          (call $get)
+          (block $block
+            (set_local $0
+              (i32.const 200)
+            )
+            (nop)
+            (br $while-in7)
           )
         )
-        (set_local $1
-          (get_local $0)
+        (set_local $0
+          (i32.const 100)
         )
+        (nop)
         (br $while-in7)
       )
     )

--- a/test/passes/coalesce-locals.wast
+++ b/test/passes/coalesce-locals.wast
@@ -985,21 +985,10 @@
         )
         (if (call $get)
           (set_local $2 (get_local $1)) ;; copy for 1/2
-          (if (call $get)
-            (set_local $2 (get_local $1)) ;; another
-            (set_local $2 (get_local $1)) ;; another, total 3
-          )
         )
         (br_if $out (get_local $2))
-        (if (call $get)
-          (block
-            (set_local $1 (i32.const 200))
-            (set_local $0 (get_local $1)) ;; one copy for 0/1, on a backedge, so expensive and best avoided
-            (br $while-in7)
-          )
-        )
         (set_local $1 (i32.const 100))
-        (set_local $0 (get_local $1)) ;; another, total 2, with double-weighting 4 (> 3)
+        (set_local $0 (get_local $1)) ;; copy for 1/0, with extra weight should win the tie
         (br $while-in7)
       )
     )

--- a/test/passes/coalesce-locals.wast
+++ b/test/passes/coalesce-locals.wast
@@ -6,6 +6,7 @@
   (type $3 (func (param i32 f32)))
   (type $4 (func (param i32)))
   (import $_emscripten_autodebug_i32 "env" "_emscripten_autodebug_i32" (param i32 i32) (result i32))
+  (import $get "env" "get" (result i32))
   (func $nothing-to-do (type $2)
     (local $x i32)
     (nop)
@@ -961,6 +962,40 @@
       (i32.store
         (get_local $x)
         (tee_local $x (i32.const 0))
+      )
+    )
+  )
+  (func $loop-backedge
+    (local $0 i32)
+    (local $1 i32)
+    (set_local $0
+      (i32.const 2)
+    )
+    (block $out
+      (loop $while-in7
+        (set_local $1
+          (i32.add
+            (get_local $0)
+            (i32.const 1)
+          )
+        )
+        (br_if $out
+          (i32.eqz
+            (i32.rem_s
+              (i32.const 1000)
+              (get_local $0)
+            )
+          )
+        )
+        (br_if $out
+          (i32.eqz
+            (get_local $1)
+          )
+        )
+        (set_local $0
+          (get_local $1)
+        )
+        (br $while-in7)
       )
     )
   )


### PR DESCRIPTION
Working harder to remove copies on backedges to loops helps both on code size (often such a copy ends up requiring a branch for) and performance (as noticed when comparing to asm.js, where the js optimizer has a special "loop variable" hack for this).