### PR TITLE
Optimize to i64.store[less]

### DIFF
--- a/test/passes/optimize-instructions.txt
+++ b/test/passes/optimize-instructions.txt
@@ -289,6 +289,18 @@
         (i32.const 65534)
       )
     )
+    (i64.store8
+      (i32.const 11)
+      (i64.const 1)
+    )
+    (i64.store16
+      (i32.const 11)
+      (i64.const 2)
+    )
+    (i64.store32
+      (i32.const 11)
+      (i64.const 3)
+    )
   )
   (func $and-neg1 (type $1)
     (drop

--- a/test/passes/optimize-instructions.wast
+++ b/test/passes/optimize-instructions.wast
@@ -269,7 +269,7 @@
     ;;
     (i32.store8 (i32.const 11) (i32.wrap/i64 (i64.const 1)))
     (i32.store16 (i32.const 11) (i32.wrap/i64 (i64.const 2)))
-    (i32.store32 (i32.const 11) (i32.wrap/i64 (i64.const 3)))
+    (i32.store (i32.const 11) (i32.wrap/i64 (i64.const 3)))
   )
   (func $and-neg1
     (drop (i32.and (i32.const 100) (i32.const -1)))

--- a/test/passes/optimize-instructions.wast
+++ b/test/passes/optimize-instructions.wast
@@ -266,6 +266,10 @@
     (i32.store8 (i32.const 9) (i32.and (i32.const -2) (i32.const 254)))
     (i32.store16 (i32.const 10) (i32.and (i32.const -3) (i32.const 65535)))
     (i32.store16 (i32.const 11) (i32.and (i32.const -4) (i32.const 65534)))
+    ;;
+    (i32.store8 (i32.const 11) (i32.wrap/i64 (i64.const 1)))
+    (i32.store16 (i32.const 11) (i32.wrap/i64 (i64.const 2)))
+    (i32.store32 (i32.const 11) (i32.wrap/i64 (i64.const 3)))
   )
   (func $and-neg1
     (drop (i32.and (i32.const 100) (i32.const -1)))


### PR DESCRIPTION
Avoids a wrap instruction when the store would wrap anyhow. See #789.