### PR TITLE
Create CMake install targets for libs and JS files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,12 @@ ELSE()
   ADD_LIBRARY(binaryen SHARED ${binaryen_SOURCES})
 ENDIF()
 TARGET_LINK_LIBRARIES(binaryen ${all_passes} wasm asmjs support)
+INSTALL(TARGETS binaryen DESTINATION lib)
+
+INSTALL(FILES src/binaryen-c.h DESTINATION include)
+INSTALL(FILES bin/wasm.js DESTINATION bin)
+INSTALL(FILES bin/binaryen.js DESTINATION bin)
+INSTALL(DIRECTORY src/js DESTINATION src)
 
 SET(wasm-shell_SOURCES
   src/tools/wasm-shell.cpp


### PR DESCRIPTION
This creates install rules for the binaryen shlib and the C header, as
well as for the various JS files (wasm.js and binaryen.js, as well as
those used by emscripten). It recreates in the install target the
current layout used by an in-tree build.