### PR TITLE
Update s2wasm for reordered call_indirect

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -896,9 +896,8 @@ class S2WasmBuilder {
         Name assign = getAssign();
         int num = getNumInputs();
         auto inputs = getInputs(num);
-        auto input = inputs.begin();
-        auto* target = *input;
-        std::vector<Expression*> operands(++input, inputs.end());
+        auto* target = *(inputs.end() - 1);
+        std::vector<Expression*> operands(inputs.begin(), inputs.end() - 1);
         auto* funcType = ensureFunctionType(getSig(type, operands), wasm);
         assert(type == funcType->result);
         auto* indirect = builder.makeCallIndirect(funcType, target, std::move(operands));

--- a/test/dot_s/bcp-1.s
+++ b/test/dot_s/bcp-1.s
@@ -263,25 +263,25 @@ main:                                   # @main
 	i32.load	$1=, bad_t1($0)
 	i32.const	$2=, 1
 	block
-	i32.call_indirect	$push12=, $1, $2
+	i32.call_indirect	$push12=, $2, $1
 	br_if   	0, $pop12       # 0: down to label1
 # BB#7:                                 # %for.cond1
 	i32.load	$push13=, bad_t1+4($0)
-	i32.call_indirect	$push14=, $pop13, $2
+	i32.call_indirect	$push14=, $2, $pop13
 	br_if   	0, $pop14       # 0: down to label1
 # BB#8:                                 # %for.cond1.1
 	i32.load	$push15=, bad_t1+8($0)
-	i32.call_indirect	$push16=, $pop15, $2
+	i32.call_indirect	$push16=, $2, $pop15
 	br_if   	0, $pop16       # 0: down to label1
 # BB#9:                                 # %for.cond1.2
 	i32.load	$1=, bad_t2($0)
 	i32.const	$2=, .L.str
 	block
-	i32.call_indirect	$push17=, $1, $2
+	i32.call_indirect	$push17=, $2, $1
 	br_if   	0, $pop17       # 0: down to label2
 # BB#10:                                # %for.cond12
 	i32.load	$push18=, bad_t2+4($0)
-	i32.call_indirect	$push19=, $pop18, $2
+	i32.call_indirect	$push19=, $2, $pop18
 	br_if   	0, $pop19       # 0: down to label2
 # BB#11:                                # %for.cond12.1
 	block

--- a/test/llvm_autogenerated/call.s
+++ b/test/llvm_autogenerated/call.s
@@ -92,14 +92,34 @@ call_indirect_i32:
 .Lfunc_end8:
 	.size	call_indirect_i32, .Lfunc_end8-call_indirect_i32
 
+	.globl	call_indirect_arg
+	.type	call_indirect_arg,@function
+call_indirect_arg:
+	.param  	i32, i32
+	call_indirect	$1, $0
+	return
+	.endfunc
+.Lfunc_end9:
+	.size	call_indirect_arg, .Lfunc_end9-call_indirect_arg
+
+	.globl	call_indirect_arg_2
+	.type	call_indirect_arg_2,@function
+call_indirect_arg_2:
+	.param  	i32, i32, i32
+	i32.call_indirect	$drop=, $1, $2, $0
+	return
+	.endfunc
+.Lfunc_end10:
+	.size	call_indirect_arg_2, .Lfunc_end10-call_indirect_arg_2
+
 	.globl	tail_call_void_nullary
 	.type	tail_call_void_nullary,@function
 tail_call_void_nullary:
 	call    	void_nullary@FUNCTION
 	return
 	.endfunc
-.Lfunc_end9:
-	.size	tail_call_void_nullary, .Lfunc_end9-tail_call_void_nullary
+.Lfunc_end11:
+	.size	tail_call_void_nullary, .Lfunc_end11-tail_call_void_nullary
 
 	.globl	fastcc_tail_call_void_nullary
 	.type	fastcc_tail_call_void_nullary,@function
@@ -107,8 +127,8 @@ fastcc_tail_call_void_nullary:
 	call    	void_nullary@FUNCTION
 	return
 	.endfunc
-.Lfunc_end10:
-	.size	fastcc_tail_call_void_nullary, .Lfunc_end10-fastcc_tail_call_void_nullary
+.Lfunc_end12:
+	.size	fastcc_tail_call_void_nullary, .Lfunc_end12-fastcc_tail_call_void_nullary
 
 	.globl	coldcc_tail_call_void_nullary
 	.type	coldcc_tail_call_void_nullary,@function
@@ -116,8 +136,8 @@ coldcc_tail_call_void_nullary:
 	call    	void_nullary@FUNCTION
 	return
 	.endfunc
-.Lfunc_end11:
-	.size	coldcc_tail_call_void_nullary, .Lfunc_end11-coldcc_tail_call_void_nullary
+.Lfunc_end13:
+	.size	coldcc_tail_call_void_nullary, .Lfunc_end13-coldcc_tail_call_void_nullary
 
 
 	.functype	i32_nullary, i32

--- a/test/llvm_autogenerated/call.wast
+++ b/test/llvm_autogenerated/call.wast
@@ -1,8 +1,9 @@
 (module
   (type $FUNCSIG$v (func))
   (type $FUNCSIG$i (func (result i32)))
-  (type $FUNCSIG$ii (func (param i32) (result i32)))
+  (type $FUNCSIG$vi (func (param i32)))
   (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+  (type $FUNCSIG$ii (func (param i32) (result i32)))
   (type $FUNCSIG$j (func (result i64)))
   (type $FUNCSIG$f (func (result f32)))
   (type $FUNCSIG$d (func (result f64)))
@@ -25,6 +26,8 @@
   (export "call_i32_binary" (func $call_i32_binary))
   (export "call_indirect_void" (func $call_indirect_void))
   (export "call_indirect_i32" (func $call_indirect_i32))
+  (export "call_indirect_arg" (func $call_indirect_arg))
+  (export "call_indirect_arg_2" (func $call_indirect_arg_2))
   (export "tail_call_void_nullary" (func $tail_call_void_nullary))
   (export "fastcc_tail_call_void_nullary" (func $fastcc_tail_call_void_nullary))
   (export "coldcc_tail_call_void_nullary" (func $coldcc_tail_call_void_nullary))
@@ -79,6 +82,23 @@
         (get_local $0)
       )
     )
+  )
+  (func $call_indirect_arg (param $0 i32) (param $1 i32)
+    (call_indirect $FUNCSIG$vi
+      (get_local $1)
+      (get_local $0)
+    )
+    (return)
+  )
+  (func $call_indirect_arg_2 (param $0 i32) (param $1 i32) (param $2 i32)
+    (drop
+      (call_indirect $FUNCSIG$iii
+        (get_local $1)
+        (get_local $2)
+        (get_local $0)
+      )
+    )
+    (return)
   )
   (func $tail_call_void_nullary
     (call $void_nullary)

--- a/test/llvm_autogenerated/irreducible-cfg.s
+++ b/test/llvm_autogenerated/irreducible-cfg.s
@@ -4,22 +4,21 @@
 	.type	test0,@function
 test0:
 	.param  	i32, i32, i32, i32
-	.local  	f64, i32, i32
-	i32.const	$5=, 0
+	.local  	f64, i32
 	block   	
 	block   	
-	i32.eqz 	$push18=, $2
-	br_if   	0, $pop18
+	br_if   	0, $2
+	i32.const	$2=, 0
+	i32.const	$5=, 1
+	br      	1
+.LBB0_3:
+	end_block
 	i32.const	$push0=, 3
 	i32.shl 	$push1=, $3, $pop0
 	i32.add 	$push2=, $0, $pop1
 	f64.load	$4=, 0($pop2):p2align=2
-	i32.const	$6=, 0
-	br      	1
-.LBB0_3:
-	end_block
-	i32.const	$6=, 1
-.LBB0_4:
+	i32.const	$5=, 0
+.LBB0_5:
 	end_block
 	loop    	
 	block   	
@@ -28,49 +27,49 @@ test0:
 	block   	
 	block   	
 	block   	
-	br_table 	$6, 2, 0, 3, 1, 1
-.LBB0_5:
+	br_table 	$5, 2, 0, 3, 1, 1
+.LBB0_6:
 	end_block
-	i32.ge_s	$push3=, $5, $1
+	i32.ge_s	$push3=, $2, $1
 	br_if   	4, $pop3
-	i32.const	$6=, 3
+	i32.const	$5=, 3
 	br      	5
-.LBB0_7:
+.LBB0_8:
 	end_block
 	i32.const	$push4=, 3
-	i32.shl 	$push5=, $5, $pop4
+	i32.shl 	$push5=, $2, $pop4
 	i32.add 	$push17=, $0, $pop5
-	tee_local	$push16=, $2=, $pop17
-	f64.load	$push6=, 0($2):p2align=2
+	tee_local	$push16=, $3=, $pop17
+	f64.load	$push6=, 0($3):p2align=2
 	f64.const	$push7=, 0x1.2666666666666p1
 	f64.mul 	$push15=, $pop6, $pop7
 	tee_local	$push14=, $4=, $pop15
 	f64.store	0($pop16):p2align=2, $pop14
-	i32.const	$6=, 0
+	i32.const	$5=, 0
 	br      	4
-.LBB0_9:
+.LBB0_10:
 	end_block
 	i32.const	$push10=, 3
-	i32.shl 	$push11=, $5, $pop10
+	i32.shl 	$push11=, $2, $pop10
 	i32.add 	$push12=, $0, $pop11
 	f64.const	$push8=, 0x1.4cccccccccccdp0
 	f64.add 	$push9=, $4, $pop8
 	f64.store	0($pop12):p2align=2, $pop9
 	i32.const	$push13=, 1
-	i32.add 	$5=, $5, $pop13
+	i32.add 	$2=, $2, $pop13
 	br      	1
-.LBB0_10:
-	end_block
-	return
 .LBB0_11:
 	end_block
-	i32.const	$6=, 1
-	br      	1
+	return
 .LBB0_12:
 	end_block
-	i32.const	$6=, 2
-	br      	0
+	i32.const	$5=, 1
+	br      	1
 .LBB0_13:
+	end_block
+	i32.const	$5=, 2
+	br      	0
+.LBB0_14:
 	end_loop
 	.endfunc
 .Lfunc_end0:
@@ -80,22 +79,21 @@ test0:
 	.type	test1,@function
 test1:
 	.param  	i32, i32, i32, i32
-	.local  	f64, i32, i32
-	i32.const	$5=, 0
+	.local  	f64, i32
 	block   	
 	block   	
-	i32.eqz 	$push23=, $2
-	br_if   	0, $pop23
+	br_if   	0, $2
+	i32.const	$3=, 0
+	i32.const	$5=, 1
+	br      	1
+.LBB1_3:
+	end_block
 	i32.const	$push0=, 3
 	i32.shl 	$push1=, $3, $pop0
 	i32.add 	$push2=, $0, $pop1
 	f64.load	$4=, 0($pop2):p2align=2
-	i32.const	$6=, 0
-	br      	1
-.LBB1_3:
-	end_block
-	i32.const	$6=, 1
-.LBB1_4:
+	i32.const	$5=, 0
+.LBB1_5:
 	end_block
 	loop    	
 	block   	
@@ -106,17 +104,17 @@ test1:
 	block   	
 	block   	
 	block   	
-	br_table 	$6, 3, 0, 4, 1, 2, 2
-.LBB1_5:
+	br_table 	$5, 3, 0, 4, 1, 2, 2
+.LBB1_6:
 	end_block
-	i32.ge_s	$push3=, $5, $1
+	i32.ge_s	$push3=, $3, $1
 	br_if   	6, $pop3
-	i32.const	$6=, 3
+	i32.const	$5=, 3
 	br      	7
-.LBB1_7:
+.LBB1_8:
 	end_block
 	i32.const	$push4=, 3
-	i32.shl 	$push5=, $5, $pop4
+	i32.shl 	$push5=, $3, $pop4
 	i32.add 	$push18=, $0, $pop5
 	tee_local	$push17=, $2=, $pop18
 	f64.load	$push6=, 0($2):p2align=2
@@ -125,9 +123,9 @@ test1:
 	tee_local	$push15=, $4=, $pop16
 	f64.store	0($pop17):p2align=2, $pop15
 	i32.const	$2=, 0
-	i32.const	$6=, 4
+	i32.const	$5=, 4
 	br      	6
-.LBB1_9:
+.LBB1_10:
 	end_block
 	i32.const	$push22=, 1
 	i32.add 	$push21=, $2, $pop22
@@ -135,35 +133,35 @@ test1:
 	i32.const	$push19=, 256
 	i32.lt_s	$push8=, $pop20, $pop19
 	br_if   	3, $pop8
-	i32.const	$6=, 0
+	i32.const	$5=, 0
 	br      	5
-.LBB1_11:
+.LBB1_12:
 	end_block
 	i32.const	$push11=, 3
-	i32.shl 	$push12=, $5, $pop11
+	i32.shl 	$push12=, $3, $pop11
 	i32.add 	$push13=, $0, $pop12
 	f64.const	$push9=, 0x1.4cccccccccccdp0
 	f64.add 	$push10=, $4, $pop9
 	f64.store	0($pop13):p2align=2, $pop10
 	i32.const	$push14=, 1
-	i32.add 	$5=, $5, $pop14
+	i32.add 	$3=, $3, $pop14
 	br      	1
-.LBB1_12:
-	end_block
-	return
 .LBB1_13:
 	end_block
-	i32.const	$6=, 1
-	br      	2
+	return
 .LBB1_14:
 	end_block
-	i32.const	$6=, 4
-	br      	1
+	i32.const	$5=, 1
+	br      	2
 .LBB1_15:
 	end_block
-	i32.const	$6=, 2
-	br      	0
+	i32.const	$5=, 4
+	br      	1
 .LBB1_16:
+	end_block
+	i32.const	$5=, 2
+	br      	0
+.LBB1_17:
 	end_loop
 	.endfunc
 .Lfunc_end1:

--- a/test/llvm_autogenerated/irreducible-cfg.wast
+++ b/test/llvm_autogenerated/irreducible-cfg.wast
@@ -7,35 +7,32 @@
   (func $test0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
     (local $4 f64)
     (local $5 i32)
-    (local $6 i32)
-    (set_local $5
-      (i32.const 0)
-    )
     (block $label$0
       (block $label$1
         (br_if $label$1
-          (i32.eqz
-            (get_local $2)
-          )
+          (get_local $2)
         )
-        (set_local $4
-          (f64.load align=4
-            (i32.add
-              (get_local $0)
-              (i32.shl
-                (get_local $3)
-                (i32.const 3)
-              )
-            )
-          )
-        )
-        (set_local $6
+        (set_local $2
           (i32.const 0)
+        )
+        (set_local $5
+          (i32.const 1)
         )
         (br $label$0)
       )
-      (set_local $6
-        (i32.const 1)
+      (set_local $4
+        (f64.load align=4
+          (i32.add
+            (get_local $0)
+            (i32.shl
+              (get_local $3)
+              (i32.const 3)
+            )
+          )
+        )
+      )
+      (set_local $5
+        (i32.const 0)
       )
     )
     (loop $label$2
@@ -46,26 +43,26 @@
               (block $label$7
                 (block $label$8
                   (br_table $label$6 $label$8 $label$5 $label$7 $label$7
-                    (get_local $6)
+                    (get_local $5)
                   )
                 )
                 (br_if $label$3
                   (i32.ge_s
-                    (get_local $5)
+                    (get_local $2)
                     (get_local $1)
                   )
                 )
-                (set_local $6
+                (set_local $5
                   (i32.const 3)
                 )
                 (br $label$2)
               )
               (f64.store align=4
-                (tee_local $2
+                (tee_local $3
                   (i32.add
                     (get_local $0)
                     (i32.shl
-                      (get_local $5)
+                      (get_local $2)
                       (i32.const 3)
                     )
                   )
@@ -73,13 +70,13 @@
                 (tee_local $4
                   (f64.mul
                     (f64.load align=4
-                      (get_local $2)
+                      (get_local $3)
                     )
                     (f64.const 2.3)
                   )
                 )
               )
-              (set_local $6
+              (set_local $5
                 (i32.const 0)
               )
               (br $label$2)
@@ -88,7 +85,7 @@
               (i32.add
                 (get_local $0)
                 (i32.shl
-                  (get_local $5)
+                  (get_local $2)
                   (i32.const 3)
                 )
               )
@@ -97,9 +94,9 @@
                 (f64.const 1.3)
               )
             )
-            (set_local $5
+            (set_local $2
               (i32.add
-                (get_local $5)
+                (get_local $2)
                 (i32.const 1)
               )
             )
@@ -107,12 +104,12 @@
           )
           (return)
         )
-        (set_local $6
+        (set_local $5
           (i32.const 1)
         )
         (br $label$2)
       )
-      (set_local $6
+      (set_local $5
         (i32.const 2)
       )
       (br $label$2)
@@ -121,35 +118,32 @@
   (func $test1 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
     (local $4 f64)
     (local $5 i32)
-    (local $6 i32)
-    (set_local $5
-      (i32.const 0)
-    )
     (block $label$0
       (block $label$1
         (br_if $label$1
-          (i32.eqz
-            (get_local $2)
-          )
+          (get_local $2)
         )
-        (set_local $4
-          (f64.load align=4
-            (i32.add
-              (get_local $0)
-              (i32.shl
-                (get_local $3)
-                (i32.const 3)
-              )
-            )
-          )
-        )
-        (set_local $6
+        (set_local $3
           (i32.const 0)
+        )
+        (set_local $5
+          (i32.const 1)
         )
         (br $label$0)
       )
-      (set_local $6
-        (i32.const 1)
+      (set_local $4
+        (f64.load align=4
+          (i32.add
+            (get_local $0)
+            (i32.shl
+              (get_local $3)
+              (i32.const 3)
+            )
+          )
+        )
+      )
+      (set_local $5
+        (i32.const 0)
       )
     )
     (loop $label$2
@@ -162,16 +156,16 @@
                   (block $label$9
                     (block $label$10
                       (br_table $label$7 $label$10 $label$6 $label$9 $label$8 $label$8
-                        (get_local $6)
+                        (get_local $5)
                       )
                     )
                     (br_if $label$3
                       (i32.ge_s
-                        (get_local $5)
+                        (get_local $3)
                         (get_local $1)
                       )
                     )
-                    (set_local $6
+                    (set_local $5
                       (i32.const 3)
                     )
                     (br $label$2)
@@ -181,7 +175,7 @@
                       (i32.add
                         (get_local $0)
                         (i32.shl
-                          (get_local $5)
+                          (get_local $3)
                           (i32.const 3)
                         )
                       )
@@ -198,7 +192,7 @@
                   (set_local $2
                     (i32.const 0)
                   )
-                  (set_local $6
+                  (set_local $5
                     (i32.const 4)
                   )
                   (br $label$2)
@@ -214,7 +208,7 @@
                     (i32.const 256)
                   )
                 )
-                (set_local $6
+                (set_local $5
                   (i32.const 0)
                 )
                 (br $label$2)
@@ -223,7 +217,7 @@
                 (i32.add
                   (get_local $0)
                   (i32.shl
-                    (get_local $5)
+                    (get_local $3)
                     (i32.const 3)
                   )
                 )
@@ -232,9 +226,9 @@
                   (f64.const 1.3)
                 )
               )
-              (set_local $5
+              (set_local $3
                 (i32.add
-                  (get_local $5)
+                  (get_local $3)
                   (i32.const 1)
                 )
               )
@@ -242,17 +236,17 @@
             )
             (return)
           )
-          (set_local $6
+          (set_local $5
             (i32.const 1)
           )
           (br $label$2)
         )
-        (set_local $6
+        (set_local $5
           (i32.const 4)
         )
         (br $label$2)
       )
-      (set_local $6
+      (set_local $5
         (i32.const 2)
       )
       (br $label$2)

--- a/test/llvm_autogenerated/load-store-i1.s
+++ b/test/llvm_autogenerated/load-store-i1.s
@@ -16,12 +16,12 @@ load_u_i1_i32:
 load_s_i1_i32:
 	.param  	i32
 	.result 	i32
+	i32.const	$push3=, 0
 	i32.load8_u	$push0=, 0($0)
-	i32.const	$push1=, 31
-	i32.shl 	$push2=, $pop0, $pop1
-	i32.const	$push4=, 31
-	i32.shr_s	$push3=, $pop2, $pop4
-	return  	$pop3
+	i32.const	$push1=, 1
+	i32.and 	$push2=, $pop0, $pop1
+	i32.sub 	$push4=, $pop3, $pop2
+	return  	$pop4
 	.endfunc
 .Lfunc_end1:
 	.size	load_s_i1_i32, .Lfunc_end1-load_s_i1_i32
@@ -42,12 +42,12 @@ load_u_i1_i64:
 load_s_i1_i64:
 	.param  	i32
 	.result 	i64
+	i64.const	$push3=, 0
 	i64.load8_u	$push0=, 0($0)
-	i64.const	$push1=, 63
-	i64.shl 	$push2=, $pop0, $pop1
-	i64.const	$push4=, 63
-	i64.shr_s	$push3=, $pop2, $pop4
-	return  	$pop3
+	i64.const	$push1=, 1
+	i64.and 	$push2=, $pop0, $pop1
+	i64.sub 	$push4=, $pop3, $pop2
+	return  	$pop4
 	.endfunc
 .Lfunc_end3:
 	.size	load_s_i1_i64, .Lfunc_end3-load_s_i1_i64

--- a/test/llvm_autogenerated/load-store-i1.wast
+++ b/test/llvm_autogenerated/load-store-i1.wast
@@ -17,14 +17,14 @@
   )
   (func $load_s_i1_i32 (param $0 i32) (result i32)
     (return
-      (i32.shr_s
-        (i32.shl
+      (i32.sub
+        (i32.const 0)
+        (i32.and
           (i32.load8_u
             (get_local $0)
           )
-          (i32.const 31)
+          (i32.const 1)
         )
-        (i32.const 31)
       )
     )
   )
@@ -37,14 +37,14 @@
   )
   (func $load_s_i1_i64 (param $0 i32) (result i64)
     (return
-      (i64.shr_s
-        (i64.shl
+      (i64.sub
+        (i64.const 0)
+        (i64.and
           (i64.load8_u
             (get_local $0)
           )
-          (i64.const 63)
+          (i64.const 1)
         )
-        (i64.const 63)
       )
     )
   )

--- a/test/llvm_autogenerated/reg-stackify.s
+++ b/test/llvm_autogenerated/reg-stackify.s
@@ -449,6 +449,22 @@ stackpointer_dependency:
 .Lfunc_end23:
 	.size	stackpointer_dependency, .Lfunc_end23-stackpointer_dependency
 
+	.globl	call_indirect_stackify
+	.type	call_indirect_stackify,@function
+call_indirect_stackify:
+.Lfunc_begin24:
+	.param  	i32, i32
+	.result 	i32
+	i32.load	$push4=, 0($0)
+	tee_local	$push3=, $0=, $pop4
+	i32.load	$push0=, 0($0)
+	i32.load	$push1=, 0($pop0)
+	i32.call_indirect	$push2=, $pop3, $1, $pop1
+	return  	$pop2
+	.endfunc
+.Lfunc_end24:
+	.size	call_indirect_stackify, .Lfunc_end24-call_indirect_stackify
+
 	.hidden	count
 	.type	count,@object
 	.bss

--- a/test/llvm_autogenerated/reg-stackify.wast
+++ b/test/llvm_autogenerated/reg-stackify.wast
@@ -1,8 +1,8 @@
 (module
+  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
   (type $FUNCSIG$i (func (result i32)))
   (type $FUNCSIG$ii (func (param i32) (result i32)))
   (type $FUNCSIG$v (func))
-  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
   (type $FUNCSIG$vii (func (param i32 i32)))
   (type $FUNCSIG$vi (func (param i32)))
   (import "env" "blue" (func $blue (result i32)))
@@ -45,6 +45,7 @@
   (export "no_stackify_past_epilogue" (func $no_stackify_past_epilogue))
   (export "stackify_indvar" (func $stackify_indvar))
   (export "stackpointer_dependency" (func $stackpointer_dependency))
+  (export "call_indirect_stackify" (func $call_indirect_stackify))
   (func $no0 (param $0 i32) (param $1 i32) (result i32)
     (set_local $1
       (i32.load
@@ -572,6 +573,23 @@
     )
     (return
       (get_local $0)
+    )
+  )
+  (func $call_indirect_stackify (param $0 i32) (param $1 i32) (result i32)
+    (return
+      (call_indirect $FUNCSIG$iii
+        (tee_local $0
+          (i32.load
+            (get_local $0)
+          )
+        )
+        (get_local $1)
+        (i32.load
+          (i32.load
+            (get_local $0)
+          )
+        )
+      )
     )
   )
 )

--- a/test/torture-s/20000224-1.c.s
+++ b/test/torture-s/20000224-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20000224-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20000224-1.c"
 	.section	.text.test,"ax",@progbits
 	.hidden	test
 	.globl	test
@@ -24,12 +24,12 @@ test:                                   # @test
 .LBB0_2:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label1:
-	i32.const	$push19=, 31
-	i32.shl 	$2=, $3, $pop19
+	i32.const	$push19=, 1
+	i32.and 	$2=, $3, $pop19
 	i32.const	$push18=, 1
 	i32.add 	$3=, $3, $pop18
-	i32.const	$push17=, 31
-	i32.shr_s	$push3=, $2, $pop17
+	i32.const	$push17=, 0
+	i32.sub 	$push3=, $pop17, $2
 	i32.const	$push16=, 0
 	i32.const	$push15=, 1
 	i32.lt_s	$push1=, $1, $pop15
@@ -94,5 +94,5 @@ flag:
 	.size	flag, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	exit, void, i32

--- a/test/torture-s/20000412-6.c.s
+++ b/test/torture-s/20000412-6.c.s
@@ -1,40 +1,34 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20000412-6.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20000412-6.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32
-# BB#0:                                 # %entry
-	i32.const	$1=, buf
-	i32.const	$0=, 512
-.LBB0_1:                                # %for.body.i
-                                        # =>This Inner Loop Header: Depth=1
-	loop    	                # label0:
-	i32.load16_u	$push0=, 0($1)
-	i32.sub 	$push1=, $0, $pop0
-	i32.const	$push10=, 65535
-	i32.and 	$0=, $pop1, $pop10
-	i32.const	$push9=, 2
-	i32.add 	$push8=, $1, $pop9
-	tee_local	$push7=, $1=, $pop8
-	i32.const	$push6=, buf+6
-	i32.lt_u	$push2=, $pop7, $pop6
-	br_if   	0, $pop2        # 0: up to label0
-# BB#2:                                 # %bug.exit
-	end_loop
+# BB#0:                                 # %bug.exit
 	block   	
-	i32.const	$push3=, 491
-	i32.ne  	$push4=, $0, $pop3
-	br_if   	0, $pop4        # 0: down to label1
-# BB#3:                                 # %if.end
-	i32.const	$push5=, 0
-	call    	exit@FUNCTION, $pop5
+	i32.const	$push1=, 512
+	i32.const	$push13=, 0
+	i32.load16_u	$push0=, buf($pop13)
+	i32.sub 	$push2=, $pop1, $pop0
+	i32.const	$push12=, 0
+	i32.load16_u	$push3=, buf+2($pop12)
+	i32.sub 	$push4=, $pop2, $pop3
+	i32.const	$push11=, 0
+	i32.load16_u	$push5=, buf+4($pop11)
+	i32.sub 	$push6=, $pop4, $pop5
+	i32.const	$push7=, 65535
+	i32.and 	$push8=, $pop6, $pop7
+	i32.const	$push9=, 491
+	i32.ne  	$push10=, $pop8, $pop9
+	br_if   	0, $pop10       # 0: down to label0
+# BB#1:                                 # %if.end
+	i32.const	$push14=, 0
+	call    	exit@FUNCTION, $pop14
 	unreachable
-.LBB0_4:                                # %if.then
-	end_block                       # label1:
+.LBB0_2:                                # %if.then
+	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -51,11 +45,11 @@ bug:                                    # @bug
 # BB#0:                                 # %entry
 	block   	
 	i32.ge_u	$push0=, $1, $2
-	br_if   	0, $pop0        # 0: down to label2
+	br_if   	0, $pop0        # 0: down to label1
 # BB#1:                                 # %for.body.preheader
 .LBB1_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label3:
+	loop    	                # label2:
 	i32.load16_u	$push1=, 0($1)
 	i32.sub 	$push2=, $0, $pop1
 	i32.const	$push7=, 65535
@@ -64,10 +58,10 @@ bug:                                    # @bug
 	i32.add 	$push5=, $1, $pop6
 	tee_local	$push4=, $1=, $pop5
 	i32.lt_u	$push3=, $pop4, $2
-	br_if   	0, $pop3        # 0: up to label3
+	br_if   	0, $pop3        # 0: up to label2
 .LBB1_3:                                # %for.end
 	end_loop
-	end_block                       # label2:
+	end_block                       # label1:
 	copy_local	$push8=, $0
                                         # fallthrough-return: $pop8
 	.endfunc
@@ -88,6 +82,6 @@ buf:
 	.size	buf, 10
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/20000815-1.c.s
+++ b/test/torture-s/20000815-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20000815-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20000815-1.c"
 	.section	.text.invalidate_memory,"ax",@progbits
 	.hidden	invalidate_memory
 	.globl	invalidate_memory
@@ -109,88 +109,148 @@ remove_from_table:                      # @remove_from_table
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$push10=, 0
 	i32.const	$push7=, 0
 	i32.load	$push8=, __stack_pointer($pop7)
 	i32.const	$push9=, 48
-	i32.sub 	$push24=, $pop8, $pop9
-	tee_local	$push23=, $3=, $pop24
-	i32.store	__stack_pointer($pop10), $pop23
+	i32.sub 	$push26=, $pop8, $pop9
+	tee_local	$push25=, $3=, $pop26
+	i32.store	__stack_pointer($pop10), $pop25
 	i32.const	$1=, 0
 	i32.const	$push14=, 8
 	i32.add 	$push15=, $3, $pop14
-	i32.const	$push22=, 0
+	i32.const	$push24=, 0
 	i32.const	$push0=, 40
-	i32.call	$drop=, memset@FUNCTION, $pop15, $pop22, $pop0
-	i32.const	$push21=, 0
+	i32.call	$drop=, memset@FUNCTION, $pop15, $pop24, $pop0
+	i32.const	$push23=, 0
 	i32.const	$push16=, 8
 	i32.add 	$push17=, $3, $pop16
-	i32.store	table($pop21), $pop17
-	i32.const	$push20=, 1
-	i32.store8	44($3), $pop20
+	i32.store	table($pop23), $pop17
+	i32.const	$push22=, 1
+	i32.store8	44($3), $pop22
+	block   	
+	block   	
 	i32.const	$push18=, 8
 	i32.add 	$push19=, $3, $pop18
-	copy_local	$2=, $pop19
-.LBB3_1:                                # %for.body.i
-                                        # =>This Loop Header: Depth=1
-                                        #     Child Loop BB3_2 Depth 2
+	copy_local	$push21=, $pop19
+	tee_local	$push20=, $2=, $pop21
+	br_if   	0, $pop20       # 0: down to label6
+# BB#1:
+	i32.const	$4=, 4
+	br      	1               # 1: down to label5
+.LBB3_2:
+	end_block                       # label6:
+	i32.const	$4=, 0
+.LBB3_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label5:
+	loop    	i32             # label7:
 	block   	
-	loop    	                # label6:
 	block   	
-	i32.eqz 	$push31=, $2
-	br_if   	0, $pop31       # 0: down to label7
-.LBB3_2:                                # %for.body6.i
-                                        #   Parent Loop BB3_1 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop    	                # label8:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$4, 1, 2, 6, 3, 4, 5, 0, 0 # 1: down to label18
+                                        # 2: down to label17
+                                        # 6: down to label13
+                                        # 3: down to label16
+                                        # 4: down to label15
+                                        # 5: down to label14
+                                        # 0: down to label19
+.LBB3_4:                                # %for.inc15.i.for.body.i_crit_edge
+                                        #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label19:
+	i32.const	$push30=, 2
+	i32.shl 	$push5=, $1, $pop30
+	i32.const	$push29=, table
+	i32.add 	$push6=, $pop5, $pop29
+	i32.load	$push28=, 0($pop6)
+	tee_local	$push27=, $2=, $pop28
+	i32.eqz 	$push35=, $pop27
+	br_if   	8, $pop35       # 8: down to label10
+# BB#5:                                 #   in Loop: Header=BB3_3 Depth=1
+	i32.const	$4=, 0
+	br      	11              # 11: up to label7
+.LBB3_6:                                # %for.body6.i
+                                        #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label18:
 	i32.load	$0=, 4($2)
-	block   	
 	i32.load8_u	$push1=, 36($2)
-	i32.eqz 	$push32=, $pop1
-	br_if   	0, $pop32       # 0: down to label9
-# BB#3:                                 # %land.lhs.true10.i
-                                        #   in Loop: Header=BB3_2 Depth=2
+	i32.eqz 	$push36=, $pop1
+	br_if   	5, $pop36       # 5: down to label12
+# BB#7:                                 #   in Loop: Header=BB3_3 Depth=1
+	i32.const	$4=, 1
+	br      	10              # 10: up to label7
+.LBB3_8:                                # %land.lhs.true10.i
+                                        #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label17:
 	i32.load8_u	$push2=, 37($2)
-	br_if   	4, $pop2        # 4: down to label5
-.LBB3_4:                                # %for.cond5.backedge.i
-                                        #   in Loop: Header=BB3_2 Depth=2
-	end_block                       # label9:
+	br_if   	7, $pop2        # 7: down to label9
+# BB#9:                                 #   in Loop: Header=BB3_3 Depth=1
+	i32.const	$4=, 3
+	br      	9               # 9: up to label7
+.LBB3_10:                               # %for.cond5.backedge.i
+                                        #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label16:
 	copy_local	$2=, $0
-	br_if   	0, $0           # 0: up to label8
-.LBB3_5:                                # %for.inc15.i
-                                        #   in Loop: Header=BB3_1 Depth=1
-	end_loop
-	end_block                       # label7:
-	block   	
-	i32.const	$push30=, 1
-	i32.add 	$push29=, $1, $pop30
-	tee_local	$push28=, $1=, $pop29
-	i32.const	$push27=, 30
-	i32.gt_s	$push3=, $pop28, $pop27
-	br_if   	0, $pop3        # 0: down to label10
-# BB#6:                                 # %for.inc15.i.for.body.i_crit_edge
-                                        #   in Loop: Header=BB3_1 Depth=1
-	i32.const	$push26=, 2
-	i32.shl 	$push5=, $1, $pop26
-	i32.const	$push25=, table
-	i32.add 	$push6=, $pop5, $pop25
-	i32.load	$2=, 0($pop6)
-	br      	1               # 1: up to label6
-.LBB3_7:                                # %invalidate_memory.exit
-	end_block                       # label10:
-	end_loop
+	br_if   	4, $0           # 4: down to label11
+# BB#11:                                #   in Loop: Header=BB3_3 Depth=1
+	i32.const	$4=, 4
+	br      	8               # 8: up to label7
+.LBB3_12:                               # %for.inc15.i
+                                        #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label15:
+	i32.const	$push34=, 1
+	i32.add 	$push33=, $1, $pop34
+	tee_local	$push32=, $1=, $pop33
+	i32.const	$push31=, 30
+	i32.le_s	$push3=, $pop32, $pop31
+	br_if   	6, $pop3        # 6: down to label8
+# BB#13:                                #   in Loop: Header=BB3_3 Depth=1
+	i32.const	$4=, 5
+	br      	7               # 7: up to label7
+.LBB3_14:                               # %invalidate_memory.exit
+	end_block                       # label14:
 	i32.const	$push13=, 0
 	i32.const	$push11=, 48
 	i32.add 	$push12=, $3, $pop11
 	i32.store	__stack_pointer($pop13), $pop12
 	i32.const	$push4=, 0
 	return  	$pop4
-.LBB3_8:                                # %if.then.i
-	end_block                       # label5:
+.LBB3_15:                               # %if.then.i
+	end_block                       # label13:
 	call    	remove_from_table@FUNCTION, $2, $2
 	unreachable
+.LBB3_16:                               #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label12:
+	i32.const	$4=, 3
+	br      	4               # 4: up to label7
+.LBB3_17:                               #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label11:
+	i32.const	$4=, 0
+	br      	3               # 3: up to label7
+.LBB3_18:                               #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label10:
+	i32.const	$4=, 4
+	br      	2               # 2: up to label7
+.LBB3_19:                               #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label9:
+	i32.const	$4=, 2
+	br      	1               # 1: up to label7
+.LBB3_20:                               #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label8:
+	i32.const	$4=, 6
+	br      	0               # 0: up to label7
+.LBB3_21:
+	end_loop
 	.endfunc
 .Lfunc_end3:
 	.size	main, .Lfunc_end3-main
@@ -203,5 +263,5 @@ table:
 	.size	table, 128
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/20001203-2.c.s
+++ b/test/torture-s/20001203-2.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20001203-2.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20001203-2.c"
 	.section	.text.create_array_type,"ax",@progbits
 	.hidden	create_array_type
 	.globl	create_array_type
@@ -11,8 +11,8 @@ create_array_type:                      # @create_array_type
 # BB#0:                                 # %entry
 	block   	
 	block   	
-	i32.eqz 	$push51=, $0
-	br_if   	0, $pop51       # 0: down to label1
+	i32.eqz 	$push52=, $0
+	br_if   	0, $pop52       # 0: down to label1
 # BB#1:                                 # %if.end
 	i32.const	$push0=, 1
 	i32.store16	8($0), $pop0
@@ -20,38 +20,37 @@ create_array_type:                      # @create_array_type
 	i32.const	$push2=, 3
 	i32.mul 	$push3=, $pop1, $pop2
 	i32.store	0($0), $pop3
-	i32.const	$7=, 0
 	block   	
-	i32.load	$push26=, 4($0)
-	tee_local	$push25=, $1=, $pop26
-	i32.eqz 	$push52=, $pop25
-	br_if   	0, $pop52       # 0: down to label2
+	i32.load	$push27=, 4($0)
+	tee_local	$push26=, $1=, $pop27
+	i32.eqz 	$push53=, $pop26
+	br_if   	0, $pop53       # 0: down to label2
 # BB#2:                                 # %cond.true
 	i32.const	$push4=, 20
 	i32.add 	$push5=, $1, $pop4
-	i32.load	$push33=, 0($pop5)
-	tee_local	$push32=, $2=, $pop33
-	i32.const	$push31=, 16
-	i32.add 	$push30=, $1, $pop31
-	tee_local	$push29=, $7=, $pop30
-	i32.load	$push28=, 0($pop29)
-	tee_local	$push27=, $3=, $pop28
-	i32.sub 	$push6=, $pop32, $pop27
+	i32.load	$push34=, 0($pop5)
+	tee_local	$push33=, $2=, $pop34
+	i32.const	$push32=, 16
+	i32.add 	$push31=, $1, $pop32
+	tee_local	$push30=, $4=, $pop31
+	i32.load	$push29=, 0($pop30)
+	tee_local	$push28=, $3=, $pop29
+	i32.sub 	$push6=, $pop33, $pop28
 	i32.const	$push7=, 15
 	i32.le_s	$push8=, $pop6, $pop7
 	br_if   	2, $pop8        # 2: down to label0
 # BB#3:                                 # %if.end9
-	i32.const	$push40=, 16
-	i32.add 	$push39=, $3, $pop40
-	tee_local	$push38=, $3=, $pop39
-	i32.store	0($7), $pop38
+	i32.const	$push41=, 16
+	i32.add 	$push40=, $3, $pop41
+	tee_local	$push39=, $3=, $pop40
+	i32.store	0($4), $pop39
 	block   	
 	i32.const	$push9=, 12
-	i32.add 	$push37=, $1, $pop9
-	tee_local	$push36=, $4=, $pop37
-	i32.load	$push35=, 0($pop36)
-	tee_local	$push34=, $7=, $pop35
-	i32.ne  	$push10=, $3, $pop34
+	i32.add 	$push38=, $1, $pop9
+	tee_local	$push37=, $4=, $pop38
+	i32.load	$push36=, 0($pop37)
+	tee_local	$push35=, $7=, $pop36
+	i32.ne  	$push10=, $3, $pop35
 	br_if   	0, $pop10       # 0: down to label3
 # BB#4:                                 # %if.then16
 	i32.const	$push11=, 28
@@ -61,32 +60,35 @@ create_array_type:                      # @create_array_type
 .LBB0_5:                                # %if.end17
 	end_block                       # label3:
 	i32.const	$push19=, 16
-	i32.add 	$push50=, $1, $pop19
-	tee_local	$push49=, $6=, $pop50
+	i32.add 	$push51=, $1, $pop19
+	tee_local	$push50=, $6=, $pop51
 	i32.const	$push14=, 24
 	i32.add 	$push15=, $1, $pop14
-	i32.load	$push48=, 0($pop15)
-	tee_local	$push47=, $5=, $pop48
-	i32.add 	$push18=, $pop47, $3
+	i32.load	$push49=, 0($pop15)
+	tee_local	$push48=, $5=, $pop49
+	i32.add 	$push18=, $pop48, $3
 	i32.const	$push16=, -1
 	i32.xor 	$push17=, $5, $pop16
-	i32.and 	$push46=, $pop18, $pop17
-	tee_local	$push45=, $3=, $pop46
-	i32.store	0($pop49), $pop45
+	i32.and 	$push47=, $pop18, $pop17
+	tee_local	$push46=, $3=, $pop47
+	i32.store	0($pop50), $pop46
 	i32.const	$push20=, 8
 	i32.add 	$push21=, $1, $pop20
-	i32.load	$push44=, 0($pop21)
-	tee_local	$push43=, $1=, $pop44
-	i32.sub 	$push22=, $3, $pop43
+	i32.load	$push45=, 0($pop21)
+	tee_local	$push44=, $1=, $pop45
+	i32.sub 	$push22=, $3, $pop44
 	i32.sub 	$push23=, $2, $1
 	i32.gt_s	$push24=, $pop22, $pop23
-	i32.select	$push42=, $2, $3, $pop24
-	tee_local	$push41=, $1=, $pop42
-	i32.store	0($6), $pop41
+	i32.select	$push43=, $2, $3, $pop24
+	tee_local	$push42=, $1=, $pop43
+	i32.store	0($6), $pop42
 	i32.store	0($4), $1
-.LBB0_6:                                # %cond.end
-	end_block                       # label2:
 	i32.store	12($0), $7
+	return  	$0
+.LBB0_6:
+	end_block                       # label2:
+	i32.const	$push25=, 0
+	i32.store	12($0), $pop25
 	return  	$0
 .LBB0_7:                                # %if.then
 	end_block                       # label1:
@@ -171,6 +173,6 @@ main:                                   # @main
 	.size	main, .Lfunc_end5-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/20010129-1.c.s
+++ b/test/torture-s/20010129-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20010129-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20010129-1.c"
 	.section	.text.baz1,"ax",@progbits
 	.hidden	baz1
 	.globl	baz1
@@ -65,96 +65,101 @@ baz3:                                   # @baz3
 foo:                                    # @foo
 	.param  	i32, i32, i32
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push29=, 0
 	i32.const	$push28=, 0
-	i32.load	$push27=, baz1.l($pop28)
-	tee_local	$push26=, $9=, $pop27
-	i32.const	$push25=, 1
-	i32.add 	$push4=, $pop26, $pop25
-	i32.store	baz1.l($pop29), $pop4
+	i32.const	$push27=, 0
+	i32.load	$push26=, baz1.l($pop27)
+	tee_local	$push25=, $11=, $pop26
+	i32.const	$push24=, 1
+	i32.add 	$push3=, $pop25, $pop24
+	i32.store	baz1.l($pop28), $pop3
 	block   	
 	block   	
-	i32.ge_s	$push5=, $9, $1
-	br_if   	0, $pop5        # 0: down to label2
+	i32.ge_s	$push4=, $11, $1
+	br_if   	0, $pop4        # 0: down to label2
 # BB#1:                                 # %if.then.lr.ph
-	i32.const	$push6=, 13834
-	i32.and 	$push7=, $2, $pop6
-	i32.const	$push36=, 0
-	i32.ne  	$push8=, $pop7, $pop36
-	i32.const	$push9=, 128
-	i32.and 	$push10=, $2, $pop9
-	i32.eqz 	$push11=, $pop10
+	i32.const	$push5=, 13834
+	i32.and 	$push6=, $2, $pop5
 	i32.const	$push35=, 0
-	i32.load	$push12=, bar($pop35)
-	i32.eqz 	$push13=, $pop12
-	i32.or  	$push34=, $pop11, $pop13
-	tee_local	$push33=, $4=, $pop34
-	i32.or  	$5=, $pop8, $pop33
-	i32.const	$push16=, 16
-	i32.and 	$3=, $2, $pop16
-	i32.const	$push32=, 2
-	i32.and 	$push1=, $2, $pop32
-	i32.const	$push31=, 0
-	i32.ne  	$6=, $pop1, $pop31
-	i32.const	$push15=, 16384
-	i32.and 	$push0=, $2, $pop15
-	i32.eqz 	$7=, $pop0
-	i32.const	$push14=, 13832
-	i32.and 	$push2=, $2, $pop14
+	i32.ne  	$push7=, $pop6, $pop35
+	i32.const	$push8=, 128
+	i32.and 	$push9=, $2, $pop8
+	i32.eqz 	$push10=, $pop9
+	i32.const	$push34=, 0
+	i32.load	$push11=, bar($pop34)
+	i32.eqz 	$push12=, $pop11
+	i32.or  	$push33=, $pop10, $pop12
+	tee_local	$push32=, $4=, $pop33
+	i32.or  	$5=, $pop7, $pop32
+	i32.const	$push15=, 16
+	i32.and 	$3=, $2, $pop15
+	i32.const	$push31=, 2
+	i32.and 	$push1=, $2, $pop31
 	i32.const	$push30=, 0
-	i32.ne  	$8=, $pop2, $pop30
-	i32.const	$10=, 0
+	i32.ne  	$8=, $pop1, $pop30
+	i32.const	$push14=, 16384
+	i32.and 	$push0=, $2, $pop14
+	i32.eqz 	$9=, $pop0
+	i32.const	$push13=, 13832
+	i32.and 	$push2=, $2, $pop13
+	i32.const	$push29=, 0
+	i32.ne  	$10=, $pop2, $pop29
+	i32.const	$2=, 0
 .LBB3_2:                                # %if.then
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label3:
-	copy_local	$2=, $10
-	i32.const	$10=, 0
 	block   	
-	i32.or  	$push17=, $2, $3
-	i32.eqz 	$push45=, $pop17
-	br_if   	0, $pop45       # 0: down to label4
+	block   	
+	block   	
+	i32.or  	$push16=, $2, $3
+	i32.eqz 	$push44=, $pop16
+	br_if   	0, $pop44       # 0: down to label6
 # BB#3:                                 # %if.end17
                                         #   in Loop: Header=BB3_2 Depth=1
-	i32.const	$push37=, 1
-	i32.select	$10=, $2, $pop37, $2
-	block   	
-	br_if   	0, $3           # 0: down to label5
+	i32.const	$push36=, 1
+	i32.select	$6=, $2, $pop36, $2
+	br_if   	1, $3           # 1: down to label5
 # BB#4:                                 # %land.lhs.true25
                                         #   in Loop: Header=BB3_2 Depth=1
-	br_if   	1, $5           # 1: down to label4
-	br      	4               # 4: down to label1
-.LBB3_5:                                # %land.lhs.true20
+	copy_local	$2=, $6
+	br_if   	2, $5           # 2: down to label4
+	br      	5               # 5: down to label1
+.LBB3_5:                                #   in Loop: Header=BB3_2 Depth=1
+	end_block                       # label6:
+	i32.const	$2=, 0
+	br      	1               # 1: down to label4
+.LBB3_6:                                # %land.lhs.true20
                                         #   in Loop: Header=BB3_2 Depth=1
 	end_block                       # label5:
-	i32.eqz 	$push3=, $2
-	i32.const	$push38=, 1
-	i32.xor 	$push18=, $pop3, $pop38
-	i32.or  	$push19=, $7, $pop18
-	i32.and 	$push20=, $6, $pop19
-	i32.or  	$push21=, $8, $pop20
-	i32.or  	$push22=, $4, $pop21
-	i32.eqz 	$push46=, $pop22
-	br_if   	3, $pop46       # 3: down to label1
-.LBB3_6:                                # %while.cond.backedge
+	i32.eqz 	$7=, $2
+	copy_local	$2=, $6
+	i32.const	$push37=, 1
+	i32.xor 	$push17=, $7, $pop37
+	i32.or  	$push18=, $9, $pop17
+	i32.and 	$push19=, $8, $pop18
+	i32.or  	$push20=, $10, $pop19
+	i32.or  	$push21=, $4, $pop20
+	i32.eqz 	$push45=, $pop21
+	br_if   	3, $pop45       # 3: down to label1
+.LBB3_7:                                # %while.cond.backedge
                                         #   in Loop: Header=BB3_2 Depth=1
 	end_block                       # label4:
-	i32.const	$push43=, 0
-	i32.const	$push42=, 2
-	i32.add 	$push23=, $9, $pop42
-	i32.store	baz1.l($pop43), $pop23
-	i32.const	$push41=, 1
-	i32.add 	$push40=, $9, $pop41
-	tee_local	$push39=, $9=, $pop40
-	i32.lt_s	$push24=, $pop39, $1
-	br_if   	0, $pop24       # 0: up to label3
-.LBB3_7:                                # %while.end
+	i32.const	$push42=, 0
+	i32.const	$push41=, 2
+	i32.add 	$push22=, $11, $pop41
+	i32.store	baz1.l($pop42), $pop22
+	i32.const	$push40=, 1
+	i32.add 	$push39=, $11, $pop40
+	tee_local	$push38=, $11=, $pop39
+	i32.lt_s	$push23=, $pop38, $1
+	br_if   	0, $pop23       # 0: up to label3
+.LBB3_8:                                # %while.end
 	end_loop
 	end_block                       # label2:
-	i32.const	$push44=, 0
-	return  	$pop44
-.LBB3_8:                                # %for.body
+	i32.const	$push43=, 0
+	return  	$pop43
+.LBB3_9:                                # %for.body
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
@@ -210,6 +215,6 @@ bar:
 	.size	bar, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/20010925-1.c.s
+++ b/test/torture-s/20010925-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20010925-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20010925-1.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
@@ -29,18 +29,17 @@ main:                                   # @main
 foo:                                    # @foo
 	.param  	i32, i32, i32
 	.result 	i32
-	.local  	i32
 # BB#0:                                 # %entry
-	i32.const	$3=, 1
 	block   	
-	i32.eqz 	$push0=, $2
-	br_if   	0, $pop0        # 0: down to label0
+	i32.eqz 	$push2=, $2
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.call	$drop=, memcpy@FUNCTION, $0, $1, $2
-	i32.const	$3=, 0
-.LBB1_2:                                # %return
+	i32.const	$push0=, 0
+	return  	$pop0
+.LBB1_2:
 	end_block                       # label0:
-	copy_local	$push1=, $3
+	i32.const	$push1=, 1
                                         # fallthrough-return: $pop1
 	.endfunc
 .Lfunc_end1:
@@ -65,5 +64,5 @@ src:
 	.size	src, 40
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	exit, void, i32

--- a/test/torture-s/20011008-3.c.s
+++ b/test/torture-s/20011008-3.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20011008-3.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20011008-3.c"
 	.section	.text.log_compare,"ax",@progbits
 	.hidden	log_compare
 	.globl	log_compare
@@ -21,44 +21,82 @@ log_compare:                            # @log_compare
 __db_txnlist_lsnadd:                    # @__db_txnlist_lsnadd
 	.param  	i32, i32, i32, i32
 	.result 	i32
-	.local  	i32, i32, i32
+	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push7=, 1
-	i32.and 	$4=, $3, $pop7
-	i32.const	$3=, 0
+	i32.const	$5=, 0
 	i32.const	$push0=, 12
-	i32.add 	$5=, $1, $pop0
-.LBB1_1:                                # %for.cond
-                                        # =>This Inner Loop Header: Depth=1
-	loop    	                # label0:
+	i32.add 	$4=, $1, $pop0
 	i32.const	$6=, 1
 	block   	
-	i32.eqz 	$push9=, $4
-	br_if   	0, $pop9        # 0: down to label1
-# BB#2:                                 # %cond.false
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$6=, 0($5)
-.LBB1_3:                                # %cond.end
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label1:
 	block   	
-	i32.ge_s	$push1=, $3, $6
-	br_if   	0, $pop1        # 0: down to label2
-# BB#4:                                 # %for.body
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push8=, 1
-	i32.add 	$3=, $3, $pop8
-	br      	1               # 1: up to label0
-.LBB1_5:                                # %for.end35
-	end_block                       # label2:
-	end_loop
+	i32.const	$push9=, 1
+	i32.and 	$push8=, $3, $pop9
+	tee_local	$push7=, $3=, $pop8
+	br_if   	0, $pop7        # 0: down to label1
+# BB#1:
+	i32.const	$7=, 1
+	br      	1               # 1: down to label0
+.LBB1_2:
+	end_block                       # label1:
+	i32.const	$7=, 0
+.LBB1_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label0:
+	loop    	i32             # label2:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$7, 1, 2, 3, 0, 0 # 1: down to label7
+                                        # 2: down to label6
+                                        # 3: down to label5
+                                        # 0: down to label8
+.LBB1_4:                                # %for.body
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label8:
+	i32.const	$push10=, 1
+	i32.add 	$5=, $5, $pop10
+	i32.const	$6=, 1
+	i32.eqz 	$push11=, $3
+	br_if   	3, $pop11       # 3: down to label4
+# BB#5:                                 #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$7=, 0
+	br      	5               # 5: up to label2
+.LBB1_6:                                # %cond.false
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label7:
+	i32.load	$6=, 0($4)
+# BB#7:                                 #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$7=, 1
+	br      	4               # 4: up to label2
+.LBB1_8:                                # %cond.end
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label6:
+	i32.lt_s	$push1=, $5, $6
+	br_if   	2, $pop1        # 2: down to label3
+# BB#9:                                 #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$7=, 2
+	br      	3               # 3: up to label2
+.LBB1_10:                               # %for.end35
+	end_block                       # label5:
 	i32.const	$push2=, 20
 	i32.add 	$push3=, $1, $pop2
 	i32.load	$push4=, 0($pop3)
 	i64.load	$push5=, 0($pop4):p2align=2
 	i64.store	0($2):p2align=2, $pop5
-	i32.add 	$push6=, $0, $3
-                                        # fallthrough-return: $pop6
+	i32.add 	$push6=, $0, $5
+	return  	$pop6
+.LBB1_11:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label4:
+	i32.const	$7=, 1
+	br      	1               # 1: up to label2
+.LBB1_12:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label3:
+	i32.const	$7=, 3
+	br      	0               # 0: up to label2
+.LBB1_13:
+	end_loop
 	.endfunc
 .Lfunc_end1:
 	.size	__db_txnlist_lsnadd, .Lfunc_end1-__db_txnlist_lsnadd
@@ -78,5 +116,5 @@ main:                                   # @main
 	.size	main, .Lfunc_end2-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	exit, void, i32

--- a/test/torture-s/20020402-3.c.s
+++ b/test/torture-s/20020402-3.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20020402-3.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20020402-3.c"
 	.section	.text.blockvector_for_pc_sect,"ax",@progbits
 	.hidden	blockvector_for_pc_sect
 	.globl	blockvector_for_pc_sect
@@ -9,59 +9,58 @@ blockvector_for_pc_sect:                # @blockvector_for_pc_sect
 	.result 	i32
 	.local  	i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$7=, 0
+	i32.const	$6=, 0
 	block   	
 	block   	
-	i32.load	$push21=, 0($1)
-	tee_local	$push20=, $2=, $pop21
-	i32.load	$push19=, 0($pop20)
-	tee_local	$push18=, $1=, $pop19
-	i32.const	$push17=, 2
-	i32.lt_s	$push0=, $pop18, $pop17
+	i32.load	$push23=, 0($1)
+	tee_local	$push22=, $7=, $pop23
+	i32.load	$push21=, 0($pop22)
+	tee_local	$push20=, $1=, $pop21
+	i32.const	$push19=, 2
+	i32.lt_s	$push0=, $pop20, $pop19
 	br_if   	0, $pop0        # 0: down to label1
 # BB#1:                                 # %while.body.preheader
-	i32.const	$7=, 0
-	copy_local	$6=, $1
+	i32.const	$6=, 0
+	copy_local	$5=, $1
 .LBB0_2:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label2:
-	i32.const	$push34=, 1
-	i32.add 	$push1=, $1, $pop34
-	i32.const	$push33=, 1
-	i32.shr_s	$push32=, $pop1, $pop33
-	tee_local	$push31=, $3=, $pop32
-	i32.add 	$push30=, $pop31, $7
-	tee_local	$push29=, $1=, $pop30
-	i32.sub 	$4=, $6, $pop29
-	i32.const	$push28=, 2
-	i32.shl 	$push2=, $1, $pop28
-	i32.add 	$push3=, $2, $pop2
-	i32.const	$push27=, 4
-	i32.add 	$push4=, $pop3, $pop27
+	i32.const	$push36=, 1
+	i32.add 	$push1=, $1, $pop36
+	i32.const	$push35=, 1
+	i32.shr_s	$push34=, $pop1, $pop35
+	tee_local	$push33=, $2=, $pop34
+	i32.add 	$push32=, $pop33, $6
+	tee_local	$push31=, $1=, $pop32
+	i32.sub 	$3=, $5, $pop31
+	i32.const	$push30=, 2
+	i32.shl 	$push2=, $1, $pop30
+	i32.add 	$push3=, $7, $pop2
+	i32.const	$push29=, 4
+	i32.add 	$push4=, $pop3, $pop29
 	i32.load	$push5=, 0($pop4)
 	i64.load	$push6=, 0($pop5)
-	i64.gt_u	$push26=, $pop6, $0
-	tee_local	$push25=, $5=, $pop26
-	i32.select	$6=, $1, $6, $pop25
-	i32.select	$7=, $7, $1, $5
-	i32.select	$push24=, $3, $4, $5
-	tee_local	$push23=, $1=, $pop24
-	i32.const	$push22=, 1
-	i32.gt_s	$push7=, $pop23, $pop22
+	i64.gt_u	$push28=, $pop6, $0
+	tee_local	$push27=, $4=, $pop28
+	i32.select	$5=, $1, $5, $pop27
+	i32.select	$6=, $6, $1, $4
+	i32.select	$push26=, $2, $3, $4
+	tee_local	$push25=, $1=, $pop26
+	i32.const	$push24=, 1
+	i32.gt_s	$push7=, $pop25, $pop24
 	br_if   	0, $pop7        # 0: up to label2
 # BB#3:                                 # %while.cond8.preheader
 	end_loop
-	i32.const	$5=, 0
 	i32.const	$push8=, -1
-	i32.le_s	$push9=, $7, $pop8
+	i32.le_s	$push9=, $6, $pop8
 	br_if   	1, $pop9        # 1: down to label0
 .LBB0_4:                                # %while.body10.preheader
 	end_block                       # label1:
-	i32.const	$push36=, 1
-	i32.add 	$6=, $7, $pop36
-	i32.const	$push35=, 2
-	i32.shl 	$push10=, $7, $pop35
-	i32.add 	$push11=, $2, $pop10
+	i32.const	$push38=, 1
+	i32.add 	$5=, $6, $pop38
+	i32.const	$push37=, 2
+	i32.shl 	$push10=, $6, $pop37
+	i32.add 	$push11=, $7, $pop10
 	i32.const	$push12=, 4
 	i32.add 	$1=, $pop11, $pop12
 .LBB0_5:                                # %while.body10
@@ -74,24 +73,25 @@ blockvector_for_pc_sect:                # @blockvector_for_pc_sect
 	br_if   	1, $pop15       # 1: down to label3
 # BB#6:                                 # %while.cond8
                                         #   in Loop: Header=BB0_5 Depth=1
-	i32.const	$push41=, -4
-	i32.add 	$1=, $1, $pop41
-	i32.const	$5=, 0
-	i32.const	$push40=, -1
-	i32.add 	$push39=, $6, $pop40
-	tee_local	$push38=, $6=, $pop39
-	i32.const	$push37=, 1
-	i32.ge_s	$push16=, $pop38, $pop37
+	i32.const	$push43=, -4
+	i32.add 	$1=, $1, $pop43
+	i32.const	$push42=, -1
+	i32.add 	$push41=, $5, $pop42
+	tee_local	$push40=, $5=, $pop41
+	i32.const	$push39=, 1
+	i32.ge_s	$push16=, $pop40, $pop39
 	br_if   	0, $pop16       # 0: up to label4
-	br      	2               # 2: down to label0
-.LBB0_7:
+# BB#7:
 	end_loop
-	end_block                       # label3:
-	copy_local	$5=, $2
+	i32.const	$push17=, 0
+	return  	$pop17
 .LBB0_8:                                # %cleanup
+	end_block                       # label3:
+	return  	$7
+.LBB0_9:
 	end_block                       # label0:
-	copy_local	$push42=, $5
-                                        # fallthrough-return: $pop42
+	i32.const	$push18=, 0
+                                        # fallthrough-return: $pop18
 	.endfunc
 .Lfunc_end0:
 	.size	blockvector_for_pc_sect, .Lfunc_end0-blockvector_for_pc_sect
@@ -110,4 +110,4 @@ main:                                   # @main
 	.size	main, .Lfunc_end1-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "

--- a/test/torture-s/20020529-1.c.s
+++ b/test/torture-s/20020529-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20020529-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20020529-1.c"
 	.section	.text.foo,"ax",@progbits
 	.hidden	foo
 	.globl	foo
@@ -9,45 +9,51 @@ foo:                                    # @foo
 	.result 	i32
 	.local  	i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push11=, 0
-	i32.load	$4=, f1.beenhere($pop11)
-	i32.const	$push2=, 8
-	i32.add 	$5=, $0, $pop2
-.LBB0_1:                                # %for.cond
+	i32.const	$push3=, 8
+	i32.add 	$5=, $0, $pop3
+	block   	
+	i32.const	$push15=, 0
+	i32.load	$push14=, f1.beenhere($pop15)
+	tee_local	$push13=, $4=, $pop14
+	i32.const	$push12=, 2
+	i32.ge_s	$push0=, $pop13, $pop12
+	br_if   	0, $pop0        # 0: down to label0
+.LBB0_1:                                # %f1.exit
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	block   	
 	loop    	                # label2:
-	i32.const	$push14=, 2
-	i32.ge_s	$push0=, $4, $pop14
-	br_if   	2, $pop0        # 2: down to label0
-# BB#2:                                 # %f1.exit
-                                        #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push15=, 1
-	i32.eq  	$push1=, $4, $pop15
-	br_if   	1, $pop1        # 1: down to label1
-# BB#3:                                 # %if.end
-                                        #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push16=, 1
-	i32.add 	$4=, $4, $pop16
-	br_if   	0, $1           # 0: up to label2
-# BB#4:                                 # %if.end3
+	i32.const	$push19=, 1
+	i32.eq  	$push2=, $4, $pop19
+	br_if   	1, $pop2        # 1: down to label1
+# BB#2:                                 # %if.end
                                         #   in Loop: Header=BB0_1 Depth=1
 	block   	
-	i32.const	$push17=, 0
-	i32.store	f1.beenhere($pop17), $4
+	i32.const	$push20=, 1
+	i32.add 	$4=, $4, $pop20
+	block   	
+	br_if   	0, $1           # 0: down to label4
+# BB#3:                                 # %if.end3
+                                        #   in Loop: Header=BB0_1 Depth=1
+	i32.const	$push21=, 0
+	i32.store	f1.beenhere($pop21), $4
 	i32.store16	0($5), $3
-	i32.load	$push3=, 0($0)
-	br_if   	0, $pop3        # 0: down to label3
-# BB#5:                                 # %if.end8
+	i32.load	$push4=, 0($0)
+	br_if   	1, $pop4        # 1: down to label3
+# BB#4:                                 # %if.end8
                                         #   in Loop: Header=BB0_1 Depth=1
-	br_if   	0, $2           # 0: down to label3
-# BB#6:                                 # %for.cond.outer.backedge
+	br_if   	1, $2           # 1: down to label3
+# BB#5:                                 # %for.cond.outer.backedge
                                         #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push13=, 16
-	i32.shl 	$push4=, $3, $pop13
-	i32.const	$push12=, 16
-	i32.shr_s	$3=, $pop4, $pop12
+	i32.const	$push17=, 16
+	i32.shl 	$push5=, $3, $pop17
+	i32.const	$push16=, 16
+	i32.shr_s	$3=, $pop5, $pop16
+.LBB0_6:                                # %for.cond
+                                        #   in Loop: Header=BB0_1 Depth=1
+	end_block                       # label4:
+	i32.const	$push18=, 2
+	i32.ge_s	$push1=, $4, $pop18
+	br_if   	3, $pop1        # 3: down to label0
 	br      	1               # 1: up to label2
 .LBB0_7:                                # %if.then10
 	end_block                       # label3:
@@ -56,18 +62,18 @@ foo:                                    # @foo
 	unreachable
 .LBB0_8:                                # %if.then
 	end_block                       # label1:
-	i32.const	$push7=, 0
-	i32.const	$push5=, 1
-	i32.add 	$push6=, $4, $pop5
-	i32.store	f1.beenhere($pop7), $pop6
-	i32.const	$push18=, 0
-	return  	$pop18
+	i32.const	$push8=, 0
+	i32.const	$push6=, 1
+	i32.add 	$push7=, $4, $pop6
+	i32.store	f1.beenhere($pop8), $pop7
+	i32.const	$push22=, 0
+	return  	$pop22
 .LBB0_9:                                # %if.then.i
 	end_block                       # label0:
-	i32.const	$push10=, 0
-	i32.const	$push8=, 1
-	i32.add 	$push9=, $4, $pop8
-	i32.store	f1.beenhere($pop10), $pop9
+	i32.const	$push11=, 0
+	i32.const	$push9=, 1
+	i32.add 	$push10=, $4, $pop9
+	i32.store	f1.beenhere($pop11), $pop10
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -93,13 +99,13 @@ f1:                                     # @f1
 	block   	
 	i32.const	$push2=, 2
 	i32.ge_s	$push3=, $1, $pop2
-	br_if   	0, $pop3        # 0: down to label4
+	br_if   	0, $pop3        # 0: down to label5
 # BB#1:                                 # %if.end
 	i32.const	$push9=, 1
 	i32.eq  	$push4=, $1, $pop9
 	return  	$pop4
 .LBB1_2:                                # %if.then
-	end_block                       # label4:
+	end_block                       # label5:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -145,17 +151,17 @@ main:                                   # @main
 	block   	
 	i32.const	$push14=, 1
 	i32.gt_s	$push0=, $1, $pop14
-	br_if   	0, $pop0        # 0: down to label6
+	br_if   	0, $pop0        # 0: down to label7
 # BB#1:                                 # %f1.exit.i.preheader
 	i32.const	$push2=, 8
 	i32.add 	$0=, $0, $pop2
 .LBB3_2:                                # %f1.exit.i
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label8:
+	loop    	                # label9:
 	i32.const	$push20=, 1
 	i32.eq  	$push1=, $1, $pop20
-	br_if   	1, $pop1        # 1: down to label7
+	br_if   	1, $pop1        # 1: down to label8
 # BB#3:                                 # %if.end.i
                                         #   in Loop: Header=BB3_2 Depth=1
 	i32.const	$2=, 0
@@ -166,16 +172,16 @@ main:                                   # @main
 	tee_local	$push22=, $1=, $pop23
 	i32.const	$push21=, 1
 	i32.le_s	$push3=, $pop22, $pop21
-	br_if   	0, $pop3        # 0: up to label8
+	br_if   	0, $pop3        # 0: up to label9
 # BB#4:                                 # %if.then.i.i.loopexit
 	end_loop
 	i32.const	$push4=, 0
 	i32.store	f1.beenhere($pop4), $1
 	i32.const	$push5=, 1
 	i32.add 	$1=, $1, $pop5
-	br      	2               # 2: down to label5
+	br      	2               # 2: down to label6
 .LBB3_5:                                # %foo.exit
-	end_block                       # label7:
+	end_block                       # label8:
 	i32.const	$push27=, 0
 	i32.const	$push6=, 1
 	i32.add 	$push7=, $1, $pop6
@@ -183,21 +189,21 @@ main:                                   # @main
 	block   	
 	i32.const	$push8=, 65535
 	i32.and 	$push9=, $2, $pop8
-	br_if   	0, $pop9        # 0: down to label9
+	br_if   	0, $pop9        # 0: down to label10
 # BB#6:                                 # %if.end
 	i32.const	$push28=, 0
 	call    	exit@FUNCTION, $pop28
 	unreachable
 .LBB3_7:                                # %if.then
-	end_block                       # label9:
+	end_block                       # label10:
 	call    	abort@FUNCTION
 	unreachable
 .LBB3_8:
-	end_block                       # label6:
+	end_block                       # label7:
 	i32.const	$push29=, 1
 	i32.add 	$1=, $1, $pop29
 .LBB3_9:                                # %if.then.i.i
-	end_block                       # label5:
+	end_block                       # label6:
 	i32.const	$push26=, 0
 	i32.store	f1.beenhere($pop26), $1
 	call    	abort@FUNCTION
@@ -214,6 +220,6 @@ f1.beenhere:
 	.size	f1.beenhere, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/20020615-1.c.s
+++ b/test/torture-s/20020615-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20020615-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20020615-1.c"
 	.section	.text.line_hints,"ax",@progbits
 	.hidden	line_hints
 	.globl	line_hints
@@ -7,92 +7,91 @@
 line_hints:                             # @line_hints
 	.param  	i32, i32, i32
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$8=, 0
-	i32.const	$push52=, 0
+	i32.const	$push53=, 0
 	i32.load	$push6=, 4($2)
 	i32.load	$push5=, 4($1)
-	i32.sub 	$push51=, $pop6, $pop5
-	tee_local	$push50=, $5=, $pop51
-	i32.sub 	$push7=, $pop52, $pop50
-	i32.load	$push49=, 8($0)
-	tee_local	$push48=, $4=, $pop49
-	i32.select	$push47=, $pop7, $5, $pop48
-	tee_local	$push46=, $6=, $pop47
-	i32.const	$push45=, 0
+	i32.sub 	$push52=, $pop6, $pop5
+	tee_local	$push51=, $5=, $pop52
+	i32.sub 	$push7=, $pop53, $pop51
+	i32.load	$push50=, 8($0)
+	tee_local	$push49=, $4=, $pop50
+	i32.select	$push48=, $pop7, $5, $pop49
+	tee_local	$push47=, $6=, $pop48
+	i32.const	$push46=, 0
 	i32.load	$push3=, 0($2)
 	i32.load	$push2=, 0($1)
-	i32.sub 	$push44=, $pop3, $pop2
-	tee_local	$push43=, $2=, $pop44
-	i32.sub 	$push4=, $pop45, $pop43
-	i32.load	$push42=, 4($0)
-	tee_local	$push41=, $3=, $pop42
-	i32.select	$push40=, $pop4, $2, $pop41
-	tee_local	$push39=, $7=, $pop40
-	i32.load	$push38=, 0($0)
-	tee_local	$push37=, $1=, $pop38
-	i32.select	$push36=, $pop46, $pop39, $pop37
-	tee_local	$push35=, $2=, $pop36
+	i32.sub 	$push45=, $pop3, $pop2
+	tee_local	$push44=, $2=, $pop45
+	i32.sub 	$push4=, $pop46, $pop44
+	i32.load	$push43=, 4($0)
+	tee_local	$push42=, $3=, $pop43
+	i32.select	$push41=, $pop4, $2, $pop42
+	tee_local	$push40=, $7=, $pop41
+	i32.load	$push39=, 0($0)
+	tee_local	$push38=, $1=, $pop39
+	i32.select	$push37=, $pop47, $pop40, $pop38
+	tee_local	$push36=, $2=, $pop37
 	i32.const	$push8=, 31
-	i32.shr_s	$push34=, $2, $pop8
-	tee_local	$push33=, $0=, $pop34
-	i32.add 	$push9=, $pop35, $pop33
+	i32.shr_s	$push35=, $2, $pop8
+	tee_local	$push34=, $0=, $pop35
+	i32.add 	$push9=, $pop36, $pop34
 	i32.xor 	$5=, $pop9, $0
-	i32.select	$push32=, $7, $6, $1
-	tee_local	$push31=, $0=, $pop32
-	i32.const	$push30=, 31
-	i32.shr_s	$push29=, $0, $pop30
-	tee_local	$push28=, $6=, $pop29
-	i32.add 	$push10=, $pop31, $pop28
+	i32.select	$push33=, $7, $6, $1
+	tee_local	$push32=, $0=, $pop33
+	i32.const	$push31=, 31
+	i32.shr_s	$push30=, $0, $pop31
+	tee_local	$push29=, $6=, $pop30
+	i32.add 	$push10=, $pop32, $pop29
 	i32.xor 	$6=, $pop10, $6
 	block   	
-	block   	
-	i32.eqz 	$push60=, $0
-	br_if   	0, $pop60       # 0: down to label1
+	i32.eqz 	$push62=, $0
+	br_if   	0, $pop62       # 0: down to label0
 # BB#1:                                 # %entry
-	i32.const	$push53=, 4
-	i32.shr_s	$push1=, $6, $pop53
+	i32.const	$push54=, 4
+	i32.shr_s	$push1=, $6, $pop54
 	i32.gt_s	$push11=, $5, $pop1
-	br_if   	0, $pop11       # 0: down to label1
+	br_if   	0, $pop11       # 0: down to label0
 # BB#2:                                 # %if.then21
 	i32.const	$push16=, 2
 	i32.const	$push15=, 1
 	i32.const	$push13=, 0
 	i32.gt_s	$push14=, $0, $pop13
-	i32.select	$push55=, $pop16, $pop15, $pop14
-	tee_local	$push54=, $0=, $pop55
+	i32.select	$push56=, $pop16, $pop15, $pop14
+	tee_local	$push55=, $0=, $pop56
 	i32.const	$push17=, 3
-	i32.xor 	$push18=, $pop54, $pop17
+	i32.xor 	$push18=, $pop55, $pop17
 	i32.select	$push12=, $4, $3, $1
-	i32.select	$8=, $pop18, $0, $pop12
-	br      	1               # 1: down to label0
+	i32.select	$push28=, $pop18, $0, $pop12
+	return  	$pop28
 .LBB0_3:                                # %if.else
-	end_block                       # label1:
-	i32.eqz 	$push61=, $2
-	br_if   	0, $pop61       # 0: down to label0
+	end_block                       # label0:
+	block   	
+	i32.eqz 	$push63=, $2
+	br_if   	0, $pop63       # 0: down to label1
 # BB#4:                                 # %if.else
-	i32.const	$push56=, 4
-	i32.shr_s	$push19=, $5, $pop56
+	i32.const	$push57=, 4
+	i32.shr_s	$push19=, $5, $pop57
 	i32.gt_s	$push20=, $6, $pop19
-	br_if   	0, $pop20       # 0: down to label0
+	br_if   	0, $pop20       # 0: down to label1
 # BB#5:                                 # %if.then31
 	i32.const	$push21=, 29
 	i32.shr_u	$push22=, $2, $pop21
 	i32.const	$push23=, 4
 	i32.and 	$push24=, $pop22, $pop23
-	i32.const	$push59=, 4
-	i32.add 	$push58=, $pop24, $pop59
-	tee_local	$push57=, $0=, $pop58
+	i32.const	$push60=, 4
+	i32.add 	$push59=, $pop24, $pop60
+	tee_local	$push58=, $0=, $pop59
 	i32.const	$push25=, 12
-	i32.xor 	$push26=, $pop57, $pop25
+	i32.xor 	$push26=, $pop58, $pop25
 	i32.select	$push0=, $3, $4, $1
 	i32.select	$push27=, $pop26, $0, $pop0
 	return  	$pop27
 .LBB0_6:                                # %if.end40
-	end_block                       # label0:
-	copy_local	$push62=, $8
-                                        # fallthrough-return: $pop62
+	end_block                       # label1:
+	i32.const	$push61=, 0
+                                        # fallthrough-return: $pop61
 	.endfunc
 .Lfunc_end0:
 	.size	line_hints, .Lfunc_end0-line_hints
@@ -168,6 +167,6 @@ main.gsf:
 	.size	main.gsf, 32
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/20021118-2.c.s
+++ b/test/torture-s/20021118-2.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20021118-2.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20021118-2.c"
 	.section	.text.t1,"ax",@progbits
 	.hidden	t1
 	.globl	t1
@@ -9,7 +9,7 @@ t1:                                     # @t1
 	.result 	i32
 # BB#0:                                 # %entry
 	f64.const	$push0=, 0x1.8p1
-	call_indirect	$2, $pop0
+	call_indirect	$pop0, $2
 	i32.const	$push1=, 2
 	i32.shl 	$push2=, $1, $pop1
 	i32.add 	$push9=, $0, $pop2
@@ -20,7 +20,7 @@ t1:                                     # @t1
 	i32.store	0($pop8), $pop5
 	f32.const	$push7=, 0x1.4p1
 	f32.const	$push6=, 0x1.cp1
-	call_indirect	$3, $pop7, $pop6
+	call_indirect	$pop7, $pop6, $3
 	copy_local	$push10=, $3
                                         # fallthrough-return: $pop10
 	.endfunc
@@ -36,9 +36,9 @@ t2:                                     # @t2
 	.result 	i32
 # BB#0:                                 # %entry
 	f32.const	$push0=, 0x1.8p2
-	call_indirect	$4, $pop0
+	call_indirect	$pop0, $4
 	f64.const	$push1=, 0x1.8p1
-	call_indirect	$2, $pop1
+	call_indirect	$pop1, $2
 	i32.const	$push2=, 2
 	i32.shl 	$push3=, $1, $pop2
 	i32.add 	$push10=, $0, $pop3
@@ -49,7 +49,7 @@ t2:                                     # @t2
 	i32.store	0($pop9), $pop6
 	f32.const	$push8=, 0x1.4p1
 	f32.const	$push7=, 0x1.cp1
-	call_indirect	$3, $pop8, $pop7
+	call_indirect	$pop8, $pop7, $3
 	copy_local	$push11=, $3
                                         # fallthrough-return: $pop11
 	.endfunc
@@ -138,6 +138,6 @@ main:                                   # @main
 	.size	main, .Lfunc_end5-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/20030714-1.c.s
+++ b/test/torture-s/20030714-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20030714-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20030714-1.c"
 	.section	.text.RenderBox_setStyle,"ax",@progbits
 	.hidden	RenderBox_setStyle
 	.globl	RenderBox_setStyle
@@ -42,7 +42,7 @@ RenderBox_setStyle:                     # @RenderBox_setStyle
 	i32.load	$2=, 0($1)
 	block   	
 	i32.load	$push14=, 28($0)
-	i32.call_indirect	$push15=, $pop14, $0
+	i32.call_indirect	$push15=, $0, $pop14
 	br_if   	0, $pop15       # 0: down to label3
 # BB#4:                                 # %if.end
 	i32.const	$3=, 8
@@ -179,5 +179,5 @@ g__style:
 	.size	g__style, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	exit, void, i32

--- a/test/torture-s/20030715-1.c.s
+++ b/test/torture-s/20030715-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20030715-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20030715-1.c"
 	.section	.text.ap_check_cmd_context,"ax",@progbits
 	.hidden	ap_check_cmd_context
 	.globl	ap_check_cmd_context
@@ -21,7 +21,7 @@ ap_check_cmd_context:                   # @ap_check_cmd_context
 server_type:                            # @server_type
 	.param  	i32, i32, i32
 	.result 	i32
-	.local  	i32, i32
+	.local  	i32
 # BB#0:                                 # %entry
 	i32.const	$3=, 0
 	block   	
@@ -31,19 +31,20 @@ server_type:                            # @server_type
 	i32.eqz 	$push5=, $pop1
 	br_if   	0, $pop5        # 0: down to label1
 # BB#1:                                 # %if.else
-	i32.const	$4=, .L.str.2
-	i32.const	$3=, 1
+	i32.const	$3=, .L.str.2
 	i32.const	$push2=, .L.str.1
 	i32.call	$push3=, strcmp@FUNCTION, $2, $pop2
 	br_if   	1, $pop3        # 1: down to label0
-.LBB1_2:                                # %if.end9
+# BB#2:
+	i32.const	$3=, 1
+.LBB1_3:                                # %if.end9
 	end_block                       # label1:
 	i32.const	$push4=, 0
 	i32.store	ap_standalone($pop4), $3
-	i32.const	$4=, 0
-.LBB1_3:                                # %cleanup
+	i32.const	$3=, 0
+.LBB1_4:                                # %cleanup
 	end_block                       # label0:
-	copy_local	$push6=, $4
+	copy_local	$push6=, $3
                                         # fallthrough-return: $pop6
 	.endfunc
 .Lfunc_end1:
@@ -92,5 +93,5 @@ ap_standalone:
 	.size	.L.str.2, 50
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	strcmp, i32, i32, i32

--- a/test/torture-s/20040709-1.c.s
+++ b/test/torture-s/20040709-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20040709-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20040709-1.c"
 	.section	.text.myrnd,"ax",@progbits
 	.hidden	myrnd
 	.globl	myrnd
@@ -6531,101 +6531,105 @@ fn3W:                                   # @fn3W
 testW:                                  # @testW
 	.local  	i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push0=, 0
-	i32.load	$2=, myrnd.s($pop0)
-	i32.const	$1=, -32
+	i32.const	$2=, -32
 .LBB138_1:                              # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label15:
-	i32.const	$push39=, sW+32
-	i32.add 	$push1=, $1, $pop39
-	i32.const	$push38=, 1103515245
-	i32.mul 	$push2=, $2, $pop38
-	i32.const	$push37=, 12345
-	i32.add 	$push36=, $pop2, $pop37
-	tee_local	$push35=, $2=, $pop36
-	i32.const	$push34=, 16
-	i32.shr_u	$push3=, $pop35, $pop34
-	i32.store8	0($pop1), $pop3
-	i32.const	$push33=, 1
-	i32.add 	$push32=, $1, $pop33
-	tee_local	$push31=, $1=, $pop32
-	br_if   	0, $pop31       # 0: up to label15
+	i32.const	$push42=, 0
+	i32.const	$push41=, 0
+	i32.load	$push0=, myrnd.s($pop41)
+	i32.const	$push40=, 1103515245
+	i32.mul 	$push1=, $pop0, $pop40
+	i32.const	$push39=, 12345
+	i32.add 	$push38=, $pop1, $pop39
+	tee_local	$push37=, $0=, $pop38
+	i32.store	myrnd.s($pop42), $pop37
+	i32.const	$push36=, sW+32
+	i32.add 	$push2=, $2, $pop36
+	i32.const	$push35=, 16
+	i32.shr_u	$push3=, $0, $pop35
+	i32.store8	0($pop2), $pop3
+	i32.const	$push34=, 1
+	i32.add 	$push33=, $2, $pop34
+	tee_local	$push32=, $2=, $pop33
+	br_if   	0, $pop32       # 0: up to label15
 # BB#2:                                 # %for.end
 	end_loop
-	i32.const	$push8=, 0
-	i32.const	$push4=, 1103515245
-	i32.mul 	$push5=, $2, $pop4
-	i32.const	$push6=, 12345
-	i32.add 	$push77=, $pop5, $pop6
-	tee_local	$push76=, $1=, $pop77
-	i32.const	$push75=, 1103515245
-	i32.mul 	$push7=, $pop76, $pop75
-	i32.const	$push74=, 12345
-	i32.add 	$push73=, $pop7, $pop74
-	tee_local	$push72=, $2=, $pop73
-	i32.store	myrnd.s($pop8), $pop72
-	i32.const	$push71=, 0
-	i64.const	$push9=, 4612055454334320640
-	i64.store	sW+8($pop71), $pop9
-	i32.const	$push70=, 0
-	i64.const	$push10=, 0
-	i64.store	sW($pop70), $pop10
-	i32.const	$push69=, 0
-	i32.const	$push13=, 16
-	i32.shr_u	$push14=, $1, $pop13
-	i32.const	$push15=, 2047
-	i32.and 	$push16=, $pop14, $pop15
-	i32.const	$push68=, 0
-	i32.load	$push11=, sW+16($pop68)
-	i32.const	$push12=, -4096
-	i32.and 	$push67=, $pop11, $pop12
-	tee_local	$push66=, $1=, $pop67
-	i32.or  	$push17=, $pop16, $pop66
-	i32.store	sW+16($pop69), $pop17
-	i32.const	$push65=, 0
-	i32.const	$push64=, 1103515245
-	i32.mul 	$push18=, $2, $pop64
-	i32.const	$push63=, 12345
-	i32.add 	$push62=, $pop18, $pop63
-	tee_local	$push61=, $2=, $pop62
-	i32.const	$push60=, 1103515245
-	i32.mul 	$push19=, $pop61, $pop60
-	i32.const	$push59=, 12345
-	i32.add 	$push58=, $pop19, $pop59
-	tee_local	$push57=, $0=, $pop58
-	i32.store	myrnd.s($pop65), $pop57
+	i32.const	$push4=, 0
+	i32.const	$push81=, 0
+	i32.load	$push5=, myrnd.s($pop81)
+	i32.const	$push6=, 1103515245
+	i32.mul 	$push7=, $pop5, $pop6
+	i32.const	$push8=, 12345
+	i32.add 	$push80=, $pop7, $pop8
+	tee_local	$push79=, $2=, $pop80
+	i32.const	$push78=, 1103515245
+	i32.mul 	$push9=, $pop79, $pop78
+	i32.const	$push77=, 12345
+	i32.add 	$push76=, $pop9, $pop77
+	tee_local	$push75=, $0=, $pop76
+	i32.store	myrnd.s($pop4), $pop75
+	i32.const	$push74=, 0
+	i64.const	$push10=, 4612055454334320640
+	i64.store	sW+8($pop74), $pop10
+	i32.const	$push73=, 0
+	i64.const	$push11=, 0
+	i64.store	sW($pop73), $pop11
+	i32.const	$push72=, 0
+	i32.const	$push71=, 1103515245
+	i32.mul 	$push12=, $0, $pop71
+	i32.const	$push70=, 12345
+	i32.add 	$push69=, $pop12, $pop70
+	tee_local	$push68=, $0=, $pop69
+	i32.const	$push67=, 1103515245
+	i32.mul 	$push13=, $pop68, $pop67
+	i32.const	$push66=, 12345
+	i32.add 	$push65=, $pop13, $pop66
+	tee_local	$push64=, $1=, $pop65
+	i32.store	myrnd.s($pop72), $pop64
+	i32.const	$push63=, 0
+	i32.const	$push16=, 16
+	i32.shr_u	$push17=, $2, $pop16
+	i32.const	$push18=, 2047
+	i32.and 	$push19=, $pop17, $pop18
+	i32.const	$push62=, 0
+	i32.load	$push14=, sW+16($pop62)
+	i32.const	$push15=, -4096
+	i32.and 	$push61=, $pop14, $pop15
+	tee_local	$push60=, $2=, $pop61
+	i32.or  	$push20=, $pop19, $pop60
+	i32.store	sW+16($pop63), $pop20
+	i32.const	$push59=, 0
+	i32.const	$push58=, 16
+	i32.shr_u	$push21=, $0, $pop58
+	i32.const	$push57=, 2047
+	i32.and 	$push22=, $pop21, $pop57
+	i32.or  	$push23=, $pop22, $2
+	i32.store	sW+16($pop59), $pop23
 	i32.const	$push56=, 0
-	i32.const	$push55=, 16
-	i32.shr_u	$push20=, $2, $pop55
-	i32.const	$push54=, 2047
-	i32.and 	$push21=, $pop20, $pop54
-	i32.or  	$push22=, $pop21, $1
-	i32.store	sW+16($pop56), $pop22
-	i32.const	$push53=, 0
-	i32.const	$push52=, 1103515245
-	i32.mul 	$push23=, $0, $pop52
-	i32.const	$push51=, 12345
-	i32.add 	$push50=, $pop23, $pop51
-	tee_local	$push49=, $2=, $pop50
-	i32.const	$push48=, 1103515245
-	i32.mul 	$push24=, $pop49, $pop48
-	i32.const	$push47=, 12345
-	i32.add 	$push46=, $pop24, $pop47
-	tee_local	$push45=, $0=, $pop46
-	i32.store	myrnd.s($pop53), $pop45
-	i32.const	$push44=, 0
-	i32.const	$push43=, 16
-	i32.shr_u	$push27=, $0, $pop43
-	i32.const	$push42=, 2047
-	i32.and 	$push28=, $pop27, $pop42
-	i32.const	$push41=, 16
-	i32.shr_u	$push25=, $2, $pop41
-	i32.const	$push40=, 2047
-	i32.and 	$push26=, $pop25, $pop40
-	i32.add 	$push29=, $pop28, $pop26
-	i32.or  	$push30=, $pop29, $1
-	i32.store	sW+16($pop44), $pop30
+	i32.const	$push55=, 1103515245
+	i32.mul 	$push24=, $1, $pop55
+	i32.const	$push54=, 12345
+	i32.add 	$push53=, $pop24, $pop54
+	tee_local	$push52=, $0=, $pop53
+	i32.const	$push51=, 1103515245
+	i32.mul 	$push25=, $pop52, $pop51
+	i32.const	$push50=, 12345
+	i32.add 	$push49=, $pop25, $pop50
+	tee_local	$push48=, $1=, $pop49
+	i32.store	myrnd.s($pop56), $pop48
+	i32.const	$push47=, 0
+	i32.const	$push46=, 16
+	i32.shr_u	$push28=, $1, $pop46
+	i32.const	$push45=, 2047
+	i32.and 	$push29=, $pop28, $pop45
+	i32.const	$push44=, 16
+	i32.shr_u	$push26=, $0, $pop44
+	i32.const	$push43=, 2047
+	i32.and 	$push27=, $pop26, $pop43
+	i32.add 	$push30=, $pop29, $pop27
+	i32.or  	$push31=, $pop30, $2
+	i32.store	sW+16($pop47), $pop31
                                         # fallthrough-return
 	.endfunc
 .Lfunc_end138:
@@ -6751,101 +6755,105 @@ fn3X:                                   # @fn3X
 testX:                                  # @testX
 	.local  	i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push0=, 0
-	i32.load	$2=, myrnd.s($pop0)
-	i32.const	$1=, -32
+	i32.const	$2=, -32
 .LBB144_1:                              # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label16:
-	i32.const	$push39=, sX+32
-	i32.add 	$push1=, $1, $pop39
-	i32.const	$push38=, 1103515245
-	i32.mul 	$push2=, $2, $pop38
-	i32.const	$push37=, 12345
-	i32.add 	$push36=, $pop2, $pop37
-	tee_local	$push35=, $2=, $pop36
-	i32.const	$push34=, 16
-	i32.shr_u	$push3=, $pop35, $pop34
-	i32.store8	0($pop1), $pop3
-	i32.const	$push33=, 1
-	i32.add 	$push32=, $1, $pop33
-	tee_local	$push31=, $1=, $pop32
-	br_if   	0, $pop31       # 0: up to label16
+	i32.const	$push42=, 0
+	i32.const	$push41=, 0
+	i32.load	$push0=, myrnd.s($pop41)
+	i32.const	$push40=, 1103515245
+	i32.mul 	$push1=, $pop0, $pop40
+	i32.const	$push39=, 12345
+	i32.add 	$push38=, $pop1, $pop39
+	tee_local	$push37=, $0=, $pop38
+	i32.store	myrnd.s($pop42), $pop37
+	i32.const	$push36=, sX+32
+	i32.add 	$push2=, $2, $pop36
+	i32.const	$push35=, 16
+	i32.shr_u	$push3=, $0, $pop35
+	i32.store8	0($pop2), $pop3
+	i32.const	$push34=, 1
+	i32.add 	$push33=, $2, $pop34
+	tee_local	$push32=, $2=, $pop33
+	br_if   	0, $pop32       # 0: up to label16
 # BB#2:                                 # %for.end
 	end_loop
-	i32.const	$push8=, 0
-	i32.const	$push4=, 1103515245
-	i32.mul 	$push5=, $2, $pop4
-	i32.const	$push6=, 12345
-	i32.add 	$push77=, $pop5, $pop6
-	tee_local	$push76=, $1=, $pop77
-	i32.const	$push75=, 1103515245
-	i32.mul 	$push7=, $pop76, $pop75
-	i32.const	$push74=, 12345
-	i32.add 	$push73=, $pop7, $pop74
-	tee_local	$push72=, $2=, $pop73
-	i32.store	myrnd.s($pop8), $pop72
-	i32.const	$push71=, 0
-	i64.const	$push9=, 4612055454334320640
-	i64.store	sX+24($pop71), $pop9
-	i32.const	$push70=, 0
-	i64.const	$push10=, 0
-	i64.store	sX+16($pop70), $pop10
-	i32.const	$push69=, 0
-	i32.const	$push13=, 16
-	i32.shr_u	$push14=, $1, $pop13
-	i32.const	$push15=, 2047
-	i32.and 	$push16=, $pop14, $pop15
-	i32.const	$push68=, 0
-	i32.load	$push11=, sX($pop68)
-	i32.const	$push12=, -4096
-	i32.and 	$push67=, $pop11, $pop12
-	tee_local	$push66=, $1=, $pop67
-	i32.or  	$push17=, $pop16, $pop66
-	i32.store	sX($pop69), $pop17
-	i32.const	$push65=, 0
-	i32.const	$push64=, 1103515245
-	i32.mul 	$push18=, $2, $pop64
-	i32.const	$push63=, 12345
-	i32.add 	$push62=, $pop18, $pop63
-	tee_local	$push61=, $2=, $pop62
-	i32.const	$push60=, 1103515245
-	i32.mul 	$push19=, $pop61, $pop60
-	i32.const	$push59=, 12345
-	i32.add 	$push58=, $pop19, $pop59
-	tee_local	$push57=, $0=, $pop58
-	i32.store	myrnd.s($pop65), $pop57
+	i32.const	$push4=, 0
+	i32.const	$push81=, 0
+	i32.load	$push5=, myrnd.s($pop81)
+	i32.const	$push6=, 1103515245
+	i32.mul 	$push7=, $pop5, $pop6
+	i32.const	$push8=, 12345
+	i32.add 	$push80=, $pop7, $pop8
+	tee_local	$push79=, $2=, $pop80
+	i32.const	$push78=, 1103515245
+	i32.mul 	$push9=, $pop79, $pop78
+	i32.const	$push77=, 12345
+	i32.add 	$push76=, $pop9, $pop77
+	tee_local	$push75=, $0=, $pop76
+	i32.store	myrnd.s($pop4), $pop75
+	i32.const	$push74=, 0
+	i64.const	$push10=, 4612055454334320640
+	i64.store	sX+24($pop74), $pop10
+	i32.const	$push73=, 0
+	i64.const	$push11=, 0
+	i64.store	sX+16($pop73), $pop11
+	i32.const	$push72=, 0
+	i32.const	$push71=, 1103515245
+	i32.mul 	$push12=, $0, $pop71
+	i32.const	$push70=, 12345
+	i32.add 	$push69=, $pop12, $pop70
+	tee_local	$push68=, $0=, $pop69
+	i32.const	$push67=, 1103515245
+	i32.mul 	$push13=, $pop68, $pop67
+	i32.const	$push66=, 12345
+	i32.add 	$push65=, $pop13, $pop66
+	tee_local	$push64=, $1=, $pop65
+	i32.store	myrnd.s($pop72), $pop64
+	i32.const	$push63=, 0
+	i32.const	$push16=, 16
+	i32.shr_u	$push17=, $2, $pop16
+	i32.const	$push18=, 2047
+	i32.and 	$push19=, $pop17, $pop18
+	i32.const	$push62=, 0
+	i32.load	$push14=, sX($pop62)
+	i32.const	$push15=, -4096
+	i32.and 	$push61=, $pop14, $pop15
+	tee_local	$push60=, $2=, $pop61
+	i32.or  	$push20=, $pop19, $pop60
+	i32.store	sX($pop63), $pop20
+	i32.const	$push59=, 0
+	i32.const	$push58=, 16
+	i32.shr_u	$push21=, $0, $pop58
+	i32.const	$push57=, 2047
+	i32.and 	$push22=, $pop21, $pop57
+	i32.or  	$push23=, $pop22, $2
+	i32.store	sX($pop59), $pop23
 	i32.const	$push56=, 0
-	i32.const	$push55=, 16
-	i32.shr_u	$push20=, $2, $pop55
-	i32.const	$push54=, 2047
-	i32.and 	$push21=, $pop20, $pop54
-	i32.or  	$push22=, $pop21, $1
-	i32.store	sX($pop56), $pop22
-	i32.const	$push53=, 0
-	i32.const	$push52=, 1103515245
-	i32.mul 	$push23=, $0, $pop52
-	i32.const	$push51=, 12345
-	i32.add 	$push50=, $pop23, $pop51
-	tee_local	$push49=, $2=, $pop50
-	i32.const	$push48=, 1103515245
-	i32.mul 	$push24=, $pop49, $pop48
-	i32.const	$push47=, 12345
-	i32.add 	$push46=, $pop24, $pop47
-	tee_local	$push45=, $0=, $pop46
-	i32.store	myrnd.s($pop53), $pop45
-	i32.const	$push44=, 0
-	i32.const	$push43=, 16
-	i32.shr_u	$push27=, $0, $pop43
-	i32.const	$push42=, 2047
-	i32.and 	$push28=, $pop27, $pop42
-	i32.const	$push41=, 16
-	i32.shr_u	$push25=, $2, $pop41
-	i32.const	$push40=, 2047
-	i32.and 	$push26=, $pop25, $pop40
-	i32.add 	$push29=, $pop28, $pop26
-	i32.or  	$push30=, $pop29, $1
-	i32.store	sX($pop44), $pop30
+	i32.const	$push55=, 1103515245
+	i32.mul 	$push24=, $1, $pop55
+	i32.const	$push54=, 12345
+	i32.add 	$push53=, $pop24, $pop54
+	tee_local	$push52=, $0=, $pop53
+	i32.const	$push51=, 1103515245
+	i32.mul 	$push25=, $pop52, $pop51
+	i32.const	$push50=, 12345
+	i32.add 	$push49=, $pop25, $pop50
+	tee_local	$push48=, $1=, $pop49
+	i32.store	myrnd.s($pop56), $pop48
+	i32.const	$push47=, 0
+	i32.const	$push46=, 16
+	i32.shr_u	$push28=, $1, $pop46
+	i32.const	$push45=, 2047
+	i32.and 	$push29=, $pop28, $pop45
+	i32.const	$push44=, 16
+	i32.shr_u	$push26=, $0, $pop44
+	i32.const	$push43=, 2047
+	i32.and 	$push27=, $pop26, $pop43
+	i32.add 	$push30=, $pop29, $pop27
+	i32.or  	$push31=, $pop30, $2
+	i32.store	sX($pop47), $pop31
                                         # fallthrough-return
 	.endfunc
 .Lfunc_end144:
@@ -6971,101 +6979,105 @@ fn3Y:                                   # @fn3Y
 testY:                                  # @testY
 	.local  	i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push0=, 0
-	i32.load	$2=, myrnd.s($pop0)
-	i32.const	$1=, -32
+	i32.const	$2=, -32
 .LBB150_1:                              # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label17:
-	i32.const	$push39=, sY+32
-	i32.add 	$push1=, $1, $pop39
-	i32.const	$push38=, 1103515245
-	i32.mul 	$push2=, $2, $pop38
-	i32.const	$push37=, 12345
-	i32.add 	$push36=, $pop2, $pop37
-	tee_local	$push35=, $2=, $pop36
-	i32.const	$push34=, 16
-	i32.shr_u	$push3=, $pop35, $pop34
-	i32.store8	0($pop1), $pop3
-	i32.const	$push33=, 1
-	i32.add 	$push32=, $1, $pop33
-	tee_local	$push31=, $1=, $pop32
-	br_if   	0, $pop31       # 0: up to label17
+	i32.const	$push42=, 0
+	i32.const	$push41=, 0
+	i32.load	$push0=, myrnd.s($pop41)
+	i32.const	$push40=, 1103515245
+	i32.mul 	$push1=, $pop0, $pop40
+	i32.const	$push39=, 12345
+	i32.add 	$push38=, $pop1, $pop39
+	tee_local	$push37=, $0=, $pop38
+	i32.store	myrnd.s($pop42), $pop37
+	i32.const	$push36=, sY+32
+	i32.add 	$push2=, $2, $pop36
+	i32.const	$push35=, 16
+	i32.shr_u	$push3=, $0, $pop35
+	i32.store8	0($pop2), $pop3
+	i32.const	$push34=, 1
+	i32.add 	$push33=, $2, $pop34
+	tee_local	$push32=, $2=, $pop33
+	br_if   	0, $pop32       # 0: up to label17
 # BB#2:                                 # %for.end
 	end_loop
-	i32.const	$push8=, 0
-	i32.const	$push4=, 1103515245
-	i32.mul 	$push5=, $2, $pop4
-	i32.const	$push6=, 12345
-	i32.add 	$push77=, $pop5, $pop6
-	tee_local	$push76=, $1=, $pop77
-	i32.const	$push75=, 1103515245
-	i32.mul 	$push7=, $pop76, $pop75
-	i32.const	$push74=, 12345
-	i32.add 	$push73=, $pop7, $pop74
-	tee_local	$push72=, $2=, $pop73
-	i32.store	myrnd.s($pop8), $pop72
-	i32.const	$push71=, 0
-	i64.const	$push9=, 4612055454334320640
-	i64.store	sY+24($pop71), $pop9
-	i32.const	$push70=, 0
-	i64.const	$push10=, 0
-	i64.store	sY+16($pop70), $pop10
-	i32.const	$push69=, 0
-	i32.const	$push13=, 16
-	i32.shr_u	$push14=, $1, $pop13
-	i32.const	$push15=, 2047
-	i32.and 	$push16=, $pop14, $pop15
-	i32.const	$push68=, 0
-	i32.load	$push11=, sY($pop68)
-	i32.const	$push12=, -4096
-	i32.and 	$push67=, $pop11, $pop12
-	tee_local	$push66=, $1=, $pop67
-	i32.or  	$push17=, $pop16, $pop66
-	i32.store	sY($pop69), $pop17
-	i32.const	$push65=, 0
-	i32.const	$push64=, 1103515245
-	i32.mul 	$push18=, $2, $pop64
-	i32.const	$push63=, 12345
-	i32.add 	$push62=, $pop18, $pop63
-	tee_local	$push61=, $2=, $pop62
-	i32.const	$push60=, 1103515245
-	i32.mul 	$push19=, $pop61, $pop60
-	i32.const	$push59=, 12345
-	i32.add 	$push58=, $pop19, $pop59
-	tee_local	$push57=, $0=, $pop58
-	i32.store	myrnd.s($pop65), $pop57
+	i32.const	$push4=, 0
+	i32.const	$push81=, 0
+	i32.load	$push5=, myrnd.s($pop81)
+	i32.const	$push6=, 1103515245
+	i32.mul 	$push7=, $pop5, $pop6
+	i32.const	$push8=, 12345
+	i32.add 	$push80=, $pop7, $pop8
+	tee_local	$push79=, $2=, $pop80
+	i32.const	$push78=, 1103515245
+	i32.mul 	$push9=, $pop79, $pop78
+	i32.const	$push77=, 12345
+	i32.add 	$push76=, $pop9, $pop77
+	tee_local	$push75=, $0=, $pop76
+	i32.store	myrnd.s($pop4), $pop75
+	i32.const	$push74=, 0
+	i64.const	$push10=, 4612055454334320640
+	i64.store	sY+24($pop74), $pop10
+	i32.const	$push73=, 0
+	i64.const	$push11=, 0
+	i64.store	sY+16($pop73), $pop11
+	i32.const	$push72=, 0
+	i32.const	$push71=, 1103515245
+	i32.mul 	$push12=, $0, $pop71
+	i32.const	$push70=, 12345
+	i32.add 	$push69=, $pop12, $pop70
+	tee_local	$push68=, $0=, $pop69
+	i32.const	$push67=, 1103515245
+	i32.mul 	$push13=, $pop68, $pop67
+	i32.const	$push66=, 12345
+	i32.add 	$push65=, $pop13, $pop66
+	tee_local	$push64=, $1=, $pop65
+	i32.store	myrnd.s($pop72), $pop64
+	i32.const	$push63=, 0
+	i32.const	$push16=, 16
+	i32.shr_u	$push17=, $2, $pop16
+	i32.const	$push18=, 2047
+	i32.and 	$push19=, $pop17, $pop18
+	i32.const	$push62=, 0
+	i32.load	$push14=, sY($pop62)
+	i32.const	$push15=, -4096
+	i32.and 	$push61=, $pop14, $pop15
+	tee_local	$push60=, $2=, $pop61
+	i32.or  	$push20=, $pop19, $pop60
+	i32.store	sY($pop63), $pop20
+	i32.const	$push59=, 0
+	i32.const	$push58=, 16
+	i32.shr_u	$push21=, $0, $pop58
+	i32.const	$push57=, 2047
+	i32.and 	$push22=, $pop21, $pop57
+	i32.or  	$push23=, $pop22, $2
+	i32.store	sY($pop59), $pop23
 	i32.const	$push56=, 0
-	i32.const	$push55=, 16
-	i32.shr_u	$push20=, $2, $pop55
-	i32.const	$push54=, 2047
-	i32.and 	$push21=, $pop20, $pop54
-	i32.or  	$push22=, $pop21, $1
-	i32.store	sY($pop56), $pop22
-	i32.const	$push53=, 0
-	i32.const	$push52=, 1103515245
-	i32.mul 	$push23=, $0, $pop52
-	i32.const	$push51=, 12345
-	i32.add 	$push50=, $pop23, $pop51
-	tee_local	$push49=, $2=, $pop50
-	i32.const	$push48=, 1103515245
-	i32.mul 	$push24=, $pop49, $pop48
-	i32.const	$push47=, 12345
-	i32.add 	$push46=, $pop24, $pop47
-	tee_local	$push45=, $0=, $pop46
-	i32.store	myrnd.s($pop53), $pop45
-	i32.const	$push44=, 0
-	i32.const	$push43=, 16
-	i32.shr_u	$push27=, $0, $pop43
-	i32.const	$push42=, 2047
-	i32.and 	$push28=, $pop27, $pop42
-	i32.const	$push41=, 16
-	i32.shr_u	$push25=, $2, $pop41
-	i32.const	$push40=, 2047
-	i32.and 	$push26=, $pop25, $pop40
-	i32.add 	$push29=, $pop28, $pop26
-	i32.or  	$push30=, $pop29, $1
-	i32.store	sY($pop44), $pop30
+	i32.const	$push55=, 1103515245
+	i32.mul 	$push24=, $1, $pop55
+	i32.const	$push54=, 12345
+	i32.add 	$push53=, $pop24, $pop54
+	tee_local	$push52=, $0=, $pop53
+	i32.const	$push51=, 1103515245
+	i32.mul 	$push25=, $pop52, $pop51
+	i32.const	$push50=, 12345
+	i32.add 	$push49=, $pop25, $pop50
+	tee_local	$push48=, $1=, $pop49
+	i32.store	myrnd.s($pop56), $pop48
+	i32.const	$push47=, 0
+	i32.const	$push46=, 16
+	i32.shr_u	$push28=, $1, $pop46
+	i32.const	$push45=, 2047
+	i32.and 	$push29=, $pop28, $pop45
+	i32.const	$push44=, 16
+	i32.shr_u	$push26=, $0, $pop44
+	i32.const	$push43=, 2047
+	i32.and 	$push27=, $pop26, $pop43
+	i32.add 	$push30=, $pop29, $pop27
+	i32.or  	$push31=, $pop30, $2
+	i32.store	sY($pop47), $pop31
                                         # fallthrough-return
 	.endfunc
 .Lfunc_end150:
@@ -7191,133 +7203,137 @@ fn3Z:                                   # @fn3Z
 testZ:                                  # @testZ
 	.local  	i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push1=, 0
-	i32.load	$4=, myrnd.s($pop1)
-	i32.const	$3=, -32
+	i32.const	$4=, -32
 .LBB156_1:                              # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label18:
-	i32.const	$push49=, sZ+32
-	i32.add 	$push2=, $3, $pop49
-	i32.const	$push48=, 1103515245
-	i32.mul 	$push3=, $4, $pop48
-	i32.const	$push47=, 12345
-	i32.add 	$push46=, $pop3, $pop47
-	tee_local	$push45=, $4=, $pop46
-	i32.const	$push44=, 16
-	i32.shr_u	$push4=, $pop45, $pop44
-	i32.store8	0($pop2), $pop4
-	i32.const	$push43=, 1
-	i32.add 	$push42=, $3, $pop43
-	tee_local	$push41=, $3=, $pop42
-	br_if   	0, $pop41       # 0: up to label18
+	i32.const	$push52=, 0
+	i32.const	$push51=, 0
+	i32.load	$push1=, myrnd.s($pop51)
+	i32.const	$push50=, 1103515245
+	i32.mul 	$push2=, $pop1, $pop50
+	i32.const	$push49=, 12345
+	i32.add 	$push48=, $pop2, $pop49
+	tee_local	$push47=, $0=, $pop48
+	i32.store	myrnd.s($pop52), $pop47
+	i32.const	$push46=, sZ+32
+	i32.add 	$push3=, $4, $pop46
+	i32.const	$push45=, 16
+	i32.shr_u	$push4=, $0, $pop45
+	i32.store8	0($pop3), $pop4
+	i32.const	$push44=, 1
+	i32.add 	$push43=, $4, $pop44
+	tee_local	$push42=, $4=, $pop43
+	br_if   	0, $pop42       # 0: up to label18
 # BB#2:                                 # %for.end
 	end_loop
-	i32.const	$push77=, 0
+	i32.const	$push81=, 0
 	i64.const	$push5=, 4612055454334320640
-	i64.store	sZ+8($pop77), $pop5
-	i32.const	$push76=, 0
+	i64.store	sZ+8($pop81), $pop5
+	i32.const	$push80=, 0
 	i64.const	$push6=, 0
-	i64.store	sZ($pop76), $pop6
-	i32.const	$push75=, 0
-	i32.const	$push74=, 1103515245
-	i32.mul 	$push7=, $4, $pop74
-	i32.const	$push73=, 12345
-	i32.add 	$push72=, $pop7, $pop73
-	tee_local	$push71=, $4=, $pop72
-	i32.const	$push70=, 1103515245
-	i32.mul 	$push8=, $pop71, $pop70
-	i32.const	$push69=, 12345
-	i32.add 	$push68=, $pop8, $pop69
-	tee_local	$push67=, $3=, $pop68
-	i32.store	myrnd.s($pop75), $pop67
-	i32.const	$push66=, 0
-	i32.const	$push65=, 16
-	i32.shr_u	$push10=, $4, $pop65
-	i32.const	$push64=, 2047
-	i32.and 	$push63=, $pop10, $pop64
-	tee_local	$push62=, $0=, $pop63
-	i32.const	$push61=, 20
-	i32.shl 	$push11=, $pop62, $pop61
-	i32.const	$push60=, 0
-	i32.load	$push0=, sZ+16($pop60)
-	i32.const	$push9=, 1048575
-	i32.and 	$push59=, $pop0, $pop9
-	tee_local	$push58=, $4=, $pop59
-	i32.or  	$push57=, $pop11, $pop58
-	tee_local	$push56=, $1=, $pop57
-	i32.store	sZ+16($pop66), $pop56
+	i64.store	sZ($pop80), $pop6
+	i32.const	$push79=, 0
+	i32.const	$push78=, 0
+	i32.load	$push7=, myrnd.s($pop78)
+	i32.const	$push77=, 1103515245
+	i32.mul 	$push8=, $pop7, $pop77
+	i32.const	$push76=, 12345
+	i32.add 	$push75=, $pop8, $pop76
+	tee_local	$push74=, $0=, $pop75
+	i32.const	$push73=, 1103515245
+	i32.mul 	$push9=, $pop74, $pop73
+	i32.const	$push72=, 12345
+	i32.add 	$push71=, $pop9, $pop72
+	tee_local	$push70=, $4=, $pop71
+	i32.store	myrnd.s($pop79), $pop70
+	i32.const	$push69=, 0
+	i32.const	$push68=, 16
+	i32.shr_u	$push11=, $0, $pop68
+	i32.const	$push67=, 2047
+	i32.and 	$push66=, $pop11, $pop67
+	tee_local	$push65=, $1=, $pop66
+	i32.const	$push64=, 20
+	i32.shl 	$push12=, $pop65, $pop64
+	i32.const	$push63=, 0
+	i32.load	$push0=, sZ+16($pop63)
+	i32.const	$push10=, 1048575
+	i32.and 	$push62=, $pop0, $pop10
+	tee_local	$push61=, $0=, $pop62
+	i32.or  	$push60=, $pop12, $pop61
+	tee_local	$push59=, $2=, $pop60
+	i32.store	sZ+16($pop69), $pop59
 	block   	
-	i32.const	$push55=, 16
-	i32.shr_u	$push12=, $3, $pop55
-	i32.const	$push54=, 2047
-	i32.and 	$push53=, $pop12, $pop54
-	tee_local	$push52=, $2=, $pop53
-	i32.add 	$push13=, $pop52, $0
-	i32.const	$push51=, 20
-	i32.shl 	$push14=, $2, $pop51
-	i32.add 	$push15=, $pop14, $1
-	i32.const	$push50=, 20
-	i32.shr_u	$push16=, $pop15, $pop50
-	i32.ne  	$push17=, $pop13, $pop16
-	br_if   	0, $pop17       # 0: down to label19
+	i32.const	$push58=, 16
+	i32.shr_u	$push13=, $4, $pop58
+	i32.const	$push57=, 2047
+	i32.and 	$push56=, $pop13, $pop57
+	tee_local	$push55=, $3=, $pop56
+	i32.add 	$push14=, $pop55, $1
+	i32.const	$push54=, 20
+	i32.shl 	$push15=, $3, $pop54
+	i32.add 	$push16=, $pop15, $2
+	i32.const	$push53=, 20
+	i32.shr_u	$push17=, $pop16, $pop53
+	i32.ne  	$push18=, $pop14, $pop17
+	br_if   	0, $pop18       # 0: down to label19
 # BB#3:                                 # %if.end80
-	i32.const	$push103=, 0
-	i32.const	$push102=, 1103515245
-	i32.mul 	$push18=, $3, $pop102
-	i32.const	$push101=, 12345
-	i32.add 	$push100=, $pop18, $pop101
-	tee_local	$push99=, $0=, $pop100
-	i32.const	$push19=, -1029531031
-	i32.mul 	$push20=, $pop99, $pop19
-	i32.const	$push21=, -740551042
-	i32.add 	$push98=, $pop20, $pop21
-	tee_local	$push97=, $3=, $pop98
-	i32.const	$push96=, 1103515245
-	i32.mul 	$push22=, $pop97, $pop96
-	i32.const	$push95=, 12345
-	i32.add 	$push94=, $pop22, $pop95
-	tee_local	$push93=, $1=, $pop94
-	i32.store	myrnd.s($pop103), $pop93
-	i32.const	$push92=, 0
-	i32.const	$push91=, 16
-	i32.shr_u	$push26=, $1, $pop91
-	i32.const	$push90=, 2047
-	i32.and 	$push89=, $pop26, $pop90
-	tee_local	$push88=, $1=, $pop89
-	i32.const	$push87=, 20
-	i32.shl 	$push27=, $pop88, $pop87
-	i32.const	$push86=, 16
-	i32.shr_u	$push23=, $3, $pop86
-	i32.const	$push85=, 2047
-	i32.and 	$push84=, $pop23, $pop85
-	tee_local	$push83=, $2=, $pop84
-	i32.const	$push82=, 20
-	i32.shl 	$push24=, $pop83, $pop82
-	i32.or  	$push25=, $pop24, $4
-	i32.add 	$push81=, $pop27, $pop25
-	tee_local	$push80=, $3=, $pop81
-	i32.store	sZ+16($pop92), $pop80
-	i32.const	$push28=, 4
-	i32.shl 	$push29=, $0, $pop28
-	i32.const	$push30=, 2146435072
-	i32.and 	$push31=, $pop29, $pop30
-	i32.or  	$push32=, $pop31, $4
-	i32.xor 	$push79=, $3, $pop32
-	tee_local	$push78=, $4=, $pop79
-	i32.const	$push33=, 1040384
-	i32.and 	$push34=, $pop78, $pop33
-	br_if   	0, $pop34       # 0: down to label19
-# BB#4:                                 # %lor.lhs.false98
-	i32.add 	$push38=, $1, $2
-	i32.const	$push36=, 20
-	i32.shr_u	$push37=, $3, $pop36
-	i32.ne  	$push39=, $pop38, $pop37
-	br_if   	0, $pop39       # 0: down to label19
-# BB#5:                                 # %lor.lhs.false98
-	i32.const	$push40=, 8191
-	i32.and 	$push35=, $4, $pop40
+	i32.const	$push107=, 0
+	i32.const	$push106=, 1103515245
+	i32.mul 	$push19=, $4, $pop106
+	i32.const	$push105=, 12345
+	i32.add 	$push104=, $pop19, $pop105
+	tee_local	$push103=, $1=, $pop104
+	i32.const	$push20=, -1029531031
+	i32.mul 	$push21=, $pop103, $pop20
+	i32.const	$push22=, -740551042
+	i32.add 	$push102=, $pop21, $pop22
+	tee_local	$push101=, $4=, $pop102
+	i32.const	$push100=, 1103515245
+	i32.mul 	$push23=, $pop101, $pop100
+	i32.const	$push99=, 12345
+	i32.add 	$push98=, $pop23, $pop99
+	tee_local	$push97=, $2=, $pop98
+	i32.store	myrnd.s($pop107), $pop97
+	i32.const	$push96=, 0
+	i32.const	$push95=, 16
+	i32.shr_u	$push27=, $2, $pop95
+	i32.const	$push94=, 2047
+	i32.and 	$push93=, $pop27, $pop94
+	tee_local	$push92=, $2=, $pop93
+	i32.const	$push91=, 20
+	i32.shl 	$push28=, $pop92, $pop91
+	i32.const	$push90=, 16
+	i32.shr_u	$push24=, $4, $pop90
+	i32.const	$push89=, 2047
+	i32.and 	$push88=, $pop24, $pop89
+	tee_local	$push87=, $3=, $pop88
+	i32.const	$push86=, 20
+	i32.shl 	$push25=, $pop87, $pop86
+	i32.or  	$push26=, $pop25, $0
+	i32.add 	$push85=, $pop28, $pop26
+	tee_local	$push84=, $4=, $pop85
+	i32.store	sZ+16($pop96), $pop84
+	i32.const	$push29=, 4
+	i32.shl 	$push30=, $1, $pop29
+	i32.const	$push31=, 2146435072
+	i32.and 	$push32=, $pop30, $pop31
+	i32.or  	$push33=, $pop32, $0
+	i32.xor 	$push83=, $4, $pop33
+	tee_local	$push82=, $0=, $pop83
+	i32.const	$push34=, 1040384
+	i32.and 	$push35=, $pop82, $pop34
 	br_if   	0, $pop35       # 0: down to label19
+# BB#4:                                 # %lor.lhs.false98
+	i32.add 	$push39=, $2, $3
+	i32.const	$push37=, 20
+	i32.shr_u	$push38=, $4, $pop37
+	i32.ne  	$push40=, $pop39, $pop38
+	br_if   	0, $pop40       # 0: down to label19
+# BB#5:                                 # %lor.lhs.false98
+	i32.const	$push41=, 8191
+	i32.and 	$push36=, $0, $pop41
+	br_if   	0, $pop36       # 0: down to label19
 # BB#6:                                 # %if.end121
 	return
 .LBB156_7:                              # %if.then120
@@ -7610,6 +7626,6 @@ sZ:
 	.size	sZ, 32
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/20050218-1.c.s
+++ b/test/torture-s/20050218-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20050218-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20050218-1.c"
 	.section	.text.foo,"ax",@progbits
 	.hidden	foo
 	.globl	foo
@@ -7,53 +7,55 @@
 foo:                                    # @foo
 	.param  	i32, i32, i32
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$7=, 0
 	block   	
-	i32.eqz 	$push12=, $2
-	br_if   	0, $pop12       # 0: down to label0
+	block   	
+	i32.eqz 	$push14=, $2
+	br_if   	0, $pop14       # 0: down to label1
 # BB#1:                                 # %for.body.lr.ph
 	i32.const	$5=, 0
 	i32.const	$4=, a
 	i32.const	$6=, 0
 .LBB0_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label1:
-	i32.const	$7=, 2
+	loop    	                # label2:
 	i32.add 	$push0=, $0, $5
-	i32.load	$push7=, 0($4)
+	i32.load	$push9=, 0($4)
+	tee_local	$push8=, $3=, $pop9
+	i32.call	$push7=, strlen@FUNCTION, $3
 	tee_local	$push6=, $3=, $pop7
-	i32.call	$push5=, strlen@FUNCTION, $3
-	tee_local	$push4=, $3=, $pop5
-	i32.call	$push1=, strncmp@FUNCTION, $pop0, $pop6, $pop4
-	br_if   	1, $pop1        # 1: down to label0
+	i32.call	$push1=, strncmp@FUNCTION, $pop0, $pop8, $pop6
+	br_if   	2, $pop1        # 2: down to label0
 # BB#3:                                 # %if.end
                                         #   in Loop: Header=BB0_2 Depth=1
 	i32.add 	$5=, $3, $5
 	block   	
-	i32.eqz 	$push13=, $1
-	br_if   	0, $pop13       # 0: down to label2
+	i32.eqz 	$push15=, $1
+	br_if   	0, $pop15       # 0: down to label3
 # BB#4:                                 # %if.then6
                                         #   in Loop: Header=BB0_2 Depth=1
 	i32.call	$push2=, strlen@FUNCTION, $1
 	i32.add 	$5=, $pop2, $5
 .LBB0_5:                                # %for.inc
                                         #   in Loop: Header=BB0_2 Depth=1
-	end_block                       # label2:
-	i32.const	$push11=, 4
-	i32.add 	$4=, $4, $pop11
-	i32.const	$7=, 0
-	i32.const	$push10=, 1
-	i32.add 	$push9=, $6, $pop10
-	tee_local	$push8=, $6=, $pop9
-	i32.lt_u	$push3=, $pop8, $2
-	br_if   	0, $pop3        # 0: up to label1
-.LBB0_6:                                # %cleanup
+	end_block                       # label3:
+	i32.const	$push13=, 4
+	i32.add 	$4=, $4, $pop13
+	i32.const	$push12=, 1
+	i32.add 	$push11=, $6, $pop12
+	tee_local	$push10=, $6=, $pop11
+	i32.lt_u	$push3=, $pop10, $2
+	br_if   	0, $pop3        # 0: up to label2
+.LBB0_6:
 	end_loop
+	end_block                       # label1:
+	i32.const	$push4=, 0
+	return  	$pop4
+.LBB0_7:
 	end_block                       # label0:
-	copy_local	$push14=, $7
-                                        # fallthrough-return: $pop14
+	i32.const	$push5=, 2
+                                        # fallthrough-return: $pop5
 	.endfunc
 .Lfunc_end0:
 	.size	foo, .Lfunc_end0-foo
@@ -74,7 +76,7 @@ main:                                   # @main
 	i32.call	$push9=, strlen@FUNCTION, $0
 	tee_local	$push8=, $0=, $pop9
 	i32.call	$push0=, strncmp@FUNCTION, $pop13, $pop10, $pop8
-	br_if   	0, $pop0        # 0: down to label3
+	br_if   	0, $pop0        # 0: down to label4
 # BB#1:                                 # %if.end.i
 	i32.const	$push19=, .L.str.4
 	i32.add 	$push1=, $0, $pop19
@@ -84,7 +86,7 @@ main:                                   # @main
 	i32.call	$push15=, strlen@FUNCTION, $1
 	tee_local	$push14=, $1=, $pop15
 	i32.call	$push2=, strncmp@FUNCTION, $pop1, $pop16, $pop14
-	br_if   	0, $pop2        # 0: down to label3
+	br_if   	0, $pop2        # 0: down to label4
 # BB#2:                                 # %if.end.i.1
 	i32.add 	$push3=, $1, $0
 	i32.const	$push4=, .L.str.4
@@ -94,12 +96,12 @@ main:                                   # @main
 	tee_local	$push20=, $0=, $pop21
 	i32.call	$push6=, strlen@FUNCTION, $0
 	i32.call	$push7=, strncmp@FUNCTION, $pop5, $pop20, $pop6
-	br_if   	0, $pop7        # 0: down to label3
+	br_if   	0, $pop7        # 0: down to label4
 # BB#3:                                 # %if.end.i.2
 	i32.const	$push23=, 0
 	return  	$pop23
 .LBB1_4:                                # %if.then
-	end_block                       # label3:
+	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -158,7 +160,7 @@ a:
 	.size	.L.str.4, 6
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	strncmp, i32, i32, i32, i32
 	.functype	strlen, i32, i32
 	.functype	abort, void

--- a/test/torture-s/20050826-2.c.s
+++ b/test/torture-s/20050826-2.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20050826-2.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20050826-2.c"
 	.section	.text.inet_check_attr,"ax",@progbits
 	.hidden	inet_check_attr
 	.globl	inet_check_attr
@@ -7,7 +7,7 @@
 inet_check_attr:                        # @inet_check_attr
 	.param  	i32, i32
 	.result 	i32
-	.local  	i32, i32, i32
+	.local  	i32, i32
 # BB#0:                                 # %entry
 	i32.const	$3=, 1
 .LBB0_1:                                # %for.body
@@ -15,48 +15,49 @@ inet_check_attr:                        # @inet_check_attr
 	block   	
 	loop    	                # label1:
 	block   	
-	i32.load	$push8=, 0($1)
-	tee_local	$push7=, $2=, $pop8
-	i32.eqz 	$push19=, $pop7
-	br_if   	0, $pop19       # 0: down to label2
+	i32.load	$push10=, 0($1)
+	tee_local	$push9=, $2=, $pop10
+	i32.eqz 	$push21=, $pop9
+	br_if   	0, $pop21       # 0: down to label2
 # BB#2:                                 # %if.then
                                         #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$4=, -22
 	i32.load16_u	$push0=, 0($2)
-	i32.const	$push10=, 65532
-	i32.and 	$push1=, $pop0, $pop10
-	i32.const	$push9=, 4
-	i32.eq  	$push2=, $pop1, $pop9
+	i32.const	$push12=, 65532
+	i32.and 	$push1=, $pop0, $pop12
+	i32.const	$push11=, 4
+	i32.eq  	$push2=, $pop1, $pop11
 	br_if   	2, $pop2        # 2: down to label0
 # BB#3:                                 # %if.end
                                         #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push12=, -2
-	i32.and 	$push3=, $3, $pop12
-	i32.const	$push11=, 8
-	i32.eq  	$push4=, $pop3, $pop11
+	i32.const	$push14=, -2
+	i32.and 	$push3=, $3, $pop14
+	i32.const	$push13=, 8
+	i32.eq  	$push4=, $pop3, $pop13
 	br_if   	0, $pop4        # 0: down to label2
 # BB#4:                                 # %if.then9
                                         #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push13=, 4
-	i32.add 	$push5=, $2, $pop13
+	i32.const	$push15=, 4
+	i32.add 	$push5=, $2, $pop15
 	i32.store	0($1), $pop5
 .LBB0_5:                                # %for.inc
                                         #   in Loop: Header=BB0_1 Depth=1
 	end_block                       # label2:
-	i32.const	$push18=, 4
-	i32.add 	$1=, $1, $pop18
-	i32.const	$4=, 0
-	i32.const	$push17=, 1
-	i32.add 	$push16=, $3, $pop17
-	tee_local	$push15=, $3=, $pop16
-	i32.const	$push14=, 15
-	i32.lt_s	$push6=, $pop15, $pop14
+	i32.const	$push20=, 4
+	i32.add 	$1=, $1, $pop20
+	i32.const	$push19=, 1
+	i32.add 	$push18=, $3, $pop19
+	tee_local	$push17=, $3=, $pop18
+	i32.const	$push16=, 15
+	i32.lt_s	$push6=, $pop17, $pop16
 	br_if   	0, $pop6        # 0: up to label1
-.LBB0_6:                                # %cleanup14
+# BB#6:
 	end_loop
+	i32.const	$push7=, 0
+	return  	$pop7
+.LBB0_7:
 	end_block                       # label0:
-	copy_local	$push20=, $4
-                                        # fallthrough-return: $pop20
+	i32.const	$push8=, -22
+                                        # fallthrough-return: $pop8
 	.endfunc
 .Lfunc_end0:
 	.size	inet_check_attr, .Lfunc_end0-inet_check_attr
@@ -357,5 +358,5 @@ main:                                   # @main
 	.size	main, .Lfunc_end1-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/20051113-1.c.s
+++ b/test/torture-s/20051113-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20051113-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20051113-1.c"
 	.section	.text.Sum,"ax",@progbits
 	.hidden	Sum
 	.globl	Sum
@@ -9,12 +9,11 @@ Sum:                                    # @Sum
 	.result 	i64
 	.local  	i32, i32, i64
 # BB#0:                                 # %entry
-	i64.const	$3=, 0
 	block   	
-	i32.load	$push7=, 0($0):p2align=0
-	tee_local	$push6=, $1=, $pop7
-	i32.const	$push5=, 1
-	i32.lt_s	$push1=, $pop6, $pop5
+	i32.load	$push8=, 0($0):p2align=0
+	tee_local	$push7=, $1=, $pop8
+	i32.const	$push6=, 1
+	i32.lt_s	$push1=, $pop7, $pop6
 	br_if   	0, $pop1        # 0: down to label0
 # BB#1:                                 # %for.body.preheader
 	i32.const	$push2=, 10
@@ -26,19 +25,21 @@ Sum:                                    # @Sum
 	loop    	                # label1:
 	i64.load	$push3=, 0($0):p2align=0
 	i64.add 	$3=, $pop3, $3
-	i32.const	$push11=, 30
-	i32.add 	$push0=, $0, $pop11
+	i32.const	$push12=, 30
+	i32.add 	$push0=, $0, $pop12
 	copy_local	$0=, $pop0
-	i32.const	$push10=, 1
-	i32.add 	$push9=, $2, $pop10
-	tee_local	$push8=, $2=, $pop9
-	i32.lt_s	$push4=, $pop8, $1
+	i32.const	$push11=, 1
+	i32.add 	$push10=, $2, $pop11
+	tee_local	$push9=, $2=, $pop10
+	i32.lt_s	$push4=, $pop9, $1
 	br_if   	0, $pop4        # 0: up to label1
-.LBB0_3:                                # %for.end
+# BB#3:                                 # %for.end
 	end_loop
+	return  	$3
+.LBB0_4:
 	end_block                       # label0:
-	copy_local	$push12=, $3
-                                        # fallthrough-return: $pop12
+	i64.const	$push5=, 0
+                                        # fallthrough-return: $pop5
 	.endfunc
 .Lfunc_end0:
 	.size	Sum, .Lfunc_end0-Sum
@@ -52,12 +53,11 @@ Sum2:                                   # @Sum2
 	.result 	i64
 	.local  	i32, i32, i64
 # BB#0:                                 # %entry
-	i64.const	$3=, 0
 	block   	
-	i32.load	$push7=, 0($0):p2align=0
-	tee_local	$push6=, $1=, $pop7
-	i32.const	$push5=, 1
-	i32.lt_s	$push1=, $pop6, $pop5
+	i32.load	$push8=, 0($0):p2align=0
+	tee_local	$push7=, $1=, $pop8
+	i32.const	$push6=, 1
+	i32.lt_s	$push1=, $pop7, $pop6
 	br_if   	0, $pop1        # 0: down to label2
 # BB#1:                                 # %for.body.preheader
 	i32.const	$push2=, 18
@@ -69,19 +69,21 @@ Sum2:                                   # @Sum2
 	loop    	                # label3:
 	i64.load	$push3=, 0($0):p2align=0
 	i64.add 	$3=, $pop3, $3
-	i32.const	$push11=, 30
-	i32.add 	$push0=, $0, $pop11
+	i32.const	$push12=, 30
+	i32.add 	$push0=, $0, $pop12
 	copy_local	$0=, $pop0
-	i32.const	$push10=, 1
-	i32.add 	$push9=, $2, $pop10
-	tee_local	$push8=, $2=, $pop9
-	i32.lt_s	$push4=, $pop8, $1
+	i32.const	$push11=, 1
+	i32.add 	$push10=, $2, $pop11
+	tee_local	$push9=, $2=, $pop10
+	i32.lt_s	$push4=, $pop9, $1
 	br_if   	0, $pop4        # 0: up to label3
-.LBB1_3:                                # %for.end
+# BB#3:                                 # %for.end
 	end_loop
+	return  	$3
+.LBB1_4:
 	end_block                       # label2:
-	copy_local	$push12=, $3
-                                        # fallthrough-return: $pop12
+	i64.const	$push5=, 0
+                                        # fallthrough-return: $pop5
 	.endfunc
 .Lfunc_end1:
 	.size	Sum2, .Lfunc_end1-Sum2
@@ -138,6 +140,6 @@ main:                                   # @main
 	.size	main, .Lfunc_end2-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	malloc, i32, i32
 	.functype	abort, void

--- a/test/torture-s/20051215-1.c.s
+++ b/test/torture-s/20051215-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20051215-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20051215-1.c"
 	.section	.text.foo,"ax",@progbits
 	.hidden	foo
 	.globl	foo
@@ -9,10 +9,9 @@ foo:                                    # @foo
 	.result 	i32
 	.local  	i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$5=, 0
 	block   	
-	i32.const	$push6=, 1
-	i32.lt_s	$push0=, $1, $pop6
+	i32.const	$push7=, 1
+	i32.lt_s	$push0=, $1, $pop7
 	br_if   	0, $pop0        # 0: down to label0
 # BB#1:                                 # %for.body.lr.ph
 	i32.const	$3=, 0
@@ -22,8 +21,8 @@ foo:                                    # @foo
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label1:
 	block   	
-	i32.eqz 	$push12=, $2
-	br_if   	0, $pop12       # 0: down to label2
+	i32.eqz 	$push13=, $2
+	br_if   	0, $pop13       # 0: down to label2
 # BB#3:                                 # %if.then
                                         #   in Loop: Header=BB0_2 Depth=1
 	i32.load	$push1=, 0($2)
@@ -32,21 +31,23 @@ foo:                                    # @foo
                                         #   in Loop: Header=BB0_2 Depth=1
 	end_block                       # label2:
 	i32.mul 	$push3=, $4, $0
+	i32.const	$push12=, 0
 	i32.const	$push11=, 0
-	i32.const	$push10=, 0
-	i32.gt_s	$push2=, $0, $pop10
-	i32.select	$push4=, $pop3, $pop11, $pop2
+	i32.gt_s	$push2=, $0, $pop11
+	i32.select	$push4=, $pop3, $pop12, $pop2
 	i32.add 	$5=, $5, $pop4
-	i32.const	$push9=, 1
-	i32.add 	$push8=, $3, $pop9
-	tee_local	$push7=, $3=, $pop8
-	i32.ne  	$push5=, $1, $pop7
+	i32.const	$push10=, 1
+	i32.add 	$push9=, $3, $pop10
+	tee_local	$push8=, $3=, $pop9
+	i32.ne  	$push5=, $1, $pop8
 	br_if   	0, $pop5        # 0: up to label1
-.LBB0_5:                                # %for.end6
+# BB#5:                                 # %for.end6
 	end_loop
+	return  	$5
+.LBB0_6:
 	end_block                       # label0:
-	copy_local	$push13=, $5
-                                        # fallthrough-return: $pop13
+	i32.const	$push6=, 0
+                                        # fallthrough-return: $pop6
 	.endfunc
 .Lfunc_end0:
 	.size	foo, .Lfunc_end0-foo
@@ -76,5 +77,5 @@ main:                                   # @main
 	.size	main, .Lfunc_end1-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/20060420-1.c.s
+++ b/test/torture-s/20060420-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20060420-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20060420-1.c"
 	.section	.text.foo,"ax",@progbits
 	.hidden	foo
 	.globl	foo
@@ -8,11 +8,11 @@ foo:                                    # @foo
 	.param  	i32, i32, i32, i32
 	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32
 # BB#0:                                 # %entry
-	i32.const	$10=, 0
+	block   	
 	block   	
 	i32.const	$push85=, 1
 	i32.lt_s	$push3=, $3, $pop85
-	br_if   	0, $pop3        # 0: down to label0
+	br_if   	0, $pop3        # 0: down to label1
 # BB#1:                                 # %land.rhs.lr.ph
 	i32.const	$push87=, -1
 	i32.add 	$8=, $2, $pop87
@@ -22,12 +22,12 @@ foo:                                    # @foo
 .LBB0_2:                                # %land.rhs
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB0_5 Depth 2
-	loop    	                # label1:
+	loop    	                # label2:
 	i32.add 	$push4=, $10, $0
 	i32.const	$push88=, 15
 	i32.and 	$push5=, $pop4, $pop88
 	i32.eqz 	$push171=, $pop5
-	br_if   	1, $pop171      # 1: down to label0
+	br_if   	2, $pop171      # 2: down to label0
 # BB#3:                                 # %for.body
                                         #   in Loop: Header=BB0_2 Depth=1
 	i32.load	$push7=, 0($1)
@@ -39,7 +39,7 @@ foo:                                    # @foo
 	block   	
 	i32.const	$push89=, 2
 	i32.lt_s	$push6=, $2, $pop89
-	br_if   	0, $pop6        # 0: down to label2
+	br_if   	0, $pop6        # 0: down to label3
 # BB#4:                                 # %for.body4.preheader
                                         #   in Loop: Header=BB0_2 Depth=1
 	copy_local	$12=, $8
@@ -47,7 +47,7 @@ foo:                                    # @foo
 .LBB0_5:                                # %for.body4
                                         #   Parent Loop BB0_2 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label3:
+	loop    	                # label4:
 	i32.load	$push9=, 0($9)
 	i32.add 	$push10=, $pop9, $11
 	f32.load	$push11=, 0($pop10)
@@ -58,28 +58,32 @@ foo:                                    # @foo
 	i32.const	$push95=, -1
 	i32.add 	$push94=, $12, $pop95
 	tee_local	$push93=, $12=, $pop94
-	br_if   	0, $pop93       # 0: up to label3
+	br_if   	0, $pop93       # 0: up to label4
 .LBB0_6:                                # %for.end
                                         #   in Loop: Header=BB0_2 Depth=1
 	end_loop
-	end_block                       # label2:
+	end_block                       # label3:
 	i32.add 	$push12=, $0, $11
 	f32.store	0($pop12), $25
 	i32.const	$push99=, 1
 	i32.add 	$push98=, $10, $pop99
 	tee_local	$push97=, $10=, $pop98
 	i32.lt_s	$push13=, $pop97, $3
-	br_if   	0, $pop13       # 0: up to label1
-.LBB0_7:                                # %for.cond12.preheader
+	br_if   	0, $pop13       # 0: up to label2
+	br      	2               # 2: down to label0
+.LBB0_7:
 	end_loop
+	end_block                       # label1:
+	i32.const	$10=, 0
+.LBB0_8:                                # %for.cond12.preheader
 	end_block                       # label0:
 	block   	
 	i32.const	$push14=, -15
 	i32.add 	$push101=, $3, $pop14
 	tee_local	$push100=, $4=, $pop101
 	i32.ge_s	$push15=, $10, $pop100
-	br_if   	0, $pop15       # 0: down to label4
-# BB#8:                                 # %for.body15.lr.ph
+	br_if   	0, $pop15       # 0: down to label5
+# BB#9:                                 # %for.body15.lr.ph
 	i32.const	$push104=, -1
 	i32.add 	$7=, $2, $pop104
 	i32.const	$push103=, 4
@@ -90,10 +94,10 @@ foo:                                    # @foo
 	i32.const	$push102=, -16
 	i32.and 	$push19=, $pop18, $pop102
 	i32.add 	$5=, $10, $pop19
-.LBB0_9:                                # %for.body15
+.LBB0_10:                               # %for.body15
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB0_11 Depth 2
-	loop    	                # label5:
+                                        #     Child Loop BB0_12 Depth 2
+	loop    	                # label6:
 	i32.load	$push21=, 0($1)
 	i32.const	$push122=, 2
 	i32.shl 	$push121=, $10, $pop122
@@ -143,15 +147,15 @@ foo:                                    # @foo
 	block   	
 	i32.const	$push105=, 2
 	i32.lt_s	$push20=, $2, $pop105
-	br_if   	0, $pop20       # 0: down to label6
-# BB#10:                                # %for.body33.preheader
-                                        #   in Loop: Header=BB0_9 Depth=1
+	br_if   	0, $pop20       # 0: down to label7
+# BB#11:                                # %for.body33.preheader
+                                        #   in Loop: Header=BB0_10 Depth=1
 	copy_local	$11=, $7
 	copy_local	$12=, $6
-.LBB0_11:                               # %for.body33
-                                        #   Parent Loop BB0_9 Depth=1
+.LBB0_12:                               # %for.body33
+                                        #   Parent Loop BB0_10 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label7:
+	loop    	                # label8:
 	i32.load	$push34=, 0($12)
 	i32.add 	$push140=, $pop34, $8
 	tee_local	$push139=, $9=, $pop140
@@ -217,11 +221,11 @@ foo:                                    # @foo
 	i32.const	$push125=, -1
 	i32.add 	$push124=, $11, $pop125
 	tee_local	$push123=, $11=, $pop124
-	br_if   	0, $pop123      # 0: up to label7
-.LBB0_12:                               # %for.end56
-                                        #   in Loop: Header=BB0_9 Depth=1
+	br_if   	0, $pop123      # 0: up to label8
+.LBB0_13:                               # %for.end56
+                                        #   in Loop: Header=BB0_10 Depth=1
 	end_loop
-	end_block                       # label6:
+	end_block                       # label7:
 	i32.add 	$push157=, $0, $8
 	tee_local	$push156=, $9=, $pop157
 	f32.store	16($pop156), $17
@@ -268,26 +272,26 @@ foo:                                    # @foo
 	i32.add 	$push142=, $10, $pop143
 	tee_local	$push141=, $10=, $pop142
 	i32.lt_s	$push75=, $pop141, $4
-	br_if   	0, $pop75       # 0: up to label5
-# BB#13:                                # %for.cond73.preheader.loopexit
+	br_if   	0, $pop75       # 0: up to label6
+# BB#14:                                # %for.cond73.preheader.loopexit
 	end_loop
 	i32.const	$push76=, 16
 	i32.add 	$10=, $5, $pop76
-.LBB0_14:                               # %for.cond73.preheader
-	end_block                       # label4:
+.LBB0_15:                               # %for.cond73.preheader
+	end_block                       # label5:
 	block   	
 	i32.ge_s	$push77=, $10, $3
-	br_if   	0, $pop77       # 0: down to label8
-# BB#15:                                # %for.body75.lr.ph
+	br_if   	0, $pop77       # 0: down to label9
+# BB#16:                                # %for.body75.lr.ph
 	i32.const	$push159=, -1
 	i32.add 	$4=, $2, $pop159
 	i32.const	$push158=, 4
 	i32.add 	$7=, $1, $pop158
 	i32.load	$8=, 0($1)
-.LBB0_16:                               # %for.body75
+.LBB0_17:                               # %for.body75
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB0_18 Depth 2
-	loop    	                # label9:
+                                        #     Child Loop BB0_19 Depth 2
+	loop    	                # label10:
 	i32.const	$push163=, 2
 	i32.shl 	$push162=, $10, $pop163
 	tee_local	$push161=, $11=, $pop162
@@ -296,15 +300,15 @@ foo:                                    # @foo
 	block   	
 	i32.const	$push160=, 2
 	i32.lt_s	$push78=, $2, $pop160
-	br_if   	0, $pop78       # 0: down to label10
-# BB#17:                                # %for.body81.preheader
-                                        #   in Loop: Header=BB0_16 Depth=1
+	br_if   	0, $pop78       # 0: down to label11
+# BB#18:                                # %for.body81.preheader
+                                        #   in Loop: Header=BB0_17 Depth=1
 	copy_local	$12=, $4
 	copy_local	$9=, $7
-.LBB0_18:                               # %for.body81
-                                        #   Parent Loop BB0_16 Depth=1
+.LBB0_19:                               # %for.body81
+                                        #   Parent Loop BB0_17 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label11:
+	loop    	                # label12:
 	i32.load	$push80=, 0($9)
 	i32.add 	$push81=, $pop80, $11
 	f32.load	$push82=, 0($pop81)
@@ -315,21 +319,21 @@ foo:                                    # @foo
 	i32.const	$push166=, -1
 	i32.add 	$push165=, $12, $pop166
 	tee_local	$push164=, $12=, $pop165
-	br_if   	0, $pop164      # 0: up to label11
-.LBB0_19:                               # %for.end87
-                                        #   in Loop: Header=BB0_16 Depth=1
+	br_if   	0, $pop164      # 0: up to label12
+.LBB0_20:                               # %for.end87
+                                        #   in Loop: Header=BB0_17 Depth=1
 	end_loop
-	end_block                       # label10:
+	end_block                       # label11:
 	i32.add 	$push83=, $0, $11
 	f32.store	0($pop83), $25
 	i32.const	$push170=, 1
 	i32.add 	$push169=, $10, $pop170
 	tee_local	$push168=, $10=, $pop169
 	i32.ne  	$push84=, $pop168, $3
-	br_if   	0, $pop84       # 0: up to label9
-.LBB0_20:                               # %for.end91
+	br_if   	0, $pop84       # 0: up to label10
+.LBB0_21:                               # %for.end91
 	end_loop
-	end_block                       # label8:
+	end_block                       # label9:
                                         # fallthrough-return
 	.endfunc
 .Lfunc_end0:
@@ -366,7 +370,7 @@ main:                                   # @main
 	i32.store	8($3), $pop36
 .LBB1_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label12:
+	loop    	                # label13:
 	i32.const	$push52=, 64
 	i32.add 	$push6=, $1, $pop52
 	f32.convert_s/i32	$push51=, $2
@@ -386,7 +390,7 @@ main:                                   # @main
 	tee_local	$push44=, $2=, $pop45
 	i32.const	$push43=, 16
 	i32.ne  	$push11=, $pop44, $pop43
-	br_if   	0, $pop11       # 0: up to label12
+	br_if   	0, $pop11       # 0: up to label13
 # BB#2:                                 # %for.end
 	end_loop
 	i32.const	$1=, 0
@@ -406,7 +410,7 @@ main:                                   # @main
 .LBB1_3:                                # %for.body16
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label14:
+	loop    	                # label15:
 	f32.load	$push23=, 0($2)
 	f32.convert_s/i32	$push60=, $1
 	tee_local	$push59=, $0=, $pop60
@@ -418,7 +422,7 @@ main:                                   # @main
 	f32.add 	$push21=, $0, $pop20
 	f32.add 	$push22=, $pop18, $pop21
 	f32.ne  	$push24=, $pop23, $pop22
-	br_if   	1, $pop24       # 1: down to label13
+	br_if   	1, $pop24       # 1: down to label14
 # BB#4:                                 # %for.cond13
                                         #   in Loop: Header=BB1_3 Depth=1
 	i32.const	$push65=, 4
@@ -428,7 +432,7 @@ main:                                   # @main
 	tee_local	$push62=, $1=, $pop63
 	i32.const	$push61=, 15
 	i32.le_s	$push25=, $pop62, $pop61
-	br_if   	0, $pop25       # 0: up to label14
+	br_if   	0, $pop25       # 0: up to label15
 # BB#5:                                 # %for.end31
 	end_loop
 	i32.const	$push33=, 0
@@ -438,7 +442,7 @@ main:                                   # @main
 	i32.const	$push26=, 0
 	return  	$pop26
 .LBB1_6:                                # %if.then
-	end_block                       # label13:
+	end_block                       # label14:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -455,5 +459,5 @@ buffer:
 	.size	buffer, 256
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/20071030-1.c.s
+++ b/test/torture-s/20071030-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20071030-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20071030-1.c"
 	.section	.text.CalcPing,"ax",@progbits
 	.hidden	CalcPing
 	.globl	CalcPing
@@ -15,8 +15,8 @@ CalcPing:                               # @CalcPing
 	i32.ne  	$push2=, $pop0, $pop1
 	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.then
-	i32.load	$push10=, 4($0)
-	return  	$pop10
+	i32.load	$push12=, 4($0)
+	return  	$pop12
 .LBB0_2:                                # %if.end
 	end_block                       # label0:
 	i32.const	$4=, 0
@@ -26,36 +26,36 @@ CalcPing:                               # @CalcPing
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label1:
 	i32.add 	$push3=, $0, $3
-	f32.load	$push19=, 0($pop3)
-	tee_local	$push18=, $1=, $pop19
-	f32.add 	$push4=, $5, $pop18
-	f32.const	$push17=, 0x0p0
-	f32.gt  	$push16=, $1, $pop17
-	tee_local	$push15=, $2=, $pop16
-	f32.select	$5=, $pop4, $5, $pop15
+	f32.load	$push21=, 0($pop3)
+	tee_local	$push20=, $1=, $pop21
+	f32.add 	$push4=, $5, $pop20
+	f32.const	$push19=, 0x0p0
+	f32.gt  	$push18=, $1, $pop19
+	tee_local	$push17=, $2=, $pop18
+	f32.select	$5=, $pop4, $5, $pop17
 	i32.add 	$4=, $2, $4
-	i32.const	$push14=, 24
-	i32.add 	$push13=, $3, $pop14
-	tee_local	$push12=, $3=, $pop13
-	i32.const	$push11=, 1552
-	i32.ne  	$push5=, $pop12, $pop11
+	i32.const	$push16=, 24
+	i32.add 	$push15=, $3, $pop16
+	tee_local	$push14=, $3=, $pop15
+	i32.const	$push13=, 1552
+	i32.ne  	$push5=, $pop14, $pop13
 	br_if   	0, $pop5        # 0: up to label1
 # BB#4:                                 # %for.end
 	end_loop
-	i32.const	$3=, 9999
 	block   	
-	i32.eqz 	$push20=, $4
-	br_if   	0, $pop20       # 0: down to label2
+	i32.eqz 	$push22=, $4
+	br_if   	0, $pop22       # 0: down to label2
 # BB#5:                                 # %if.end9
 	f32.convert_s/i32	$push6=, $4
 	f32.div 	$push7=, $5, $pop6
 	f32.const	$push8=, 0x1.f4p9
 	f32.mul 	$push9=, $pop7, $pop8
-	i32.trunc_s/f32	$3=, $pop9
-.LBB0_6:                                # %cleanup
+	i32.trunc_s/f32	$push10=, $pop9
+	return  	$pop10
+.LBB0_6:
 	end_block                       # label2:
-	copy_local	$push21=, $3
-                                        # fallthrough-return: $pop21
+	i32.const	$push11=, 9999
+                                        # fallthrough-return: $pop11
 	.endfunc
 .Lfunc_end0:
 	.size	CalcPing, .Lfunc_end0-CalcPing
@@ -139,5 +139,5 @@ main:                                   # @main
 	.size	main, .Lfunc_end1-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/20090113-1.c.s
+++ b/test/torture-s/20090113-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20090113-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20090113-1.c"
 	.section	.text.msum_i4,"ax",@progbits
 	.hidden	msum_i4
 	.globl	msum_i4
@@ -81,9 +81,9 @@ msum_i4:                                # @msum_i4
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB0_6 Depth 2
 	loop    	                # label2:
-	i32.const	$7=, 0
 	block   	
-	br_if   	0, $0           # 0: down to label3
+	block   	
+	br_if   	0, $0           # 0: down to label4
 # BB#5:                                 # %for.body18.preheader
                                         #   in Loop: Header=BB0_4 Depth=1
 	i32.const	$7=, 0
@@ -92,7 +92,7 @@ msum_i4:                                # @msum_i4
 .LBB0_6:                                # %for.body18
                                         #   Parent Loop BB0_4 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label4:
+	loop    	                # label5:
 	i32.load	$push16=, 0($2)
 	i32.add 	$7=, $pop16, $7
 	i32.const	$push58=, 4
@@ -101,12 +101,16 @@ msum_i4:                                # @msum_i4
 	i32.const	$push57=, -1
 	i32.add 	$push56=, $6, $pop57
 	tee_local	$push55=, $6=, $pop56
-	br_if   	0, $pop55       # 0: up to label4
+	br_if   	0, $pop55       # 0: up to label5
 # BB#7:                                 # %for.end22.loopexit
                                         #   in Loop: Header=BB0_4 Depth=1
 	end_loop
 	i32.add 	$5=, $5, $4
-.LBB0_8:                                # %for.end22
+	br      	1               # 1: down to label3
+.LBB0_8:                                #   in Loop: Header=BB0_4 Depth=1
+	end_block                       # label4:
+	i32.const	$7=, 0
+.LBB0_9:                                # %for.end22
                                         #   in Loop: Header=BB0_4 Depth=1
 	end_block                       # label3:
 	i32.store	0($1), $7
@@ -120,7 +124,7 @@ msum_i4:                                # @msum_i4
 	i32.load	$push18=, 0($8)
 	i32.ne  	$push19=, $2, $pop18
 	br_if   	0, $pop19       # 0: up to label2
-# BB#9:                                 # %do.end
+# BB#10:                                # %do.end
 	end_loop
 	i32.const	$push26=, 0
 	i32.const	$push24=, 64
@@ -145,4 +149,4 @@ main:                                   # @main
 	.size	main, .Lfunc_end1-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "

--- a/test/torture-s/20090113-2.c.s
+++ b/test/torture-s/20090113-2.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20090113-2.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20090113-2.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
@@ -55,59 +55,58 @@ main:                                   # @main
 	.type	foobar,@function
 foobar:                                 # @foobar
 	.param  	i32
-	.local  	i32, i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push13=, 0
-	i32.const	$push10=, 0
-	i32.load	$push11=, __stack_pointer($pop10)
-	i32.const	$push12=, 32
-	i32.sub 	$push33=, $pop11, $pop12
-	tee_local	$push32=, $7=, $pop33
-	i32.store	__stack_pointer($pop13), $pop32
-	i32.const	$push17=, 16
-	i32.add 	$push18=, $7, $pop17
-	i32.const	$push19=, 12
-	i32.add 	$push20=, $7, $pop19
-	call    	bmp_iter_set_init@FUNCTION, $pop18, $0, $pop20
-	i32.const	$push21=, 16
-	i32.add 	$push22=, $7, $pop21
-	i32.const	$push31=, 12
-	i32.add 	$2=, $pop22, $pop31
+	i32.const	$push14=, 0
+	i32.const	$push11=, 0
+	i32.load	$push12=, __stack_pointer($pop11)
+	i32.const	$push13=, 32
+	i32.sub 	$push34=, $pop12, $pop13
+	tee_local	$push33=, $7=, $pop34
+	i32.store	__stack_pointer($pop14), $pop33
+	i32.const	$push18=, 16
+	i32.add 	$push19=, $7, $pop18
+	i32.const	$push20=, 12
+	i32.add 	$push21=, $7, $pop20
+	call    	bmp_iter_set_init@FUNCTION, $pop19, $0, $pop21
+	i32.const	$push22=, 16
+	i32.add 	$push23=, $7, $pop22
+	i32.const	$push32=, 12
+	i32.add 	$2=, $pop23, $pop32
 	i32.const	$push2=, 24
 	i32.add 	$3=, $7, $pop2
 .LBB1_1:                                # %for.cond
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB1_3 Depth 2
-                                        #     Child Loop BB1_6 Depth 2
-                                        #       Child Loop BB1_8 Depth 3
-	block   	
-	loop    	                # label1:
+                                        #     Child Loop BB1_9 Depth 2
+	loop    	                # label0:
 	i32.load	$0=, 12($7)
 	block   	
 	block   	
-	i32.load	$push35=, 0($2)
-	tee_local	$push34=, $5=, $pop35
-	i32.eqz 	$push69=, $pop34
-	br_if   	0, $pop69       # 0: down to label3
+	block   	
+	i32.load	$push36=, 0($2)
+	tee_local	$push35=, $5=, $pop36
+	i32.eqz 	$push72=, $pop35
+	br_if   	0, $pop72       # 0: down to label3
 # BB#2:                                 # %while.cond.preheader.i
                                         #   in Loop: Header=BB1_1 Depth=1
 	block   	
-	i32.const	$push36=, 1
-	i32.and 	$push0=, $5, $pop36
+	i32.const	$push37=, 1
+	i32.and 	$push0=, $5, $pop37
 	br_if   	0, $pop0        # 0: down to label4
 .LBB1_3:                                # %while.body.i
                                         #   Parent Loop BB1_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	loop    	                # label5:
+	i32.const	$push42=, 1
+	i32.add 	$0=, $0, $pop42
 	i32.const	$push41=, 1
-	i32.add 	$0=, $0, $pop41
-	i32.const	$push40=, 1
-	i32.shr_u	$push39=, $5, $pop40
-	tee_local	$push38=, $5=, $pop39
-	i32.const	$push37=, 1
-	i32.and 	$push1=, $pop38, $pop37
-	i32.eqz 	$push70=, $pop1
-	br_if   	0, $pop70       # 0: up to label5
+	i32.shr_u	$push40=, $5, $pop41
+	tee_local	$push39=, $5=, $pop40
+	i32.const	$push38=, 1
+	i32.and 	$push1=, $pop39, $pop38
+	i32.eqz 	$push73=, $pop1
+	br_if   	0, $pop73       # 0: up to label5
 .LBB1_4:                                # %while.end.i
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_loop
@@ -118,113 +117,184 @@ foobar:                                 # @foobar
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label3:
 	i32.load	$push3=, 0($3)
-	i32.const	$push48=, 1
-	i32.add 	$push47=, $pop3, $pop48
-	tee_local	$push46=, $1=, $pop47
-	i32.store	0($3), $pop46
-	i32.const	$push45=, 63
-	i32.add 	$push4=, $0, $pop45
-	i32.const	$push44=, -64
-	i32.and 	$push43=, $pop4, $pop44
-	tee_local	$push42=, $0=, $pop43
-	i32.store	12($7), $pop42
+	i32.const	$push50=, 1
+	i32.add 	$push49=, $pop3, $pop50
+	tee_local	$push48=, $1=, $pop49
+	i32.store	0($3), $pop48
+	i32.const	$push47=, 63
+	i32.add 	$push4=, $0, $pop47
+	i32.const	$push46=, -64
+	i32.and 	$push45=, $pop4, $pop46
+	tee_local	$push44=, $0=, $pop45
+	i32.store	12($7), $pop44
 	i32.load	$4=, 16($7)
-.LBB1_6:                                # %while.cond5.i
-                                        #   Parent Loop BB1_1 Depth=1
-                                        # =>  This Loop Header: Depth=2
-                                        #       Child Loop BB1_8 Depth 3
 	block   	
-	loop    	                # label7:
-	block   	
-	i32.const	$push53=, 2
-	i32.eq  	$push5=, $1, $pop53
-	br_if   	0, $pop5        # 0: down to label8
-# BB#7:                                 # %while.body9.i.preheader
-                                        #   in Loop: Header=BB1_6 Depth=2
-	i32.const	$push57=, 1
-	i32.add 	$5=, $1, $pop57
-	i32.const	$push56=, 64
-	i32.add 	$6=, $0, $pop56
-	i32.const	$push55=, 2
-	i32.shl 	$push6=, $1, $pop55
-	i32.add 	$push7=, $4, $pop6
-	i32.const	$push54=, 12
-	i32.add 	$0=, $pop7, $pop54
-.LBB1_8:                                # %while.body9.i
-                                        #   Parent Loop BB1_1 Depth=1
-                                        #     Parent Loop BB1_6 Depth=2
-                                        # =>    This Inner Loop Header: Depth=3
-	loop    	                # label9:
-	i32.load	$push59=, 0($0)
-	tee_local	$push58=, $1=, $pop59
-	br_if   	3, $pop58       # 3: down to label6
-# BB#9:                                 # %if.end17.i
-                                        #   in Loop: Header=BB1_8 Depth=3
-	i32.store	0($3), $5
-	i32.const	$push65=, 4
-	i32.add 	$0=, $0, $pop65
-	i32.store	12($7), $6
-	i32.const	$push64=, 64
-	i32.add 	$6=, $6, $pop64
-	i32.const	$push63=, 1
-	i32.add 	$push62=, $5, $pop63
-	tee_local	$push61=, $5=, $pop62
-	i32.const	$push60=, 3
-	i32.ne  	$push8=, $pop61, $pop60
-	br_if   	0, $pop8        # 0: up to label9
-# BB#10:                                # %while.end21.i.loopexit
-                                        #   in Loop: Header=BB1_6 Depth=2
-	end_loop
-	i32.const	$push66=, 0
-	i32.store	0($2), $pop66
-.LBB1_11:                               # %while.end21.i
-                                        #   in Loop: Header=BB1_6 Depth=2
-	end_block                       # label8:
-	i32.load	$push68=, 0($4)
-	tee_local	$push67=, $4=, $pop68
-	i32.eqz 	$push71=, $pop67
-	br_if   	4, $pop71       # 4: down to label0
-# BB#12:                                # %if.end25.i
-                                        #   in Loop: Header=BB1_6 Depth=2
-	i32.const	$1=, 0
-	i32.const	$push52=, 0
-	i32.store	0($3), $pop52
-	i32.load	$push9=, 8($4)
-	i32.const	$push51=, 7
-	i32.shl 	$push50=, $pop9, $pop51
-	tee_local	$push49=, $0=, $pop50
-	i32.store	12($7), $pop49
-	br      	0               # 0: up to label7
-.LBB1_13:                               # %if.then15.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_loop
+	i32.const	$push43=, 2
+	i32.ne  	$push5=, $1, $pop43
+	br_if   	0, $pop5        # 0: down to label6
+# BB#6:                                 #   in Loop: Header=BB1_1 Depth=1
+	i32.const	$8=, 1
+	br      	2               # 2: down to label1
+.LBB1_7:                                #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label6:
+	i32.const	$8=, 3
+	br      	1               # 1: down to label1
+.LBB1_8:                                #   in Loop: Header=BB1_1 Depth=1
+	end_block                       # label2:
+	i32.const	$8=, 6
+.LBB1_9:                                #   Parent Loop BB1_1 Depth=1
+                                        # =>  This Inner Loop Header: Depth=2
+	end_block                       # label1:
+	block   	
+	loop    	                # label8:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$8, 4, 5, 0, 1, 2, 6, 14, 3, 3 # 4: down to label17
+                                        # 5: down to label16
+                                        # 0: down to label21
+                                        # 1: down to label20
+                                        # 2: down to label19
+                                        # 6: down to label15
+                                        # 14: down to label7
+                                        # 3: down to label18
+.LBB1_10:                               # %if.end25.i
+                                        #   in Loop: Header=BB1_9 Depth=2
+	end_block                       # label21:
+	i32.const	$1=, 0
+	i32.const	$push56=, 0
+	i32.store	0($3), $pop56
+	i32.load	$push10=, 8($4)
+	i32.const	$push55=, 7
+	i32.shl 	$push54=, $pop10, $pop55
+	tee_local	$push53=, $0=, $pop54
+	i32.store	12($7), $pop53
+	i32.const	$push52=, 0
+	i32.const	$push51=, 2
+	i32.eq  	$push6=, $pop52, $pop51
+	br_if   	8, $pop6        # 8: down to label12
+# BB#11:                                #   in Loop: Header=BB1_9 Depth=2
+	i32.const	$8=, 3
+	br      	12              # 12: up to label8
+.LBB1_12:                               # %while.body9.i.preheader
+                                        #   in Loop: Header=BB1_9 Depth=2
+	end_block                       # label20:
+	i32.const	$push60=, 1
+	i32.add 	$5=, $1, $pop60
+	i32.const	$push59=, 64
+	i32.add 	$6=, $0, $pop59
+	i32.const	$push58=, 2
+	i32.shl 	$push7=, $1, $pop58
+	i32.add 	$push8=, $4, $pop7
+	i32.const	$push57=, 12
+	i32.add 	$0=, $pop8, $pop57
+# BB#13:                                #   in Loop: Header=BB1_9 Depth=2
+	i32.const	$8=, 4
+	br      	11              # 11: up to label8
+.LBB1_14:                               # %while.body9.i
+                                        #   in Loop: Header=BB1_9 Depth=2
+	end_block                       # label19:
+	i32.load	$push62=, 0($0)
+	tee_local	$push61=, $1=, $pop62
+	br_if   	8, $pop61       # 8: down to label10
+# BB#15:                                #   in Loop: Header=BB1_9 Depth=2
+	i32.const	$8=, 7
+	br      	10              # 10: up to label8
+.LBB1_16:                               # %if.end17.i
+                                        #   in Loop: Header=BB1_9 Depth=2
+	end_block                       # label18:
+	i32.store	0($3), $5
+	i32.const	$push68=, 4
+	i32.add 	$0=, $0, $pop68
+	i32.store	12($7), $6
+	i32.const	$push67=, 64
+	i32.add 	$6=, $6, $pop67
+	i32.const	$push66=, 1
+	i32.add 	$push65=, $5, $pop66
+	tee_local	$push64=, $5=, $pop65
+	i32.const	$push63=, 3
+	i32.ne  	$push9=, $pop64, $pop63
+	br_if   	4, $pop9        # 4: down to label13
+# BB#17:                                #   in Loop: Header=BB1_9 Depth=2
+	i32.const	$8=, 0
+	br      	9               # 9: up to label8
+.LBB1_18:                               # %while.end21.i.loopexit
+                                        #   in Loop: Header=BB1_9 Depth=2
+	end_block                       # label17:
+	i32.const	$push69=, 0
+	i32.store	0($2), $pop69
+# BB#19:                                #   in Loop: Header=BB1_9 Depth=2
+	i32.const	$8=, 1
+	br      	8               # 8: up to label8
+.LBB1_20:                               # %while.end21.i
+                                        #   in Loop: Header=BB1_9 Depth=2
+	end_block                       # label16:
+	i32.load	$push71=, 0($4)
+	tee_local	$push70=, $4=, $pop71
+	br_if   	4, $pop70       # 4: down to label11
+	br      	1               # 1: down to label14
+.LBB1_21:                               # %if.then15.i
+                                        #   in Loop: Header=BB1_9 Depth=2
+	end_block                       # label15:
 	i32.store	0($2), $1
 	i32.store	16($7), $4
-	i32.const	$push23=, 16
-	i32.add 	$push24=, $7, $pop23
-	i32.const	$push25=, 12
-	i32.add 	$push26=, $7, $pop25
-	call    	bmp_iter_set_tail@FUNCTION, $pop24, $pop26
+	i32.const	$push24=, 16
+	i32.add 	$push25=, $7, $pop24
+	i32.const	$push26=, 12
+	i32.add 	$push27=, $7, $pop26
+	call    	bmp_iter_set_tail@FUNCTION, $pop25, $pop27
 	i32.load	$0=, 12($7)
-.LBB1_14:                               # %for.body
+	br      	5               # 5: down to label9
+.LBB1_22:                               # %for.end
+	end_block                       # label14:
+	i32.const	$push17=, 0
+	i32.const	$push15=, 32
+	i32.add 	$push16=, $7, $pop15
+	i32.store	__stack_pointer($pop17), $pop16
+	return
+.LBB1_23:                               #   in Loop: Header=BB1_9 Depth=2
+	end_block                       # label13:
+	i32.const	$8=, 4
+	br      	4               # 4: up to label8
+.LBB1_24:                               #   in Loop: Header=BB1_9 Depth=2
+	end_block                       # label12:
+	i32.const	$8=, 1
+	br      	3               # 3: up to label8
+.LBB1_25:                               #   in Loop: Header=BB1_9 Depth=2
+	end_block                       # label11:
+	i32.const	$8=, 2
+	br      	2               # 2: up to label8
+.LBB1_26:                               #   in Loop: Header=BB1_9 Depth=2
+	end_block                       # label10:
+	i32.const	$8=, 5
+	br      	1               # 1: up to label8
+.LBB1_27:                               #   in Loop: Header=BB1_9 Depth=2
+	end_block                       # label9:
+	i32.const	$8=, 6
+	br      	0               # 0: up to label8
+.LBB1_28:                               # %for.body
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label2:
-	call    	catchme@FUNCTION, $0
-	i32.const	$push27=, 16
-	i32.add 	$push28=, $7, $pop27
-	i32.const	$push29=, 12
-	i32.add 	$push30=, $7, $pop29
-	call    	bmp_iter_next@FUNCTION, $pop28, $pop30
-	br      	0               # 0: up to label1
-.LBB1_15:                               # %for.end
 	end_loop
-	end_block                       # label0:
-	i32.const	$push16=, 0
-	i32.const	$push14=, 32
-	i32.add 	$push15=, $7, $pop14
-	i32.store	__stack_pointer($pop16), $pop15
-                                        # fallthrough-return
+	end_block                       # label7:
+	call    	catchme@FUNCTION, $0
+	i32.const	$push28=, 16
+	i32.add 	$push29=, $7, $pop28
+	i32.const	$push30=, 12
+	i32.add 	$push31=, $7, $pop30
+	call    	bmp_iter_next@FUNCTION, $pop29, $pop31
+	br      	0               # 0: up to label0
+.LBB1_29:
+	end_loop
 	.endfunc
 .Lfunc_end1:
 	.size	foobar, .Lfunc_end1-foobar
@@ -241,13 +311,13 @@ bmp_iter_set_init:                      # @bmp_iter_set_init
 	tee_local	$push5=, $1=, $pop6
 	i32.store	0($0), $pop5
 	block   	
-	br_if   	0, $1           # 0: down to label10
+	br_if   	0, $1           # 0: down to label22
 # BB#1:                                 # %if.then
 	i32.const	$1=, bitmap_zero_bits
 	i32.const	$push8=, bitmap_zero_bits
 	i32.store	0($0), $pop8
 .LBB2_2:                                # %while.end
-	end_block                       # label10:
+	end_block                       # label22:
 	i32.const	$push11=, 0
 	i32.store	8($0), $pop11
 	i32.load	$push10=, 12($1)
@@ -274,11 +344,11 @@ catchme:                                # @catchme
 	i32.or  	$push1=, $0, $pop0
 	i32.const	$push3=, 64
 	i32.ne  	$push2=, $pop1, $pop3
-	br_if   	0, $pop2        # 0: down to label11
+	br_if   	0, $pop2        # 0: down to label23
 # BB#1:                                 # %if.end
 	return
 .LBB3_2:                                # %if.then
-	end_block                       # label11:
+	end_block                       # label23:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -314,12 +384,12 @@ bmp_iter_set_tail:                      # @bmp_iter_set_tail
 	tee_local	$push5=, $3=, $pop6
 	i32.const	$push4=, 1
 	i32.and 	$push0=, $pop5, $pop4
-	br_if   	0, $pop0        # 0: down to label12
+	br_if   	0, $pop0        # 0: down to label24
 # BB#1:                                 # %while.body.lr.ph
 	i32.load	$2=, 0($1)
 .LBB5_2:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label13:
+	loop    	                # label25:
 	i32.const	$push11=, 1
 	i32.add 	$2=, $2, $pop11
 	i32.const	$push10=, 1
@@ -328,7 +398,7 @@ bmp_iter_set_tail:                      # @bmp_iter_set_tail
 	i32.const	$push7=, 1
 	i32.and 	$push1=, $pop8, $pop7
 	i32.eqz 	$push12=, $pop1
-	br_if   	0, $pop12       # 0: up to label13
+	br_if   	0, $pop12       # 0: up to label25
 # BB#3:                                 # %while.cond.while.end_crit_edge
 	end_loop
 	i32.store	0($1), $2
@@ -336,7 +406,7 @@ bmp_iter_set_tail:                      # @bmp_iter_set_tail
 	i32.add 	$push3=, $0, $pop2
 	i32.store	0($pop3), $3
 .LBB5_4:                                # %while.end
-	end_block                       # label12:
+	end_block                       # label24:
                                         # fallthrough-return
 	.endfunc
 .Lfunc_end5:
@@ -363,5 +433,5 @@ bitmap_zero_bits:
 	.size	bitmap_zero_bits, 20
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/20090113-3.c.s
+++ b/test/torture-s/20090113-3.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20090113-3.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20090113-3.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
@@ -55,168 +55,289 @@ main:                                   # @main
 	.type	foobar,@function
 foobar:                                 # @foobar
 	.param  	i32
-	.local  	i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$push16=, 0
 	i32.const	$push13=, 0
 	i32.load	$push14=, __stack_pointer($pop13)
 	i32.const	$push15=, 32
-	i32.sub 	$push33=, $pop14, $pop15
-	tee_local	$push32=, $5=, $pop33
-	i32.store	__stack_pointer($pop16), $pop32
+	i32.sub 	$push35=, $pop14, $pop15
+	tee_local	$push34=, $5=, $pop35
+	i32.store	__stack_pointer($pop16), $pop34
 	i32.const	$push20=, 16
 	i32.add 	$push21=, $5, $pop20
 	i32.const	$push22=, 12
 	i32.add 	$push23=, $5, $pop22
 	call    	bmp_iter_set_init@FUNCTION, $pop21, $0, $pop23
-	i32.load	$0=, 28($5)
 	i32.load	$4=, 16($5)
 	i32.const	$push3=, 24
 	i32.add 	$1=, $5, $pop3
-.LBB1_1:                                # %for.cond
-                                        # =>This Loop Header: Depth=1
-                                        #     Child Loop BB1_3 Depth 2
-                                        #     Child Loop BB1_6 Depth 2
-                                        #       Child Loop BB1_8 Depth 3
-                                        #     Child Loop BB1_13 Depth 2
-	block   	
-	loop    	                # label1:
 	block   	
 	block   	
-	i32.eqz 	$push67=, $0
-	br_if   	0, $pop67       # 0: down to label3
-# BB#2:                                 # %while.cond.preheader.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push38=, 1
-	i32.and 	$push0=, $0, $pop38
-	br_if   	1, $pop0        # 1: down to label2
-.LBB1_3:                                # %while.body.i
-                                        #   Parent Loop BB1_1 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop    	                # label4:
-	i32.const	$push42=, 1
-	i32.shr_u	$push41=, $0, $pop42
-	tee_local	$push40=, $0=, $pop41
-	i32.const	$push39=, 1
-	i32.and 	$push1=, $pop40, $pop39
-	i32.eqz 	$push68=, $pop1
-	br_if   	0, $pop68       # 0: up to label4
-# BB#4:                                 # %while.cond.return.loopexit62_crit_edge.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_loop
-	i32.const	$push30=, 16
-	i32.add 	$push31=, $5, $pop30
-	i32.const	$push43=, 12
-	i32.add 	$push2=, $pop31, $pop43
-	i32.store	0($pop2), $0
-	br      	1               # 1: down to label2
-.LBB1_5:                                # %if.end.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label3:
-	i32.load	$push4=, 0($1)
-	i32.const	$push44=, 1
-	i32.add 	$3=, $pop4, $pop44
-.LBB1_6:                                # %while.body6.i
-                                        #   Parent Loop BB1_1 Depth=1
-                                        # =>  This Loop Header: Depth=2
-                                        #       Child Loop BB1_8 Depth 3
+	i32.load	$push33=, 28($5)
+	tee_local	$push32=, $0=, $pop33
+	br_if   	0, $pop32       # 0: down to label1
+# BB#1:
+	i32.const	$6=, 2
+	br      	1               # 1: down to label0
+.LBB1_2:
+	end_block                       # label1:
+	i32.const	$6=, 0
+.LBB1_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label0:
+	loop    	                # label2:
 	block   	
-	loop    	                # label6:
 	block   	
-	i32.const	$push45=, 2
-	i32.eq  	$push5=, $3, $pop45
-	br_if   	0, $pop5        # 0: down to label7
-# BB#7:                                 # %while.body9.i.preheader
-                                        #   in Loop: Header=BB1_6 Depth=2
-	i32.const	$push47=, 2
-	i32.shl 	$push6=, $3, $pop47
-	i32.add 	$push7=, $4, $pop6
-	i32.const	$push46=, 12
-	i32.add 	$2=, $pop7, $pop46
-.LBB1_8:                                # %while.body9.i
-                                        #   Parent Loop BB1_1 Depth=1
-                                        #     Parent Loop BB1_6 Depth=2
-                                        # =>    This Inner Loop Header: Depth=3
-	loop    	                # label8:
-	i32.load	$push49=, 0($2)
-	tee_local	$push48=, $0=, $pop49
-	br_if   	3, $pop48       # 3: down to label5
-# BB#9:                                 # %if.end26.i
-                                        #   in Loop: Header=BB1_8 Depth=3
-	i32.const	$push54=, 4
-	i32.add 	$2=, $2, $pop54
-	i32.const	$push53=, 1
-	i32.add 	$push52=, $3, $pop53
-	tee_local	$push51=, $3=, $pop52
-	i32.const	$push50=, 2
-	i32.ne  	$push11=, $pop51, $pop50
-	br_if   	0, $pop11       # 0: up to label8
-# BB#10:                                # %while.end30.i.loopexit
-                                        #   in Loop: Header=BB1_6 Depth=2
-	end_loop
-	i32.const	$push24=, 16
-	i32.add 	$push25=, $5, $pop24
-	i32.const	$push56=, 12
-	i32.add 	$push12=, $pop25, $pop56
-	i32.const	$push55=, 0
-	i32.store	0($pop12), $pop55
-.LBB1_11:                               # %while.end30.i
-                                        #   in Loop: Header=BB1_6 Depth=2
-	end_block                       # label7:
-	i32.const	$3=, 0
-	i32.load	$push58=, 0($4)
-	tee_local	$push57=, $4=, $pop58
-	br_if   	0, $pop57       # 0: up to label6
-	br      	4               # 4: down to label0
-.LBB1_12:                               # %while.cond16.preheader.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_loop
-	end_block                       # label5:
-	i32.const	$push26=, 16
-	i32.add 	$push27=, $5, $pop26
-	i32.const	$push62=, 12
-	i32.add 	$push61=, $pop27, $pop62
-	tee_local	$push60=, $2=, $pop61
-	i32.store	0($pop60), $0
-	i32.store	0($1), $3
-	i32.const	$push59=, 1
-	i32.and 	$push8=, $0, $pop59
-	br_if   	0, $pop8        # 0: down to label2
-.LBB1_13:                               # %while.body21.i
-                                        #   Parent Loop BB1_1 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop    	                # label9:
-	i32.const	$push66=, 1
-	i32.shr_u	$push65=, $0, $pop66
-	tee_local	$push64=, $0=, $pop65
-	i32.const	$push63=, 1
-	i32.and 	$push9=, $pop64, $pop63
-	i32.eqz 	$push69=, $pop9
-	br_if   	0, $pop69       # 0: up to label9
-# BB#14:                                # %while.cond16.return.loopexit_crit_edge.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_loop
-	i32.store	0($2), $0
-.LBB1_15:                               # %for.inc
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label2:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$6, 1, 0, 4, 5, 6, 7, 11, 12, 13, 8, 9, 10, 14, 2, 3, 3 # 1: down to label28
+                                        # 0: down to label29
+                                        # 4: down to label25
+                                        # 5: down to label24
+                                        # 6: down to label23
+                                        # 7: down to label22
+                                        # 11: down to label18
+                                        # 12: down to label17
+                                        # 13: down to label16
+                                        # 8: down to label21
+                                        # 9: down to label20
+                                        # 10: down to label19
+                                        # 14: down to label15
+                                        # 2: down to label27
+                                        # 3: down to label26
+.LBB1_4:                                # %for.inc
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label29:
 	i32.const	$push28=, 16
 	i32.add 	$push29=, $5, $pop28
-	i32.const	$push37=, 12
-	i32.add 	$push10=, $pop29, $pop37
-	i32.const	$push36=, 1
-	i32.shr_u	$push35=, $0, $pop36
-	tee_local	$push34=, $0=, $pop35
-	i32.store	0($pop10), $pop34
-	br      	0               # 0: up to label1
-.LBB1_16:                               # %for.end
-	end_loop
-	end_block                       # label0:
+	i32.const	$push39=, 12
+	i32.add 	$push10=, $pop29, $pop39
+	i32.const	$push38=, 1
+	i32.shr_u	$push37=, $0, $pop38
+	tee_local	$push36=, $0=, $pop37
+	i32.store	0($pop10), $pop36
+	i32.eqz 	$push69=, $0
+	br_if   	14, $pop69      # 14: down to label14
+# BB#5:                                 #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$6=, 0
+	br      	26              # 26: up to label2
+.LBB1_6:                                # %while.cond.preheader.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label28:
+	i32.const	$push40=, 1
+	i32.and 	$push0=, $0, $pop40
+	br_if   	15, $pop0       # 15: down to label12
+# BB#7:                                 #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$6=, 13
+	br      	25              # 25: up to label2
+.LBB1_8:                                # %while.body.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label27:
+	i32.const	$push44=, 1
+	i32.shr_u	$push43=, $0, $pop44
+	tee_local	$push42=, $0=, $pop43
+	i32.const	$push41=, 1
+	i32.and 	$push1=, $pop42, $pop41
+	i32.eqz 	$push70=, $pop1
+	br_if   	23, $pop70      # 23: down to label3
+# BB#9:                                 #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$6=, 14
+	br      	24              # 24: up to label2
+.LBB1_10:                               # %while.cond.return.loopexit62_crit_edge.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label26:
+	i32.const	$push30=, 16
+	i32.add 	$push31=, $5, $pop30
+	i32.const	$push45=, 12
+	i32.add 	$push2=, $pop31, $pop45
+	i32.store	0($pop2), $0
+	br      	12              # 12: down to label13
+.LBB1_11:                               # %if.end.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label25:
+	i32.load	$push4=, 0($1)
+	i32.const	$push46=, 1
+	i32.add 	$3=, $pop4, $pop46
+# BB#12:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$6=, 3
+	br      	22              # 22: up to label2
+.LBB1_13:                               # %while.body6.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label24:
+	i32.const	$push47=, 2
+	i32.eq  	$push5=, $3, $pop47
+	br_if   	16, $pop5       # 16: down to label7
+# BB#14:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$6=, 4
+	br      	21              # 21: up to label2
+.LBB1_15:                               # %while.body9.i.preheader
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label23:
+	i32.const	$push49=, 2
+	i32.shl 	$push6=, $3, $pop49
+	i32.add 	$push7=, $4, $pop6
+	i32.const	$push48=, 12
+	i32.add 	$2=, $pop7, $pop48
+# BB#16:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$6=, 5
+	br      	20              # 20: up to label2
+.LBB1_17:                               # %while.body9.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label22:
+	i32.load	$push51=, 0($2)
+	tee_local	$push50=, $0=, $pop51
+	br_if   	16, $pop50      # 16: down to label5
+# BB#18:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$6=, 9
+	br      	19              # 19: up to label2
+.LBB1_19:                               # %if.end26.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label21:
+	i32.const	$push56=, 4
+	i32.add 	$2=, $2, $pop56
+	i32.const	$push55=, 1
+	i32.add 	$push54=, $3, $pop55
+	tee_local	$push53=, $3=, $pop54
+	i32.const	$push52=, 2
+	i32.ne  	$push11=, $pop53, $pop52
+	br_if   	14, $pop11      # 14: down to label6
+# BB#20:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$6=, 10
+	br      	18              # 18: up to label2
+.LBB1_21:                               # %while.end30.i.loopexit
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label20:
+	i32.const	$push24=, 16
+	i32.add 	$push25=, $5, $pop24
+	i32.const	$push58=, 12
+	i32.add 	$push12=, $pop25, $pop58
+	i32.const	$push57=, 0
+	i32.store	0($pop12), $pop57
+# BB#22:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$6=, 11
+	br      	17              # 17: up to label2
+.LBB1_23:                               # %while.end30.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label19:
+	i32.const	$3=, 0
+	i32.load	$push60=, 0($4)
+	tee_local	$push59=, $4=, $pop60
+	br_if   	10, $pop59      # 10: down to label8
+	br      	9               # 9: down to label9
+.LBB1_24:                               # %while.cond16.preheader.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label18:
+	i32.const	$push26=, 16
+	i32.add 	$push27=, $5, $pop26
+	i32.const	$push64=, 12
+	i32.add 	$push63=, $pop27, $pop64
+	tee_local	$push62=, $2=, $pop63
+	i32.store	0($pop62), $0
+	i32.store	0($1), $3
+	i32.const	$push61=, 1
+	i32.and 	$push8=, $0, $pop61
+	br_if   	7, $pop8        # 7: down to label10
+# BB#25:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$6=, 7
+	br      	15              # 15: up to label2
+.LBB1_26:                               # %while.body21.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label17:
+	i32.const	$push68=, 1
+	i32.shr_u	$push67=, $0, $pop68
+	tee_local	$push66=, $0=, $pop67
+	i32.const	$push65=, 1
+	i32.and 	$push9=, $pop66, $pop65
+	i32.eqz 	$push71=, $pop9
+	br_if   	12, $pop71      # 12: down to label4
+# BB#27:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$6=, 8
+	br      	14              # 14: up to label2
+.LBB1_28:                               # %while.cond16.return.loopexit_crit_edge.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label16:
+	i32.store	0($2), $0
+	br      	4               # 4: down to label11
+.LBB1_29:                               # %for.end
+	end_block                       # label15:
 	i32.const	$push19=, 0
 	i32.const	$push17=, 32
 	i32.add 	$push18=, $5, $pop17
 	i32.store	__stack_pointer($pop19), $pop18
-                                        # fallthrough-return
+	return
+.LBB1_30:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label14:
+	i32.const	$6=, 2
+	br      	11              # 11: up to label2
+.LBB1_31:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label13:
+	i32.const	$6=, 1
+	br      	10              # 10: up to label2
+.LBB1_32:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label12:
+	i32.const	$6=, 1
+	br      	9               # 9: up to label2
+.LBB1_33:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label11:
+	i32.const	$6=, 1
+	br      	8               # 8: up to label2
+.LBB1_34:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label10:
+	i32.const	$6=, 1
+	br      	7               # 7: up to label2
+.LBB1_35:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label9:
+	i32.const	$6=, 12
+	br      	6               # 6: up to label2
+.LBB1_36:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label8:
+	i32.const	$6=, 3
+	br      	5               # 5: up to label2
+.LBB1_37:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label7:
+	i32.const	$6=, 11
+	br      	4               # 4: up to label2
+.LBB1_38:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label6:
+	i32.const	$6=, 5
+	br      	3               # 3: up to label2
+.LBB1_39:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label5:
+	i32.const	$6=, 6
+	br      	2               # 2: up to label2
+.LBB1_40:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label4:
+	i32.const	$6=, 7
+	br      	1               # 1: up to label2
+.LBB1_41:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label3:
+	i32.const	$6=, 13
+	br      	0               # 0: up to label2
+.LBB1_42:
+	end_loop
 	.endfunc
 .Lfunc_end1:
 	.size	foobar, .Lfunc_end1-foobar
@@ -233,13 +354,13 @@ bmp_iter_set_init:                      # @bmp_iter_set_init
 	tee_local	$push5=, $1=, $pop6
 	i32.store	0($0), $pop5
 	block   	
-	br_if   	0, $1           # 0: down to label10
+	br_if   	0, $1           # 0: down to label30
 # BB#1:                                 # %if.then
 	i32.const	$1=, bitmap_zero_bits
 	i32.const	$push8=, bitmap_zero_bits
 	i32.store	0($0), $pop8
 .LBB2_2:                                # %while.end
-	end_block                       # label10:
+	end_block                       # label30:
 	i32.const	$push11=, 0
 	i32.store	8($0), $pop11
 	i32.load	$push10=, 12($1)
@@ -277,4 +398,4 @@ bitmap_zero_bits:
 	.size	bitmap_zero_bits, 20
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "

--- a/test/torture-s/20100827-1.c.s
+++ b/test/torture-s/20100827-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20100827-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20100827-1.c"
 	.section	.text.foo,"ax",@progbits
 	.hidden	foo
 	.globl	foo
@@ -9,34 +9,36 @@ foo:                                    # @foo
 	.result 	i32
 	.local  	i32, i32
 # BB#0:                                 # %entry
-	i32.const	$2=, 0
 	block   	
 	block   	
 	i32.load8_u	$push0=, 0($0)
-	i32.eqz 	$push7=, $pop0
-	br_if   	0, $pop7        # 0: down to label1
+	i32.eqz 	$push8=, $pop0
+	br_if   	0, $pop8        # 0: down to label1
 # BB#1:                                 # %if.end.preheader
 	i32.const	$2=, 0
 .LBB0_2:                                # %if.end
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label2:
-	i32.add 	$push4=, $0, $2
-	tee_local	$push3=, $1=, $pop4
-	i32.eqz 	$push8=, $pop3
-	br_if   	2, $pop8        # 2: down to label0
+	i32.add 	$push5=, $0, $2
+	tee_local	$push4=, $1=, $pop5
+	i32.eqz 	$push9=, $pop4
+	br_if   	2, $pop9        # 2: down to label0
 # BB#3:                                 # %if.end5
                                         #   in Loop: Header=BB0_2 Depth=1
+	i32.const	$push7=, 1
+	i32.add 	$2=, $2, $pop7
 	i32.const	$push6=, 1
-	i32.add 	$2=, $2, $pop6
-	i32.const	$push5=, 1
-	i32.add 	$push1=, $1, $pop5
+	i32.add 	$push1=, $1, $pop6
 	i32.load8_u	$push2=, 0($pop1)
 	br_if   	0, $pop2        # 0: up to label2
-.LBB0_4:                                # %do.end
+# BB#4:                                 # %do.end
 	end_loop
-	end_block                       # label1:
 	return  	$2
-.LBB0_5:                                # %if.then4
+.LBB0_5:
+	end_block                       # label1:
+	i32.const	$push3=, 0
+	return  	$pop3
+.LBB0_6:                                # %if.then4
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -75,5 +77,5 @@ main:                                   # @main
 	.size	.L.str, 2
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/20111208-1.c.s
+++ b/test/torture-s/20111208-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20111208-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20111208-1.c"
 	.section	.text.pack_unpack,"ax",@progbits
 	.hidden	pack_unpack
 	.globl	pack_unpack
@@ -9,52 +9,59 @@ pack_unpack:                            # @pack_unpack
 	.result 	i32
 	.local  	i32, i32, i32
 # BB#0:                                 # %entry
-	i32.call	$push0=, strlen@FUNCTION, $1
-	i32.add 	$2=, $1, $pop0
-.LBB0_1:                                # %while.cond
-                                        # =>This Inner Loop Header: Depth=1
 	block   	
+	i32.call	$push0=, strlen@FUNCTION, $1
+	i32.add 	$push10=, $1, $pop0
+	tee_local	$push9=, $2=, $pop10
+	i32.ge_u	$push1=, $1, $pop9
+	br_if   	0, $pop1        # 0: down to label0
+.LBB0_1:                                # %while.body
+                                        # =>This Inner Loop Header: Depth=1
 	loop    	                # label1:
-	i32.ge_u	$push1=, $1, $2
-	br_if   	1, $pop1        # 1: down to label0
+	i32.const	$push15=, 1
+	i32.add 	$3=, $1, $pop15
+	block   	
+	i32.load8_s	$push14=, 0($1)
+	tee_local	$push13=, $4=, $pop14
+	i32.const	$push12=, 108
+	i32.eq  	$push5=, $pop13, $pop12
+	br_if   	0, $pop5        # 0: down to label2
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$3=, $1, $pop11
+	copy_local	$1=, $3
 	block   	
-	i32.load8_s	$push10=, 0($1)
-	tee_local	$push9=, $4=, $pop10
-	i32.const	$push8=, 108
-	i32.eq  	$push3=, $pop9, $pop8
-	br_if   	0, $pop3        # 0: down to label2
-# BB#3:                                 # %while.body
+	i32.const	$push16=, 115
+	i32.ne  	$push6=, $4, $pop16
+	br_if   	0, $pop6        # 0: down to label3
+# BB#3:                                 # %sw.bb4
                                         #   in Loop: Header=BB0_1 Depth=1
+	i32.load16_s	$push8=, 0($0):p2align=0
+	call    	do_something@FUNCTION, $pop8
+	i32.const	$push11=, 2
+	i32.add 	$0=, $0, $pop11
 	copy_local	$1=, $3
-	i32.const	$push12=, 115
-	i32.ne  	$push4=, $4, $pop12
-	br_if   	1, $pop4        # 1: up to label1
-# BB#4:                                 # %sw.bb4
+.LBB0_4:                                # %while.cond
                                         #   in Loop: Header=BB0_1 Depth=1
-	i32.load16_s	$push6=, 0($0):p2align=0
-	call    	do_something@FUNCTION, $pop6
-	i32.const	$push7=, 2
-	i32.add 	$0=, $0, $pop7
-	copy_local	$1=, $3
+	end_block                       # label3:
+	i32.ge_u	$push3=, $1, $2
+	br_if   	2, $pop3        # 2: down to label0
 	br      	1               # 1: up to label1
 .LBB0_5:                                # %sw.bb7
                                         #   in Loop: Header=BB0_1 Depth=1
 	end_block                       # label2:
-	i32.load	$push5=, 0($0):p2align=0
-	call    	do_something@FUNCTION, $pop5
-	i32.const	$push13=, 4
-	i32.add 	$0=, $0, $pop13
-	copy_local	$1=, $3
-	br      	0               # 0: up to label1
+	i32.load	$push7=, 0($0):p2align=0
+	call    	do_something@FUNCTION, $pop7
+	i32.const	$push19=, 4
+	i32.add 	$0=, $0, $pop19
+	copy_local	$push18=, $3
+	tee_local	$push17=, $1=, $pop18
+	i32.lt_u	$push2=, $pop17, $2
+	br_if   	0, $pop2        # 0: up to label1
 .LBB0_6:                                # %while.end
 	end_loop
 	end_block                       # label0:
-	i32.load8_s	$push2=, 0($0)
-                                        # fallthrough-return: $pop2
+	i32.load8_s	$push4=, 0($0)
+                                        # fallthrough-return: $pop4
 	.endfunc
 .Lfunc_end0:
 	.size	pack_unpack, .Lfunc_end0-pack_unpack
@@ -81,57 +88,69 @@ main:                                   # @main
 # BB#0:                                 # %entry
 	i32.const	$3=, .L.str
 	i32.const	$2=, .L.str.1
-.LBB2_1:                                # %while.cond.i
+	block   	
+	i32.const	$push10=, .L.str.1
+	i32.const	$push9=, .L.str.1+2
+	i32.ge_u	$push0=, $pop10, $pop9
+	br_if   	0, $pop0        # 0: down to label4
+.LBB2_1:                                # %while.body.i
                                         # =>This Inner Loop Header: Depth=1
+	loop    	                # label5:
+	i32.const	$push16=, 1
+	i32.add 	$0=, $2, $pop16
 	block   	
-	loop    	                # label4:
-	i32.const	$push8=, .L.str.1+2
-	i32.ge_u	$push0=, $2, $pop8
-	br_if   	1, $pop0        # 1: down to label3
-# BB#2:                                 # %while.body.i
-                                        #   in Loop: Header=BB2_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$0=, $2, $pop12
 	block   	
-	i32.load8_s	$push11=, 0($2)
-	tee_local	$push10=, $1=, $pop11
-	i32.const	$push9=, 108
-	i32.ne  	$push3=, $pop10, $pop9
-	br_if   	0, $pop3        # 0: down to label5
-# BB#3:                                 # %sw.bb7.i
+	block   	
+	i32.load8_s	$push15=, 0($2)
+	tee_local	$push14=, $1=, $pop15
+	i32.const	$push13=, 108
+	i32.ne  	$push5=, $pop14, $pop13
+	br_if   	0, $pop5        # 0: down to label8
+# BB#2:                                 # %sw.bb7.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load	$push5=, 0($3):p2align=0
-	call    	do_something@FUNCTION, $pop5
-	i32.const	$push7=, 4
-	i32.add 	$3=, $3, $pop7
+	i32.load	$push7=, 0($3):p2align=0
+	call    	do_something@FUNCTION, $pop7
+	i32.const	$push11=, 4
+	i32.add 	$3=, $3, $pop11
 	copy_local	$2=, $0
-	br      	1               # 1: up to label4
-.LBB2_4:                                # %while.body.i
+	br      	1               # 1: down to label7
+.LBB2_3:                                # %while.body.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_block                       # label5:
+	end_block                       # label8:
 	copy_local	$2=, $0
-	i32.const	$push13=, 115
-	i32.ne  	$push4=, $1, $pop13
-	br_if   	0, $pop4        # 0: up to label4
-# BB#5:                                 # %sw.bb4.i
+	i32.const	$push17=, 115
+	i32.eq  	$push6=, $1, $pop17
+	br_if   	1, $pop6        # 1: down to label6
+.LBB2_4:                                # %while.cond.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load16_s	$push6=, 0($3):p2align=0
-	call    	do_something@FUNCTION, $pop6
-	i32.const	$push14=, 2
-	i32.add 	$3=, $3, $pop14
-	copy_local	$2=, $0
-	br      	0               # 0: up to label4
+	end_block                       # label7:
+	i32.const	$push12=, .L.str.1+2
+	i32.ge_u	$push2=, $2, $pop12
+	br_if   	2, $pop2        # 2: down to label4
+	br      	1               # 1: up to label5
+.LBB2_5:                                # %sw.bb4.i
+                                        #   in Loop: Header=BB2_1 Depth=1
+	end_block                       # label6:
+	i32.load16_s	$push8=, 0($3):p2align=0
+	call    	do_something@FUNCTION, $pop8
+	i32.const	$push21=, 2
+	i32.add 	$3=, $3, $pop21
+	copy_local	$push20=, $0
+	tee_local	$push19=, $2=, $pop20
+	i32.const	$push18=, .L.str.1+2
+	i32.lt_u	$push1=, $pop19, $pop18
+	br_if   	0, $pop1        # 0: up to label5
 .LBB2_6:                                # %pack_unpack.exit
 	end_loop
-	end_block                       # label3:
+	end_block                       # label4:
 	block   	
-	i32.load8_u	$push1=, 0($3)
-	br_if   	0, $pop1        # 0: down to label6
+	i32.load8_u	$push3=, 0($3)
+	br_if   	0, $pop3        # 0: down to label9
 # BB#7:                                 # %if.end
-	i32.const	$push2=, 0
-	return  	$pop2
+	i32.const	$push4=, 0
+	return  	$pop4
 .LBB2_8:                                # %if.then
-	end_block                       # label6:
+	end_block                       # label9:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -159,6 +178,6 @@ a:
 	.size	a, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	strlen, i32, i32
 	.functype	abort, void

--- a/test/torture-s/20121108-1.c.s
+++ b/test/torture-s/20121108-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20121108-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20121108-1.c"
 	.section	.text.strtoul1,"ax",@progbits
 	.hidden	strtoul1
 	.globl	strtoul1
@@ -11,34 +11,43 @@ strtoul1:                               # @strtoul1
 	i32.const	$push0=, 3
 	i32.add 	$push1=, $0, $pop0
 	i32.store	0($1), $pop1
-	i32.const	$1=, 192
+	block   	
+	block   	
 	block   	
 	block   	
 	i32.const	$push2=, temp
 	i32.eq  	$push3=, $0, $pop2
-	br_if   	0, $pop3        # 0: down to label1
+	br_if   	0, $pop3        # 0: down to label3
 # BB#1:                                 # %if.else
-	i32.const	$1=, 168
 	i32.const	$push4=, temp+4
 	i32.eq  	$push5=, $0, $pop4
-	br_if   	0, $pop5        # 0: down to label1
+	br_if   	2, $pop5        # 2: down to label1
 # BB#2:                                 # %if.else3
-	i32.const	$1=, 190
 	i32.const	$push6=, temp+8
 	i32.eq  	$push7=, $0, $pop6
-	br_if   	0, $pop7        # 0: down to label1
+	br_if   	3, $pop7        # 3: down to label0
 # BB#3:                                 # %if.else6
 	i32.const	$1=, 160
 	i32.const	$push8=, temp+12
-	i32.ne  	$push9=, $0, $pop8
-	br_if   	1, $pop9        # 1: down to label0
-.LBB0_4:                                # %return
-	end_block                       # label1:
-	return  	$1
-.LBB0_5:                                # %if.end11
-	end_block                       # label0:
+	i32.eq  	$push9=, $0, $pop8
+	br_if   	1, $pop9        # 1: down to label2
+# BB#4:                                 # %if.end11
 	call    	abort@FUNCTION
 	unreachable
+.LBB0_5:
+	end_block                       # label3:
+	i32.const	$1=, 192
+.LBB0_6:                                # %return
+	end_block                       # label2:
+	return  	$1
+.LBB0_7:
+	end_block                       # label1:
+	i32.const	$push11=, 168
+	return  	$pop11
+.LBB0_8:
+	end_block                       # label0:
+	i32.const	$push10=, 190
+                                        # fallthrough-return: $pop10
 	.endfunc
 .Lfunc_end0:
 	.size	strtoul1, .Lfunc_end0-strtoul1
@@ -59,10 +68,12 @@ string_to_ip:                           # @string_to_ip
 	i32.sub 	$push36=, $pop21, $pop22
 	tee_local	$push35=, $2=, $pop36
 	i32.store	__stack_pointer($pop23), $pop35
-	i32.const	$1=, 0
+	block   	
+	block   	
+	block   	
 	block   	
 	i32.eqz 	$push57=, $0
-	br_if   	0, $pop57       # 0: down to label2
+	br_if   	0, $pop57       # 0: down to label7
 # BB#1:                                 # %if.end9
 	i32.const	$push27=, 12
 	i32.add 	$push28=, $2, $pop27
@@ -71,8 +82,6 @@ string_to_ip:                           # @string_to_ip
 	i32.shl 	$push3=, $pop0, $pop42
 	i32.const	$push4=, 65280
 	i32.and 	$0=, $pop3, $pop4
-	block   	
-	block   	
 	i32.load	$push41=, 12($2)
 	tee_local	$push40=, $1=, $pop41
 	i32.const	$push39=, 1
@@ -81,7 +90,7 @@ string_to_ip:                           # @string_to_ip
 	i32.select	$push38=, $pop1, $1, $pop2
 	tee_local	$push37=, $1=, $pop38
 	i32.eqz 	$push58=, $pop37
-	br_if   	0, $pop58       # 0: down to label4
+	br_if   	1, $pop58       # 1: down to label6
 # BB#2:                                 # %if.end9.1
 	i32.const	$push29=, 12
 	i32.add 	$push30=, $2, $pop29
@@ -97,7 +106,7 @@ string_to_ip:                           # @string_to_ip
 	i32.select	$push44=, $pop6, $1, $pop7
 	tee_local	$push43=, $1=, $pop44
 	i32.eqz 	$push59=, $pop43
-	br_if   	0, $pop59       # 0: down to label4
+	br_if   	1, $pop59       # 1: down to label6
 # BB#3:                                 # %if.end9.2
 	i32.const	$push31=, 12
 	i32.add 	$push32=, $2, $pop31
@@ -115,7 +124,7 @@ string_to_ip:                           # @string_to_ip
 	i32.select	$push50=, $pop13, $1, $pop14
 	tee_local	$push49=, $1=, $pop50
 	i32.eqz 	$push60=, $pop49
-	br_if   	1, $pop60       # 1: down to label3
+	br_if   	2, $pop60       # 2: down to label5
 # BB#4:                                 # %if.then3.3
 	i32.const	$push33=, 12
 	i32.add 	$push34=, $2, $pop33
@@ -124,23 +133,27 @@ string_to_ip:                           # @string_to_ip
 	i32.and 	$push18=, $pop16, $pop17
 	i32.const	$push55=, 8
 	i32.shl 	$push15=, $0, $pop55
-	i32.or  	$1=, $pop18, $pop15
-	br      	2               # 2: down to label2
-.LBB1_5:                                # %if.end9.2.thread
-	end_block                       # label4:
+	i32.or  	$0=, $pop18, $pop15
+	br      	3               # 3: down to label4
+.LBB1_5:
+	end_block                       # label7:
+	i32.const	$0=, 0
+	br      	2               # 2: down to label4
+.LBB1_6:                                # %if.end9.2.thread
+	end_block                       # label6:
 	i32.const	$push56=, 8
 	i32.shl 	$0=, $0, $pop56
-.LBB1_6:                                # %cond.end.3
-	end_block                       # label3:
+.LBB1_7:                                # %cond.end.3
+	end_block                       # label5:
 	i32.const	$push19=, 8
-	i32.shl 	$1=, $0, $pop19
-.LBB1_7:                                # %cleanup
-	end_block                       # label2:
+	i32.shl 	$0=, $0, $pop19
+.LBB1_8:                                # %cleanup
+	end_block                       # label4:
 	i32.const	$push26=, 0
 	i32.const	$push24=, 16
 	i32.add 	$push25=, $2, $pop24
 	i32.store	__stack_pointer($pop26), $pop25
-	copy_local	$push61=, $1
+	copy_local	$push61=, $0
                                         # fallthrough-return: $pop61
 	.endfunc
 .Lfunc_end1:
@@ -178,7 +191,7 @@ main:                                   # @main
 	i32.const	$push15=, 0
 	i32.load	$push3=, result($pop15)
 	i32.ne  	$push4=, $0, $pop3
-	br_if   	0, $pop4        # 0: down to label5
+	br_if   	0, $pop4        # 0: down to label8
 # BB#1:                                 # %if.end
 	i32.const	$push5=, .Lstr
 	i32.call	$drop=, puts@FUNCTION, $pop5
@@ -189,7 +202,7 @@ main:                                   # @main
 	i32.const	$push22=, 0
 	return  	$pop22
 .LBB2_2:                                # %if.then
-	end_block                       # label5:
+	end_block                       # label8:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -226,7 +239,7 @@ result:
 	.size	.Lstr, 7
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	printf, i32, i32
 	.functype	puts, i32, i32

--- a/test/torture-s/20140212-1.c.s
+++ b/test/torture-s/20140212-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20140212-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/20140212-1.c"
 	.section	.text.fn1,"ax",@progbits
 	.hidden	fn1
 	.globl	fn1
@@ -35,8 +35,8 @@ fn1:                                    # @fn1
 	i32.load	$3=, d($pop7)
 .LBB0_1:                                # %for.cond
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label0:
 	block   	
+	loop    	                # label1:
 	block   	
 	i32.eqz 	$push30=, $3
 	br_if   	0, $pop30       # 0: down to label2
@@ -45,7 +45,9 @@ fn1:                                    # @fn1
 	i32.const	$push23=, 0
 	i32.const	$push22=, 1
 	i32.store	c($pop23), $pop22
-	br      	1               # 1: down to label1
+	i32.eqz 	$push31=, $4
+	br_if   	1, $pop31       # 1: up to label1
+	br      	2               # 2: down to label0
 .LBB0_3:                                # %if.else
                                         #   in Loop: Header=BB0_1 Depth=1
 	end_block                       # label2:
@@ -55,13 +57,11 @@ fn1:                                    # @fn1
 	i32.const	$push25=, 0
 	i32.const	$push24=, 9
 	i32.store	i($pop25), $pop24
-.LBB0_4:                                # %if.end
-                                        #   in Loop: Header=BB0_1 Depth=1
-	end_block                       # label1:
-	i32.eqz 	$push31=, $4
-	br_if   	0, $pop31       # 0: up to label0
-# BB#5:                                 # %if.then15
+	i32.eqz 	$push32=, $4
+	br_if   	0, $pop32       # 0: up to label1
+.LBB0_4:                                # %if.then15
 	end_loop
+	end_block                       # label0:
 	i32.const	$push6=, 0
 	i32.store8	j($pop6), $1
 	i32.const	$push29=, 0
@@ -107,8 +107,8 @@ main:                                   # @main
 	i32.const	$4=, 0
 .LBB1_1:                                # %for.cond.i
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label3:
 	block   	
+	loop    	                # label4:
 	block   	
 	i32.eqz 	$push32=, $2
 	br_if   	0, $pop32       # 0: down to label5
@@ -118,7 +118,9 @@ main:                                   # @main
 	i32.const	$push23=, 0
 	i32.const	$push22=, 1
 	i32.store	c($pop23), $pop22
-	br      	1               # 1: down to label4
+	i32.eqz 	$push33=, $3
+	br_if   	1, $pop33       # 1: up to label4
+	br      	2               # 2: down to label3
 .LBB1_3:                                # %if.else.i
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label5:
@@ -128,13 +130,11 @@ main:                                   # @main
 	i32.const	$push25=, 0
 	i32.const	$push24=, 9
 	i32.store	i($pop25), $pop24
-.LBB1_4:                                # %if.end.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label4:
-	i32.eqz 	$push33=, $3
-	br_if   	0, $pop33       # 0: up to label3
-# BB#5:                                 # %fn1.exit
+	i32.eqz 	$push34=, $3
+	br_if   	0, $pop34       # 0: up to label4
+.LBB1_4:                                # %fn1.exit
 	end_loop
+	end_block                       # label3:
 	i32.const	$push30=, 0
 	i32.store8	j($pop30), $1
 	i32.const	$push29=, 0
@@ -147,10 +147,10 @@ main:                                   # @main
 	i32.const	$push7=, 1
 	i32.ne  	$push8=, $4, $pop7
 	br_if   	0, $pop8        # 0: down to label6
-# BB#6:                                 # %if.end
+# BB#5:                                 # %if.end
 	i32.const	$push31=, 0
 	return  	$pop31
-.LBB1_7:                                # %if.then
+.LBB1_6:                                # %if.then
 	end_block                       # label6:
 	call    	abort@FUNCTION
 	unreachable
@@ -256,5 +256,5 @@ h:
 	.size	h, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/920501-2.c.s
+++ b/test/torture-s/920501-2.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/920501-2.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/920501-2.c"
 	.section	.text.gcd_ll,"ax",@progbits
 	.hidden	gcd_ll
 	.globl	gcd_ll
@@ -50,29 +50,28 @@ powmod_ll:                              # @powmod_ll
 	.result 	i64
 	.local  	i32, i32, i64
 # BB#0:                                 # %entry
-	i64.const	$5=, 1
 	block   	
 	block   	
-	i32.eqz 	$push21=, $1
-	br_if   	0, $pop21       # 0: down to label4
+	i32.eqz 	$push22=, $1
+	br_if   	0, $pop22       # 0: down to label4
 # BB#1:                                 # %for.body.preheader
 	i32.const	$3=, 0
 	copy_local	$4=, $1
 .LBB1_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label5:
+	i32.const	$push13=, 1
+	i32.add 	$3=, $3, $pop13
 	i32.const	$push12=, 1
-	i32.add 	$3=, $3, $pop12
-	i32.const	$push11=, 1
-	i32.shr_u	$push10=, $4, $pop11
-	tee_local	$push9=, $4=, $pop10
-	br_if   	0, $pop9        # 0: up to label5
+	i32.shr_u	$push11=, $4, $pop12
+	tee_local	$push10=, $4=, $pop11
+	br_if   	0, $pop10       # 0: up to label5
 # BB#3:                                 # %for.end
 	end_loop
-	i32.const	$push14=, -1
-	i32.add 	$push0=, $3, $pop14
-	i32.const	$push13=, 1
-	i32.lt_s	$push1=, $pop0, $pop13
+	i32.const	$push15=, -1
+	i32.add 	$push0=, $3, $pop15
+	i32.const	$push14=, 1
+	i32.lt_s	$push1=, $pop0, $pop14
 	br_if   	1, $pop1        # 1: down to label3
 # BB#4:                                 # %for.body4.preheader
 	copy_local	$5=, $0
@@ -82,13 +81,13 @@ powmod_ll:                              # @powmod_ll
 	i64.mul 	$push2=, $5, $5
 	i64.rem_u	$5=, $pop2, $2
 	block   	
-	i32.const	$push16=, 1
-	i32.const	$push15=, -2
-	i32.add 	$push3=, $3, $pop15
-	i32.shl 	$push4=, $pop16, $pop3
+	i32.const	$push17=, 1
+	i32.const	$push16=, -2
+	i32.add 	$push3=, $3, $pop16
+	i32.shl 	$push4=, $pop17, $pop3
 	i32.and 	$push5=, $pop4, $1
-	i32.eqz 	$push22=, $pop5
-	br_if   	0, $pop22       # 0: down to label7
+	i32.eqz 	$push23=, $pop5
+	br_if   	0, $pop23       # 0: down to label7
 # BB#6:                                 # %if.then5
                                         #   in Loop: Header=BB1_5 Depth=1
 	i64.mul 	$push6=, $5, $0
@@ -96,17 +95,20 @@ powmod_ll:                              # @powmod_ll
 .LBB1_7:                                # %for.inc9
                                         #   in Loop: Header=BB1_5 Depth=1
 	end_block                       # label7:
-	i32.const	$push20=, -1
-	i32.add 	$push19=, $3, $pop20
-	tee_local	$push18=, $3=, $pop19
-	i32.const	$push17=, 1
-	i32.gt_s	$push7=, $pop18, $pop17
+	i32.const	$push21=, -1
+	i32.add 	$push20=, $3, $pop21
+	tee_local	$push19=, $3=, $pop20
+	i32.const	$push18=, 1
+	i32.gt_s	$push7=, $pop19, $pop18
 	br_if   	0, $pop7        # 0: up to label6
-.LBB1_8:                                # %cleanup
+# BB#8:                                 # %cleanup
 	end_loop
-	end_block                       # label4:
 	return  	$5
 .LBB1_9:
+	end_block                       # label4:
+	i64.const	$push9=, 1
+	return  	$pop9
+.LBB1_10:
 	end_block                       # label3:
 	copy_local	$push8=, $0
                                         # fallthrough-return: $pop8
@@ -479,6 +481,6 @@ factab:
 	.size	factab, 40
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/920501-6.c.s
+++ b/test/torture-s/920501-6.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/920501-6.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/920501-6.c"
 	.section	.text.str2llu,"ax",@progbits
 	.hidden	str2llu
 	.globl	str2llu
@@ -76,10 +76,10 @@ sqrtllu:                                # @sqrtllu
 	i64.shr_u	$push4=, $2, $pop19
 	i64.shl 	$push18=, $pop20, $pop4
 	tee_local	$push17=, $1=, $pop18
-	i64.const	$push1=, 63
-	i64.shl 	$push2=, $2, $pop1
-	i64.const	$push16=, 63
-	i64.shr_s	$push3=, $pop2, $pop16
+	i64.const	$push2=, 0
+	i64.const	$push16=, 1
+	i64.and 	$push1=, $2, $pop16
+	i64.sub 	$push3=, $pop2, $pop1
 	i64.const	$push15=, 1
 	i64.shr_u	$push5=, $1, $pop15
 	i64.and 	$push6=, $pop3, $pop5
@@ -141,10 +141,10 @@ plist:                                  # @plist
 # BB#4:                                 # %for.end.i
                                         #   in Loop: Header=BB2_2 Depth=1
 	end_loop
-	i64.const	$push30=, 63
-	i64.shl 	$push2=, $6, $pop30
-	i64.const	$push29=, 63
-	i64.shr_s	$push3=, $pop2, $pop29
+	i64.const	$push30=, 0
+	i64.const	$push29=, 1
+	i64.and 	$push2=, $6, $pop29
+	i64.sub 	$push3=, $pop30, $pop2
 	i64.const	$push28=, 1
 	i64.const	$push27=, 1
 	i64.shr_u	$push4=, $6, $pop27
@@ -263,10 +263,10 @@ main:                                   # @main
 # BB#3:                                 # %for.end.i.i
                                         #   in Loop: Header=BB3_1 Depth=1
 	end_loop
-	i64.const	$push44=, 63
-	i64.shl 	$push1=, $6, $pop44
-	i64.const	$push43=, 63
-	i64.shr_s	$push2=, $pop1, $pop43
+	i64.const	$push44=, 0
+	i64.const	$push43=, 1
+	i64.and 	$push1=, $6, $pop43
+	i64.sub 	$push2=, $pop44, $pop1
 	i64.const	$push42=, 1
 	i64.const	$push41=, 1
 	i64.shr_u	$push3=, $6, $pop41
@@ -369,6 +369,6 @@ main:                                   # @main
 	.size	main, .Lfunc_end3-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/921208-1.c.s
+++ b/test/torture-s/921208-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/921208-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/921208-1.c"
 	.section	.text.f,"ax",@progbits
 	.hidden	f
 	.globl	f
@@ -22,7 +22,7 @@ Int:                                    # @Int
 	.param  	i32, f64
 	.result 	f64
 # BB#0:                                 # %entry
-	f64.call_indirect	$push0=, $0, $1
+	f64.call_indirect	$push0=, $1, $0
                                         # fallthrough-return: $pop0
 	.endfunc
 .Lfunc_end1:
@@ -43,5 +43,5 @@ main:                                   # @main
 	.size	main, .Lfunc_end2-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	exit, void, i32

--- a/test/torture-s/930513-1.c.s
+++ b/test/torture-s/930513-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/930513-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/930513-1.c"
 	.section	.text.f,"ax",@progbits
 	.hidden	f
 	.globl	f
@@ -20,7 +20,7 @@ f:                                      # @f
 	i64.store	0($1), $pop0
 	i32.const	$push2=, buf
 	i32.const	$push1=, .L.str
-	i32.call_indirect	$drop=, $0, $pop2, $pop1, $1
+	i32.call_indirect	$drop=, $pop2, $pop1, $1, $0
 	i32.const	$push9=, 0
 	i32.const	$push7=, 16
 	i32.add 	$push8=, $1, $pop7
@@ -90,7 +90,7 @@ buf:
 	.size	.L.str, 5
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	sprintf, i32, i32, i32
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/960909-1.c.s
+++ b/test/torture-s/960909-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/960909-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/960909-1.c"
 	.section	.text.ffs,"ax",@progbits
 	.hidden	ffs
 	.globl	ffs
@@ -9,34 +9,37 @@ ffs:                                    # @ffs
 	.result 	i32
 	.local  	i32, i32
 # BB#0:                                 # %entry
-	i32.const	$2=, 0
 	block   	
-	i32.eqz 	$push7=, $0
-	br_if   	0, $pop7        # 0: down to label0
+	i32.eqz 	$push8=, $0
+	br_if   	0, $pop8        # 0: down to label0
 # BB#1:                                 # %for.cond.preheader
 	i32.const	$2=, 1
-	i32.const	$push2=, 1
-	i32.and 	$push0=, $0, $pop2
-	br_if   	0, $pop0        # 0: down to label0
+	block   	
+	i32.const	$push3=, 1
+	i32.and 	$push0=, $0, $pop3
+	br_if   	0, $pop0        # 0: down to label1
 # BB#2:                                 # %for.inc.preheader
 	i32.const	$1=, 1
 	i32.const	$2=, 1
 .LBB0_3:                                # %for.inc
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label1:
+	loop    	                # label2:
+	i32.const	$push7=, 1
+	i32.add 	$2=, $2, $pop7
 	i32.const	$push6=, 1
-	i32.add 	$2=, $2, $pop6
-	i32.const	$push5=, 1
-	i32.shl 	$push4=, $1, $pop5
-	tee_local	$push3=, $1=, $pop4
-	i32.and 	$push1=, $pop3, $0
-	i32.eqz 	$push8=, $pop1
-	br_if   	0, $pop8        # 0: up to label1
+	i32.shl 	$push5=, $1, $pop6
+	tee_local	$push4=, $1=, $pop5
+	i32.and 	$push1=, $pop4, $0
+	i32.eqz 	$push9=, $pop1
+	br_if   	0, $pop9        # 0: up to label2
 .LBB0_4:                                # %cleanup
 	end_loop
+	end_block                       # label1:
+	return  	$2
+.LBB0_5:
 	end_block                       # label0:
-	copy_local	$push9=, $2
-                                        # fallthrough-return: $pop9
+	i32.const	$push2=, 0
+                                        # fallthrough-return: $pop2
 	.endfunc
 .Lfunc_end0:
 	.size	ffs, .Lfunc_end0-ffs
@@ -51,11 +54,11 @@ f:                                      # @f
 # BB#0:                                 # %entry
 	block   	
 	i32.eqz 	$push0=, $0
-	br_if   	0, $pop0        # 0: down to label2
+	br_if   	0, $pop0        # 0: down to label3
 # BB#1:                                 # %if.end
 	return  	$0
 .LBB1_2:                                # %if.then
-	end_block                       # label2:
+	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -77,6 +80,6 @@ main:                                   # @main
 	.size	main, .Lfunc_end2-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/980707-1.c.s
+++ b/test/torture-s/980707-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/980707-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/980707-1.c"
 	.section	.text.buildargv,"ax",@progbits
 	.hidden	buildargv
 	.globl	buildargv
@@ -29,46 +29,49 @@ buildargv:                              # @buildargv
                                         #   in Loop: Header=BB0_1 Depth=1
 	end_block                       # label1:
 	block   	
-	i32.eqz 	$push23=, $1
-	br_if   	0, $pop23       # 0: down to label2
+	i32.eqz 	$push27=, $1
+	br_if   	0, $pop27       # 0: down to label2
 # BB#4:                                 # %if.end
                                         #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push15=, 2
-	i32.shl 	$push1=, $2, $pop15
-	i32.const	$push14=, buildargv.arglist
-	i32.add 	$push2=, $pop1, $pop14
+	i32.const	$push17=, 2
+	i32.shl 	$push1=, $2, $pop17
+	i32.const	$push16=, buildargv.arglist
+	i32.add 	$push2=, $pop1, $pop16
 	i32.store	0($pop2), $0
-	i32.const	$push13=, 1
-	i32.add 	$2=, $2, $pop13
+	i32.const	$push15=, 1
+	i32.add 	$2=, $2, $pop15
+	i32.load8_u	$push14=, 0($0)
+	tee_local	$push13=, $1=, $pop14
+	i32.eqz 	$push28=, $pop13
+	br_if   	0, $pop28       # 0: down to label2
 .LBB0_5:                                # %while.cond7
                                         #   Parent Loop BB0_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label3:
-	i32.load8_u	$push18=, 0($0)
-	tee_local	$push17=, $1=, $pop18
-	i32.eqz 	$push24=, $pop17
-	br_if   	1, $pop24       # 1: down to label2
-# BB#6:                                 # %while.cond7
-                                        #   in Loop: Header=BB0_5 Depth=2
 	block   	
-	i32.const	$push19=, 32
-	i32.eq  	$push3=, $1, $pop19
-	br_if   	0, $pop3        # 0: down to label4
-# BB#7:                                 # %while.body14
+	loop    	                # label4:
+	i32.const	$push23=, 32
+	i32.eq  	$push3=, $1, $pop23
+	br_if   	1, $pop3        # 1: down to label3
+# BB#6:                                 # %while.body14
                                         #   in Loop: Header=BB0_5 Depth=2
-	i32.const	$push16=, 1
-	i32.add 	$0=, $0, $pop16
-	br      	1               # 1: up to label3
-.LBB0_8:                                # %if.end21
+	i32.const	$push22=, 1
+	i32.add 	$push21=, $0, $pop22
+	tee_local	$push20=, $0=, $pop21
+	i32.load8_u	$push19=, 0($pop20)
+	tee_local	$push18=, $1=, $pop19
+	i32.eqz 	$push29=, $pop18
+	br_if   	2, $pop29       # 2: down to label2
+	br      	0               # 0: up to label4
+.LBB0_7:                                # %if.end21
                                         #   in Loop: Header=BB0_1 Depth=1
-	end_block                       # label4:
 	end_loop
-	i32.const	$push21=, 0
-	i32.store8	0($0), $pop21
-	i32.const	$push20=, 1
-	i32.add 	$0=, $0, $pop20
+	end_block                       # label3:
+	i32.const	$push25=, 0
+	i32.store8	0($0), $pop25
+	i32.const	$push24=, 1
+	i32.add 	$0=, $0, $pop24
 	br      	1               # 1: up to label0
-.LBB0_9:                                # %while.end23
+.LBB0_8:                                # %while.end23
 	end_block                       # label2:
 	end_loop
 	i32.const	$push4=, 2
@@ -77,8 +80,8 @@ buildargv:                              # @buildargv
 	i32.add 	$push7=, $pop5, $pop6
 	i32.const	$push8=, 0
 	i32.store	0($pop7), $pop8
-	i32.const	$push22=, buildargv.arglist
-                                        # fallthrough-return: $pop22
+	i32.const	$push26=, buildargv.arglist
+                                        # fallthrough-return: $pop26
 	.endfunc
 .Lfunc_end0:
 	.size	buildargv, .Lfunc_end0-buildargv
@@ -225,7 +228,7 @@ buildargv.arglist:
 	.size	.L.str.2, 2
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	strcmp, i32, i32, i32
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/bcp-1.c.s
+++ b/test/torture-s/bcp-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/bcp-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/bcp-1.c"
 	.section	.text.bad0,"ax",@progbits
 	.hidden	bad0
 	.globl	bad0
@@ -267,34 +267,34 @@ main:                                   # @main
 	i32.call_indirect	$push11=, $pop10
 	br_if   	0, $pop11       # 0: down to label3
 # BB#6:                                 # %for.cond.5
-	i32.const	$push42=, 0
-	i32.load	$push12=, bad_t1($pop42)
-	i32.const	$push41=, 1
-	i32.call_indirect	$push13=, $pop12, $pop41
+	i32.const	$push42=, 1
+	i32.const	$push41=, 0
+	i32.load	$push12=, bad_t1($pop41)
+	i32.call_indirect	$push13=, $pop42, $pop12
 	br_if   	1, $pop13       # 1: down to label2
 # BB#7:                                 # %for.cond1
-	i32.const	$push44=, 0
-	i32.load	$push14=, bad_t1+4($pop44)
-	i32.const	$push43=, 1
-	i32.call_indirect	$push15=, $pop14, $pop43
+	i32.const	$push44=, 1
+	i32.const	$push43=, 0
+	i32.load	$push14=, bad_t1+4($pop43)
+	i32.call_indirect	$push15=, $pop44, $pop14
 	br_if   	1, $pop15       # 1: down to label2
 # BB#8:                                 # %for.cond1.1
+	i32.const	$push17=, 1
 	i32.const	$push45=, 0
 	i32.load	$push16=, bad_t1+8($pop45)
-	i32.const	$push17=, 1
-	i32.call_indirect	$push18=, $pop16, $pop17
+	i32.call_indirect	$push18=, $pop17, $pop16
 	br_if   	1, $pop18       # 1: down to label2
 # BB#9:                                 # %for.cond1.2
-	i32.const	$push47=, 0
-	i32.load	$push19=, bad_t2($pop47)
-	i32.const	$push46=, .L.str
-	i32.call_indirect	$push20=, $pop19, $pop46
+	i32.const	$push47=, .L.str
+	i32.const	$push46=, 0
+	i32.load	$push19=, bad_t2($pop46)
+	i32.call_indirect	$push20=, $pop47, $pop19
 	br_if   	2, $pop20       # 2: down to label1
 # BB#10:                                # %for.cond12
-	i32.const	$push49=, 0
-	i32.load	$push21=, bad_t2+4($pop49)
-	i32.const	$push48=, .L.str
-	i32.call_indirect	$push22=, $pop21, $pop48
+	i32.const	$push49=, .L.str
+	i32.const	$push48=, 0
+	i32.load	$push21=, bad_t2+4($pop48)
+	i32.call_indirect	$push22=, $pop49, $pop21
 	br_if   	2, $pop22       # 2: down to label1
 # BB#11:                                # %for.cond12.1
 	block   	
@@ -436,6 +436,6 @@ global:
 	.size	global, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/builtin-bitops-1.c.s
+++ b/test/torture-s/builtin-bitops-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/builtin-bitops-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/builtin-bitops-1.c"
 	.section	.text.my_ffs,"ax",@progbits
 	.hidden	my_ffs
 	.globl	my_ffs
@@ -9,37 +9,40 @@ my_ffs:                                 # @my_ffs
 	.result 	i32
 	.local  	i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$3=, 0
 	block   	
-	i32.eqz 	$push11=, $0
-	br_if   	0, $pop11       # 0: down to label0
+	i32.eqz 	$push12=, $0
+	br_if   	0, $pop12       # 0: down to label0
 # BB#1:                                 # %for.cond.preheader
 	i32.const	$2=, 1
 .LBB0_2:                                # %for.cond
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label1:
-	copy_local	$push8=, $2
-	tee_local	$push7=, $3=, $pop8
-	i32.const	$push6=, -1
-	i32.add 	$push5=, $pop7, $pop6
-	tee_local	$push4=, $1=, $pop5
-	i32.const	$push3=, 31
-	i32.gt_u	$push0=, $pop4, $pop3
-	br_if   	1, $pop0        # 1: down to label0
+	block   	
+	loop    	                # label2:
+	copy_local	$push9=, $2
+	tee_local	$push8=, $3=, $pop9
+	i32.const	$push7=, -1
+	i32.add 	$push6=, $pop8, $pop7
+	tee_local	$push5=, $1=, $pop6
+	i32.const	$push4=, 31
+	i32.gt_u	$push0=, $pop5, $pop4
+	br_if   	1, $pop0        # 1: down to label1
 # BB#3:                                 # %for.body
                                         #   in Loop: Header=BB0_2 Depth=1
+	i32.const	$push11=, 1
+	i32.add 	$2=, $3, $pop11
 	i32.const	$push10=, 1
-	i32.add 	$2=, $3, $pop10
-	i32.const	$push9=, 1
-	i32.shl 	$push1=, $pop9, $1
+	i32.shl 	$push1=, $pop10, $1
 	i32.and 	$push2=, $pop1, $0
-	i32.eqz 	$push12=, $pop2
-	br_if   	0, $pop12       # 0: up to label1
+	i32.eqz 	$push13=, $pop2
+	br_if   	0, $pop13       # 0: up to label2
 .LBB0_4:                                # %cleanup
 	end_loop
+	end_block                       # label1:
+	return  	$3
+.LBB0_5:
 	end_block                       # label0:
-	copy_local	$push13=, $3
-                                        # fallthrough-return: $pop13
+	i32.const	$push3=, 0
+                                        # fallthrough-return: $pop3
 	.endfunc
 .Lfunc_end0:
 	.size	my_ffs, .Lfunc_end0-my_ffs
@@ -57,11 +60,11 @@ my_ctz:                                 # @my_ctz
 .LBB1_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label3:
+	loop    	                # label4:
 	i32.const	$push3=, 1
 	i32.shl 	$push0=, $pop3, $1
 	i32.and 	$push1=, $pop0, $0
-	br_if   	1, $pop1        # 1: down to label2
+	br_if   	1, $pop1        # 1: down to label3
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB1_1 Depth=1
 	i32.const	$push7=, 1
@@ -69,10 +72,10 @@ my_ctz:                                 # @my_ctz
 	tee_local	$push5=, $1=, $pop6
 	i32.const	$push4=, 32
 	i32.lt_u	$push2=, $pop5, $pop4
-	br_if   	0, $pop2        # 0: up to label3
+	br_if   	0, $pop2        # 0: up to label4
 .LBB1_3:                                # %for.end
 	end_loop
-	end_block                       # label2:
+	end_block                       # label3:
 	copy_local	$push8=, $1
                                         # fallthrough-return: $pop8
 	.endfunc
@@ -93,11 +96,11 @@ my_clz:                                 # @my_clz
 .LBB2_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label5:
+	loop    	                # label6:
 	i32.const	$push3=, 1
 	i32.shl 	$push0=, $pop3, $1
 	i32.and 	$push1=, $pop0, $0
-	br_if   	1, $pop1        # 1: down to label4
+	br_if   	1, $pop1        # 1: down to label5
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push8=, -1
@@ -107,10 +110,10 @@ my_clz:                                 # @my_clz
 	tee_local	$push5=, $2=, $pop6
 	i32.const	$push4=, 32
 	i32.lt_u	$push2=, $pop5, $pop4
-	br_if   	0, $pop2        # 0: up to label5
+	br_if   	0, $pop2        # 0: up to label6
 .LBB2_3:                                # %for.end
 	end_loop
-	end_block                       # label4:
+	end_block                       # label5:
 	copy_local	$push9=, $2
                                         # fallthrough-return: $pop9
 	.endfunc
@@ -133,12 +136,12 @@ my_clrsb:                               # @my_clrsb
 .LBB3_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label7:
+	loop    	                # label8:
 	i32.shr_u	$push1=, $0, $2
 	i32.const	$push7=, 1
 	i32.and 	$push2=, $pop1, $pop7
 	i32.ne  	$push3=, $pop2, $1
-	br_if   	1, $pop3        # 1: down to label6
+	br_if   	1, $pop3        # 1: down to label7
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB3_1 Depth=1
 	i32.const	$push12=, -1
@@ -148,10 +151,10 @@ my_clrsb:                               # @my_clrsb
 	tee_local	$push9=, $3=, $pop10
 	i32.const	$push8=, 32
 	i32.lt_u	$push4=, $pop9, $pop8
-	br_if   	0, $pop4        # 0: up to label7
+	br_if   	0, $pop4        # 0: up to label8
 .LBB3_3:                                # %for.end
 	end_loop
-	end_block                       # label6:
+	end_block                       # label7:
 	i32.const	$push5=, -1
 	i32.add 	$push6=, $3, $pop5
                                         # fallthrough-return: $pop6
@@ -172,7 +175,7 @@ my_popcount:                            # @my_popcount
 	i32.const	$2=, 0
 .LBB4_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label8:
+	loop    	                # label9:
 	i32.const	$push9=, 1
 	i32.shl 	$push0=, $pop9, $2
 	i32.and 	$push1=, $pop0, $0
@@ -184,7 +187,7 @@ my_popcount:                            # @my_popcount
 	tee_local	$push5=, $2=, $pop6
 	i32.const	$push4=, 32
 	i32.ne  	$push3=, $pop5, $pop4
-	br_if   	0, $pop3        # 0: up to label8
+	br_if   	0, $pop3        # 0: up to label9
 # BB#2:                                 # %for.end
 	end_loop
 	copy_local	$push10=, $1
@@ -206,7 +209,7 @@ my_parity:                              # @my_parity
 	i32.const	$2=, 0
 .LBB5_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label9:
+	loop    	                # label10:
 	i32.const	$push11=, 1
 	i32.shl 	$push0=, $pop11, $2
 	i32.and 	$push1=, $pop0, $0
@@ -218,7 +221,7 @@ my_parity:                              # @my_parity
 	tee_local	$push7=, $2=, $pop8
 	i32.const	$push6=, 32
 	i32.ne  	$push3=, $pop7, $pop6
-	br_if   	0, $pop3        # 0: up to label9
+	br_if   	0, $pop3        # 0: up to label10
 # BB#2:                                 # %for.end
 	end_loop
 	i32.const	$push4=, 1
@@ -237,37 +240,40 @@ my_ffsl:                                # @my_ffsl
 	.result 	i32
 	.local  	i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$3=, 0
 	block   	
-	i32.eqz 	$push11=, $0
-	br_if   	0, $pop11       # 0: down to label10
+	i32.eqz 	$push12=, $0
+	br_if   	0, $pop12       # 0: down to label11
 # BB#1:                                 # %for.cond.preheader
 	i32.const	$2=, 1
 .LBB6_2:                                # %for.cond
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label11:
-	copy_local	$push8=, $2
-	tee_local	$push7=, $3=, $pop8
-	i32.const	$push6=, -1
-	i32.add 	$push5=, $pop7, $pop6
-	tee_local	$push4=, $1=, $pop5
-	i32.const	$push3=, 31
-	i32.gt_u	$push0=, $pop4, $pop3
-	br_if   	1, $pop0        # 1: down to label10
+	block   	
+	loop    	                # label13:
+	copy_local	$push9=, $2
+	tee_local	$push8=, $3=, $pop9
+	i32.const	$push7=, -1
+	i32.add 	$push6=, $pop8, $pop7
+	tee_local	$push5=, $1=, $pop6
+	i32.const	$push4=, 31
+	i32.gt_u	$push0=, $pop5, $pop4
+	br_if   	1, $pop0        # 1: down to label12
 # BB#3:                                 # %for.body
                                         #   in Loop: Header=BB6_2 Depth=1
+	i32.const	$push11=, 1
+	i32.add 	$2=, $3, $pop11
 	i32.const	$push10=, 1
-	i32.add 	$2=, $3, $pop10
-	i32.const	$push9=, 1
-	i32.shl 	$push1=, $pop9, $1
+	i32.shl 	$push1=, $pop10, $1
 	i32.and 	$push2=, $pop1, $0
-	i32.eqz 	$push12=, $pop2
-	br_if   	0, $pop12       # 0: up to label11
+	i32.eqz 	$push13=, $pop2
+	br_if   	0, $pop13       # 0: up to label13
 .LBB6_4:                                # %cleanup
 	end_loop
-	end_block                       # label10:
-	copy_local	$push13=, $3
-                                        # fallthrough-return: $pop13
+	end_block                       # label12:
+	return  	$3
+.LBB6_5:
+	end_block                       # label11:
+	i32.const	$push3=, 0
+                                        # fallthrough-return: $pop3
 	.endfunc
 .Lfunc_end6:
 	.size	my_ffsl, .Lfunc_end6-my_ffsl
@@ -285,11 +291,11 @@ my_ctzl:                                # @my_ctzl
 .LBB7_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label13:
+	loop    	                # label15:
 	i32.const	$push3=, 1
 	i32.shl 	$push0=, $pop3, $1
 	i32.and 	$push1=, $pop0, $0
-	br_if   	1, $pop1        # 1: down to label12
+	br_if   	1, $pop1        # 1: down to label14
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB7_1 Depth=1
 	i32.const	$push7=, 1
@@ -297,10 +303,10 @@ my_ctzl:                                # @my_ctzl
 	tee_local	$push5=, $1=, $pop6
 	i32.const	$push4=, 32
 	i32.lt_u	$push2=, $pop5, $pop4
-	br_if   	0, $pop2        # 0: up to label13
+	br_if   	0, $pop2        # 0: up to label15
 .LBB7_3:                                # %for.end
 	end_loop
-	end_block                       # label12:
+	end_block                       # label14:
 	copy_local	$push8=, $1
                                         # fallthrough-return: $pop8
 	.endfunc
@@ -321,11 +327,11 @@ my_clzl:                                # @my_clzl
 .LBB8_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label15:
+	loop    	                # label17:
 	i32.const	$push3=, 1
 	i32.shl 	$push0=, $pop3, $1
 	i32.and 	$push1=, $pop0, $0
-	br_if   	1, $pop1        # 1: down to label14
+	br_if   	1, $pop1        # 1: down to label16
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB8_1 Depth=1
 	i32.const	$push8=, -1
@@ -335,10 +341,10 @@ my_clzl:                                # @my_clzl
 	tee_local	$push5=, $2=, $pop6
 	i32.const	$push4=, 32
 	i32.lt_u	$push2=, $pop5, $pop4
-	br_if   	0, $pop2        # 0: up to label15
+	br_if   	0, $pop2        # 0: up to label17
 .LBB8_3:                                # %for.end
 	end_loop
-	end_block                       # label14:
+	end_block                       # label16:
 	copy_local	$push9=, $2
                                         # fallthrough-return: $pop9
 	.endfunc
@@ -361,12 +367,12 @@ my_clrsbl:                              # @my_clrsbl
 .LBB9_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label17:
+	loop    	                # label19:
 	i32.shr_u	$push1=, $0, $2
 	i32.const	$push7=, 1
 	i32.and 	$push2=, $pop1, $pop7
 	i32.ne  	$push3=, $pop2, $1
-	br_if   	1, $pop3        # 1: down to label16
+	br_if   	1, $pop3        # 1: down to label18
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB9_1 Depth=1
 	i32.const	$push12=, -1
@@ -376,10 +382,10 @@ my_clrsbl:                              # @my_clrsbl
 	tee_local	$push9=, $3=, $pop10
 	i32.const	$push8=, 32
 	i32.lt_u	$push4=, $pop9, $pop8
-	br_if   	0, $pop4        # 0: up to label17
+	br_if   	0, $pop4        # 0: up to label19
 .LBB9_3:                                # %for.end
 	end_loop
-	end_block                       # label16:
+	end_block                       # label18:
 	i32.const	$push5=, -1
 	i32.add 	$push6=, $3, $pop5
                                         # fallthrough-return: $pop6
@@ -400,7 +406,7 @@ my_popcountl:                           # @my_popcountl
 	i32.const	$2=, 0
 .LBB10_1:                               # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label18:
+	loop    	                # label20:
 	i32.const	$push9=, 1
 	i32.shl 	$push0=, $pop9, $2
 	i32.and 	$push1=, $pop0, $0
@@ -412,7 +418,7 @@ my_popcountl:                           # @my_popcountl
 	tee_local	$push5=, $2=, $pop6
 	i32.const	$push4=, 32
 	i32.ne  	$push3=, $pop5, $pop4
-	br_if   	0, $pop3        # 0: up to label18
+	br_if   	0, $pop3        # 0: up to label20
 # BB#2:                                 # %for.end
 	end_loop
 	copy_local	$push10=, $1
@@ -434,7 +440,7 @@ my_parityl:                             # @my_parityl
 	i32.const	$2=, 0
 .LBB11_1:                               # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label19:
+	loop    	                # label21:
 	i32.const	$push11=, 1
 	i32.shl 	$push0=, $pop11, $2
 	i32.and 	$push1=, $pop0, $0
@@ -446,7 +452,7 @@ my_parityl:                             # @my_parityl
 	tee_local	$push7=, $2=, $pop8
 	i32.const	$push6=, 32
 	i32.ne  	$push3=, $pop7, $pop6
-	br_if   	0, $pop3        # 0: up to label19
+	br_if   	0, $pop3        # 0: up to label21
 # BB#2:                                 # %for.end
 	end_loop
 	i32.const	$push4=, 1
@@ -465,37 +471,40 @@ my_ffsll:                               # @my_ffsll
 	.result 	i32
 	.local  	i64, i32, i64, i32
 # BB#0:                                 # %entry
-	i32.const	$4=, 0
 	block   	
 	i64.eqz 	$push1=, $0
-	br_if   	0, $pop1        # 0: down to label20
+	br_if   	0, $pop1        # 0: down to label22
 # BB#1:                                 # %for.cond.preheader
 	i64.const	$3=, 0
 	i32.const	$2=, 1
 .LBB12_2:                               # %for.cond
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label21:
+	block   	
+	loop    	                # label24:
 	copy_local	$4=, $2
-	i64.const	$push5=, 63
-	i64.gt_u	$push2=, $3, $pop5
-	br_if   	1, $pop2        # 1: down to label20
+	i64.const	$push6=, 63
+	i64.gt_u	$push2=, $3, $pop6
+	br_if   	1, $pop2        # 1: down to label23
 # BB#3:                                 # %for.body
                                         #   in Loop: Header=BB12_2 Depth=1
-	i32.const	$push8=, 1
-	i32.add 	$2=, $4, $pop8
+	i32.const	$push9=, 1
+	i32.add 	$2=, $4, $pop9
+	i64.const	$push8=, 1
+	i64.shl 	$1=, $pop8, $3
 	i64.const	$push7=, 1
-	i64.shl 	$1=, $pop7, $3
-	i64.const	$push6=, 1
-	i64.add 	$push0=, $3, $pop6
+	i64.add 	$push0=, $3, $pop7
 	copy_local	$3=, $pop0
 	i64.and 	$push3=, $1, $0
 	i64.eqz 	$push4=, $pop3
-	br_if   	0, $pop4        # 0: up to label21
+	br_if   	0, $pop4        # 0: up to label24
 .LBB12_4:                               # %cleanup
 	end_loop
-	end_block                       # label20:
-	copy_local	$push9=, $4
-                                        # fallthrough-return: $pop9
+	end_block                       # label23:
+	return  	$4
+.LBB12_5:
+	end_block                       # label22:
+	i32.const	$push5=, 0
+                                        # fallthrough-return: $pop5
 	.endfunc
 .Lfunc_end12:
 	.size	my_ffsll, .Lfunc_end12-my_ffsll
@@ -514,13 +523,13 @@ my_ctzll:                               # @my_ctzll
 .LBB13_1:                               # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label23:
+	loop    	                # label26:
 	i64.const	$push5=, 1
 	i64.shl 	$push0=, $pop5, $1
 	i64.and 	$push1=, $pop0, $0
 	i64.const	$push4=, 0
 	i64.ne  	$push2=, $pop1, $pop4
-	br_if   	1, $pop2        # 1: down to label22
+	br_if   	1, $pop2        # 1: down to label25
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB13_1 Depth=1
 	i32.const	$push10=, 1
@@ -530,10 +539,10 @@ my_ctzll:                               # @my_ctzll
 	tee_local	$push7=, $1=, $pop8
 	i64.const	$push6=, 64
 	i64.lt_u	$push3=, $pop7, $pop6
-	br_if   	0, $pop3        # 0: up to label23
+	br_if   	0, $pop3        # 0: up to label26
 .LBB13_3:                               # %for.end
 	end_loop
-	end_block                       # label22:
+	end_block                       # label25:
 	copy_local	$push11=, $2
                                         # fallthrough-return: $pop11
 	.endfunc
@@ -555,13 +564,13 @@ my_clzll:                               # @my_clzll
 .LBB14_1:                               # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label25:
+	loop    	                # label28:
 	i64.const	$push5=, 1
 	i64.shl 	$push0=, $pop5, $1
 	i64.and 	$push1=, $pop0, $0
 	i64.const	$push4=, 0
 	i64.ne  	$push2=, $pop1, $pop4
-	br_if   	1, $pop2        # 1: down to label24
+	br_if   	1, $pop2        # 1: down to label27
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB14_1 Depth=1
 	i64.const	$push11=, -1
@@ -573,10 +582,10 @@ my_clzll:                               # @my_clzll
 	tee_local	$push7=, $2=, $pop8
 	i64.const	$push6=, 64
 	i64.lt_u	$push3=, $pop7, $pop6
-	br_if   	0, $pop3        # 0: up to label25
+	br_if   	0, $pop3        # 0: up to label28
 .LBB14_3:                               # %for.end
 	end_loop
-	end_block                       # label24:
+	end_block                       # label27:
 	copy_local	$push12=, $3
                                         # fallthrough-return: $pop12
 	.endfunc
@@ -600,12 +609,12 @@ my_clrsbll:                             # @my_clrsbll
 .LBB15_1:                               # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label27:
+	loop    	                # label30:
 	i64.shr_u	$push1=, $0, $2
 	i64.const	$push7=, 1
 	i64.and 	$push2=, $pop1, $pop7
 	i64.ne  	$push3=, $pop2, $1
-	br_if   	1, $pop3        # 1: down to label26
+	br_if   	1, $pop3        # 1: down to label29
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB15_1 Depth=1
 	i64.const	$push13=, -1
@@ -617,10 +626,10 @@ my_clrsbll:                             # @my_clrsbll
 	tee_local	$push9=, $3=, $pop10
 	i64.const	$push8=, 64
 	i64.lt_u	$push4=, $pop9, $pop8
-	br_if   	0, $pop4        # 0: up to label27
+	br_if   	0, $pop4        # 0: up to label30
 .LBB15_3:                               # %for.end
 	end_loop
-	end_block                       # label26:
+	end_block                       # label29:
 	i32.const	$push5=, -1
 	i32.add 	$push6=, $4, $pop5
                                         # fallthrough-return: $pop6
@@ -641,7 +650,7 @@ my_popcountll:                          # @my_popcountll
 	i64.const	$1=, 0
 .LBB16_1:                               # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label28:
+	loop    	                # label31:
 	i64.const	$push9=, 1
 	i64.shl 	$push0=, $pop9, $1
 	i64.and 	$push1=, $pop0, $0
@@ -653,7 +662,7 @@ my_popcountll:                          # @my_popcountll
 	tee_local	$push5=, $1=, $pop6
 	i64.const	$push4=, 64
 	i64.ne  	$push3=, $pop5, $pop4
-	br_if   	0, $pop3        # 0: up to label28
+	br_if   	0, $pop3        # 0: up to label31
 # BB#2:                                 # %for.end
 	end_loop
 	copy_local	$push10=, $2
@@ -675,7 +684,7 @@ my_parityll:                            # @my_parityll
 	i64.const	$1=, 0
 .LBB17_1:                               # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label29:
+	loop    	                # label32:
 	i64.const	$push11=, 1
 	i64.shl 	$push0=, $pop11, $1
 	i64.and 	$push1=, $pop0, $0
@@ -687,7 +696,7 @@ my_parityll:                            # @my_parityll
 	tee_local	$push7=, $1=, $pop8
 	i64.const	$push6=, 64
 	i64.ne  	$push3=, $pop7, $pop6
-	br_if   	0, $pop3        # 0: up to label29
+	br_if   	0, $pop3        # 0: up to label32
 # BB#2:                                 # %for.end
 	end_loop
 	i32.const	$push4=, 1
@@ -716,24 +725,24 @@ main:                                   # @main
                                         #     Child Loop BB18_24 Depth 2
 	block   	
 	block   	
-	loop    	                # label32:
-	i32.const	$push205=, 2
-	i32.shl 	$push1=, $0, $pop205
-	i32.const	$push204=, ints
-	i32.add 	$push203=, $pop1, $pop204
-	tee_local	$push202=, $1=, $pop203
-	i32.load	$push201=, 0($pop202)
-	tee_local	$push200=, $10=, $pop201
-	i32.ctz 	$push199=, $pop200
-	tee_local	$push198=, $2=, $pop199
-	i32.const	$push197=, 1
-	i32.add 	$push2=, $pop198, $pop197
-	i32.const	$push196=, 0
-	i32.select	$6=, $pop2, $pop196, $10
+	loop    	                # label35:
+	i32.const	$push208=, 2
+	i32.shl 	$push1=, $0, $pop208
+	i32.const	$push207=, ints
+	i32.add 	$push206=, $pop1, $pop207
+	tee_local	$push205=, $1=, $pop206
+	i32.load	$push204=, 0($pop205)
+	tee_local	$push203=, $10=, $pop204
+	i32.ctz 	$push202=, $pop203
+	tee_local	$push201=, $2=, $pop202
+	i32.const	$push200=, 1
+	i32.add 	$push2=, $pop201, $pop200
+	i32.const	$push199=, 0
+	i32.select	$6=, $pop2, $pop199, $10
 	i32.const	$3=, 0
 	block   	
-	i32.eqz 	$push397=, $10
-	br_if   	0, $pop397      # 0: down to label33
+	i32.eqz 	$push400=, $10
+	br_if   	0, $pop400      # 0: down to label36
 # BB#2:                                 # %for.cond.i.preheader
                                         #   in Loop: Header=BB18_1 Depth=1
 	i32.const	$5=, 0
@@ -741,37 +750,37 @@ main:                                   # @main
                                         #   Parent Loop BB18_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	block   	
-	loop    	                # label35:
-	copy_local	$push208=, $5
-	tee_local	$push207=, $3=, $pop208
-	i32.const	$push206=, 31
-	i32.gt_u	$push3=, $pop207, $pop206
-	br_if   	1, $pop3        # 1: down to label34
+	loop    	                # label38:
+	copy_local	$push211=, $5
+	tee_local	$push210=, $3=, $pop211
+	i32.const	$push209=, 31
+	i32.gt_u	$push3=, $pop210, $pop209
+	br_if   	1, $pop3        # 1: down to label37
 # BB#4:                                 # %for.body.i
                                         #   in Loop: Header=BB18_3 Depth=2
-	i32.const	$push210=, 1
-	i32.add 	$5=, $3, $pop210
-	i32.const	$push209=, 1
-	i32.shl 	$push4=, $pop209, $3
+	i32.const	$push213=, 1
+	i32.add 	$5=, $3, $pop213
+	i32.const	$push212=, 1
+	i32.shl 	$push4=, $pop212, $3
 	i32.and 	$push5=, $pop4, $10
-	i32.eqz 	$push398=, $pop5
-	br_if   	0, $pop398      # 0: up to label35
+	i32.eqz 	$push401=, $pop5
+	br_if   	0, $pop401      # 0: up to label38
 .LBB18_5:                               # %my_ffs.exit.loopexit
                                         #   in Loop: Header=BB18_1 Depth=1
 	end_loop
-	end_block                       # label34:
-	i32.const	$push211=, 1
-	i32.add 	$3=, $3, $pop211
+	end_block                       # label37:
+	i32.const	$push214=, 1
+	i32.add 	$3=, $3, $pop214
 .LBB18_6:                               # %my_ffs.exit
                                         #   in Loop: Header=BB18_1 Depth=1
-	end_block                       # label33:
+	end_block                       # label36:
 	i32.ne  	$push6=, $6, $3
-	br_if   	1, $pop6        # 1: down to label31
+	br_if   	1, $pop6        # 1: down to label34
 # BB#7:                                 # %if.end
                                         #   in Loop: Header=BB18_1 Depth=1
 	block   	
-	i32.eqz 	$push399=, $10
-	br_if   	0, $pop399      # 0: down to label36
+	i32.eqz 	$push402=, $10
+	br_if   	0, $pop402      # 0: down to label39
 # BB#8:                                 # %land.lhs.true
                                         #   in Loop: Header=BB18_1 Depth=1
 	i32.clz 	$6=, $10
@@ -781,27 +790,27 @@ main:                                   # @main
                                         #   Parent Loop BB18_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	block   	
-	loop    	                # label38:
-	i32.const	$push212=, 1
-	i32.shl 	$push7=, $pop212, $3
+	loop    	                # label41:
+	i32.const	$push215=, 1
+	i32.shl 	$push7=, $pop215, $3
 	i32.and 	$push8=, $pop7, $10
-	br_if   	1, $pop8        # 1: down to label37
+	br_if   	1, $pop8        # 1: down to label40
 # BB#10:                                # %for.inc.i819
                                         #   in Loop: Header=BB18_9 Depth=2
-	i32.const	$push217=, -1
-	i32.add 	$3=, $3, $pop217
-	i32.const	$push216=, 1
-	i32.add 	$push215=, $5, $pop216
-	tee_local	$push214=, $5=, $pop215
-	i32.const	$push213=, 32
-	i32.lt_u	$push9=, $pop214, $pop213
-	br_if   	0, $pop9        # 0: up to label38
+	i32.const	$push220=, -1
+	i32.add 	$3=, $3, $pop220
+	i32.const	$push219=, 1
+	i32.add 	$push218=, $5, $pop219
+	tee_local	$push217=, $5=, $pop218
+	i32.const	$push216=, 32
+	i32.lt_u	$push9=, $pop217, $pop216
+	br_if   	0, $pop9        # 0: up to label41
 .LBB18_11:                              # %my_clz.exit
                                         #   in Loop: Header=BB18_1 Depth=1
 	end_loop
-	end_block                       # label37:
+	end_block                       # label40:
 	i32.ne  	$push10=, $6, $5
-	br_if   	2, $pop10       # 2: down to label31
+	br_if   	2, $pop10       # 2: down to label34
 # BB#12:                                # %land.lhs.true13
                                         #   in Loop: Header=BB18_1 Depth=1
 	i32.const	$3=, 0
@@ -809,63 +818,63 @@ main:                                   # @main
                                         #   Parent Loop BB18_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	block   	
-	loop    	                # label40:
-	i32.const	$push218=, 1
-	i32.shl 	$push11=, $pop218, $3
+	loop    	                # label43:
+	i32.const	$push221=, 1
+	i32.shl 	$push11=, $pop221, $3
 	i32.and 	$push12=, $pop11, $10
-	br_if   	1, $pop12       # 1: down to label39
+	br_if   	1, $pop12       # 1: down to label42
 # BB#14:                                # %for.inc.i878
                                         #   in Loop: Header=BB18_13 Depth=2
-	i32.const	$push222=, 1
-	i32.add 	$push221=, $3, $pop222
-	tee_local	$push220=, $3=, $pop221
-	i32.const	$push219=, 32
-	i32.lt_u	$push13=, $pop220, $pop219
-	br_if   	0, $pop13       # 0: up to label40
+	i32.const	$push225=, 1
+	i32.add 	$push224=, $3, $pop225
+	tee_local	$push223=, $3=, $pop224
+	i32.const	$push222=, 32
+	i32.lt_u	$push13=, $pop223, $pop222
+	br_if   	0, $pop13       # 0: up to label43
 .LBB18_15:                              # %my_ctz.exit
                                         #   in Loop: Header=BB18_1 Depth=1
 	end_loop
-	end_block                       # label39:
+	end_block                       # label42:
 	i32.ne  	$push14=, $2, $3
-	br_if   	2, $pop14       # 2: down to label31
+	br_if   	2, $pop14       # 2: down to label34
 .LBB18_16:                              # %if.end19
                                         #   in Loop: Header=BB18_1 Depth=1
-	end_block                       # label36:
+	end_block                       # label39:
 	i32.call	$2=, __builtin_clrsb@FUNCTION, $10
-	i32.load	$push225=, 0($1)
-	tee_local	$push224=, $3=, $pop225
-	i32.const	$push223=, 31
-	i32.shr_u	$6=, $pop224, $pop223
+	i32.load	$push228=, 0($1)
+	tee_local	$push227=, $3=, $pop228
+	i32.const	$push226=, 31
+	i32.shr_u	$6=, $pop227, $pop226
 	i32.const	$5=, 1
 	i32.const	$10=, 30
 .LBB18_17:                              # %for.body.i948
                                         #   Parent Loop BB18_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	block   	
-	loop    	                # label42:
+	loop    	                # label45:
 	i32.shr_u	$push15=, $3, $10
-	i32.const	$push226=, 1
-	i32.and 	$push16=, $pop15, $pop226
+	i32.const	$push229=, 1
+	i32.and 	$push16=, $pop15, $pop229
 	i32.ne  	$push17=, $pop16, $6
-	br_if   	1, $pop17       # 1: down to label41
+	br_if   	1, $pop17       # 1: down to label44
 # BB#18:                                # %for.inc.i951
                                         #   in Loop: Header=BB18_17 Depth=2
-	i32.const	$push231=, -1
-	i32.add 	$10=, $10, $pop231
-	i32.const	$push230=, 1
-	i32.add 	$push229=, $5, $pop230
-	tee_local	$push228=, $5=, $pop229
-	i32.const	$push227=, 32
-	i32.lt_u	$push18=, $pop228, $pop227
-	br_if   	0, $pop18       # 0: up to label42
+	i32.const	$push234=, -1
+	i32.add 	$10=, $10, $pop234
+	i32.const	$push233=, 1
+	i32.add 	$push232=, $5, $pop233
+	tee_local	$push231=, $5=, $pop232
+	i32.const	$push230=, 32
+	i32.lt_u	$push18=, $pop231, $pop230
+	br_if   	0, $pop18       # 0: up to label45
 .LBB18_19:                              # %my_clrsb.exit
                                         #   in Loop: Header=BB18_1 Depth=1
 	end_loop
-	end_block                       # label41:
-	i32.const	$push232=, -1
-	i32.add 	$push19=, $5, $pop232
+	end_block                       # label44:
+	i32.const	$push235=, -1
+	i32.add 	$push19=, $5, $pop235
 	i32.ne  	$push20=, $2, $pop19
-	br_if   	1, $pop20       # 1: down to label31
+	br_if   	1, $pop20       # 1: down to label34
 # BB#20:                                # %for.body.i1030.preheader
                                         #   in Loop: Header=BB18_1 Depth=1
 	i32.const	$5=, 0
@@ -873,25 +882,25 @@ main:                                   # @main
 .LBB18_21:                              # %for.body.i1030
                                         #   Parent Loop BB18_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label43:
-	i32.const	$push238=, 1
-	i32.shl 	$push21=, $pop238, $10
+	loop    	                # label46:
+	i32.const	$push241=, 1
+	i32.shl 	$push21=, $pop241, $10
 	i32.and 	$push22=, $pop21, $3
-	i32.const	$push237=, 0
-	i32.ne  	$push23=, $pop22, $pop237
+	i32.const	$push240=, 0
+	i32.ne  	$push23=, $pop22, $pop240
 	i32.add 	$5=, $pop23, $5
-	i32.const	$push236=, 1
-	i32.add 	$push235=, $10, $pop236
-	tee_local	$push234=, $10=, $pop235
-	i32.const	$push233=, 32
-	i32.ne  	$push24=, $pop234, $pop233
-	br_if   	0, $pop24       # 0: up to label43
+	i32.const	$push239=, 1
+	i32.add 	$push238=, $10, $pop239
+	tee_local	$push237=, $10=, $pop238
+	i32.const	$push236=, 32
+	i32.ne  	$push24=, $pop237, $pop236
+	br_if   	0, $pop24       # 0: up to label46
 # BB#22:                                # %my_popcount.exit
                                         #   in Loop: Header=BB18_1 Depth=1
 	end_loop
 	i32.popcnt	$push25=, $3
 	i32.ne  	$push26=, $pop25, $5
-	br_if   	1, $pop26       # 1: down to label31
+	br_if   	1, $pop26       # 1: down to label34
 # BB#23:                                # %for.body.i1109.preheader
                                         #   in Loop: Header=BB18_1 Depth=1
 	i32.const	$6=, 0
@@ -899,34 +908,34 @@ main:                                   # @main
 .LBB18_24:                              # %for.body.i1109
                                         #   Parent Loop BB18_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label44:
-	i32.const	$push244=, 1
-	i32.shl 	$push27=, $pop244, $10
+	loop    	                # label47:
+	i32.const	$push247=, 1
+	i32.shl 	$push27=, $pop247, $10
 	i32.and 	$push28=, $pop27, $3
-	i32.const	$push243=, 0
-	i32.ne  	$push29=, $pop28, $pop243
+	i32.const	$push246=, 0
+	i32.ne  	$push29=, $pop28, $pop246
 	i32.add 	$6=, $pop29, $6
-	i32.const	$push242=, 1
-	i32.add 	$push241=, $10, $pop242
-	tee_local	$push240=, $10=, $pop241
-	i32.const	$push239=, 32
-	i32.ne  	$push30=, $pop240, $pop239
-	br_if   	0, $pop30       # 0: up to label44
+	i32.const	$push245=, 1
+	i32.add 	$push244=, $10, $pop245
+	tee_local	$push243=, $10=, $pop244
+	i32.const	$push242=, 32
+	i32.ne  	$push30=, $pop243, $pop242
+	br_if   	0, $pop30       # 0: up to label47
 # BB#25:                                # %my_parity.exit
                                         #   in Loop: Header=BB18_1 Depth=1
 	end_loop
 	i32.xor 	$push31=, $6, $5
-	i32.const	$push245=, 1
-	i32.and 	$push32=, $pop31, $pop245
-	br_if   	1, $pop32       # 1: down to label31
+	i32.const	$push248=, 1
+	i32.and 	$push32=, $pop31, $pop248
+	br_if   	1, $pop32       # 1: down to label34
 # BB#26:                                # %for.cond
                                         #   in Loop: Header=BB18_1 Depth=1
-	i32.const	$push249=, 1
-	i32.add 	$push248=, $0, $pop249
-	tee_local	$push247=, $0=, $pop248
-	i32.const	$push246=, 13
-	i32.lt_u	$push33=, $pop247, $pop246
-	br_if   	0, $pop33       # 0: up to label32
+	i32.const	$push252=, 1
+	i32.add 	$push251=, $0, $pop252
+	tee_local	$push250=, $0=, $pop251
+	i32.const	$push249=, 13
+	i32.lt_u	$push33=, $pop250, $pop249
+	br_if   	0, $pop33       # 0: up to label35
 # BB#27:                                # %for.body41.preheader
 	end_loop
 	i32.const	$0=, 0
@@ -938,24 +947,24 @@ main:                                   # @main
                                         #     Child Loop BB18_44 Depth 2
                                         #     Child Loop BB18_48 Depth 2
                                         #     Child Loop BB18_51 Depth 2
-	loop    	                # label45:
-	i32.const	$push259=, 2
-	i32.shl 	$push34=, $0, $pop259
-	i32.const	$push258=, longs
-	i32.add 	$push257=, $pop34, $pop258
-	tee_local	$push256=, $1=, $pop257
-	i32.load	$push255=, 0($pop256)
-	tee_local	$push254=, $10=, $pop255
-	i32.ctz 	$push253=, $pop254
-	tee_local	$push252=, $2=, $pop253
-	i32.const	$push251=, 1
-	i32.add 	$push35=, $pop252, $pop251
-	i32.const	$push250=, 0
-	i32.select	$6=, $pop35, $pop250, $10
+	loop    	                # label48:
+	i32.const	$push262=, 2
+	i32.shl 	$push34=, $0, $pop262
+	i32.const	$push261=, longs
+	i32.add 	$push260=, $pop34, $pop261
+	tee_local	$push259=, $1=, $pop260
+	i32.load	$push258=, 0($pop259)
+	tee_local	$push257=, $10=, $pop258
+	i32.ctz 	$push256=, $pop257
+	tee_local	$push255=, $2=, $pop256
+	i32.const	$push254=, 1
+	i32.add 	$push35=, $pop255, $pop254
+	i32.const	$push253=, 0
+	i32.select	$6=, $pop35, $pop253, $10
 	i32.const	$3=, 0
 	block   	
-	i32.eqz 	$push400=, $10
-	br_if   	0, $pop400      # 0: down to label46
+	i32.eqz 	$push403=, $10
+	br_if   	0, $pop403      # 0: down to label49
 # BB#29:                                # %for.cond.i1185.preheader
                                         #   in Loop: Header=BB18_28 Depth=1
 	i32.const	$5=, 0
@@ -963,37 +972,37 @@ main:                                   # @main
                                         #   Parent Loop BB18_28 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	block   	
-	loop    	                # label48:
-	copy_local	$push262=, $5
-	tee_local	$push261=, $3=, $pop262
-	i32.const	$push260=, 31
-	i32.gt_u	$push36=, $pop261, $pop260
-	br_if   	1, $pop36       # 1: down to label47
+	loop    	                # label51:
+	copy_local	$push265=, $5
+	tee_local	$push264=, $3=, $pop265
+	i32.const	$push263=, 31
+	i32.gt_u	$push36=, $pop264, $pop263
+	br_if   	1, $pop36       # 1: down to label50
 # BB#31:                                # %for.body.i1189
                                         #   in Loop: Header=BB18_30 Depth=2
-	i32.const	$push264=, 1
-	i32.add 	$5=, $3, $pop264
-	i32.const	$push263=, 1
-	i32.shl 	$push37=, $pop263, $3
+	i32.const	$push267=, 1
+	i32.add 	$5=, $3, $pop267
+	i32.const	$push266=, 1
+	i32.shl 	$push37=, $pop266, $3
 	i32.and 	$push38=, $pop37, $10
-	i32.eqz 	$push401=, $pop38
-	br_if   	0, $pop401      # 0: up to label48
+	i32.eqz 	$push404=, $pop38
+	br_if   	0, $pop404      # 0: up to label51
 .LBB18_32:                              # %my_ffsl.exit.loopexit
                                         #   in Loop: Header=BB18_28 Depth=1
 	end_loop
-	end_block                       # label47:
-	i32.const	$push265=, 1
-	i32.add 	$3=, $3, $pop265
+	end_block                       # label50:
+	i32.const	$push268=, 1
+	i32.add 	$3=, $3, $pop268
 .LBB18_33:                              # %my_ffsl.exit
                                         #   in Loop: Header=BB18_28 Depth=1
-	end_block                       # label46:
+	end_block                       # label49:
 	i32.ne  	$push39=, $6, $3
-	br_if   	1, $pop39       # 1: down to label31
+	br_if   	1, $pop39       # 1: down to label34
 # BB#34:                                # %if.end49
                                         #   in Loop: Header=BB18_28 Depth=1
 	block   	
-	i32.eqz 	$push402=, $10
-	br_if   	0, $pop402      # 0: down to label49
+	i32.eqz 	$push405=, $10
+	br_if   	0, $pop405      # 0: down to label52
 # BB#35:                                # %land.lhs.true52
                                         #   in Loop: Header=BB18_28 Depth=1
 	i32.clz 	$6=, $10
@@ -1003,27 +1012,27 @@ main:                                   # @main
                                         #   Parent Loop BB18_28 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	block   	
-	loop    	                # label51:
-	i32.const	$push266=, 1
-	i32.shl 	$push40=, $pop266, $3
+	loop    	                # label54:
+	i32.const	$push269=, 1
+	i32.shl 	$push40=, $pop269, $3
 	i32.and 	$push41=, $pop40, $10
-	br_if   	1, $pop41       # 1: down to label50
+	br_if   	1, $pop41       # 1: down to label53
 # BB#37:                                # %for.inc.i1269
                                         #   in Loop: Header=BB18_36 Depth=2
-	i32.const	$push271=, -1
-	i32.add 	$3=, $3, $pop271
-	i32.const	$push270=, 1
-	i32.add 	$push269=, $5, $pop270
-	tee_local	$push268=, $5=, $pop269
-	i32.const	$push267=, 32
-	i32.lt_u	$push42=, $pop268, $pop267
-	br_if   	0, $pop42       # 0: up to label51
+	i32.const	$push274=, -1
+	i32.add 	$3=, $3, $pop274
+	i32.const	$push273=, 1
+	i32.add 	$push272=, $5, $pop273
+	tee_local	$push271=, $5=, $pop272
+	i32.const	$push270=, 32
+	i32.lt_u	$push42=, $pop271, $pop270
+	br_if   	0, $pop42       # 0: up to label54
 .LBB18_38:                              # %my_clzl.exit
                                         #   in Loop: Header=BB18_28 Depth=1
 	end_loop
-	end_block                       # label50:
+	end_block                       # label53:
 	i32.ne  	$push43=, $6, $5
-	br_if   	2, $pop43       # 2: down to label31
+	br_if   	2, $pop43       # 2: down to label34
 # BB#39:                                # %land.lhs.true61
                                         #   in Loop: Header=BB18_28 Depth=1
 	i32.const	$3=, 0
@@ -1031,63 +1040,63 @@ main:                                   # @main
                                         #   Parent Loop BB18_28 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	block   	
-	loop    	                # label53:
-	i32.const	$push272=, 1
-	i32.shl 	$push44=, $pop272, $3
+	loop    	                # label56:
+	i32.const	$push275=, 1
+	i32.shl 	$push44=, $pop275, $3
 	i32.and 	$push45=, $pop44, $10
-	br_if   	1, $pop45       # 1: down to label52
+	br_if   	1, $pop45       # 1: down to label55
 # BB#41:                                # %for.inc.i1348
                                         #   in Loop: Header=BB18_40 Depth=2
-	i32.const	$push276=, 1
-	i32.add 	$push275=, $3, $pop276
-	tee_local	$push274=, $3=, $pop275
-	i32.const	$push273=, 32
-	i32.lt_u	$push46=, $pop274, $pop273
-	br_if   	0, $pop46       # 0: up to label53
+	i32.const	$push279=, 1
+	i32.add 	$push278=, $3, $pop279
+	tee_local	$push277=, $3=, $pop278
+	i32.const	$push276=, 32
+	i32.lt_u	$push46=, $pop277, $pop276
+	br_if   	0, $pop46       # 0: up to label56
 .LBB18_42:                              # %my_ctzl.exit
                                         #   in Loop: Header=BB18_28 Depth=1
 	end_loop
-	end_block                       # label52:
+	end_block                       # label55:
 	i32.ne  	$push47=, $2, $3
-	br_if   	2, $pop47       # 2: down to label31
+	br_if   	2, $pop47       # 2: down to label34
 .LBB18_43:                              # %if.end67
                                         #   in Loop: Header=BB18_28 Depth=1
-	end_block                       # label49:
+	end_block                       # label52:
 	i32.call	$2=, __builtin_clrsbl@FUNCTION, $10
-	i32.load	$push279=, 0($1)
-	tee_local	$push278=, $3=, $pop279
-	i32.const	$push277=, 31
-	i32.shr_u	$6=, $pop278, $pop277
+	i32.load	$push282=, 0($1)
+	tee_local	$push281=, $3=, $pop282
+	i32.const	$push280=, 31
+	i32.shr_u	$6=, $pop281, $pop280
 	i32.const	$5=, 1
 	i32.const	$10=, 30
 .LBB18_44:                              # %for.body.i1426
                                         #   Parent Loop BB18_28 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	block   	
-	loop    	                # label55:
+	loop    	                # label58:
 	i32.shr_u	$push48=, $3, $10
-	i32.const	$push280=, 1
-	i32.and 	$push49=, $pop48, $pop280
+	i32.const	$push283=, 1
+	i32.and 	$push49=, $pop48, $pop283
 	i32.ne  	$push50=, $pop49, $6
-	br_if   	1, $pop50       # 1: down to label54
+	br_if   	1, $pop50       # 1: down to label57
 # BB#45:                                # %for.inc.i1429
                                         #   in Loop: Header=BB18_44 Depth=2
-	i32.const	$push285=, -1
-	i32.add 	$10=, $10, $pop285
-	i32.const	$push284=, 1
-	i32.add 	$push283=, $5, $pop284
-	tee_local	$push282=, $5=, $pop283
-	i32.const	$push281=, 32
-	i32.lt_u	$push51=, $pop282, $pop281
-	br_if   	0, $pop51       # 0: up to label55
+	i32.const	$push288=, -1
+	i32.add 	$10=, $10, $pop288
+	i32.const	$push287=, 1
+	i32.add 	$push286=, $5, $pop287
+	tee_local	$push285=, $5=, $pop286
+	i32.const	$push284=, 32
+	i32.lt_u	$push51=, $pop285, $pop284
+	br_if   	0, $pop51       # 0: up to label58
 .LBB18_46:                              # %my_clrsbl.exit
                                         #   in Loop: Header=BB18_28 Depth=1
 	end_loop
-	end_block                       # label54:
-	i32.const	$push286=, -1
-	i32.add 	$push52=, $5, $pop286
+	end_block                       # label57:
+	i32.const	$push289=, -1
+	i32.add 	$push52=, $5, $pop289
 	i32.ne  	$push53=, $2, $pop52
-	br_if   	1, $pop53       # 1: down to label31
+	br_if   	1, $pop53       # 1: down to label34
 # BB#47:                                # %for.body.i1511.preheader
                                         #   in Loop: Header=BB18_28 Depth=1
 	i32.const	$5=, 0
@@ -1095,25 +1104,25 @@ main:                                   # @main
 .LBB18_48:                              # %for.body.i1511
                                         #   Parent Loop BB18_28 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label56:
-	i32.const	$push292=, 1
-	i32.shl 	$push54=, $pop292, $10
+	loop    	                # label59:
+	i32.const	$push295=, 1
+	i32.shl 	$push54=, $pop295, $10
 	i32.and 	$push55=, $pop54, $3
-	i32.const	$push291=, 0
-	i32.ne  	$push56=, $pop55, $pop291
+	i32.const	$push294=, 0
+	i32.ne  	$push56=, $pop55, $pop294
 	i32.add 	$5=, $pop56, $5
-	i32.const	$push290=, 1
-	i32.add 	$push289=, $10, $pop290
-	tee_local	$push288=, $10=, $pop289
-	i32.const	$push287=, 32
-	i32.ne  	$push57=, $pop288, $pop287
-	br_if   	0, $pop57       # 0: up to label56
+	i32.const	$push293=, 1
+	i32.add 	$push292=, $10, $pop293
+	tee_local	$push291=, $10=, $pop292
+	i32.const	$push290=, 32
+	i32.ne  	$push57=, $pop291, $pop290
+	br_if   	0, $pop57       # 0: up to label59
 # BB#49:                                # %my_popcountl.exit
                                         #   in Loop: Header=BB18_28 Depth=1
 	end_loop
 	i32.popcnt	$push58=, $3
 	i32.ne  	$push59=, $pop58, $5
-	br_if   	1, $pop59       # 1: down to label31
+	br_if   	1, $pop59       # 1: down to label34
 # BB#50:                                # %for.body.i1591.preheader
                                         #   in Loop: Header=BB18_28 Depth=1
 	i32.const	$6=, 0
@@ -1121,34 +1130,34 @@ main:                                   # @main
 .LBB18_51:                              # %for.body.i1591
                                         #   Parent Loop BB18_28 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label57:
-	i32.const	$push298=, 1
-	i32.shl 	$push60=, $pop298, $10
+	loop    	                # label60:
+	i32.const	$push301=, 1
+	i32.shl 	$push60=, $pop301, $10
 	i32.and 	$push61=, $pop60, $3
-	i32.const	$push297=, 0
-	i32.ne  	$push62=, $pop61, $pop297
+	i32.const	$push300=, 0
+	i32.ne  	$push62=, $pop61, $pop300
 	i32.add 	$6=, $pop62, $6
-	i32.const	$push296=, 1
-	i32.add 	$push295=, $10, $pop296
-	tee_local	$push294=, $10=, $pop295
-	i32.const	$push293=, 32
-	i32.ne  	$push63=, $pop294, $pop293
-	br_if   	0, $pop63       # 0: up to label57
+	i32.const	$push299=, 1
+	i32.add 	$push298=, $10, $pop299
+	tee_local	$push297=, $10=, $pop298
+	i32.const	$push296=, 32
+	i32.ne  	$push63=, $pop297, $pop296
+	br_if   	0, $pop63       # 0: up to label60
 # BB#52:                                # %my_parityl.exit
                                         #   in Loop: Header=BB18_28 Depth=1
 	end_loop
 	i32.xor 	$push64=, $6, $5
-	i32.const	$push299=, 1
-	i32.and 	$push65=, $pop64, $pop299
-	br_if   	1, $pop65       # 1: down to label31
+	i32.const	$push302=, 1
+	i32.and 	$push65=, $pop64, $pop302
+	br_if   	1, $pop65       # 1: down to label34
 # BB#53:                                # %for.cond39
                                         #   in Loop: Header=BB18_28 Depth=1
-	i32.const	$push303=, 1
-	i32.add 	$push302=, $0, $pop303
-	tee_local	$push301=, $0=, $pop302
-	i32.const	$push300=, 13
-	i32.lt_u	$push66=, $pop301, $pop300
-	br_if   	0, $pop66       # 0: up to label45
+	i32.const	$push306=, 1
+	i32.add 	$push305=, $0, $pop306
+	tee_local	$push304=, $0=, $pop305
+	i32.const	$push303=, 13
+	i32.lt_u	$push66=, $pop304, $pop303
+	br_if   	0, $pop66       # 0: up to label48
 # BB#54:                                # %for.body92.preheader
 	end_loop
 	i32.const	$5=, 0
@@ -1160,26 +1169,26 @@ main:                                   # @main
                                         #     Child Loop BB18_70 Depth 2
                                         #     Child Loop BB18_74 Depth 2
                                         #     Child Loop BB18_77 Depth 2
-	loop    	                # label58:
-	i32.const	$push315=, 0
-	i32.const	$push314=, 3
-	i32.shl 	$push67=, $5, $pop314
-	i32.const	$push313=, longlongs
-	i32.add 	$push312=, $pop67, $pop313
-	tee_local	$push311=, $1=, $pop312
-	i64.load	$push310=, 0($pop311)
-	tee_local	$push309=, $9=, $pop310
-	i64.ctz 	$push308=, $pop309
-	tee_local	$push307=, $4=, $pop308
-	i64.const	$push306=, 1
-	i64.add 	$push68=, $pop307, $pop306
+	loop    	                # label61:
+	i32.const	$push318=, 0
+	i32.const	$push317=, 3
+	i32.shl 	$push67=, $5, $pop317
+	i32.const	$push316=, longlongs
+	i32.add 	$push315=, $pop67, $pop316
+	tee_local	$push314=, $1=, $pop315
+	i64.load	$push313=, 0($pop314)
+	tee_local	$push312=, $9=, $pop313
+	i64.ctz 	$push311=, $pop312
+	tee_local	$push310=, $4=, $pop311
+	i64.const	$push309=, 1
+	i64.add 	$push68=, $pop310, $pop309
 	i32.wrap/i64	$push69=, $pop68
-	i64.eqz 	$push305=, $9
-	tee_local	$push304=, $6=, $pop305
-	i32.select	$0=, $pop315, $pop69, $pop304
+	i64.eqz 	$push308=, $9
+	tee_local	$push307=, $6=, $pop308
+	i32.select	$0=, $pop318, $pop69, $pop307
 	i32.const	$10=, 0
 	block   	
-	br_if   	0, $6           # 0: down to label59
+	br_if   	0, $6           # 0: down to label62
 # BB#56:                                # %for.cond.i1667.preheader
                                         #   in Loop: Header=BB18_55 Depth=1
 	i64.const	$8=, 0
@@ -1187,33 +1196,33 @@ main:                                   # @main
 .LBB18_57:                              # %for.cond.i1667
                                         #   Parent Loop BB18_55 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label60:
+	loop    	                # label63:
 	copy_local	$10=, $3
-	i64.const	$push316=, 63
-	i64.gt_u	$push70=, $8, $pop316
-	br_if   	1, $pop70       # 1: down to label59
+	i64.const	$push319=, 63
+	i64.gt_u	$push70=, $8, $pop319
+	br_if   	1, $pop70       # 1: down to label62
 # BB#58:                                # %for.body.i1671
                                         #   in Loop: Header=BB18_57 Depth=2
-	i32.const	$push319=, 1
-	i32.add 	$3=, $10, $pop319
-	i64.const	$push318=, 1
-	i64.shl 	$7=, $pop318, $8
-	i64.const	$push317=, 1
-	i64.add 	$push0=, $8, $pop317
+	i32.const	$push322=, 1
+	i32.add 	$3=, $10, $pop322
+	i64.const	$push321=, 1
+	i64.shl 	$7=, $pop321, $8
+	i64.const	$push320=, 1
+	i64.add 	$push0=, $8, $pop320
 	copy_local	$8=, $pop0
 	i64.and 	$push71=, $7, $9
 	i64.eqz 	$push72=, $pop71
-	br_if   	0, $pop72       # 0: up to label60
+	br_if   	0, $pop72       # 0: up to label63
 .LBB18_59:                              # %my_ffsll.exit1673
                                         #   in Loop: Header=BB18_55 Depth=1
 	end_loop
-	end_block                       # label59:
+	end_block                       # label62:
 	i32.ne  	$push73=, $0, $10
-	br_if   	1, $pop73       # 1: down to label31
+	br_if   	1, $pop73       # 1: down to label34
 # BB#60:                                # %if.end100
                                         #   in Loop: Header=BB18_55 Depth=1
 	block   	
-	br_if   	0, $6           # 0: down to label61
+	br_if   	0, $6           # 0: down to label64
 # BB#61:                                # %land.lhs.true103
                                         #   in Loop: Header=BB18_55 Depth=1
 	i64.clz 	$push74=, $9
@@ -1225,31 +1234,31 @@ main:                                   # @main
                                         #   Parent Loop BB18_55 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	block   	
-	loop    	                # label63:
-	i64.const	$push321=, 1
-	i64.shl 	$push75=, $pop321, $8
+	loop    	                # label66:
+	i64.const	$push324=, 1
+	i64.shl 	$push75=, $pop324, $8
 	i64.and 	$push76=, $pop75, $9
-	i64.const	$push320=, 0
-	i64.ne  	$push77=, $pop76, $pop320
-	br_if   	1, $pop77       # 1: down to label62
+	i64.const	$push323=, 0
+	i64.ne  	$push77=, $pop76, $pop323
+	br_if   	1, $pop77       # 1: down to label65
 # BB#63:                                # %for.inc.i1743
                                         #   in Loop: Header=BB18_62 Depth=2
-	i64.const	$push327=, -1
-	i64.add 	$8=, $8, $pop327
-	i32.const	$push326=, 1
-	i32.add 	$10=, $10, $pop326
-	i64.const	$push325=, 1
-	i64.add 	$push324=, $7, $pop325
-	tee_local	$push323=, $7=, $pop324
-	i64.const	$push322=, 64
-	i64.lt_u	$push78=, $pop323, $pop322
-	br_if   	0, $pop78       # 0: up to label63
+	i64.const	$push330=, -1
+	i64.add 	$8=, $8, $pop330
+	i32.const	$push329=, 1
+	i32.add 	$10=, $10, $pop329
+	i64.const	$push328=, 1
+	i64.add 	$push327=, $7, $pop328
+	tee_local	$push326=, $7=, $pop327
+	i64.const	$push325=, 64
+	i64.lt_u	$push78=, $pop326, $pop325
+	br_if   	0, $pop78       # 0: up to label66
 .LBB18_64:                              # %my_clzll.exit1745
                                         #   in Loop: Header=BB18_55 Depth=1
 	end_loop
-	end_block                       # label62:
+	end_block                       # label65:
 	i32.ne  	$push79=, $3, $10
-	br_if   	2, $pop79       # 2: down to label31
+	br_if   	2, $pop79       # 2: down to label34
 # BB#65:                                # %land.lhs.true113
                                         #   in Loop: Header=BB18_55 Depth=1
 	i32.wrap/i64	$3=, $4
@@ -1259,37 +1268,37 @@ main:                                   # @main
                                         #   Parent Loop BB18_55 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	block   	
-	loop    	                # label65:
-	i64.const	$push329=, 1
-	i64.shl 	$push80=, $pop329, $8
+	loop    	                # label68:
+	i64.const	$push332=, 1
+	i64.shl 	$push80=, $pop332, $8
 	i64.and 	$push81=, $pop80, $9
-	i64.const	$push328=, 0
-	i64.ne  	$push82=, $pop81, $pop328
-	br_if   	1, $pop82       # 1: down to label64
+	i64.const	$push331=, 0
+	i64.ne  	$push82=, $pop81, $pop331
+	br_if   	1, $pop82       # 1: down to label67
 # BB#67:                                # %for.inc.i1785
                                         #   in Loop: Header=BB18_66 Depth=2
-	i32.const	$push334=, 1
-	i32.add 	$10=, $10, $pop334
-	i64.const	$push333=, 1
-	i64.add 	$push332=, $8, $pop333
-	tee_local	$push331=, $8=, $pop332
-	i64.const	$push330=, 64
-	i64.lt_u	$push83=, $pop331, $pop330
-	br_if   	0, $pop83       # 0: up to label65
+	i32.const	$push337=, 1
+	i32.add 	$10=, $10, $pop337
+	i64.const	$push336=, 1
+	i64.add 	$push335=, $8, $pop336
+	tee_local	$push334=, $8=, $pop335
+	i64.const	$push333=, 64
+	i64.lt_u	$push83=, $pop334, $pop333
+	br_if   	0, $pop83       # 0: up to label68
 .LBB18_68:                              # %my_ctzll.exit1787
                                         #   in Loop: Header=BB18_55 Depth=1
 	end_loop
-	end_block                       # label64:
+	end_block                       # label67:
 	i32.ne  	$push84=, $3, $10
-	br_if   	2, $pop84       # 2: down to label31
+	br_if   	2, $pop84       # 2: down to label34
 .LBB18_69:                              # %if.end120
                                         #   in Loop: Header=BB18_55 Depth=1
-	end_block                       # label61:
+	end_block                       # label64:
 	i32.call	$3=, __builtin_clrsbll@FUNCTION, $9
-	i64.load	$push337=, 0($1)
-	tee_local	$push336=, $9=, $pop337
-	i64.const	$push335=, 63
-	i64.shr_u	$4=, $pop336, $pop335
+	i64.load	$push340=, 0($1)
+	tee_local	$push339=, $9=, $pop340
+	i64.const	$push338=, 63
+	i64.shr_u	$4=, $pop339, $pop338
 	i32.const	$10=, 1
 	i64.const	$7=, 1
 	i64.const	$8=, 62
@@ -1297,32 +1306,32 @@ main:                                   # @main
                                         #   Parent Loop BB18_55 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	block   	
-	loop    	                # label67:
+	loop    	                # label70:
 	i64.shr_u	$push85=, $9, $8
-	i64.const	$push338=, 1
-	i64.and 	$push86=, $pop85, $pop338
+	i64.const	$push341=, 1
+	i64.and 	$push86=, $pop85, $pop341
 	i64.ne  	$push87=, $pop86, $4
-	br_if   	1, $pop87       # 1: down to label66
+	br_if   	1, $pop87       # 1: down to label69
 # BB#71:                                # %for.inc.i1849
                                         #   in Loop: Header=BB18_70 Depth=2
-	i64.const	$push344=, -1
-	i64.add 	$8=, $8, $pop344
-	i32.const	$push343=, 1
-	i32.add 	$10=, $10, $pop343
-	i64.const	$push342=, 1
-	i64.add 	$push341=, $7, $pop342
-	tee_local	$push340=, $7=, $pop341
-	i64.const	$push339=, 64
-	i64.lt_u	$push88=, $pop340, $pop339
-	br_if   	0, $pop88       # 0: up to label67
+	i64.const	$push347=, -1
+	i64.add 	$8=, $8, $pop347
+	i32.const	$push346=, 1
+	i32.add 	$10=, $10, $pop346
+	i64.const	$push345=, 1
+	i64.add 	$push344=, $7, $pop345
+	tee_local	$push343=, $7=, $pop344
+	i64.const	$push342=, 64
+	i64.lt_u	$push88=, $pop343, $pop342
+	br_if   	0, $pop88       # 0: up to label70
 .LBB18_72:                              # %my_clrsbll.exit1852
                                         #   in Loop: Header=BB18_55 Depth=1
 	end_loop
-	end_block                       # label66:
-	i32.const	$push345=, -1
-	i32.add 	$push89=, $10, $pop345
+	end_block                       # label69:
+	i32.const	$push348=, -1
+	i32.add 	$push89=, $10, $pop348
 	i32.ne  	$push90=, $3, $pop89
-	br_if   	1, $pop90       # 1: down to label31
+	br_if   	1, $pop90       # 1: down to label34
 # BB#73:                                # %if.end127
                                         #   in Loop: Header=BB18_55 Depth=1
 	i64.popcnt	$7=, $9
@@ -1331,25 +1340,25 @@ main:                                   # @main
 .LBB18_74:                              # %for.body.i1928
                                         #   Parent Loop BB18_55 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label68:
-	i64.const	$push351=, 1
-	i64.shl 	$push91=, $pop351, $8
+	loop    	                # label71:
+	i64.const	$push354=, 1
+	i64.shl 	$push91=, $pop354, $8
 	i64.and 	$push92=, $pop91, $9
-	i64.const	$push350=, 0
-	i64.ne  	$push93=, $pop92, $pop350
+	i64.const	$push353=, 0
+	i64.ne  	$push93=, $pop92, $pop353
 	i32.add 	$10=, $pop93, $10
-	i64.const	$push349=, 1
-	i64.add 	$push348=, $8, $pop349
-	tee_local	$push347=, $8=, $pop348
-	i64.const	$push346=, 64
-	i64.ne  	$push94=, $pop347, $pop346
-	br_if   	0, $pop94       # 0: up to label68
+	i64.const	$push352=, 1
+	i64.add 	$push351=, $8, $pop352
+	tee_local	$push350=, $8=, $pop351
+	i64.const	$push349=, 64
+	i64.ne  	$push94=, $pop350, $pop349
+	br_if   	0, $pop94       # 0: up to label71
 # BB#75:                                # %my_popcountll.exit1929
                                         #   in Loop: Header=BB18_55 Depth=1
 	end_loop
 	i32.wrap/i64	$push95=, $7
 	i32.ne  	$push96=, $pop95, $10
-	br_if   	1, $pop96       # 1: down to label31
+	br_if   	1, $pop96       # 1: down to label34
 # BB#76:                                # %for.body.i2005.preheader
                                         #   in Loop: Header=BB18_55 Depth=1
 	i32.const	$3=, 0
@@ -1357,298 +1366,304 @@ main:                                   # @main
 .LBB18_77:                              # %for.body.i2005
                                         #   Parent Loop BB18_55 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label69:
-	i64.const	$push357=, 1
-	i64.shl 	$push97=, $pop357, $8
+	loop    	                # label72:
+	i64.const	$push360=, 1
+	i64.shl 	$push97=, $pop360, $8
 	i64.and 	$push98=, $pop97, $9
-	i64.const	$push356=, 0
-	i64.ne  	$push99=, $pop98, $pop356
+	i64.const	$push359=, 0
+	i64.ne  	$push99=, $pop98, $pop359
 	i32.add 	$3=, $pop99, $3
-	i64.const	$push355=, 1
-	i64.add 	$push354=, $8, $pop355
-	tee_local	$push353=, $8=, $pop354
-	i64.const	$push352=, 64
-	i64.ne  	$push100=, $pop353, $pop352
-	br_if   	0, $pop100      # 0: up to label69
+	i64.const	$push358=, 1
+	i64.add 	$push357=, $8, $pop358
+	tee_local	$push356=, $8=, $pop357
+	i64.const	$push355=, 64
+	i64.ne  	$push100=, $pop356, $pop355
+	br_if   	0, $pop100      # 0: up to label72
 # BB#78:                                # %my_parityll.exit2007
                                         #   in Loop: Header=BB18_55 Depth=1
 	end_loop
 	i32.xor 	$push101=, $3, $10
-	i32.const	$push358=, 1
-	i32.and 	$push102=, $pop101, $pop358
-	br_if   	2, $pop102      # 2: down to label30
+	i32.const	$push361=, 1
+	i32.and 	$push102=, $pop101, $pop361
+	br_if   	2, $pop102      # 2: down to label33
 # BB#79:                                # %for.cond90
                                         #   in Loop: Header=BB18_55 Depth=1
-	i32.const	$push362=, 1
-	i32.add 	$push361=, $5, $pop362
-	tee_local	$push360=, $5=, $pop361
-	i32.const	$push359=, 12
-	i32.le_u	$push103=, $pop360, $pop359
-	br_if   	0, $pop103      # 0: up to label58
+	i32.const	$push365=, 1
+	i32.add 	$push364=, $5, $pop365
+	tee_local	$push363=, $5=, $pop364
+	i32.const	$push362=, 12
+	i32.le_u	$push103=, $pop363, $pop362
+	br_if   	0, $pop103      # 0: up to label61
 # BB#80:                                # %if.end148
 	end_loop
 	i32.const	$push104=, 0
 	i32.call	$push105=, __builtin_clrsb@FUNCTION, $pop104
 	i32.const	$push106=, 31
 	i32.ne  	$push107=, $pop105, $pop106
-	br_if   	0, $pop107      # 0: down to label31
+	br_if   	0, $pop107      # 0: down to label34
 # BB#81:                                # %my_clrsb.exit2515
 	i32.const	$push108=, 1
 	i32.call	$push109=, __builtin_clrsb@FUNCTION, $pop108
 	i32.const	$push110=, 30
 	i32.ne  	$push111=, $pop109, $pop110
-	br_if   	0, $pop111      # 0: down to label31
+	br_if   	0, $pop111      # 0: down to label34
 # BB#82:                                # %if.end198
 	i32.const	$push112=, -2147483648
 	i32.call	$push113=, __builtin_clrsb@FUNCTION, $pop112
-	br_if   	0, $pop113      # 0: down to label31
+	br_if   	0, $pop113      # 0: down to label34
 # BB#83:                                # %my_clrsb.exit2362
 	i32.const	$push114=, 1073741824
 	i32.call	$push115=, __builtin_clrsb@FUNCTION, $pop114
-	br_if   	0, $pop115      # 0: down to label31
+	br_if   	0, $pop115      # 0: down to label34
 # BB#84:                                # %my_clrsb.exit2288
 	i32.const	$push116=, 65536
 	i32.call	$push117=, __builtin_clrsb@FUNCTION, $pop116
 	i32.const	$push118=, 14
 	i32.ne  	$push119=, $pop117, $pop118
-	br_if   	0, $pop119      # 0: down to label31
+	br_if   	0, $pop119      # 0: down to label34
 # BB#85:                                # %my_clrsb.exit2215
 	i32.const	$push120=, 32768
 	i32.call	$push121=, __builtin_clrsb@FUNCTION, $pop120
 	i32.const	$push122=, 15
 	i32.ne  	$push123=, $pop121, $pop122
-	br_if   	0, $pop123      # 0: down to label31
+	br_if   	0, $pop123      # 0: down to label34
 # BB#86:                                # %my_clrsb.exit2140
 	i32.const	$push124=, -1515870811
 	i32.call	$push125=, __builtin_clrsb@FUNCTION, $pop124
-	br_if   	0, $pop125      # 0: down to label31
+	br_if   	0, $pop125      # 0: down to label34
 # BB#87:                                # %my_clrsb.exit2073
 	i32.const	$push126=, 1515870810
 	i32.call	$push127=, __builtin_clrsb@FUNCTION, $pop126
-	br_if   	0, $pop127      # 0: down to label31
+	br_if   	0, $pop127      # 0: down to label34
 # BB#88:                                # %for.body.i1989
 	i32.const	$push128=, -889323520
 	i32.call	$push129=, __builtin_clrsb@FUNCTION, $pop128
 	i32.const	$push130=, 1
 	i32.ne  	$push131=, $pop129, $pop130
-	br_if   	0, $pop131      # 0: down to label31
+	br_if   	0, $pop131      # 0: down to label34
 # BB#89:                                # %for.body.i1912
 	i32.const	$push132=, 13303296
 	i32.call	$push133=, __builtin_clrsb@FUNCTION, $pop132
 	i32.const	$push134=, 7
 	i32.ne  	$push135=, $pop133, $pop134
-	br_if   	0, $pop135      # 0: down to label31
+	br_if   	0, $pop135      # 0: down to label34
 # BB#90:                                # %for.body.i1832
 	i32.const	$push136=, 51966
 	i32.call	$push137=, __builtin_clrsb@FUNCTION, $pop136
 	i32.const	$push138=, 15
 	i32.ne  	$push139=, $pop137, $pop138
-	br_if   	0, $pop139      # 0: down to label31
+	br_if   	0, $pop139      # 0: down to label34
 # BB#91:                                # %if.end423
-	i32.const	$push363=, -1
-	i32.call	$5=, __builtin_clrsb@FUNCTION, $pop363
+	i32.const	$push366=, -1
+	i32.call	$5=, __builtin_clrsb@FUNCTION, $pop366
 	i32.const	$10=, 30
 	i32.const	$3=, 1
 .LBB18_92:                              # %for.body.i1769
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label71:
-	i32.const	$push365=, -1
-	i32.shr_u	$push140=, $pop365, $10
-	i32.const	$push364=, 1
-	i32.and 	$push141=, $pop140, $pop364
-	i32.eqz 	$push403=, $pop141
-	br_if   	1, $pop403      # 1: down to label70
+	loop    	                # label74:
+	i32.const	$push368=, -1
+	i32.shr_u	$push140=, $pop368, $10
+	i32.const	$push367=, 1
+	i32.and 	$push141=, $pop140, $pop367
+	i32.eqz 	$push406=, $pop141
+	br_if   	1, $pop406      # 1: down to label73
 # BB#93:                                # %for.inc.i1772
                                         #   in Loop: Header=BB18_92 Depth=1
-	i32.const	$push370=, -1
-	i32.add 	$10=, $10, $pop370
-	i32.const	$push369=, 1
-	i32.add 	$push368=, $3, $pop369
-	tee_local	$push367=, $3=, $pop368
-	i32.const	$push366=, 32
-	i32.lt_u	$push142=, $pop367, $pop366
-	br_if   	0, $pop142      # 0: up to label71
+	i32.const	$push373=, -1
+	i32.add 	$10=, $10, $pop373
+	i32.const	$push372=, 1
+	i32.add 	$push371=, $3, $pop372
+	tee_local	$push370=, $3=, $pop371
+	i32.const	$push369=, 32
+	i32.lt_u	$push142=, $pop370, $pop369
+	br_if   	0, $pop142      # 0: up to label74
 .LBB18_94:                              # %my_clrsb.exit1775
 	end_loop
-	end_block                       # label70:
+	end_block                       # label73:
 	i32.const	$push143=, -1
 	i32.add 	$push144=, $3, $pop143
 	i32.ne  	$push145=, $5, $pop144
-	br_if   	0, $pop145      # 0: down to label31
+	br_if   	0, $pop145      # 0: down to label34
 # BB#95:                                # %if.end440
 	i64.const	$8=, 0
-	i64.const	$push371=, 0
-	i32.call	$push146=, __builtin_clrsbll@FUNCTION, $pop371
+	i64.const	$push374=, 0
+	i32.call	$push146=, __builtin_clrsbll@FUNCTION, $pop374
 	i32.const	$push147=, 63
 	i32.ne  	$push148=, $pop146, $pop147
-	br_if   	0, $pop148      # 0: down to label31
+	br_if   	0, $pop148      # 0: down to label34
 # BB#96:                                # %for.body.i1691.preheader
 .LBB18_97:                              # %for.body.i1691
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label73:
-	i64.const	$push372=, 63
-	i64.eq  	$push149=, $8, $pop372
-	br_if   	1, $pop149      # 1: down to label72
+	loop    	                # label76:
+	i64.const	$push375=, 63
+	i64.eq  	$push149=, $8, $pop375
+	br_if   	1, $pop149      # 1: down to label75
 # BB#98:                                # %for.inc.i1695
                                         #   in Loop: Header=BB18_97 Depth=1
-	i64.const	$push376=, 1
-	i64.add 	$push375=, $8, $pop376
-	tee_local	$push374=, $8=, $pop375
-	i64.const	$push373=, 64
-	i64.lt_u	$push150=, $pop374, $pop373
-	br_if   	0, $pop150      # 0: up to label73
+	i64.const	$push379=, 1
+	i64.add 	$push378=, $8, $pop379
+	tee_local	$push377=, $8=, $pop378
+	i64.const	$push376=, 64
+	i64.lt_u	$push150=, $pop377, $pop376
+	br_if   	0, $pop150      # 0: up to label76
 # BB#99:                                # %if.then460
 	end_loop
 	call    	abort@FUNCTION
 	unreachable
 .LBB18_100:                             # %if.end465
-	end_block                       # label72:
-	i64.const	$push377=, 1
-	i32.call	$3=, __builtin_clrsbll@FUNCTION, $pop377
+	end_block                       # label75:
+	i64.const	$push380=, 1
+	i32.call	$10=, __builtin_clrsbll@FUNCTION, $pop380
 	i64.const	$8=, 1
 .LBB18_101:                             # %for.body.i1655
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label75:
-	i32.const	$10=, 62
-	i64.const	$push378=, 63
-	i64.eq  	$push151=, $8, $pop378
-	br_if   	1, $pop151      # 1: down to label74
+	block   	
+	loop    	                # label79:
+	i64.const	$push381=, 63
+	i64.eq  	$push151=, $8, $pop381
+	br_if   	1, $pop151      # 1: down to label78
 # BB#102:                               # %for.inc.i1659
                                         #   in Loop: Header=BB18_101 Depth=1
-	i32.const	$10=, 63
-	i64.const	$push382=, 1
-	i64.add 	$push381=, $8, $pop382
-	tee_local	$push380=, $8=, $pop381
-	i64.const	$push379=, 64
-	i64.lt_u	$push152=, $pop380, $pop379
-	br_if   	0, $pop152      # 0: up to label75
-.LBB18_103:                             # %my_clrsbll.exit1662
+	i64.const	$push385=, 1
+	i64.add 	$push384=, $8, $pop385
+	tee_local	$push383=, $8=, $pop384
+	i64.const	$push382=, 64
+	i64.lt_u	$push152=, $pop383, $pop382
+	br_if   	0, $pop152      # 0: up to label79
+# BB#103:
 	end_loop
-	end_block                       # label74:
-	i32.ne  	$push153=, $3, $10
-	br_if   	0, $pop153      # 0: down to label31
-# BB#104:                               # %for.body.i1598.preheader
+	i32.const	$push197=, 63
+	i32.eq  	$push153=, $10, $pop197
+	br_if   	1, $pop153      # 1: down to label77
+	br      	2               # 2: down to label34
+.LBB18_104:
+	end_block                       # label78:
+	i32.const	$push198=, 62
+	i32.ne  	$push154=, $10, $pop198
+	br_if   	1, $pop154      # 1: down to label34
+.LBB18_105:                             # %for.body.i1598.preheader
+	end_block                       # label77:
 	i64.const	$8=, 0
-.LBB18_105:                             # %for.body.i1598
+.LBB18_106:                             # %for.body.i1598
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label77:
-	i64.const	$push383=, 63
-	i64.eq  	$push154=, $8, $pop383
-	br_if   	1, $pop154      # 1: down to label76
-# BB#106:                               # %for.inc.i1602
-                                        #   in Loop: Header=BB18_105 Depth=1
-	i64.const	$push387=, 1
-	i64.add 	$push386=, $8, $pop387
-	tee_local	$push385=, $8=, $pop386
-	i64.const	$push384=, 64
-	i64.lt_u	$push155=, $pop385, $pop384
-	br_if   	0, $pop155      # 0: up to label77
-# BB#107:                               # %if.then489
+	loop    	                # label81:
+	i64.const	$push386=, 63
+	i64.eq  	$push155=, $8, $pop386
+	br_if   	1, $pop155      # 1: down to label80
+# BB#107:                               # %for.inc.i1602
+                                        #   in Loop: Header=BB18_106 Depth=1
+	i64.const	$push390=, 1
+	i64.add 	$push389=, $8, $pop390
+	tee_local	$push388=, $8=, $pop389
+	i64.const	$push387=, 64
+	i64.lt_u	$push156=, $pop388, $pop387
+	br_if   	0, $pop156      # 0: up to label81
+# BB#108:                               # %if.then489
 	end_loop
 	call    	abort@FUNCTION
 	unreachable
-.LBB18_108:                             # %if.end490
-	end_block                       # label76:
-	i64.const	$push156=, -9223372036854775808
-	i32.call	$push157=, __builtin_clrsbll@FUNCTION, $pop156
-	br_if   	0, $pop157      # 0: down to label31
-# BB#109:                               # %for.body.i1494
-	i64.const	$push158=, 2
-	i32.call	$push159=, __builtin_clrsbll@FUNCTION, $pop158
-	i32.const	$push160=, 61
-	i32.ne  	$push161=, $pop159, $pop160
-	br_if   	0, $pop161      # 0: down to label31
-# BB#110:                               # %my_clrsbll.exit1419
-	i64.const	$push162=, 4611686018427387904
-	i32.call	$push163=, __builtin_clrsbll@FUNCTION, $pop162
-	br_if   	0, $pop163      # 0: down to label31
-# BB#111:                               # %for.body.i1333
-	i64.const	$push164=, 4294967296
-	i32.call	$push165=, __builtin_clrsbll@FUNCTION, $pop164
-	i32.const	$push166=, 30
-	i32.ne  	$push167=, $pop165, $pop166
-	br_if   	0, $pop167      # 0: down to label31
-# BB#112:                               # %for.body.i1253
-	i64.const	$push168=, 2147483648
-	i32.call	$push169=, __builtin_clrsbll@FUNCTION, $pop168
-	i32.const	$push170=, 31
-	i32.ne  	$push171=, $pop169, $pop170
-	br_if   	0, $pop171      # 0: down to label31
-# BB#113:                               # %my_clrsbll.exit1180
-	i64.const	$push172=, -6510615555426900571
-	i32.call	$push173=, __builtin_clrsbll@FUNCTION, $pop172
-	br_if   	0, $pop173      # 0: down to label31
-# BB#114:                               # %my_clrsbll.exit1100
-	i64.const	$push174=, 6510615555426900570
-	i32.call	$push175=, __builtin_clrsbll@FUNCTION, $pop174
-	br_if   	0, $pop175      # 0: down to label31
-# BB#115:                               # %for.body.i1015
-	i64.const	$push176=, -3819392241693097984
-	i32.call	$push177=, __builtin_clrsbll@FUNCTION, $pop176
-	i32.const	$push178=, 1
-	i32.ne  	$push179=, $pop177, $pop178
-	br_if   	0, $pop179      # 0: down to label31
-# BB#116:                               # %for.body.i939
-	i64.const	$push180=, 223195676147712
-	i32.call	$push181=, __builtin_clrsbll@FUNCTION, $pop180
-	i32.const	$push182=, 15
-	i32.ne  	$push183=, $pop181, $pop182
-	br_if   	0, $pop183      # 0: down to label31
-# BB#117:                               # %for.body.i864
-	i64.const	$push184=, 3405695742
-	i32.call	$push185=, __builtin_clrsbll@FUNCTION, $pop184
-	i32.const	$push186=, 31
-	i32.ne  	$push187=, $pop185, $pop186
-	br_if   	0, $pop187      # 0: down to label31
-# BB#118:                               # %if.end740
-	i64.const	$push388=, -1
-	i32.call	$3=, __builtin_clrsbll@FUNCTION, $pop388
+.LBB18_109:                             # %if.end490
+	end_block                       # label80:
+	i64.const	$push157=, -9223372036854775808
+	i32.call	$push158=, __builtin_clrsbll@FUNCTION, $pop157
+	br_if   	0, $pop158      # 0: down to label34
+# BB#110:                               # %for.body.i1494
+	i64.const	$push159=, 2
+	i32.call	$push160=, __builtin_clrsbll@FUNCTION, $pop159
+	i32.const	$push161=, 61
+	i32.ne  	$push162=, $pop160, $pop161
+	br_if   	0, $pop162      # 0: down to label34
+# BB#111:                               # %my_clrsbll.exit1419
+	i64.const	$push163=, 4611686018427387904
+	i32.call	$push164=, __builtin_clrsbll@FUNCTION, $pop163
+	br_if   	0, $pop164      # 0: down to label34
+# BB#112:                               # %for.body.i1333
+	i64.const	$push165=, 4294967296
+	i32.call	$push166=, __builtin_clrsbll@FUNCTION, $pop165
+	i32.const	$push167=, 30
+	i32.ne  	$push168=, $pop166, $pop167
+	br_if   	0, $pop168      # 0: down to label34
+# BB#113:                               # %for.body.i1253
+	i64.const	$push169=, 2147483648
+	i32.call	$push170=, __builtin_clrsbll@FUNCTION, $pop169
+	i32.const	$push171=, 31
+	i32.ne  	$push172=, $pop170, $pop171
+	br_if   	0, $pop172      # 0: down to label34
+# BB#114:                               # %my_clrsbll.exit1180
+	i64.const	$push173=, -6510615555426900571
+	i32.call	$push174=, __builtin_clrsbll@FUNCTION, $pop173
+	br_if   	0, $pop174      # 0: down to label34
+# BB#115:                               # %my_clrsbll.exit1100
+	i64.const	$push175=, 6510615555426900570
+	i32.call	$push176=, __builtin_clrsbll@FUNCTION, $pop175
+	br_if   	0, $pop176      # 0: down to label34
+# BB#116:                               # %for.body.i1015
+	i64.const	$push177=, -3819392241693097984
+	i32.call	$push178=, __builtin_clrsbll@FUNCTION, $pop177
+	i32.const	$push179=, 1
+	i32.ne  	$push180=, $pop178, $pop179
+	br_if   	0, $pop180      # 0: down to label34
+# BB#117:                               # %for.body.i939
+	i64.const	$push181=, 223195676147712
+	i32.call	$push182=, __builtin_clrsbll@FUNCTION, $pop181
+	i32.const	$push183=, 15
+	i32.ne  	$push184=, $pop182, $pop183
+	br_if   	0, $pop184      # 0: down to label34
+# BB#118:                               # %for.body.i864
+	i64.const	$push185=, 3405695742
+	i32.call	$push186=, __builtin_clrsbll@FUNCTION, $pop185
+	i32.const	$push187=, 31
+	i32.ne  	$push188=, $pop186, $pop187
+	br_if   	0, $pop188      # 0: down to label34
+# BB#119:                               # %if.end740
+	i64.const	$push391=, -1
+	i32.call	$3=, __builtin_clrsbll@FUNCTION, $pop391
 	i64.const	$8=, 62
 	i64.const	$9=, 1
 	i32.const	$10=, 1
-.LBB18_119:                             # %for.body.i810
+.LBB18_120:                             # %for.body.i810
                                         # =>This Inner Loop Header: Depth=1
 	block   	
-	loop    	                # label79:
-	i64.const	$push390=, -1
-	i64.shr_u	$push188=, $pop390, $8
-	i64.const	$push389=, 1
-	i64.and 	$push189=, $pop188, $pop389
-	i64.eqz 	$push190=, $pop189
-	br_if   	1, $pop190      # 1: down to label78
-# BB#120:                               # %for.inc.i
-                                        #   in Loop: Header=BB18_119 Depth=1
-	i64.const	$push396=, -1
-	i64.add 	$8=, $8, $pop396
-	i32.const	$push395=, 1
-	i32.add 	$10=, $10, $pop395
-	i64.const	$push394=, 1
-	i64.add 	$push393=, $9, $pop394
-	tee_local	$push392=, $9=, $pop393
-	i64.const	$push391=, 64
-	i64.lt_u	$push191=, $pop392, $pop391
-	br_if   	0, $pop191      # 0: up to label79
-.LBB18_121:                             # %my_clrsbll.exit
+	loop    	                # label83:
+	i64.const	$push393=, -1
+	i64.shr_u	$push189=, $pop393, $8
+	i64.const	$push392=, 1
+	i64.and 	$push190=, $pop189, $pop392
+	i64.eqz 	$push191=, $pop190
+	br_if   	1, $pop191      # 1: down to label82
+# BB#121:                               # %for.inc.i
+                                        #   in Loop: Header=BB18_120 Depth=1
+	i64.const	$push399=, -1
+	i64.add 	$8=, $8, $pop399
+	i32.const	$push398=, 1
+	i32.add 	$10=, $10, $pop398
+	i64.const	$push397=, 1
+	i64.add 	$push396=, $9, $pop397
+	tee_local	$push395=, $9=, $pop396
+	i64.const	$push394=, 64
+	i64.lt_u	$push192=, $pop395, $pop394
+	br_if   	0, $pop192      # 0: up to label83
+.LBB18_122:                             # %my_clrsbll.exit
 	end_loop
-	end_block                       # label78:
-	i32.const	$push192=, -1
-	i32.add 	$push193=, $10, $pop192
-	i32.ne  	$push194=, $3, $pop193
-	br_if   	0, $pop194      # 0: down to label31
-# BB#122:                               # %if.end753
-	i32.const	$push195=, 0
-	call    	exit@FUNCTION, $pop195
+	end_block                       # label82:
+	i32.const	$push193=, -1
+	i32.add 	$push194=, $10, $pop193
+	i32.ne  	$push195=, $3, $pop194
+	br_if   	0, $pop195      # 0: down to label34
+# BB#123:                               # %if.end753
+	i32.const	$push196=, 0
+	call    	exit@FUNCTION, $pop196
 	unreachable
-.LBB18_123:                             # %if.then37
-	end_block                       # label31:
+.LBB18_124:                             # %if.then37
+	end_block                       # label34:
 	call    	abort@FUNCTION
 	unreachable
-.LBB18_124:                             # %if.then140
-	end_block                       # label30:
+.LBB18_125:                             # %if.then140
+	end_block                       # label33:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -1719,7 +1734,7 @@ longlongs:
 	.size	longlongs, 104
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	__builtin_clrsb, i32
 	.functype	__builtin_clrsbl, i32

--- a/test/torture-s/inst-check.c.s
+++ b/test/torture-s/inst-check.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/inst-check.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/inst-check.c"
 	.section	.text.f,"ax",@progbits
 	.hidden	f
 	.globl	f
@@ -7,9 +7,7 @@
 f:                                      # @f
 	.param  	i32
 	.result 	i32
-	.local  	i32
 # BB#0:                                 # %entry
-	i32.const	$1=, 0
 	block   	
 	i32.const	$push0=, 1
 	i32.lt_s	$push1=, $0, $pop0
@@ -26,11 +24,12 @@ f:                                      # @f
 	i64.shr_u	$push10=, $pop8, $pop9
 	i32.wrap/i64	$push11=, $pop10
 	i32.add 	$push12=, $pop11, $0
-	i32.const	$push13=, -1
-	i32.add 	$1=, $pop12, $pop13
-.LBB0_2:                                # %for.end
+	i32.const	$push15=, -1
+	i32.add 	$push13=, $pop12, $pop15
+	return  	$pop13
+.LBB0_2:
 	end_block                       # label0:
-	copy_local	$push14=, $1
+	i32.const	$push14=, 0
                                         # fallthrough-return: $pop14
 	.endfunc
 .Lfunc_end0:
@@ -51,5 +50,5 @@ main:                                   # @main
 	.size	main, .Lfunc_end1-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	exit, void, i32

--- a/test/torture-s/loop-ivopts-1.c.s
+++ b/test/torture-s/loop-ivopts-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/loop-ivopts-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/loop-ivopts-1.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
@@ -27,15 +27,16 @@ foo:                                    # @foo
 	.param  	i32
 # BB#0:                                 # %for.inc9.3
 	i32.const	$push1=, 0
-	i64.const	$push0=, 4838273375797772288
-	i64.store	foo.tmp+4($pop1):p2align=2, $pop0
-	i32.const	$push9=, 0
-	i32.const	$push2=, 1095761920
-	i32.store	foo.tmp($pop9), $pop2
-	i32.const	$push3=, 1118306304
+	i32.const	$push0=, 1095761920
+	i32.store	foo.tmp($pop1), $pop0
+	i32.const	$push10=, 0
+	i64.const	$push2=, 4838273375797772288
+	i64.store	foo.tmp+4($pop10):p2align=2, $pop2
+	i32.const	$push9=, 1095761920
+	i32.store	0($0), $pop9
+	i32.const	$push8=, 0
+	i32.load	$push3=, foo.tmp+4($pop8)
 	i32.store	4($0), $pop3
-	i32.const	$push8=, 1095761920
-	i32.store	0($0), $pop8
 	i32.const	$push7=, 0
 	i32.load	$push4=, foo.tmp+8($pop7)
 	i32.store	8($0), $pop4
@@ -55,4 +56,4 @@ foo.tmp:
 	.size	foo.tmp, 16
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "

--- a/test/torture-s/memcpy-2.c.s
+++ b/test/torture-s/memcpy-2.c.s
@@ -1,53 +1,53 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/memcpy-2.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/memcpy-2.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$1=, 0
+	i32.const	$0=, 0
 .LBB0_1:                                # %for.cond1.preheader
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB0_2 Depth 2
                                         #       Child Loop BB0_3 Depth 3
                                         #         Child Loop BB0_4 Depth 4
                                         #         Child Loop BB0_7 Depth 4
-                                        #         Child Loop BB0_11 Depth 4
+                                        #         Child Loop BB0_12 Depth 4
 	block   	
 	loop    	                # label1:
 	i32.const	$push44=, u1
-	i32.add 	$2=, $1, $pop44
-	i32.const	$3=, 0
+	i32.add 	$1=, $0, $pop44
+	i32.const	$2=, 0
 .LBB0_2:                                # %for.cond4.preheader
                                         #   Parent Loop BB0_1 Depth=1
                                         # =>  This Loop Header: Depth=2
                                         #       Child Loop BB0_3 Depth 3
                                         #         Child Loop BB0_4 Depth 4
                                         #         Child Loop BB0_7 Depth 4
-                                        #         Child Loop BB0_11 Depth 4
+                                        #         Child Loop BB0_12 Depth 4
 	loop    	                # label2:
 	i32.const	$push46=, 65
-	i32.add 	$5=, $3, $pop46
+	i32.add 	$4=, $2, $pop46
 	i32.const	$push45=, u2
-	i32.add 	$4=, $3, $pop45
-	i32.const	$6=, 1
+	i32.add 	$3=, $2, $pop45
+	i32.const	$5=, 1
 .LBB0_3:                                # %for.cond7.preheader
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         # =>    This Loop Header: Depth=3
                                         #         Child Loop BB0_4 Depth 4
                                         #         Child Loop BB0_7 Depth 4
-                                        #         Child Loop BB0_11 Depth 4
+                                        #         Child Loop BB0_12 Depth 4
 	loop    	                # label3:
 	i32.const	$push49=, u1
 	i32.const	$push48=, 97
 	i32.const	$push47=, 96
-	i32.call	$0=, memset@FUNCTION, $pop49, $pop48, $pop47
-	i32.const	$9=, 65
-	i32.const	$7=, -96
+	i32.call	$7=, memset@FUNCTION, $pop49, $pop48, $pop47
+	i32.const	$8=, 65
+	i32.const	$6=, -96
 .LBB0_4:                                # %for.body9
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
@@ -55,189 +55,193 @@ main:                                   # @main
                                         # =>      This Inner Loop Header: Depth=4
 	loop    	                # label4:
 	i32.const	$push60=, u2+96
-	i32.add 	$push3=, $7, $pop60
+	i32.add 	$push3=, $6, $pop60
 	i32.const	$push59=, 65
 	i32.const	$push58=, 24
-	i32.shl 	$push0=, $9, $pop58
+	i32.shl 	$push0=, $8, $pop58
 	i32.const	$push57=, 24
 	i32.shr_s	$push1=, $pop0, $pop57
 	i32.const	$push56=, 95
 	i32.gt_s	$push2=, $pop1, $pop56
-	i32.select	$push55=, $pop59, $9, $pop2
-	tee_local	$push54=, $9=, $pop55
+	i32.select	$push55=, $pop59, $8, $pop2
+	tee_local	$push54=, $8=, $pop55
 	i32.store8	0($pop3), $pop54
 	i32.const	$push53=, 1
-	i32.add 	$9=, $9, $pop53
+	i32.add 	$8=, $8, $pop53
 	i32.const	$push52=, 1
-	i32.add 	$push51=, $7, $pop52
-	tee_local	$push50=, $7=, $pop51
+	i32.add 	$push51=, $6, $pop52
+	tee_local	$push50=, $6=, $pop51
 	br_if   	0, $pop50       # 0: up to label4
 # BB#5:                                 # %for.end
                                         #   in Loop: Header=BB0_3 Depth=3
 	end_loop
-	i32.call	$drop=, memcpy@FUNCTION, $2, $4, $6
-	i32.const	$8=, u1
+	i32.call	$drop=, memcpy@FUNCTION, $1, $3, $5
+	block   	
 	block   	
 	i32.const	$push61=, 1
-	i32.lt_s	$push4=, $1, $pop61
-	br_if   	0, $pop4        # 0: down to label5
+	i32.lt_s	$push4=, $0, $pop61
+	br_if   	0, $pop4        # 0: down to label6
 # BB#6:                                 # %for.body23.preheader
                                         #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$9=, 0
+	i32.const	$8=, 0
 .LBB0_7:                                # %for.body23
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         #       Parent Loop BB0_3 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	loop    	                # label6:
-	i32.add 	$push5=, $9, $0
+	loop    	                # label7:
+	i32.add 	$push5=, $8, $7
 	i32.load8_u	$push6=, 0($pop5)
 	i32.const	$push62=, 97
 	i32.ne  	$push7=, $pop6, $pop62
-	br_if   	5, $pop7        # 5: down to label0
+	br_if   	6, $pop7        # 6: down to label0
 # BB#8:                                 # %for.inc29
                                         #   in Loop: Header=BB0_7 Depth=4
 	i32.const	$push65=, 1
-	i32.add 	$push64=, $9, $pop65
-	tee_local	$push63=, $9=, $pop64
-	i32.lt_s	$push8=, $pop63, $1
-	br_if   	0, $pop8        # 0: up to label6
+	i32.add 	$push64=, $8, $pop65
+	tee_local	$push63=, $8=, $pop64
+	i32.lt_s	$push8=, $pop63, $0
+	br_if   	0, $pop8        # 0: up to label7
 # BB#9:                                 # %for.body36.preheader.loopexit
                                         #   in Loop: Header=BB0_3 Depth=3
 	end_loop
-	i32.add 	$8=, $9, $0
-.LBB0_10:                               # %for.body36.preheader
+	i32.add 	$7=, $8, $7
+	br      	1               # 1: down to label5
+.LBB0_10:                               #   in Loop: Header=BB0_3 Depth=3
+	end_block                       # label6:
+	i32.const	$7=, u1
+.LBB0_11:                               # %for.body36.preheader
                                         #   in Loop: Header=BB0_3 Depth=3
 	end_block                       # label5:
-	i32.const	$9=, 0
-	copy_local	$7=, $5
-.LBB0_11:                               # %for.body36
+	i32.const	$8=, 0
+	copy_local	$6=, $4
+.LBB0_12:                               # %for.body36
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         #       Parent Loop BB0_3 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	loop    	                # label7:
-	i32.add 	$push13=, $8, $9
+	loop    	                # label8:
+	i32.add 	$push13=, $7, $8
 	i32.load8_u	$push14=, 0($pop13)
 	i32.const	$push72=, 65
 	i32.const	$push71=, 24
-	i32.shl 	$push9=, $7, $pop71
+	i32.shl 	$push9=, $6, $pop71
 	i32.const	$push70=, 24
 	i32.shr_s	$push10=, $pop9, $pop70
 	i32.const	$push69=, 95
 	i32.gt_s	$push11=, $pop10, $pop69
-	i32.select	$push68=, $pop72, $7, $pop11
-	tee_local	$push67=, $7=, $pop68
+	i32.select	$push68=, $pop72, $6, $pop11
+	tee_local	$push67=, $6=, $pop68
 	i32.const	$push66=, 255
 	i32.and 	$push12=, $pop67, $pop66
 	i32.ne  	$push15=, $pop14, $pop12
 	br_if   	4, $pop15       # 4: down to label0
-# BB#12:                                # %for.inc48
-                                        #   in Loop: Header=BB0_11 Depth=4
+# BB#13:                                # %for.inc48
+                                        #   in Loop: Header=BB0_12 Depth=4
 	i32.const	$push76=, 1
-	i32.add 	$7=, $7, $pop76
+	i32.add 	$6=, $6, $pop76
 	i32.const	$push75=, 1
-	i32.add 	$push74=, $9, $pop75
-	tee_local	$push73=, $9=, $pop74
-	i32.lt_s	$push16=, $pop73, $6
-	br_if   	0, $pop16       # 0: up to label7
-# BB#13:                                # %for.body56.preheader
+	i32.add 	$push74=, $8, $pop75
+	tee_local	$push73=, $8=, $pop74
+	i32.lt_s	$push16=, $pop73, $5
+	br_if   	0, $pop16       # 0: up to label8
+# BB#14:                                # %for.body56.preheader
                                         #   in Loop: Header=BB0_3 Depth=3
 	end_loop
-	i32.add 	$push79=, $8, $9
-	tee_local	$push78=, $9=, $pop79
+	i32.add 	$push79=, $7, $8
+	tee_local	$push78=, $8=, $pop79
 	i32.load8_u	$push17=, 0($pop78)
 	i32.const	$push77=, 97
 	i32.ne  	$push18=, $pop17, $pop77
 	br_if   	3, $pop18       # 3: down to label0
-# BB#14:                                # %for.inc62
+# BB#15:                                # %for.inc62
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push81=, 1
-	i32.add 	$push19=, $9, $pop81
+	i32.add 	$push19=, $8, $pop81
 	i32.load8_u	$push20=, 0($pop19)
 	i32.const	$push80=, 97
 	i32.ne  	$push21=, $pop20, $pop80
 	br_if   	3, $pop21       # 3: down to label0
-# BB#15:                                # %for.inc62.1
+# BB#16:                                # %for.inc62.1
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push83=, 2
-	i32.add 	$push22=, $9, $pop83
+	i32.add 	$push22=, $8, $pop83
 	i32.load8_u	$push23=, 0($pop22)
 	i32.const	$push82=, 97
 	i32.ne  	$push24=, $pop23, $pop82
 	br_if   	3, $pop24       # 3: down to label0
-# BB#16:                                # %for.inc62.2
+# BB#17:                                # %for.inc62.2
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push85=, 3
-	i32.add 	$push25=, $9, $pop85
+	i32.add 	$push25=, $8, $pop85
 	i32.load8_u	$push26=, 0($pop25)
 	i32.const	$push84=, 97
 	i32.ne  	$push27=, $pop26, $pop84
 	br_if   	3, $pop27       # 3: down to label0
-# BB#17:                                # %for.inc62.3
+# BB#18:                                # %for.inc62.3
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push87=, 4
-	i32.add 	$push28=, $9, $pop87
+	i32.add 	$push28=, $8, $pop87
 	i32.load8_u	$push29=, 0($pop28)
 	i32.const	$push86=, 97
 	i32.ne  	$push30=, $pop29, $pop86
 	br_if   	3, $pop30       # 3: down to label0
-# BB#18:                                # %for.inc62.4
+# BB#19:                                # %for.inc62.4
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push89=, 5
-	i32.add 	$push31=, $9, $pop89
+	i32.add 	$push31=, $8, $pop89
 	i32.load8_u	$push32=, 0($pop31)
 	i32.const	$push88=, 97
 	i32.ne  	$push33=, $pop32, $pop88
 	br_if   	3, $pop33       # 3: down to label0
-# BB#19:                                # %for.inc62.5
+# BB#20:                                # %for.inc62.5
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push91=, 6
-	i32.add 	$push34=, $9, $pop91
+	i32.add 	$push34=, $8, $pop91
 	i32.load8_u	$push35=, 0($pop34)
 	i32.const	$push90=, 97
 	i32.ne  	$push36=, $pop35, $pop90
 	br_if   	3, $pop36       # 3: down to label0
-# BB#20:                                # %for.inc62.6
+# BB#21:                                # %for.inc62.6
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push93=, 7
-	i32.add 	$push37=, $9, $pop93
+	i32.add 	$push37=, $8, $pop93
 	i32.load8_u	$push38=, 0($pop37)
 	i32.const	$push92=, 97
 	i32.ne  	$push39=, $pop38, $pop92
 	br_if   	3, $pop39       # 3: down to label0
-# BB#21:                                # %for.inc62.7
+# BB#22:                                # %for.inc62.7
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push97=, 1
-	i32.add 	$push96=, $6, $pop97
-	tee_local	$push95=, $6=, $pop96
+	i32.add 	$push96=, $5, $pop97
+	tee_local	$push95=, $5=, $pop96
 	i32.const	$push94=, 80
 	i32.lt_u	$push40=, $pop95, $pop94
 	br_if   	0, $pop40       # 0: up to label3
-# BB#22:                                # %for.inc69
+# BB#23:                                # %for.inc69
                                         #   in Loop: Header=BB0_2 Depth=2
 	end_loop
 	i32.const	$push101=, 1
-	i32.add 	$push100=, $3, $pop101
-	tee_local	$push99=, $3=, $pop100
+	i32.add 	$push100=, $2, $pop101
+	tee_local	$push99=, $2=, $pop100
 	i32.const	$push98=, 8
 	i32.lt_u	$push41=, $pop99, $pop98
 	br_if   	0, $pop41       # 0: up to label2
-# BB#23:                                # %for.inc72
+# BB#24:                                # %for.inc72
                                         #   in Loop: Header=BB0_1 Depth=1
 	end_loop
 	i32.const	$push105=, 1
-	i32.add 	$push104=, $1, $pop105
-	tee_local	$push103=, $1=, $pop104
+	i32.add 	$push104=, $0, $pop105
+	tee_local	$push103=, $0=, $pop104
 	i32.const	$push102=, 8
 	i32.lt_u	$push42=, $pop103, $pop102
 	br_if   	0, $pop42       # 0: up to label1
-# BB#24:                                # %for.end74
+# BB#25:                                # %for.end74
 	end_loop
 	i32.const	$push43=, 0
 	call    	exit@FUNCTION, $pop43
 	unreachable
-.LBB0_25:                               # %if.then60
+.LBB0_26:                               # %if.then60
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -260,6 +264,6 @@ u2:
 	.size	u2, 96
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/memset-1.c.s
+++ b/test/torture-s/memset-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/memset-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/memset-1.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
@@ -15,9 +15,9 @@ main:                                   # @main
                                         #       Child Loop BB0_4 Depth 3
                                         #       Child Loop BB0_8 Depth 3
                                         #       Child Loop BB0_20 Depth 3
-                                        #       Child Loop BB0_24 Depth 3
-                                        #       Child Loop BB0_36 Depth 3
-                                        #       Child Loop BB0_40 Depth 3
+                                        #       Child Loop BB0_25 Depth 3
+                                        #       Child Loop BB0_37 Depth 3
+                                        #       Child Loop BB0_42 Depth 3
 	block   	
 	loop    	                # label1:
 	i32.const	$push96=, u
@@ -29,9 +29,9 @@ main:                                   # @main
                                         #       Child Loop BB0_4 Depth 3
                                         #       Child Loop BB0_8 Depth 3
                                         #       Child Loop BB0_20 Depth 3
-                                        #       Child Loop BB0_24 Depth 3
-                                        #       Child Loop BB0_36 Depth 3
-                                        #       Child Loop BB0_40 Depth 3
+                                        #       Child Loop BB0_25 Depth 3
+                                        #       Child Loop BB0_37 Depth 3
+                                        #       Child Loop BB0_42 Depth 3
 	loop    	                # label2:
 	i32.const	$5=, u
 	i32.const	$push103=, u
@@ -160,9 +160,9 @@ main:                                   # @main
 	i32.const	$push130=, 0
 	i32.load8_u	$push30=, A($pop130)
 	i32.call	$drop=, memset@FUNCTION, $0, $pop30, $3
-	i32.const	$5=, u
 	block   	
-	br_if   	0, $4           # 0: down to label6
+	block   	
+	br_if   	0, $4           # 0: down to label7
 # BB#19:                                # %for.body55.preheader
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$6=, 0
@@ -170,47 +170,51 @@ main:                                   # @main
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
-	loop    	                # label7:
+	loop    	                # label8:
 	i32.const	$push132=, u
 	i32.add 	$push31=, $6, $pop132
 	i32.load8_u	$push32=, 0($pop31)
 	i32.const	$push131=, 97
 	i32.ne  	$push33=, $pop32, $pop131
-	br_if   	4, $pop33       # 4: down to label0
+	br_if   	5, $pop33       # 5: down to label0
 # BB#21:                                # %for.inc61
                                         #   in Loop: Header=BB0_20 Depth=3
 	i32.const	$push135=, 1
 	i32.add 	$push134=, $6, $pop135
 	tee_local	$push133=, $6=, $pop134
 	i32.lt_s	$push34=, $pop133, $1
-	br_if   	0, $pop34       # 0: up to label7
+	br_if   	0, $pop34       # 0: up to label8
 # BB#22:                                # %for.body68.preheader.loopexit
                                         #   in Loop: Header=BB0_2 Depth=2
 	end_loop
 	i32.const	$push136=, u
 	i32.add 	$5=, $6, $pop136
-.LBB0_23:                               # %for.body68.preheader
+	br      	1               # 1: down to label6
+.LBB0_23:                               #   in Loop: Header=BB0_2 Depth=2
+	end_block                       # label7:
+	i32.const	$5=, u
+.LBB0_24:                               # %for.body68.preheader
                                         #   in Loop: Header=BB0_2 Depth=2
 	end_block                       # label6:
 	i32.const	$6=, 0
-.LBB0_24:                               # %for.body68
+.LBB0_25:                               # %for.body68
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
-	loop    	                # label8:
+	loop    	                # label9:
 	i32.add 	$push35=, $5, $6
 	i32.load8_u	$push36=, 0($pop35)
 	i32.const	$push137=, 65
 	i32.ne  	$push37=, $pop36, $pop137
 	br_if   	3, $pop37       # 3: down to label0
-# BB#25:                                # %for.inc74
-                                        #   in Loop: Header=BB0_24 Depth=3
+# BB#26:                                # %for.inc74
+                                        #   in Loop: Header=BB0_25 Depth=3
 	i32.const	$push140=, 1
 	i32.add 	$push139=, $6, $pop140
 	tee_local	$push138=, $6=, $pop139
 	i32.lt_s	$push38=, $pop138, $3
-	br_if   	0, $pop38       # 0: up to label8
-# BB#26:                                # %for.body81.preheader
+	br_if   	0, $pop38       # 0: up to label9
+# BB#27:                                # %for.body81.preheader
                                         #   in Loop: Header=BB0_2 Depth=2
 	end_loop
 	i32.add 	$push143=, $5, $6
@@ -219,7 +223,7 @@ main:                                   # @main
 	i32.const	$push141=, 97
 	i32.ne  	$push40=, $pop39, $pop141
 	br_if   	2, $pop40       # 2: down to label0
-# BB#27:                                # %for.inc87
+# BB#28:                                # %for.inc87
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push145=, 1
 	i32.add 	$push41=, $6, $pop145
@@ -227,7 +231,7 @@ main:                                   # @main
 	i32.const	$push144=, 97
 	i32.ne  	$push43=, $pop42, $pop144
 	br_if   	2, $pop43       # 2: down to label0
-# BB#28:                                # %for.inc87.1
+# BB#29:                                # %for.inc87.1
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push147=, 2
 	i32.add 	$push44=, $6, $pop147
@@ -235,7 +239,7 @@ main:                                   # @main
 	i32.const	$push146=, 97
 	i32.ne  	$push46=, $pop45, $pop146
 	br_if   	2, $pop46       # 2: down to label0
-# BB#29:                                # %for.inc87.2
+# BB#30:                                # %for.inc87.2
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push149=, 3
 	i32.add 	$push47=, $6, $pop149
@@ -243,7 +247,7 @@ main:                                   # @main
 	i32.const	$push148=, 97
 	i32.ne  	$push49=, $pop48, $pop148
 	br_if   	2, $pop49       # 2: down to label0
-# BB#30:                                # %for.inc87.3
+# BB#31:                                # %for.inc87.3
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push151=, 4
 	i32.add 	$push50=, $6, $pop151
@@ -251,7 +255,7 @@ main:                                   # @main
 	i32.const	$push150=, 97
 	i32.ne  	$push52=, $pop51, $pop150
 	br_if   	2, $pop52       # 2: down to label0
-# BB#31:                                # %for.inc87.4
+# BB#32:                                # %for.inc87.4
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push153=, 5
 	i32.add 	$push53=, $6, $pop153
@@ -259,7 +263,7 @@ main:                                   # @main
 	i32.const	$push152=, 97
 	i32.ne  	$push55=, $pop54, $pop152
 	br_if   	2, $pop55       # 2: down to label0
-# BB#32:                                # %for.inc87.5
+# BB#33:                                # %for.inc87.5
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push155=, 6
 	i32.add 	$push56=, $6, $pop155
@@ -267,7 +271,7 @@ main:                                   # @main
 	i32.const	$push154=, 97
 	i32.ne  	$push58=, $pop57, $pop154
 	br_if   	2, $pop58       # 2: down to label0
-# BB#33:                                # %for.inc87.6
+# BB#34:                                # %for.inc87.6
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push157=, 7
 	i32.add 	$push59=, $6, $pop157
@@ -275,61 +279,65 @@ main:                                   # @main
 	i32.const	$push156=, 97
 	i32.ne  	$push61=, $pop60, $pop156
 	br_if   	2, $pop61       # 2: down to label0
-# BB#34:                                # %for.inc87.7
+# BB#35:                                # %for.inc87.7
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push158=, 66
 	i32.call	$drop=, memset@FUNCTION, $0, $pop158, $3
-	i32.const	$5=, u
 	block   	
-	br_if   	0, $4           # 0: down to label9
-# BB#35:                                # %for.body100.preheader
+	block   	
+	br_if   	0, $4           # 0: down to label11
+# BB#36:                                # %for.body100.preheader
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$6=, 0
-.LBB0_36:                               # %for.body100
+.LBB0_37:                               # %for.body100
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
-	loop    	                # label10:
+	loop    	                # label12:
 	i32.const	$push160=, u
 	i32.add 	$push62=, $6, $pop160
 	i32.load8_u	$push63=, 0($pop62)
 	i32.const	$push159=, 97
 	i32.ne  	$push64=, $pop63, $pop159
-	br_if   	4, $pop64       # 4: down to label0
-# BB#37:                                # %for.inc106
-                                        #   in Loop: Header=BB0_36 Depth=3
+	br_if   	5, $pop64       # 5: down to label0
+# BB#38:                                # %for.inc106
+                                        #   in Loop: Header=BB0_37 Depth=3
 	i32.const	$push163=, 1
 	i32.add 	$push162=, $6, $pop163
 	tee_local	$push161=, $6=, $pop162
 	i32.lt_s	$push65=, $pop161, $1
-	br_if   	0, $pop65       # 0: up to label10
-# BB#38:                                # %for.body113.preheader.loopexit
+	br_if   	0, $pop65       # 0: up to label12
+# BB#39:                                # %for.body113.preheader.loopexit
                                         #   in Loop: Header=BB0_2 Depth=2
 	end_loop
 	i32.const	$push164=, u
 	i32.add 	$5=, $6, $pop164
-.LBB0_39:                               # %for.body113.preheader
+	br      	1               # 1: down to label10
+.LBB0_40:                               #   in Loop: Header=BB0_2 Depth=2
+	end_block                       # label11:
+	i32.const	$5=, u
+.LBB0_41:                               # %for.body113.preheader
                                         #   in Loop: Header=BB0_2 Depth=2
-	end_block                       # label9:
+	end_block                       # label10:
 	i32.const	$6=, 0
-.LBB0_40:                               # %for.body113
+.LBB0_42:                               # %for.body113
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
-	loop    	                # label11:
+	loop    	                # label13:
 	i32.add 	$push66=, $5, $6
 	i32.load8_u	$push67=, 0($pop66)
 	i32.const	$push165=, 66
 	i32.ne  	$push68=, $pop67, $pop165
 	br_if   	3, $pop68       # 3: down to label0
-# BB#41:                                # %for.inc119
-                                        #   in Loop: Header=BB0_40 Depth=3
+# BB#43:                                # %for.inc119
+                                        #   in Loop: Header=BB0_42 Depth=3
 	i32.const	$push168=, 1
 	i32.add 	$push167=, $6, $pop168
 	tee_local	$push166=, $6=, $pop167
 	i32.lt_s	$push69=, $pop166, $3
-	br_if   	0, $pop69       # 0: up to label11
-# BB#42:                                # %for.body126.preheader
+	br_if   	0, $pop69       # 0: up to label13
+# BB#44:                                # %for.body126.preheader
                                         #   in Loop: Header=BB0_2 Depth=2
 	end_loop
 	i32.add 	$push171=, $5, $6
@@ -338,7 +346,7 @@ main:                                   # @main
 	i32.const	$push169=, 97
 	i32.ne  	$push71=, $pop70, $pop169
 	br_if   	2, $pop71       # 2: down to label0
-# BB#43:                                # %for.inc132
+# BB#45:                                # %for.inc132
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push173=, 1
 	i32.add 	$push72=, $6, $pop173
@@ -346,7 +354,7 @@ main:                                   # @main
 	i32.const	$push172=, 97
 	i32.ne  	$push74=, $pop73, $pop172
 	br_if   	2, $pop74       # 2: down to label0
-# BB#44:                                # %for.inc132.1
+# BB#46:                                # %for.inc132.1
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push175=, 2
 	i32.add 	$push75=, $6, $pop175
@@ -354,7 +362,7 @@ main:                                   # @main
 	i32.const	$push174=, 97
 	i32.ne  	$push77=, $pop76, $pop174
 	br_if   	2, $pop77       # 2: down to label0
-# BB#45:                                # %for.inc132.2
+# BB#47:                                # %for.inc132.2
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push177=, 3
 	i32.add 	$push78=, $6, $pop177
@@ -362,7 +370,7 @@ main:                                   # @main
 	i32.const	$push176=, 97
 	i32.ne  	$push80=, $pop79, $pop176
 	br_if   	2, $pop80       # 2: down to label0
-# BB#46:                                # %for.inc132.3
+# BB#48:                                # %for.inc132.3
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push179=, 4
 	i32.add 	$push81=, $6, $pop179
@@ -370,7 +378,7 @@ main:                                   # @main
 	i32.const	$push178=, 97
 	i32.ne  	$push83=, $pop82, $pop178
 	br_if   	2, $pop83       # 2: down to label0
-# BB#47:                                # %for.inc132.4
+# BB#49:                                # %for.inc132.4
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push181=, 5
 	i32.add 	$push84=, $6, $pop181
@@ -378,7 +386,7 @@ main:                                   # @main
 	i32.const	$push180=, 97
 	i32.ne  	$push86=, $pop85, $pop180
 	br_if   	2, $pop86       # 2: down to label0
-# BB#48:                                # %for.inc132.5
+# BB#50:                                # %for.inc132.5
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push183=, 6
 	i32.add 	$push87=, $6, $pop183
@@ -386,7 +394,7 @@ main:                                   # @main
 	i32.const	$push182=, 97
 	i32.ne  	$push89=, $pop88, $pop182
 	br_if   	2, $pop89       # 2: down to label0
-# BB#49:                                # %for.inc132.6
+# BB#51:                                # %for.inc132.6
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push185=, 7
 	i32.add 	$push90=, $6, $pop185
@@ -394,7 +402,7 @@ main:                                   # @main
 	i32.const	$push184=, 97
 	i32.ne  	$push92=, $pop91, $pop184
 	br_if   	2, $pop92       # 2: down to label0
-# BB#50:                                # %for.inc132.7
+# BB#52:                                # %for.inc132.7
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push189=, 1
 	i32.add 	$push188=, $3, $pop189
@@ -402,7 +410,7 @@ main:                                   # @main
 	i32.const	$push186=, 80
 	i32.lt_u	$push93=, $pop187, $pop186
 	br_if   	0, $pop93       # 0: up to label2
-# BB#51:                                # %for.inc139
+# BB#53:                                # %for.inc139
                                         #   in Loop: Header=BB0_1 Depth=1
 	end_loop
 	i32.const	$push193=, 1
@@ -411,12 +419,12 @@ main:                                   # @main
 	i32.const	$push190=, 8
 	i32.lt_u	$push94=, $pop191, $pop190
 	br_if   	0, $pop94       # 0: up to label1
-# BB#52:                                # %for.end141
+# BB#54:                                # %for.end141
 	end_loop
 	i32.const	$push95=, 0
 	call    	exit@FUNCTION, $pop95
 	unreachable
-.LBB0_53:                               # %if.then130
+.LBB0_55:                               # %if.then130
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -440,6 +448,6 @@ u:
 	.size	u, 96
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/memset-2.c.s
+++ b/test/torture-s/memset-2.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/memset-2.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/memset-2.c"
 	.section	.text.reset,"ax",@progbits
 	.hidden	reset
 	.globl	reset
@@ -21,102 +21,108 @@ reset:                                  # @reset
 	.type	check,@function
 check:                                  # @check
 	.param  	i32, i32, i32
-	.local  	i32, i32
+	.local  	i32
 # BB#0:                                 # %entry
-	i32.const	$3=, u
 	block   	
 	block   	
-	i32.const	$push27=, 1
-	i32.lt_s	$push0=, $0, $pop27
-	br_if   	0, $pop0        # 0: down to label1
+	block   	
+	block   	
+	i32.const	$push28=, 1
+	i32.lt_s	$push0=, $0, $pop28
+	br_if   	0, $pop0        # 0: down to label3
 # BB#1:                                 # %for.body.preheader
-	i32.const	$4=, 0
+	i32.const	$3=, 0
 .LBB1_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label2:
-	i32.const	$push29=, u
-	i32.add 	$push1=, $4, $pop29
+	loop    	                # label4:
+	i32.const	$push30=, u
+	i32.add 	$push1=, $3, $pop30
 	i32.load8_u	$push2=, 0($pop1)
-	i32.const	$push28=, 97
-	i32.ne  	$push3=, $pop2, $pop28
-	br_if   	2, $pop3        # 2: down to label0
+	i32.const	$push29=, 97
+	i32.ne  	$push3=, $pop2, $pop29
+	br_if   	4, $pop3        # 4: down to label0
 # BB#3:                                 # %for.inc
                                         #   in Loop: Header=BB1_2 Depth=1
-	i32.const	$push32=, 1
-	i32.add 	$push31=, $4, $pop32
-	tee_local	$push30=, $4=, $pop31
-	i32.lt_s	$push4=, $pop30, $0
-	br_if   	0, $pop4        # 0: up to label2
+	i32.const	$push33=, 1
+	i32.add 	$push32=, $3, $pop33
+	tee_local	$push31=, $3=, $pop32
+	i32.lt_s	$push4=, $pop31, $0
+	br_if   	0, $pop4        # 0: up to label4
 # BB#4:                                 # %for.cond3.preheader.loopexit
 	end_loop
 	i32.const	$push5=, u
-	i32.add 	$3=, $4, $pop5
-.LBB1_5:                                # %for.cond3.preheader
-	end_block                       # label1:
-	block   	
-	i32.const	$push33=, 1
-	i32.lt_s	$push6=, $1, $pop33
-	br_if   	0, $pop6        # 0: down to label3
-# BB#6:                                 # %for.body6.preheader
-	i32.const	$4=, 0
+	i32.add 	$0=, $3, $pop5
+	i32.const	$push34=, 1
+	i32.ge_s	$push6=, $1, $pop34
+	br_if   	1, $pop6        # 1: down to label2
+	br      	2               # 2: down to label1
+.LBB1_5:
+	end_block                       # label3:
+	i32.const	$0=, u
+	i32.const	$push35=, 1
+	i32.lt_s	$push7=, $1, $pop35
+	br_if   	1, $pop7        # 1: down to label1
+.LBB1_6:                                # %for.body6.preheader
+	end_block                       # label2:
+	i32.const	$3=, 0
 .LBB1_7:                                # %for.body6
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label4:
-	i32.add 	$push7=, $3, $4
-	i32.load8_s	$push8=, 0($pop7)
-	i32.ne  	$push9=, $pop8, $2
-	br_if   	2, $pop9        # 2: down to label0
+	loop    	                # label5:
+	i32.add 	$push8=, $0, $3
+	i32.load8_s	$push9=, 0($pop8)
+	i32.ne  	$push10=, $pop9, $2
+	br_if   	2, $pop10       # 2: down to label0
 # BB#8:                                 # %for.inc12
                                         #   in Loop: Header=BB1_7 Depth=1
-	i32.const	$push36=, 1
-	i32.add 	$push35=, $4, $pop36
-	tee_local	$push34=, $4=, $pop35
-	i32.lt_s	$push10=, $pop34, $1
-	br_if   	0, $pop10       # 0: up to label4
+	i32.const	$push38=, 1
+	i32.add 	$push37=, $3, $pop38
+	tee_local	$push36=, $3=, $pop37
+	i32.lt_s	$push11=, $pop36, $1
+	br_if   	0, $pop11       # 0: up to label5
 # BB#9:                                 # %for.body19.preheader.loopexit
 	end_loop
-	i32.add 	$3=, $3, $4
+	i32.add 	$0=, $0, $3
 .LBB1_10:                               # %for.body19.preheader
-	end_block                       # label3:
-	i32.load8_u	$push11=, 0($3)
-	i32.const	$push37=, 97
-	i32.ne  	$push12=, $pop11, $pop37
-	br_if   	0, $pop12       # 0: down to label0
-# BB#11:                                # %for.inc25
-	i32.load8_u	$push13=, 1($3)
-	i32.const	$push38=, 97
-	i32.ne  	$push14=, $pop13, $pop38
-	br_if   	0, $pop14       # 0: down to label0
-# BB#12:                                # %for.inc25.1
-	i32.load8_u	$push15=, 2($3)
+	end_block                       # label1:
+	i32.load8_u	$push12=, 0($0)
 	i32.const	$push39=, 97
-	i32.ne  	$push16=, $pop15, $pop39
-	br_if   	0, $pop16       # 0: down to label0
-# BB#13:                                # %for.inc25.2
-	i32.load8_u	$push17=, 3($3)
+	i32.ne  	$push13=, $pop12, $pop39
+	br_if   	0, $pop13       # 0: down to label0
+# BB#11:                                # %for.inc25
+	i32.load8_u	$push14=, 1($0)
 	i32.const	$push40=, 97
-	i32.ne  	$push18=, $pop17, $pop40
-	br_if   	0, $pop18       # 0: down to label0
-# BB#14:                                # %for.inc25.3
-	i32.load8_u	$push19=, 4($3)
+	i32.ne  	$push15=, $pop14, $pop40
+	br_if   	0, $pop15       # 0: down to label0
+# BB#12:                                # %for.inc25.1
+	i32.load8_u	$push16=, 2($0)
 	i32.const	$push41=, 97
-	i32.ne  	$push20=, $pop19, $pop41
-	br_if   	0, $pop20       # 0: down to label0
-# BB#15:                                # %for.inc25.4
-	i32.load8_u	$push21=, 5($3)
+	i32.ne  	$push17=, $pop16, $pop41
+	br_if   	0, $pop17       # 0: down to label0
+# BB#13:                                # %for.inc25.2
+	i32.load8_u	$push18=, 3($0)
 	i32.const	$push42=, 97
-	i32.ne  	$push22=, $pop21, $pop42
-	br_if   	0, $pop22       # 0: down to label0
-# BB#16:                                # %for.inc25.5
-	i32.load8_u	$push23=, 6($3)
+	i32.ne  	$push19=, $pop18, $pop42
+	br_if   	0, $pop19       # 0: down to label0
+# BB#14:                                # %for.inc25.3
+	i32.load8_u	$push20=, 4($0)
 	i32.const	$push43=, 97
-	i32.ne  	$push24=, $pop23, $pop43
-	br_if   	0, $pop24       # 0: down to label0
-# BB#17:                                # %for.inc25.6
-	i32.load8_u	$push25=, 7($3)
+	i32.ne  	$push21=, $pop20, $pop43
+	br_if   	0, $pop21       # 0: down to label0
+# BB#15:                                # %for.inc25.4
+	i32.load8_u	$push22=, 5($0)
 	i32.const	$push44=, 97
-	i32.ne  	$push26=, $pop25, $pop44
-	br_if   	0, $pop26       # 0: down to label0
+	i32.ne  	$push23=, $pop22, $pop44
+	br_if   	0, $pop23       # 0: down to label0
+# BB#16:                                # %for.inc25.5
+	i32.load8_u	$push24=, 6($0)
+	i32.const	$push45=, 97
+	i32.ne  	$push25=, $pop24, $pop45
+	br_if   	0, $pop25       # 0: down to label0
+# BB#17:                                # %for.inc25.6
+	i32.load8_u	$push26=, 7($0)
+	i32.const	$push46=, 97
+	i32.ne  	$push27=, $pop26, $pop46
+	br_if   	0, $pop27       # 0: down to label0
 # BB#18:                                # %for.inc25.7
 	return
 .LBB1_19:                               # %if.then23
@@ -138,7 +144,7 @@ main:                                   # @main
 	i32.const	$5=, 0
 .LBB2_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label5:
+	loop    	                # label6:
 	i32.const	$push59=, u
 	i32.const	$push58=, 97
 	i32.const	$push57=, 31
@@ -166,13 +172,13 @@ main:                                   # @main
 	tee_local	$push43=, $5=, $pop44
 	i32.const	$push42=, 8
 	i32.ne  	$push5=, $pop43, $pop42
-	br_if   	0, $pop5        # 0: up to label5
+	br_if   	0, $pop5        # 0: up to label6
 # BB#2:                                 # %for.body18.preheader
 	end_loop
 	i32.const	$5=, 0
 .LBB2_3:                                # %for.body18
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label6:
+	loop    	                # label7:
 	i32.const	$push78=, u
 	i32.const	$push77=, 97
 	i32.const	$push76=, 31
@@ -202,13 +208,13 @@ main:                                   # @main
 	tee_local	$push61=, $5=, $pop62
 	i32.const	$push60=, 8
 	i32.ne  	$push8=, $pop61, $pop60
-	br_if   	0, $pop8        # 0: up to label6
+	br_if   	0, $pop8        # 0: up to label7
 # BB#4:                                 # %for.body44.preheader
 	end_loop
 	i32.const	$5=, 0
 .LBB2_5:                                # %for.body44
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label7:
+	loop    	                # label8:
 	i32.const	$push104=, u
 	i32.const	$push103=, 97
 	i32.const	$push102=, 31
@@ -247,13 +253,13 @@ main:                                   # @main
 	tee_local	$push80=, $5=, $pop81
 	i32.const	$push79=, 8
 	i32.ne  	$push10=, $pop80, $pop79
-	br_if   	0, $pop10       # 0: up to label7
+	br_if   	0, $pop10       # 0: up to label8
 # BB#6:                                 # %for.body70.preheader
 	end_loop
 	i32.const	$5=, 0
 .LBB2_7:                                # %for.body70
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label8:
+	loop    	                # label9:
 	i32.const	$push123=, u
 	i32.const	$push122=, 97
 	i32.const	$push121=, 31
@@ -283,13 +289,13 @@ main:                                   # @main
 	tee_local	$push106=, $5=, $pop107
 	i32.const	$push105=, 8
 	i32.ne  	$push13=, $pop106, $pop105
-	br_if   	0, $pop13       # 0: up to label8
+	br_if   	0, $pop13       # 0: up to label9
 # BB#8:                                 # %for.body96.preheader
 	end_loop
 	i32.const	$5=, 0
 .LBB2_9:                                # %for.body96
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label9:
+	loop    	                # label10:
 	i32.const	$push149=, u
 	i32.const	$push148=, 97
 	i32.const	$push147=, 31
@@ -328,13 +334,13 @@ main:                                   # @main
 	tee_local	$push125=, $5=, $pop126
 	i32.const	$push124=, 8
 	i32.ne  	$push15=, $pop125, $pop124
-	br_if   	0, $pop15       # 0: up to label9
+	br_if   	0, $pop15       # 0: up to label10
 # BB#10:                                # %for.body122.preheader
 	end_loop
 	i32.const	$5=, 0
 .LBB2_11:                               # %for.body122
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label10:
+	loop    	                # label11:
 	i32.const	$push176=, u
 	i32.const	$push175=, 97
 	i32.const	$push174=, 31
@@ -375,13 +381,13 @@ main:                                   # @main
 	tee_local	$push151=, $5=, $pop152
 	i32.const	$push150=, 8
 	i32.ne  	$push18=, $pop151, $pop150
-	br_if   	0, $pop18       # 0: up to label10
+	br_if   	0, $pop18       # 0: up to label11
 # BB#12:                                # %for.body148.preheader
 	end_loop
 	i32.const	$5=, 0
 .LBB2_13:                               # %for.body148
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label11:
+	loop    	                # label12:
 	i32.const	$push208=, u
 	i32.const	$push207=, 97
 	i32.const	$push206=, 31
@@ -430,13 +436,13 @@ main:                                   # @main
 	tee_local	$push178=, $5=, $pop179
 	i32.const	$push177=, 8
 	i32.ne  	$push21=, $pop178, $pop177
-	br_if   	0, $pop21       # 0: up to label11
+	br_if   	0, $pop21       # 0: up to label12
 # BB#14:                                # %for.body174.preheader
 	end_loop
 	i32.const	$5=, 0
 .LBB2_15:                               # %for.body174
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label12:
+	loop    	                # label13:
 	i32.const	$push230=, u
 	i32.const	$push229=, 97
 	i32.const	$push228=, 31
@@ -470,13 +476,13 @@ main:                                   # @main
 	tee_local	$push210=, $5=, $pop211
 	i32.const	$push209=, 8
 	i32.ne  	$push24=, $pop210, $pop209
-	br_if   	0, $pop24       # 0: up to label12
+	br_if   	0, $pop24       # 0: up to label13
 # BB#16:                                # %for.body200.preheader
 	end_loop
 	i32.const	$5=, 0
 .LBB2_17:                               # %for.body200
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label13:
+	loop    	                # label14:
 	i32.const	$push263=, u
 	i32.const	$push262=, 97
 	i32.const	$push261=, 31
@@ -524,13 +530,13 @@ main:                                   # @main
 	tee_local	$push232=, $5=, $pop233
 	i32.const	$push231=, 8
 	i32.ne  	$push25=, $pop232, $pop231
-	br_if   	0, $pop25       # 0: up to label13
+	br_if   	0, $pop25       # 0: up to label14
 # BB#18:                                # %for.body226.preheader
 	end_loop
 	i32.const	$5=, 0
 .LBB2_19:                               # %for.body226
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label14:
+	loop    	                # label15:
 	i32.const	$push297=, u
 	i32.const	$push296=, 97
 	i32.const	$push295=, 31
@@ -580,13 +586,13 @@ main:                                   # @main
 	tee_local	$push265=, $5=, $pop266
 	i32.const	$push264=, 8
 	i32.ne  	$push27=, $pop265, $pop264
-	br_if   	0, $pop27       # 0: up to label14
+	br_if   	0, $pop27       # 0: up to label15
 # BB#20:                                # %for.body252.preheader
 	end_loop
 	i32.const	$5=, 0
 .LBB2_21:                               # %for.body252
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label15:
+	loop    	                # label16:
 	i32.const	$push336=, u
 	i32.const	$push335=, 97
 	i32.const	$push334=, 31
@@ -644,13 +650,13 @@ main:                                   # @main
 	tee_local	$push299=, $5=, $pop300
 	i32.const	$push298=, 8
 	i32.ne  	$push29=, $pop299, $pop298
-	br_if   	0, $pop29       # 0: up to label15
+	br_if   	0, $pop29       # 0: up to label16
 # BB#22:                                # %for.body278.preheader
 	end_loop
 	i32.const	$5=, 0
 .LBB2_23:                               # %for.body278
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label16:
+	loop    	                # label17:
 	i32.const	$push363=, u
 	i32.const	$push362=, 97
 	i32.const	$push361=, 31
@@ -692,13 +698,13 @@ main:                                   # @main
 	tee_local	$push338=, $5=, $pop339
 	i32.const	$push337=, 8
 	i32.ne  	$push32=, $pop338, $pop337
-	br_if   	0, $pop32       # 0: up to label16
+	br_if   	0, $pop32       # 0: up to label17
 # BB#24:                                # %for.body304.preheader
 	end_loop
 	i32.const	$5=, 0
 .LBB2_25:                               # %for.body304
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label17:
+	loop    	                # label18:
 	i32.const	$push397=, u
 	i32.const	$push396=, 97
 	i32.const	$push395=, 31
@@ -749,13 +755,13 @@ main:                                   # @main
 	tee_local	$push365=, $5=, $pop366
 	i32.const	$push364=, 8
 	i32.ne  	$push34=, $pop365, $pop364
-	br_if   	0, $pop34       # 0: up to label17
+	br_if   	0, $pop34       # 0: up to label18
 # BB#26:                                # %for.body330.preheader
 	end_loop
 	i32.const	$5=, 0
 .LBB2_27:                               # %for.body330
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label18:
+	loop    	                # label19:
 	i32.const	$push432=, u
 	i32.const	$push431=, 97
 	i32.const	$push430=, 31
@@ -808,13 +814,13 @@ main:                                   # @main
 	tee_local	$push399=, $5=, $pop400
 	i32.const	$push398=, 8
 	i32.ne  	$push37=, $pop399, $pop398
-	br_if   	0, $pop37       # 0: up to label18
+	br_if   	0, $pop37       # 0: up to label19
 # BB#28:                                # %for.body356.preheader
 	end_loop
 	i32.const	$5=, 0
 .LBB2_29:                               # %for.body356
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label19:
+	loop    	                # label20:
 	i32.const	$push472=, u
 	i32.const	$push471=, 97
 	i32.const	$push470=, 31
@@ -875,7 +881,7 @@ main:                                   # @main
 	tee_local	$push434=, $5=, $pop435
 	i32.const	$push433=, 8
 	i32.ne  	$push40=, $pop434, $pop433
-	br_if   	0, $pop40       # 0: up to label19
+	br_if   	0, $pop40       # 0: up to label20
 # BB#30:                                # %for.end378
 	end_loop
 	i32.const	$push41=, 0
@@ -901,6 +907,6 @@ u:
 	.size	u, 32
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/memset-3.c.s
+++ b/test/torture-s/memset-3.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/memset-3.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/memset-3.c"
 	.section	.text.reset,"ax",@progbits
 	.hidden	reset
 	.globl	reset
@@ -21,102 +21,108 @@ reset:                                  # @reset
 	.type	check,@function
 check:                                  # @check
 	.param  	i32, i32, i32
-	.local  	i32, i32
+	.local  	i32
 # BB#0:                                 # %entry
-	i32.const	$3=, u
 	block   	
 	block   	
-	i32.const	$push27=, 1
-	i32.lt_s	$push0=, $0, $pop27
-	br_if   	0, $pop0        # 0: down to label1
+	block   	
+	block   	
+	i32.const	$push28=, 1
+	i32.lt_s	$push0=, $0, $pop28
+	br_if   	0, $pop0        # 0: down to label3
 # BB#1:                                 # %for.body.preheader
-	i32.const	$4=, 0
+	i32.const	$3=, 0
 .LBB1_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label2:
-	i32.const	$push29=, u
-	i32.add 	$push1=, $4, $pop29
+	loop    	                # label4:
+	i32.const	$push30=, u
+	i32.add 	$push1=, $3, $pop30
 	i32.load8_u	$push2=, 0($pop1)
-	i32.const	$push28=, 97
-	i32.ne  	$push3=, $pop2, $pop28
-	br_if   	2, $pop3        # 2: down to label0
+	i32.const	$push29=, 97
+	i32.ne  	$push3=, $pop2, $pop29
+	br_if   	4, $pop3        # 4: down to label0
 # BB#3:                                 # %for.inc
                                         #   in Loop: Header=BB1_2 Depth=1
-	i32.const	$push32=, 1
-	i32.add 	$push31=, $4, $pop32
-	tee_local	$push30=, $4=, $pop31
-	i32.lt_s	$push4=, $pop30, $0
-	br_if   	0, $pop4        # 0: up to label2
+	i32.const	$push33=, 1
+	i32.add 	$push32=, $3, $pop33
+	tee_local	$push31=, $3=, $pop32
+	i32.lt_s	$push4=, $pop31, $0
+	br_if   	0, $pop4        # 0: up to label4
 # BB#4:                                 # %for.cond3.preheader.loopexit
 	end_loop
 	i32.const	$push5=, u
-	i32.add 	$3=, $4, $pop5
-.LBB1_5:                                # %for.cond3.preheader
-	end_block                       # label1:
-	block   	
-	i32.const	$push33=, 1
-	i32.lt_s	$push6=, $1, $pop33
-	br_if   	0, $pop6        # 0: down to label3
-# BB#6:                                 # %for.body6.preheader
-	i32.const	$4=, 0
+	i32.add 	$0=, $3, $pop5
+	i32.const	$push34=, 1
+	i32.ge_s	$push6=, $1, $pop34
+	br_if   	1, $pop6        # 1: down to label2
+	br      	2               # 2: down to label1
+.LBB1_5:
+	end_block                       # label3:
+	i32.const	$0=, u
+	i32.const	$push35=, 1
+	i32.lt_s	$push7=, $1, $pop35
+	br_if   	1, $pop7        # 1: down to label1
+.LBB1_6:                                # %for.body6.preheader
+	end_block                       # label2:
+	i32.const	$3=, 0
 .LBB1_7:                                # %for.body6
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label4:
-	i32.add 	$push7=, $3, $4
-	i32.load8_s	$push8=, 0($pop7)
-	i32.ne  	$push9=, $pop8, $2
-	br_if   	2, $pop9        # 2: down to label0
+	loop    	                # label5:
+	i32.add 	$push8=, $0, $3
+	i32.load8_s	$push9=, 0($pop8)
+	i32.ne  	$push10=, $pop9, $2
+	br_if   	2, $pop10       # 2: down to label0
 # BB#8:                                 # %for.inc12
                                         #   in Loop: Header=BB1_7 Depth=1
-	i32.const	$push36=, 1
-	i32.add 	$push35=, $4, $pop36
-	tee_local	$push34=, $4=, $pop35
-	i32.lt_s	$push10=, $pop34, $1
-	br_if   	0, $pop10       # 0: up to label4
+	i32.const	$push38=, 1
+	i32.add 	$push37=, $3, $pop38
+	tee_local	$push36=, $3=, $pop37
+	i32.lt_s	$push11=, $pop36, $1
+	br_if   	0, $pop11       # 0: up to label5
 # BB#9:                                 # %for.body19.preheader.loopexit
 	end_loop
-	i32.add 	$3=, $3, $4
+	i32.add 	$0=, $0, $3
 .LBB1_10:                               # %for.body19.preheader
-	end_block                       # label3:
-	i32.load8_u	$push11=, 0($3)
-	i32.const	$push37=, 97
-	i32.ne  	$push12=, $pop11, $pop37
-	br_if   	0, $pop12       # 0: down to label0
-# BB#11:                                # %for.inc25
-	i32.load8_u	$push13=, 1($3)
-	i32.const	$push38=, 97
-	i32.ne  	$push14=, $pop13, $pop38
-	br_if   	0, $pop14       # 0: down to label0
-# BB#12:                                # %for.inc25.1
-	i32.load8_u	$push15=, 2($3)
+	end_block                       # label1:
+	i32.load8_u	$push12=, 0($0)
 	i32.const	$push39=, 97
-	i32.ne  	$push16=, $pop15, $pop39
-	br_if   	0, $pop16       # 0: down to label0
-# BB#13:                                # %for.inc25.2
-	i32.load8_u	$push17=, 3($3)
+	i32.ne  	$push13=, $pop12, $pop39
+	br_if   	0, $pop13       # 0: down to label0
+# BB#11:                                # %for.inc25
+	i32.load8_u	$push14=, 1($0)
 	i32.const	$push40=, 97
-	i32.ne  	$push18=, $pop17, $pop40
-	br_if   	0, $pop18       # 0: down to label0
-# BB#14:                                # %for.inc25.3
-	i32.load8_u	$push19=, 4($3)
+	i32.ne  	$push15=, $pop14, $pop40
+	br_if   	0, $pop15       # 0: down to label0
+# BB#12:                                # %for.inc25.1
+	i32.load8_u	$push16=, 2($0)
 	i32.const	$push41=, 97
-	i32.ne  	$push20=, $pop19, $pop41
-	br_if   	0, $pop20       # 0: down to label0
-# BB#15:                                # %for.inc25.4
-	i32.load8_u	$push21=, 5($3)
+	i32.ne  	$push17=, $pop16, $pop41
+	br_if   	0, $pop17       # 0: down to label0
+# BB#13:                                # %for.inc25.2
+	i32.load8_u	$push18=, 3($0)
 	i32.const	$push42=, 97
-	i32.ne  	$push22=, $pop21, $pop42
-	br_if   	0, $pop22       # 0: down to label0
-# BB#16:                                # %for.inc25.5
-	i32.load8_u	$push23=, 6($3)
+	i32.ne  	$push19=, $pop18, $pop42
+	br_if   	0, $pop19       # 0: down to label0
+# BB#14:                                # %for.inc25.3
+	i32.load8_u	$push20=, 4($0)
 	i32.const	$push43=, 97
-	i32.ne  	$push24=, $pop23, $pop43
-	br_if   	0, $pop24       # 0: down to label0
-# BB#17:                                # %for.inc25.6
-	i32.load8_u	$push25=, 7($3)
+	i32.ne  	$push21=, $pop20, $pop43
+	br_if   	0, $pop21       # 0: down to label0
+# BB#15:                                # %for.inc25.4
+	i32.load8_u	$push22=, 5($0)
 	i32.const	$push44=, 97
-	i32.ne  	$push26=, $pop25, $pop44
-	br_if   	0, $pop26       # 0: down to label0
+	i32.ne  	$push23=, $pop22, $pop44
+	br_if   	0, $pop23       # 0: down to label0
+# BB#16:                                # %for.inc25.5
+	i32.load8_u	$push24=, 6($0)
+	i32.const	$push45=, 97
+	i32.ne  	$push25=, $pop24, $pop45
+	br_if   	0, $pop25       # 0: down to label0
+# BB#17:                                # %for.inc25.6
+	i32.load8_u	$push26=, 7($0)
+	i32.const	$push46=, 97
+	i32.ne  	$push27=, $pop26, $pop46
+	br_if   	0, $pop27       # 0: down to label0
 # BB#18:                                # %for.inc25.7
 	return
 .LBB1_19:                               # %if.then23
@@ -142,7 +148,7 @@ main:                                   # @main
                                         #     Child Loop BB2_16 Depth 2
                                         #     Child Loop BB2_29 Depth 2
 	block   	
-	loop    	                # label6:
+	loop    	                # label7:
 	i32.const	$push83=, u
 	i32.const	$push82=, 97
 	i32.const	$push81=, 31
@@ -154,77 +160,77 @@ main:                                   # @main
 	i32.const	$push79=, 1
 	i32.lt_s	$push78=, $3, $pop79
 	tee_local	$push77=, $1=, $pop78
-	br_if   	0, $pop77       # 0: down to label7
+	br_if   	0, $pop77       # 0: down to label8
 # BB#2:                                 # %for.body6.i.preheader
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$2=, 0
 .LBB2_3:                                # %for.body6.i
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label8:
+	loop    	                # label9:
 	i32.add 	$push1=, $2, $0
 	i32.load8_u	$push2=, 0($pop1)
-	br_if   	3, $pop2        # 3: down to label5
+	br_if   	3, $pop2        # 3: down to label6
 # BB#4:                                 # %for.inc12.i
                                         #   in Loop: Header=BB2_3 Depth=2
 	i32.const	$push86=, 1
 	i32.add 	$push85=, $2, $pop86
 	tee_local	$push84=, $2=, $pop85
 	i32.lt_s	$push3=, $pop84, $3
-	br_if   	0, $pop3        # 0: up to label8
+	br_if   	0, $pop3        # 0: up to label9
 # BB#5:                                 # %for.body19.preheader.i.loopexit
                                         #   in Loop: Header=BB2_1 Depth=1
 	end_loop
 	i32.add 	$2=, $2, $0
 .LBB2_6:                                # %for.body19.preheader.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_block                       # label7:
+	end_block                       # label8:
 	i32.load8_u	$push4=, 0($2)
 	i32.const	$push87=, 97
 	i32.ne  	$push5=, $pop4, $pop87
-	br_if   	1, $pop5        # 1: down to label5
+	br_if   	1, $pop5        # 1: down to label6
 # BB#7:                                 # %for.inc25.i
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push6=, 1($2)
 	i32.const	$push88=, 97
 	i32.ne  	$push7=, $pop6, $pop88
-	br_if   	1, $pop7        # 1: down to label5
+	br_if   	1, $pop7        # 1: down to label6
 # BB#8:                                 # %for.inc25.1.i
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push8=, 2($2)
 	i32.const	$push89=, 97
 	i32.ne  	$push9=, $pop8, $pop89
-	br_if   	1, $pop9        # 1: down to label5
+	br_if   	1, $pop9        # 1: down to label6
 # BB#9:                                 # %for.inc25.2.i
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push10=, 3($2)
 	i32.const	$push90=, 97
 	i32.ne  	$push11=, $pop10, $pop90
-	br_if   	1, $pop11       # 1: down to label5
+	br_if   	1, $pop11       # 1: down to label6
 # BB#10:                                # %for.inc25.3.i
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push12=, 4($2)
 	i32.const	$push91=, 97
 	i32.ne  	$push13=, $pop12, $pop91
-	br_if   	1, $pop13       # 1: down to label5
+	br_if   	1, $pop13       # 1: down to label6
 # BB#11:                                # %for.inc25.4.i
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push14=, 5($2)
 	i32.const	$push92=, 97
 	i32.ne  	$push15=, $pop14, $pop92
-	br_if   	1, $pop15       # 1: down to label5
+	br_if   	1, $pop15       # 1: down to label6
 # BB#12:                                # %for.inc25.5.i
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push16=, 6($2)
 	i32.const	$push93=, 97
 	i32.ne  	$push17=, $pop16, $pop93
-	br_if   	1, $pop17       # 1: down to label5
+	br_if   	1, $pop17       # 1: down to label6
 # BB#13:                                # %for.inc25.6.i
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push18=, 7($2)
 	i32.const	$push94=, 97
 	i32.ne  	$push19=, $pop18, $pop94
-	br_if   	1, $pop19       # 1: down to label5
+	br_if   	1, $pop19       # 1: down to label6
 # BB#14:                                # %check.exit
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$2=, u
@@ -233,79 +239,79 @@ main:                                   # @main
 	i32.load8_u	$push20=, A($pop95)
 	i32.call	$drop=, memset@FUNCTION, $pop96, $pop20, $3
 	block   	
-	br_if   	0, $1           # 0: down to label9
+	br_if   	0, $1           # 0: down to label10
 # BB#15:                                # %for.body6.i241.preheader
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$2=, 0
 .LBB2_16:                               # %for.body6.i241
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label10:
+	loop    	                # label11:
 	i32.add 	$push21=, $2, $0
 	i32.load8_u	$push22=, 0($pop21)
 	i32.const	$push97=, 65
 	i32.ne  	$push23=, $pop22, $pop97
-	br_if   	3, $pop23       # 3: down to label5
+	br_if   	3, $pop23       # 3: down to label6
 # BB#17:                                # %for.inc12.i246
                                         #   in Loop: Header=BB2_16 Depth=2
 	i32.const	$push100=, 1
 	i32.add 	$push99=, $2, $pop100
 	tee_local	$push98=, $2=, $pop99
 	i32.lt_s	$push24=, $pop98, $3
-	br_if   	0, $pop24       # 0: up to label10
+	br_if   	0, $pop24       # 0: up to label11
 # BB#18:                                # %for.body19.preheader.i249.loopexit
                                         #   in Loop: Header=BB2_1 Depth=1
 	end_loop
 	i32.add 	$2=, $2, $0
 .LBB2_19:                               # %for.body19.preheader.i249
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_block                       # label9:
+	end_block                       # label10:
 	i32.load8_u	$push25=, 0($2)
 	i32.const	$push101=, 97
 	i32.ne  	$push26=, $pop25, $pop101
-	br_if   	1, $pop26       # 1: down to label5
+	br_if   	1, $pop26       # 1: down to label6
 # BB#20:                                # %for.inc25.i253
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push27=, 1($2)
 	i32.const	$push102=, 97
 	i32.ne  	$push28=, $pop27, $pop102
-	br_if   	1, $pop28       # 1: down to label5
+	br_if   	1, $pop28       # 1: down to label6
 # BB#21:                                # %for.inc25.1.i256
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push29=, 2($2)
 	i32.const	$push103=, 97
 	i32.ne  	$push30=, $pop29, $pop103
-	br_if   	1, $pop30       # 1: down to label5
+	br_if   	1, $pop30       # 1: down to label6
 # BB#22:                                # %for.inc25.2.i259
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push31=, 3($2)
 	i32.const	$push104=, 97
 	i32.ne  	$push32=, $pop31, $pop104
-	br_if   	1, $pop32       # 1: down to label5
+	br_if   	1, $pop32       # 1: down to label6
 # BB#23:                                # %for.inc25.3.i262
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push33=, 4($2)
 	i32.const	$push105=, 97
 	i32.ne  	$push34=, $pop33, $pop105
-	br_if   	1, $pop34       # 1: down to label5
+	br_if   	1, $pop34       # 1: down to label6
 # BB#24:                                # %for.inc25.4.i265
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push35=, 5($2)
 	i32.const	$push106=, 97
 	i32.ne  	$push36=, $pop35, $pop106
-	br_if   	1, $pop36       # 1: down to label5
+	br_if   	1, $pop36       # 1: down to label6
 # BB#25:                                # %for.inc25.5.i268
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push37=, 6($2)
 	i32.const	$push107=, 97
 	i32.ne  	$push38=, $pop37, $pop107
-	br_if   	1, $pop38       # 1: down to label5
+	br_if   	1, $pop38       # 1: down to label6
 # BB#26:                                # %for.inc25.6.i271
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push39=, 7($2)
 	i32.const	$push108=, 97
 	i32.ne  	$push40=, $pop39, $pop108
-	br_if   	1, $pop40       # 1: down to label5
+	br_if   	1, $pop40       # 1: down to label6
 # BB#27:                                # %check.exit272
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$2=, u
@@ -313,79 +319,79 @@ main:                                   # @main
 	i32.const	$push109=, 66
 	i32.call	$drop=, memset@FUNCTION, $pop110, $pop109, $3
 	block   	
-	br_if   	0, $1           # 0: down to label11
+	br_if   	0, $1           # 0: down to label12
 # BB#28:                                # %for.body6.i278.preheader
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$2=, 0
 .LBB2_29:                               # %for.body6.i278
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label12:
+	loop    	                # label13:
 	i32.add 	$push41=, $2, $0
 	i32.load8_u	$push42=, 0($pop41)
 	i32.const	$push111=, 66
 	i32.ne  	$push43=, $pop42, $pop111
-	br_if   	3, $pop43       # 3: down to label5
+	br_if   	3, $pop43       # 3: down to label6
 # BB#30:                                # %for.inc12.i283
                                         #   in Loop: Header=BB2_29 Depth=2
 	i32.const	$push114=, 1
 	i32.add 	$push113=, $2, $pop114
 	tee_local	$push112=, $2=, $pop113
 	i32.lt_s	$push44=, $pop112, $3
-	br_if   	0, $pop44       # 0: up to label12
+	br_if   	0, $pop44       # 0: up to label13
 # BB#31:                                # %for.body19.preheader.i286.loopexit
                                         #   in Loop: Header=BB2_1 Depth=1
 	end_loop
 	i32.add 	$2=, $2, $0
 .LBB2_32:                               # %for.body19.preheader.i286
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_block                       # label11:
+	end_block                       # label12:
 	i32.load8_u	$push45=, 0($2)
 	i32.const	$push115=, 97
 	i32.ne  	$push46=, $pop45, $pop115
-	br_if   	1, $pop46       # 1: down to label5
+	br_if   	1, $pop46       # 1: down to label6
 # BB#33:                                # %for.inc25.i290
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push47=, 1($2)
 	i32.const	$push116=, 97
 	i32.ne  	$push48=, $pop47, $pop116
-	br_if   	1, $pop48       # 1: down to label5
+	br_if   	1, $pop48       # 1: down to label6
 # BB#34:                                # %for.inc25.1.i293
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push49=, 2($2)
 	i32.const	$push117=, 97
 	i32.ne  	$push50=, $pop49, $pop117
-	br_if   	1, $pop50       # 1: down to label5
+	br_if   	1, $pop50       # 1: down to label6
 # BB#35:                                # %for.inc25.2.i296
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push51=, 3($2)
 	i32.const	$push118=, 97
 	i32.ne  	$push52=, $pop51, $pop118
-	br_if   	1, $pop52       # 1: down to label5
+	br_if   	1, $pop52       # 1: down to label6
 # BB#36:                                # %for.inc25.3.i299
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push53=, 4($2)
 	i32.const	$push119=, 97
 	i32.ne  	$push54=, $pop53, $pop119
-	br_if   	1, $pop54       # 1: down to label5
+	br_if   	1, $pop54       # 1: down to label6
 # BB#37:                                # %for.inc25.4.i302
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push55=, 5($2)
 	i32.const	$push120=, 97
 	i32.ne  	$push56=, $pop55, $pop120
-	br_if   	1, $pop56       # 1: down to label5
+	br_if   	1, $pop56       # 1: down to label6
 # BB#38:                                # %for.inc25.5.i305
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push57=, 6($2)
 	i32.const	$push121=, 97
 	i32.ne  	$push58=, $pop57, $pop121
-	br_if   	1, $pop58       # 1: down to label5
+	br_if   	1, $pop58       # 1: down to label6
 # BB#39:                                # %for.inc25.6.i308
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push59=, 7($2)
 	i32.const	$push122=, 97
 	i32.ne  	$push60=, $pop59, $pop122
-	br_if   	1, $pop60       # 1: down to label5
+	br_if   	1, $pop60       # 1: down to label6
 # BB#40:                                # %for.cond
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push126=, 1
@@ -393,13 +399,13 @@ main:                                   # @main
 	tee_local	$push124=, $3=, $pop125
 	i32.const	$push123=, 15
 	i32.lt_s	$push61=, $pop124, $pop123
-	br_if   	0, $pop61       # 0: up to label6
+	br_if   	0, $pop61       # 0: up to label7
 # BB#41:                                # %for.body13.preheader
 	end_loop
 	i32.const	$3=, 0
 .LBB2_42:                               # %for.body13
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label13:
+	loop    	                # label14:
 	i32.const	$push143=, u
 	i32.const	$push142=, 97
 	i32.const	$push141=, 31
@@ -426,13 +432,13 @@ main:                                   # @main
 	tee_local	$push128=, $3=, $pop129
 	i32.const	$push127=, 15
 	i32.ne  	$push63=, $pop128, $pop127
-	br_if   	0, $pop63       # 0: up to label13
+	br_if   	0, $pop63       # 0: up to label14
 # BB#43:                                # %for.body33.preheader
 	end_loop
 	i32.const	$3=, 0
 .LBB2_44:                               # %for.body33
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label14:
+	loop    	                # label15:
 	i32.const	$push160=, u
 	i32.const	$push159=, 97
 	i32.const	$push158=, 31
@@ -459,13 +465,13 @@ main:                                   # @main
 	tee_local	$push145=, $3=, $pop146
 	i32.const	$push144=, 15
 	i32.ne  	$push65=, $pop145, $pop144
-	br_if   	0, $pop65       # 0: up to label14
+	br_if   	0, $pop65       # 0: up to label15
 # BB#45:                                # %for.body53.preheader
 	end_loop
 	i32.const	$3=, 0
 .LBB2_46:                               # %for.body53
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label15:
+	loop    	                # label16:
 	i32.const	$push177=, u
 	i32.const	$push176=, 97
 	i32.const	$push175=, 31
@@ -492,13 +498,13 @@ main:                                   # @main
 	tee_local	$push162=, $3=, $pop163
 	i32.const	$push161=, 15
 	i32.ne  	$push67=, $pop162, $pop161
-	br_if   	0, $pop67       # 0: up to label15
+	br_if   	0, $pop67       # 0: up to label16
 # BB#47:                                # %for.body73.preheader
 	end_loop
 	i32.const	$3=, 0
 .LBB2_48:                               # %for.body73
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label16:
+	loop    	                # label17:
 	i32.const	$push194=, u
 	i32.const	$push193=, 97
 	i32.const	$push192=, 31
@@ -525,13 +531,13 @@ main:                                   # @main
 	tee_local	$push179=, $3=, $pop180
 	i32.const	$push178=, 15
 	i32.ne  	$push69=, $pop179, $pop178
-	br_if   	0, $pop69       # 0: up to label16
+	br_if   	0, $pop69       # 0: up to label17
 # BB#49:                                # %for.body93.preheader
 	end_loop
 	i32.const	$3=, 0
 .LBB2_50:                               # %for.body93
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label17:
+	loop    	                # label18:
 	i32.const	$push211=, u
 	i32.const	$push210=, 97
 	i32.const	$push209=, 31
@@ -558,13 +564,13 @@ main:                                   # @main
 	tee_local	$push196=, $3=, $pop197
 	i32.const	$push195=, 15
 	i32.ne  	$push71=, $pop196, $pop195
-	br_if   	0, $pop71       # 0: up to label17
+	br_if   	0, $pop71       # 0: up to label18
 # BB#51:                                # %for.body113.preheader
 	end_loop
 	i32.const	$3=, 0
 .LBB2_52:                               # %for.body113
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label18:
+	loop    	                # label19:
 	i32.const	$push228=, u
 	i32.const	$push227=, 97
 	i32.const	$push226=, 31
@@ -591,13 +597,13 @@ main:                                   # @main
 	tee_local	$push213=, $3=, $pop214
 	i32.const	$push212=, 15
 	i32.ne  	$push73=, $pop213, $pop212
-	br_if   	0, $pop73       # 0: up to label18
+	br_if   	0, $pop73       # 0: up to label19
 # BB#53:                                # %for.body133.preheader
 	end_loop
 	i32.const	$3=, 0
 .LBB2_54:                               # %for.body133
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label19:
+	loop    	                # label20:
 	i32.const	$push245=, u
 	i32.const	$push244=, 97
 	i32.const	$push243=, 31
@@ -624,14 +630,14 @@ main:                                   # @main
 	tee_local	$push230=, $3=, $pop231
 	i32.const	$push229=, 15
 	i32.ne  	$push75=, $pop230, $pop229
-	br_if   	0, $pop75       # 0: up to label19
+	br_if   	0, $pop75       # 0: up to label20
 # BB#55:                                # %for.end149
 	end_loop
 	i32.const	$push76=, 0
 	call    	exit@FUNCTION, $pop76
 	unreachable
 .LBB2_56:                               # %if.then23.i287
-	end_block                       # label5:
+	end_block                       # label6:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -654,6 +660,6 @@ u:
 	.size	u, 32
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/pr15296.c.s
+++ b/test/torture-s/pr15296.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr15296.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr15296.c"
 	.section	.text.f,"ax",@progbits
 	.hidden	f
 	.globl	f
@@ -17,61 +17,60 @@ f:                                      # @f
 .LBB0_2:                                # %if.end.split
 	end_loop
 	end_block                       # label0:
-	i32.const	$4=, 0
-	block   	
-	block   	
 	block   	
 	block   	
 	block   	
 	i32.eqz 	$push16=, $3
-	br_if   	0, $pop16       # 0: down to label6
+	br_if   	0, $pop16       # 0: down to label4
 # BB#3:                                 # %if.end3
-	copy_local	$4=, $5
-	i32.eqz 	$push17=, $5
-	br_if   	1, $pop17       # 1: down to label5
-.LBB0_4:                                # %l3
-	end_block                       # label6:
-	i32.const	$push4=, 4
-	i32.add 	$push5=, $1, $pop4
-	i32.store	0($pop5), $4
-	i32.const	$push6=, 8
-	i32.add 	$push7=, $1, $pop6
-	i32.load	$push13=, 0($pop7)
-	tee_local	$push12=, $3=, $pop13
-	br_if   	1, $pop12       # 1: down to label4
-# BB#5:                                 # %if.end19
-	i32.eqz 	$push18=, $4
-	br_if   	2, $pop18       # 2: down to label3
-# BB#6:                                 # %if.end24
-	i32.const	$push8=, 8
-	i32.add 	$push9=, $4, $pop8
-	i32.store	0($pop9), $3
-	return
-.LBB0_7:                                # %if.end6
-	end_block                       # label5:
+	br_if   	1, $5           # 1: down to label3
+# BB#4:                                 # %if.end6
 	i32.const	$push2=, 4
 	i32.add 	$push3=, $1, $pop2
 	i32.load	$push0=, 0($1)
-	i32.load	$push15=, 0($pop0)
-	tee_local	$push14=, $3=, $pop15
-	i32.store	0($pop3), $pop14
-	br_if   	2, $3           # 2: down to label2
-# BB#8:
+	i32.load	$push13=, 0($pop0)
+	tee_local	$push12=, $5=, $pop13
+	i32.store	0($pop3), $pop12
+	br_if   	2, $5           # 2: down to label2
+# BB#5:
 	i32.const	$push10=, 12
 	i32.const	$push11=, -1
 	i32.store	0($pop10), $pop11
 	return
-.LBB0_9:                                # %if.then18
+.LBB0_6:
 	end_block                       # label4:
-	call    	g@FUNCTION, $3, $3
-	unreachable
-.LBB0_10:                               # %if.then23
+	i32.const	$5=, 0
+.LBB0_7:                                # %l3
 	end_block                       # label3:
-	call    	g@FUNCTION, $3, $3
+	i32.const	$push4=, 4
+	i32.add 	$push5=, $1, $pop4
+	i32.store	0($pop5), $5
+	block   	
+	block   	
+	i32.const	$push6=, 8
+	i32.add 	$push7=, $1, $pop6
+	i32.load	$push15=, 0($pop7)
+	tee_local	$push14=, $3=, $pop15
+	br_if   	0, $pop14       # 0: down to label6
+# BB#8:                                 # %if.end19
+	i32.eqz 	$push17=, $5
+	br_if   	1, $pop17       # 1: down to label5
+# BB#9:                                 # %if.end24
+	i32.const	$push8=, 8
+	i32.add 	$push9=, $5, $pop8
+	i32.store	0($pop9), $3
+	return
+.LBB0_10:                               # %if.then18
+	end_block                       # label6:
+	call    	g@FUNCTION, $5, $5
 	unreachable
-.LBB0_11:                               # %if.then11
+.LBB0_11:                               # %if.then23
+	end_block                       # label5:
+	call    	g@FUNCTION, $5, $5
+	unreachable
+.LBB0_12:                               # %if.then11
 	end_block                       # label2:
-	call    	g@FUNCTION, $3, $3
+	call    	g@FUNCTION, $5, $5
 	unreachable
 	.endfunc
 .Lfunc_end0:
@@ -208,6 +207,6 @@ main:                                   # @main
 	.size	.Lmain.s, 20
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/pr24716.c.s
+++ b/test/torture-s/pr24716.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr24716.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr24716.c"
 	.section	.text.f,"ax",@progbits
 	.hidden	f
 	.globl	f
@@ -7,146 +7,300 @@
 f:                                      # @f
 	.param  	i32, i32
 	.result 	i32
-	.local  	i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$5=, 0
-	i32.const	$2=, 0
-.LBB0_1:                                # %for.cond
-                                        # =>This Loop Header: Depth=1
-                                        #     Child Loop BB0_6 Depth 2
-                                        #     Child Loop BB0_8 Depth 2
-                                        #       Child Loop BB0_9 Depth 3
-                                        #     Child Loop BB0_14 Depth 2
-                                        #       Child Loop BB0_15 Depth 3
-	block   	
-	loop    	                # label1:
-	block   	
-	block   	
-	i32.const	$push25=, 3
-	i32.lt_s	$push0=, $5, $pop25
-	br_if   	0, $pop0        # 0: down to label3
-# BB#2:                                 # %if.end.thread
-                                        #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push27=, 1
-	i32.add 	$5=, $5, $pop27
-	i32.const	$push26=, -1
-	i32.add 	$3=, $2, $pop26
-	br      	1               # 1: down to label2
-.LBB0_3:                                # %if.end
-                                        #   in Loop: Header=BB0_1 Depth=1
-	end_block                       # label3:
-	i32.const	$3=, 0
-	i32.const	$push28=, 1
-	i32.eq  	$push1=, $2, $pop28
-	br_if   	2, $pop1        # 2: down to label0
-.LBB0_4:                                # %while.cond.preheader
-                                        #   in Loop: Header=BB0_1 Depth=1
-	end_block                       # label2:
-	block   	
-	i32.le_s	$push2=, $5, $1
-	br_if   	0, $pop2        # 0: down to label4
-# BB#5:                                 # %while.body.lr.ph
-                                        #   in Loop: Header=BB0_1 Depth=1
-	i32.eq  	$4=, $3, $1
-.LBB0_6:                                # %while.body
-                                        #   Parent Loop BB0_1 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop    	                # label5:
-	i32.add 	$push13=, $5, $4
-	tee_local	$push12=, $5=, $pop13
-	i32.gt_s	$push3=, $pop12, $1
-	br_if   	0, $pop3        # 0: up to label5
-.LBB0_7:                                # %do.body10.preheader
-                                        #   in Loop: Header=BB0_1 Depth=1
-	end_loop
-	end_block                       # label4:
-	i32.const	$push15=, 2
-	i32.shl 	$push4=, $0, $pop15
-	i32.const	$push14=, W
-	i32.add 	$2=, $pop4, $pop14
-.LBB0_8:                                # %do.body10
-                                        #   Parent Loop BB0_1 Depth=1
-                                        # =>  This Loop Header: Depth=2
-                                        #       Child Loop BB0_9 Depth 3
-	loop    	                # label6:
-	i32.load	$4=, 0($2)
-.LBB0_9:                                # %do.body11
-                                        #   Parent Loop BB0_1 Depth=1
-                                        #     Parent Loop BB0_8 Depth=2
-                                        # =>    This Inner Loop Header: Depth=3
-	loop    	                # label7:
-	block   	
-	i32.eqz 	$push29=, $4
-	br_if   	0, $pop29       # 0: down to label8
-# BB#10:                                # %if.then13
-                                        #   in Loop: Header=BB0_9 Depth=3
-	i32.const	$push16=, 0
-	i32.store	0($2), $pop16
-	i32.const	$5=, 1
-.LBB0_11:                               # %do.cond16
-                                        #   in Loop: Header=BB0_9 Depth=3
-	end_block                       # label8:
 	i32.const	$4=, 0
-	i32.const	$push17=, 1
-	i32.lt_s	$push5=, $1, $pop17
-	br_if   	0, $pop5        # 0: up to label7
-# BB#12:                                # %do.cond19
-                                        #   in Loop: Header=BB0_8 Depth=2
-	end_loop
-	i32.const	$push18=, 0
-	i32.gt_s	$push6=, $0, $pop18
-	br_if   	0, $pop6        # 0: up to label6
-# BB#13:                                # %do.body22.preheader
-                                        #   in Loop: Header=BB0_1 Depth=1
-	end_loop
-	copy_local	$4=, $0
-.LBB0_14:                               # %do.body22
-                                        #   Parent Loop BB0_1 Depth=1
-                                        # =>  This Loop Header: Depth=2
-                                        #       Child Loop BB0_15 Depth 3
-	loop    	                # label9:
-	i32.const	$push20=, 2
-	i32.shl 	$push7=, $4, $pop20
-	i32.const	$push19=, Link
-	i32.add 	$push8=, $pop7, $pop19
-	i32.load	$4=, 0($pop8)
-	i32.const	$1=, 0
-.LBB0_15:                               # %while.cond24
-                                        #   Parent Loop BB0_1 Depth=1
-                                        #     Parent Loop BB0_14 Depth=2
-                                        # =>    This Inner Loop Header: Depth=3
 	block   	
-	loop    	                # label11:
-	i32.ge_s	$push9=, $1, $3
-	br_if   	1, $pop9        # 1: down to label10
-# BB#16:                                # %while.body26
-                                        #   in Loop: Header=BB0_15 Depth=3
-	i32.const	$push23=, -1
-	i32.eq  	$push11=, $4, $pop23
-	br_if   	0, $pop11       # 0: up to label11
-# BB#17:                                # %if.then28
-                                        #   in Loop: Header=BB0_15 Depth=3
-	i32.const	$push22=, 1
-	i32.add 	$1=, $1, $pop22
-	i32.const	$push21=, 1
-	i32.add 	$5=, $5, $pop21
-	br      	0               # 0: up to label11
-.LBB0_18:                               # %do.cond33
-                                        #   in Loop: Header=BB0_14 Depth=2
-	end_loop
-	end_block                       # label10:
-	i32.const	$0=, -1
-	i32.const	$2=, 1
-	i32.const	$push24=, -1
-	i32.ne  	$push10=, $4, $pop24
-	br_if   	0, $pop10       # 0: up to label9
-	br      	1               # 1: up to label1
-.LBB0_19:                               # %for.end
-	end_loop
-	end_loop
+	block   	
+	i32.const	$push17=, 0
+	i32.const	$push16=, 3
+	i32.lt_s	$push0=, $pop17, $pop16
+	br_if   	0, $pop0        # 0: down to label1
+# BB#1:
+	i32.const	$6=, 12
+	br      	1               # 1: down to label0
+.LBB0_2:
+	end_block                       # label1:
+	i32.const	$6=, 10
+.LBB0_3:                                # =>This Inner Loop Header: Depth=1
 	end_block                       # label0:
-	copy_local	$push30=, $5
-                                        # fallthrough-return: $pop30
+	loop    	i32             # label2:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$6, 3, 6, 7, 8, 9, 10, 11, 12, 16, 0, 2, 17, 1, 4, 5, 15, 14, 13, 13 # 3: down to label33
+                                        # 6: down to label30
+                                        # 7: down to label29
+                                        # 8: down to label28
+                                        # 9: down to label27
+                                        # 10: down to label26
+                                        # 11: down to label25
+                                        # 12: down to label24
+                                        # 16: down to label20
+                                        # 0: down to label36
+                                        # 2: down to label34
+                                        # 17: down to label19
+                                        # 1: down to label35
+                                        # 4: down to label32
+                                        # 5: down to label31
+                                        # 15: down to label21
+                                        # 14: down to label22
+                                        # 13: down to label23
+.LBB0_4:                                #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label36:
+	i32.const	$4=, 1
+	i32.const	$0=, -1
+	i32.const	$push18=, 3
+	i32.lt_s	$push1=, $5, $pop18
+	br_if   	17, $pop1       # 17: down to label18
+# BB#5:                                 #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$6=, 12
+	br      	33              # 33: up to label2
+.LBB0_6:                                # %if.end.thread
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label35:
+	i32.const	$push22=, -1
+	i32.add 	$3=, $4, $pop22
+	i32.const	$push21=, 1
+	i32.add 	$push20=, $5, $pop21
+	tee_local	$push19=, $5=, $pop20
+	i32.gt_s	$push3=, $pop19, $1
+	br_if   	20, $pop3       # 20: down to label14
+	br      	21              # 21: down to label13
+.LBB0_7:                                # %if.end
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label34:
+	i32.const	$3=, 0
+	i32.const	$push23=, 1
+	i32.eq  	$push2=, $4, $pop23
+	br_if   	17, $pop2       # 17: down to label16
+# BB#8:                                 #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$6=, 0
+	br      	31              # 31: up to label2
+.LBB0_9:                                # %while.cond.preheader
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label33:
+	i32.le_s	$push4=, $5, $1
+	br_if   	15, $pop4       # 15: down to label17
+# BB#10:                                #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$6=, 13
+	br      	30              # 30: up to label2
+.LBB0_11:                               # %while.body.lr.ph
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label32:
+	i32.eq  	$4=, $3, $1
+# BB#12:                                #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$6=, 14
+	br      	29              # 29: up to label2
+.LBB0_13:                               # %while.body
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label31:
+	i32.add 	$push25=, $5, $4
+	tee_local	$push24=, $5=, $pop25
+	i32.gt_s	$push5=, $pop24, $1
+	br_if   	15, $pop5       # 15: down to label15
+# BB#14:                                #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$6=, 1
+	br      	28              # 28: up to label2
+.LBB0_15:                               # %do.body10.preheader
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label30:
+	i32.const	$push27=, 2
+	i32.shl 	$push6=, $0, $pop27
+	i32.const	$push26=, W
+	i32.add 	$2=, $pop6, $pop26
+# BB#16:                                #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$6=, 2
+	br      	27              # 27: up to label2
+.LBB0_17:                               # %do.body10
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label29:
+	i32.load	$4=, 0($2)
+# BB#18:                                #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$6=, 3
+	br      	26              # 26: up to label2
+.LBB0_19:                               # %do.body11
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label28:
+	i32.eqz 	$push37=, $4
+	br_if   	17, $pop37      # 17: down to label10
+# BB#20:                                #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$6=, 4
+	br      	25              # 25: up to label2
+.LBB0_21:                               # %if.then13
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label27:
+	i32.const	$push28=, 0
+	i32.store	0($2), $pop28
+	i32.const	$5=, 1
+# BB#22:                                #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$6=, 5
+	br      	24              # 24: up to label2
+.LBB0_23:                               # %do.cond16
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label26:
+	i32.const	$4=, 0
+	i32.const	$push29=, 1
+	i32.lt_s	$push7=, $1, $pop29
+	br_if   	14, $pop7       # 14: down to label11
+# BB#24:                                #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$6=, 6
+	br      	23              # 23: up to label2
+.LBB0_25:                               # %do.cond19
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label25:
+	i32.const	$push30=, 0
+	i32.gt_s	$push8=, $0, $pop30
+	br_if   	12, $pop8       # 12: down to label12
+# BB#26:                                #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$6=, 7
+	br      	22              # 22: up to label2
+.LBB0_27:                               # %do.body22
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label24:
+	i32.const	$push33=, 2
+	i32.shl 	$push9=, $0, $pop33
+	i32.const	$push32=, Link
+	i32.add 	$push10=, $pop9, $pop32
+	i32.load	$0=, 0($pop10)
+	i32.const	$1=, 0
+	i32.const	$push31=, 0
+	i32.lt_s	$push11=, $pop31, $3
+	br_if   	17, $pop11      # 17: down to label6
+	br      	18              # 18: down to label5
+.LBB0_28:                               # %if.then28
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label23:
+	i32.const	$push35=, 1
+	i32.add 	$1=, $1, $pop35
+	i32.const	$push34=, 1
+	i32.add 	$5=, $5, $pop34
+# BB#29:                                #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$6=, 16
+	br      	20              # 20: up to label2
+.LBB0_30:                               # %while.cond24
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label22:
+	i32.ge_s	$push12=, $1, $3
+	br_if   	14, $pop12      # 14: down to label7
+# BB#31:                                #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$6=, 15
+	br      	19              # 19: up to label2
+.LBB0_32:                               # %while.body26
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label21:
+	i32.const	$push36=, -1
+	i32.eq  	$push15=, $0, $pop36
+	br_if   	17, $pop15      # 17: down to label3
+	br      	16              # 16: down to label4
+.LBB0_33:                               # %do.cond33
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label20:
+	i32.const	$push13=, -1
+	i32.ne  	$push14=, $0, $pop13
+	br_if   	10, $pop14      # 10: down to label9
+	br      	11              # 11: down to label8
+.LBB0_34:                               # %for.end
+	end_block                       # label19:
+	return  	$5
+.LBB0_35:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label18:
+	i32.const	$6=, 10
+	br      	15              # 15: up to label2
+.LBB0_36:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label17:
+	i32.const	$6=, 1
+	br      	14              # 14: up to label2
+.LBB0_37:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label16:
+	i32.const	$6=, 11
+	br      	13              # 13: up to label2
+.LBB0_38:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label15:
+	i32.const	$6=, 14
+	br      	12              # 12: up to label2
+.LBB0_39:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label14:
+	i32.const	$6=, 13
+	br      	11              # 11: up to label2
+.LBB0_40:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label13:
+	i32.const	$6=, 1
+	br      	10              # 10: up to label2
+.LBB0_41:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label12:
+	i32.const	$6=, 2
+	br      	9               # 9: up to label2
+.LBB0_42:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label11:
+	i32.const	$6=, 3
+	br      	8               # 8: up to label2
+.LBB0_43:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label10:
+	i32.const	$6=, 5
+	br      	7               # 7: up to label2
+.LBB0_44:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label9:
+	i32.const	$6=, 7
+	br      	6               # 6: up to label2
+.LBB0_45:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label8:
+	i32.const	$6=, 9
+	br      	5               # 5: up to label2
+.LBB0_46:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label7:
+	i32.const	$6=, 8
+	br      	4               # 4: up to label2
+.LBB0_47:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label6:
+	i32.const	$6=, 15
+	br      	3               # 3: up to label2
+.LBB0_48:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label5:
+	i32.const	$6=, 8
+	br      	2               # 2: up to label2
+.LBB0_49:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label4:
+	i32.const	$6=, 17
+	br      	1               # 1: up to label2
+.LBB0_50:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label3:
+	i32.const	$6=, 16
+	br      	0               # 0: up to label2
+.LBB0_51:
+	end_loop
 	.endfunc
 .Lfunc_end0:
 	.size	f, .Lfunc_end0-f
@@ -157,119 +311,235 @@ f:                                      # @f
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$4=, 0
 	i32.const	$1=, 2
 	i32.const	$2=, 0
 	i32.const	$3=, 0
-.LBB1_1:                                # %for.cond.i
-                                        # =>This Loop Header: Depth=1
-                                        #     Child Loop BB1_6 Depth 2
-                                        #     Child Loop BB1_8 Depth 2
-                                        #     Child Loop BB1_11 Depth 2
-	loop    	i32             # label12:
+	block   	
+	block   	
+	i32.const	$push13=, 0
+	i32.const	$push12=, 3
+	i32.lt_s	$push0=, $pop13, $pop12
+	br_if   	0, $pop0        # 0: down to label38
+# BB#1:
+	i32.const	$5=, 11
+	br      	1               # 1: down to label37
+.LBB1_2:
+	end_block                       # label38:
+	i32.const	$5=, 7
+.LBB1_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label37:
+	loop    	i32             # label39:
 	block   	
 	block   	
 	block   	
 	block   	
-	i32.const	$push10=, 3
-	i32.lt_s	$push0=, $2, $pop10
-	br_if   	0, $pop0        # 0: down to label16
-# BB#2:                                 # %if.end.thread.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$2=, $2, $pop12
-	i32.const	$push11=, -1
-	i32.add 	$0=, $3, $pop11
-	br      	1               # 1: down to label15
-.LBB1_3:                                # %if.end.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label16:
-	i32.const	$0=, 0
-	i32.const	$push13=, 1
-	i32.eq  	$push1=, $3, $pop13
-	br_if   	1, $pop1        # 1: down to label14
-.LBB1_4:                                # %while.cond.preheader.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label15:
 	block   	
-	i32.le_s	$push3=, $2, $1
-	br_if   	0, $pop3        # 0: down to label17
-# BB#5:                                 # %while.body.lr.ph.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.eq  	$3=, $0, $1
-.LBB1_6:                                # %while.body.i
-                                        #   Parent Loop BB1_1 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop    	                # label18:
-	i32.add 	$push15=, $2, $3
-	tee_local	$push14=, $2=, $pop15
-	i32.gt_s	$push4=, $pop14, $1
-	br_if   	0, $pop4        # 0: up to label18
-.LBB1_7:                                # %do.body10.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_loop
-	end_block                       # label17:
-	i32.const	$push19=, 2
-	i32.shl 	$push5=, $4, $pop19
-	i32.const	$push18=, W
-	i32.add 	$push17=, $pop5, $pop18
-	tee_local	$push16=, $0=, $pop17
-	i32.load	$3=, 0($pop16)
-.LBB1_8:                                # %do.body11.i
-                                        #   Parent Loop BB1_1 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop    	                # label19:
 	block   	
-	i32.eqz 	$push25=, $3
-	br_if   	0, $pop25       # 0: down to label20
-# BB#9:                                 # %if.then13.i
-                                        #   in Loop: Header=BB1_8 Depth=2
-	i32.const	$push20=, 0
-	i32.store	0($0), $pop20
-	i32.const	$2=, 1
-.LBB1_10:                               # %do.cond16.i
-                                        #   in Loop: Header=BB1_8 Depth=2
-	end_block                       # label20:
-	i32.const	$3=, 0
-	i32.eqz 	$push26=, $1
-	br_if   	0, $pop26       # 0: up to label19
-.LBB1_11:                               # %do.cond33.i
-                                        #   Parent Loop BB1_1 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	end_loop
-	loop    	                # label21:
-	i32.const	$push24=, 2
-	i32.shl 	$push7=, $4, $pop24
-	i32.const	$push23=, Link
-	i32.add 	$push8=, $pop7, $pop23
-	i32.load	$push22=, 0($pop8)
-	tee_local	$push21=, $4=, $pop22
-	i32.const	$push6=, -1
-	i32.ne  	$push9=, $pop21, $pop6
-	br_if   	0, $pop9        # 0: up to label21
-	br      	2               # 2: down to label13
-.LBB1_12:                               # %f.exit
-	end_loop
-	end_block                       # label14:
 	block   	
-	i32.eqz 	$push27=, $2
-	br_if   	0, $pop27       # 0: down to label22
-# BB#13:                                # %if.end
-	i32.const	$push2=, 0
-	return  	$pop2
-.LBB1_14:                               # %if.then
-	end_block                       # label22:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_15:                               #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label13:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$5, 3, 6, 7, 8, 9, 10, 0, 2, 11, 12, 13, 1, 4, 5, 5 # 3: down to label61
+                                        # 6: down to label58
+                                        # 7: down to label57
+                                        # 8: down to label56
+                                        # 9: down to label55
+                                        # 10: down to label54
+                                        # 0: down to label64
+                                        # 2: down to label62
+                                        # 11: down to label53
+                                        # 12: down to label52
+                                        # 13: down to label51
+                                        # 1: down to label63
+                                        # 4: down to label60
+                                        # 5: down to label59
+.LBB1_4:                                #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label64:
 	i32.const	$3=, 1
 	i32.const	$1=, 0
 	i32.const	$4=, -1
-	br      	0               # 0: up to label12
-.LBB1_16:
+	i32.const	$push14=, 3
+	i32.lt_s	$push1=, $2, $pop14
+	br_if   	13, $pop1       # 13: down to label50
+# BB#5:                                 #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$5=, 11
+	br      	24              # 24: up to label39
+.LBB1_6:                                # %if.end.thread.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label63:
+	i32.const	$push18=, -1
+	i32.add 	$0=, $3, $pop18
+	i32.const	$push17=, 1
+	i32.add 	$push16=, $2, $pop17
+	tee_local	$push15=, $2=, $pop16
+	i32.gt_s	$push4=, $pop15, $1
+	br_if   	16, $pop4       # 16: down to label46
+	br      	17              # 17: down to label45
+.LBB1_7:                                # %if.end.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label62:
+	i32.const	$0=, 0
+	i32.const	$push19=, 1
+	i32.eq  	$push2=, $3, $pop19
+	br_if   	13, $pop2       # 13: down to label48
+# BB#8:                                 #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$5=, 0
+	br      	22              # 22: up to label39
+.LBB1_9:                                # %while.cond.preheader.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label61:
+	i32.le_s	$push5=, $2, $1
+	br_if   	11, $pop5       # 11: down to label49
+# BB#10:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$5=, 12
+	br      	21              # 21: up to label39
+.LBB1_11:                               # %while.body.lr.ph.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label60:
+	i32.eq  	$3=, $0, $1
+# BB#12:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$5=, 13
+	br      	20              # 20: up to label39
+.LBB1_13:                               # %while.body.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label59:
+	i32.add 	$push21=, $2, $3
+	tee_local	$push20=, $2=, $pop21
+	i32.gt_s	$push6=, $pop20, $1
+	br_if   	11, $pop6       # 11: down to label47
+# BB#14:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$5=, 1
+	br      	19              # 19: up to label39
+.LBB1_15:                               # %do.body10.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label58:
+	i32.const	$push25=, 2
+	i32.shl 	$push7=, $4, $pop25
+	i32.const	$push24=, W
+	i32.add 	$push23=, $pop7, $pop24
+	tee_local	$push22=, $0=, $pop23
+	i32.load	$3=, 0($pop22)
+# BB#16:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$5=, 2
+	br      	18              # 18: up to label39
+.LBB1_17:                               # %do.body11.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label57:
+	i32.eqz 	$push31=, $3
+	br_if   	13, $pop31      # 13: down to label43
+# BB#18:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$5=, 3
+	br      	17              # 17: up to label39
+.LBB1_19:                               # %if.then13.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label56:
+	i32.const	$push26=, 0
+	i32.store	0($0), $pop26
+	i32.const	$2=, 1
+# BB#20:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$5=, 4
+	br      	16              # 16: up to label39
+.LBB1_21:                               # %do.cond16.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label55:
+	i32.const	$3=, 0
+	i32.eqz 	$push32=, $1
+	br_if   	10, $pop32      # 10: down to label44
+# BB#22:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$5=, 5
+	br      	15              # 15: up to label39
+.LBB1_23:                               # %do.cond33.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label54:
+	i32.const	$push30=, 2
+	i32.shl 	$push9=, $4, $pop30
+	i32.const	$push29=, Link
+	i32.add 	$push10=, $pop9, $pop29
+	i32.load	$push28=, 0($pop10)
+	tee_local	$push27=, $4=, $pop28
+	i32.const	$push8=, -1
+	i32.ne  	$push11=, $pop27, $pop8
+	br_if   	12, $pop11      # 12: down to label41
+	br      	11              # 11: down to label42
+.LBB1_24:                               # %f.exit
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label53:
+	i32.eqz 	$push33=, $2
+	br_if   	12, $pop33      # 12: down to label40
+# BB#25:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$5=, 9
+	br      	13              # 13: up to label39
+.LBB1_26:                               # %if.end
+	end_block                       # label52:
+	i32.const	$push3=, 0
+	return  	$pop3
+.LBB1_27:                               # %if.then
+	end_block                       # label51:
+	call    	abort@FUNCTION
+	unreachable
+.LBB1_28:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label50:
+	i32.const	$5=, 7
+	br      	10              # 10: up to label39
+.LBB1_29:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label49:
+	i32.const	$5=, 1
+	br      	9               # 9: up to label39
+.LBB1_30:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label48:
+	i32.const	$5=, 8
+	br      	8               # 8: up to label39
+.LBB1_31:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label47:
+	i32.const	$5=, 13
+	br      	7               # 7: up to label39
+.LBB1_32:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label46:
+	i32.const	$5=, 12
+	br      	6               # 6: up to label39
+.LBB1_33:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label45:
+	i32.const	$5=, 1
+	br      	5               # 5: up to label39
+.LBB1_34:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label44:
+	i32.const	$5=, 2
+	br      	4               # 4: up to label39
+.LBB1_35:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label43:
+	i32.const	$5=, 4
+	br      	3               # 3: up to label39
+.LBB1_36:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label42:
+	i32.const	$5=, 6
+	br      	2               # 2: up to label39
+.LBB1_37:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label41:
+	i32.const	$5=, 5
+	br      	1               # 1: up to label39
+.LBB1_38:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label40:
+	i32.const	$5=, 10
+	br      	0               # 0: up to label39
+.LBB1_39:
 	end_loop
 	.endfunc
 .Lfunc_end1:
@@ -294,5 +564,5 @@ W:
 	.size	W, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr28289.c.s
+++ b/test/torture-s/pr28289.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr28289.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr28289.c"
 	.section	.text.ix86_split_ashr,"ax",@progbits
 	.hidden	ix86_split_ashr
 	.globl	ix86_split_ashr
@@ -7,11 +7,11 @@
 ix86_split_ashr:                        # @ix86_split_ashr
 	.param  	i32
 # BB#0:                                 # %entry
+	i32.const	$push3=, 0
 	i32.const	$push1=, ok@FUNCTION
 	i32.const	$push0=, gen_x86_64_shrd@FUNCTION
 	i32.select	$push2=, $pop1, $pop0, $0
-	i32.const	$push3=, 0
-	i32.call_indirect	$drop=, $pop2, $pop3
+	i32.call_indirect	$drop=, $pop3, $pop2
                                         # fallthrough-return
 	.endfunc
 .Lfunc_end0:
@@ -50,13 +50,13 @@ gen_x86_64_shrd:                        # @gen_x86_64_shrd
 main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
+	i32.const	$push0=, 0
 	i32.const	$push3=, ok@FUNCTION
 	i32.const	$push2=, gen_x86_64_shrd@FUNCTION
-	i32.const	$push0=, 0
-	i32.load	$push1=, one($pop0)
-	i32.select	$push4=, $pop3, $pop2, $pop1
 	i32.const	$push6=, 0
-	i32.call_indirect	$drop=, $pop4, $pop6
+	i32.load	$push1=, one($pop6)
+	i32.select	$push4=, $pop3, $pop2, $pop1
+	i32.call_indirect	$drop=, $pop0, $pop4
 	i32.const	$push5=, 1
                                         # fallthrough-return: $pop5
 	.endfunc
@@ -73,5 +73,5 @@ one:
 	.size	one, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	exit, void, i32

--- a/test/torture-s/pr28982a.c.s
+++ b/test/torture-s/pr28982a.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr28982a.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr28982a.c"
 	.section	.text.foo,"ax",@progbits
 	.hidden	foo
 	.globl	foo
@@ -8,29 +8,10 @@ foo:                                    # @foo
 	.param  	i32
 	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32
 # BB#0:                                 # %entry
-	f32.const	$41=, 0x0p0
-	f32.const	$42=, 0x0p0
-	f32.const	$43=, 0x0p0
-	f32.const	$44=, 0x0p0
-	f32.const	$45=, 0x0p0
-	f32.const	$46=, 0x0p0
-	f32.const	$47=, 0x0p0
-	f32.const	$48=, 0x0p0
-	f32.const	$49=, 0x0p0
-	f32.const	$50=, 0x0p0
-	f32.const	$51=, 0x0p0
-	f32.const	$52=, 0x0p0
-	f32.const	$53=, 0x0p0
-	f32.const	$54=, 0x0p0
-	f32.const	$55=, 0x0p0
-	f32.const	$56=, 0x0p0
-	f32.const	$57=, 0x0p0
-	f32.const	$58=, 0x0p0
-	f32.const	$59=, 0x0p0
-	f32.const	$60=, 0x0p0
+	block   	
 	block   	
 	i32.eqz 	$push143=, $0
-	br_if   	0, $pop143      # 0: down to label0
+	br_if   	0, $pop143      # 0: down to label1
 # BB#1:                                 # %while.body.preheader
 	i32.const	$push119=, 0
 	i32.load	$push0=, incs($pop119)
@@ -174,7 +155,7 @@ foo:                                    # @foo
 	f32.const	$41=, 0x0p0
 .LBB0_2:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label1:
+	loop    	                # label2:
 	f32.load	$push41=, 0($40)
 	f32.add 	$60=, $60, $pop41
 	f32.load	$push42=, 0($39)
@@ -258,9 +239,32 @@ foo:                                    # @foo
 	i32.const	$push122=, -1
 	i32.add 	$push121=, $0, $pop122
 	tee_local	$push120=, $0=, $pop121
-	br_if   	0, $pop120      # 0: up to label1
-.LBB0_3:                                # %while.end
+	br_if   	0, $pop120      # 0: up to label2
+	br      	2               # 2: down to label0
+.LBB0_3:
 	end_loop
+	end_block                       # label1:
+	f32.const	$41=, 0x0p0
+	f32.const	$42=, 0x0p0
+	f32.const	$43=, 0x0p0
+	f32.const	$44=, 0x0p0
+	f32.const	$45=, 0x0p0
+	f32.const	$46=, 0x0p0
+	f32.const	$47=, 0x0p0
+	f32.const	$48=, 0x0p0
+	f32.const	$49=, 0x0p0
+	f32.const	$50=, 0x0p0
+	f32.const	$51=, 0x0p0
+	f32.const	$52=, 0x0p0
+	f32.const	$53=, 0x0p0
+	f32.const	$54=, 0x0p0
+	f32.const	$55=, 0x0p0
+	f32.const	$56=, 0x0p0
+	f32.const	$57=, 0x0p0
+	f32.const	$58=, 0x0p0
+	f32.const	$59=, 0x0p0
+	f32.const	$60=, 0x0p0
+.LBB0_4:                                # %while.end
 	end_block                       # label0:
 	i32.const	$push142=, 0
 	f32.store	results+4($pop142), $42
@@ -436,7 +440,7 @@ main:                                   # @main
 	i32.store	incs+76($pop121), $pop35
 .LBB1_1:                                # %for.body4
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label2:
+	loop    	                # label3:
 	f32.convert_s/i32	$push36=, $1
 	f32.store	0($0), $pop36
 	i32.const	$push167=, 4
@@ -446,7 +450,7 @@ main:                                   # @main
 	tee_local	$push164=, $1=, $pop165
 	i32.const	$push163=, 80
 	i32.ne  	$push37=, $pop164, $pop163
-	br_if   	0, $pop37       # 0: up to label2
+	br_if   	0, $pop37       # 0: up to label3
 # BB#2:                                 # %for.end8
 	end_loop
 	i32.const	$push38=, 4
@@ -594,4 +598,4 @@ input:
 	.size	input, 320
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "

--- a/test/torture-s/pr28982b.c.s
+++ b/test/torture-s/pr28982b.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr28982b.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr28982b.c"
 	.section	.text.bar,"ax",@progbits
 	.hidden	bar
 	.globl	bar
@@ -38,29 +38,10 @@ foo:                                    # @foo
 	i32.const	$push73=, 0
 	i32.const	$push72=, 262144
 	i32.call	$drop=, memset@FUNCTION, $pop69, $pop73, $pop72
-	f32.const	$41=, 0x0p0
-	f32.const	$42=, 0x0p0
-	f32.const	$43=, 0x0p0
-	f32.const	$44=, 0x0p0
-	f32.const	$45=, 0x0p0
-	f32.const	$46=, 0x0p0
-	f32.const	$47=, 0x0p0
-	f32.const	$48=, 0x0p0
-	f32.const	$49=, 0x0p0
-	f32.const	$50=, 0x0p0
-	f32.const	$51=, 0x0p0
-	f32.const	$52=, 0x0p0
-	f32.const	$53=, 0x0p0
-	f32.const	$54=, 0x0p0
-	f32.const	$55=, 0x0p0
-	f32.const	$56=, 0x0p0
-	f32.const	$57=, 0x0p0
-	f32.const	$58=, 0x0p0
-	f32.const	$59=, 0x0p0
-	f32.const	$60=, 0x0p0
+	block   	
 	block   	
 	i32.eqz 	$push161=, $0
-	br_if   	0, $pop161      # 0: down to label0
+	br_if   	0, $pop161      # 0: down to label1
 # BB#1:                                 # %while.body.preheader
 	i32.const	$push134=, 0
 	i32.load	$push0=, incs($pop134)
@@ -204,7 +185,7 @@ foo:                                    # @foo
 	f32.const	$41=, 0x0p0
 .LBB1_2:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label1:
+	loop    	                # label2:
 	f32.load	$push41=, 0($40)
 	f32.add 	$60=, $60, $pop41
 	f32.load	$push42=, 0($39)
@@ -288,9 +269,32 @@ foo:                                    # @foo
 	i32.const	$push137=, -1
 	i32.add 	$push136=, $0, $pop137
 	tee_local	$push135=, $0=, $pop136
-	br_if   	0, $pop135      # 0: up to label1
-.LBB1_3:                                # %while.end
+	br_if   	0, $pop135      # 0: up to label2
+	br      	2               # 2: down to label0
+.LBB1_3:
 	end_loop
+	end_block                       # label1:
+	f32.const	$41=, 0x0p0
+	f32.const	$42=, 0x0p0
+	f32.const	$43=, 0x0p0
+	f32.const	$44=, 0x0p0
+	f32.const	$45=, 0x0p0
+	f32.const	$46=, 0x0p0
+	f32.const	$47=, 0x0p0
+	f32.const	$48=, 0x0p0
+	f32.const	$49=, 0x0p0
+	f32.const	$50=, 0x0p0
+	f32.const	$51=, 0x0p0
+	f32.const	$52=, 0x0p0
+	f32.const	$53=, 0x0p0
+	f32.const	$54=, 0x0p0
+	f32.const	$55=, 0x0p0
+	f32.const	$56=, 0x0p0
+	f32.const	$57=, 0x0p0
+	f32.const	$58=, 0x0p0
+	f32.const	$59=, 0x0p0
+	f32.const	$60=, 0x0p0
+.LBB1_4:                                # %while.end
 	end_block                       # label0:
 	i32.const	$push160=, 0
 	f32.store	results+4($pop160), $42
@@ -476,7 +480,7 @@ main:                                   # @main
 	i32.store	incs+76($pop121), $pop35
 .LBB2_1:                                # %for.body4
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label2:
+	loop    	                # label3:
 	f32.convert_s/i32	$push36=, $1
 	f32.store	0($0), $pop36
 	i32.const	$push167=, 4
@@ -486,7 +490,7 @@ main:                                   # @main
 	tee_local	$push164=, $1=, $pop165
 	i32.const	$push163=, 80
 	i32.ne  	$push37=, $pop164, $pop163
-	br_if   	0, $pop37       # 0: up to label2
+	br_if   	0, $pop37       # 0: up to label3
 # BB#2:                                 # %for.end8
 	end_loop
 	i32.const	$push38=, 4
@@ -634,4 +638,4 @@ input:
 	.size	input, 320
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "

--- a/test/torture-s/pr33870-1.c.s
+++ b/test/torture-s/pr33870-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr33870-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr33870-1.c"
 	.section	.text.sort_pagelist,"ax",@progbits
 	.hidden	sort_pagelist
 	.globl	sort_pagelist
@@ -53,43 +53,42 @@ sort_pagelist:                          # @sort_pagelist
 	block   	
 	block   	
 	block   	
-	loop    	                # label6:
+	block   	
+	loop    	                # label7:
 	i32.const	$push78=, 2
 	i32.shl 	$push1=, $6, $pop78
 	i32.add 	$push77=, $1, $pop1
 	tee_local	$push76=, $4=, $pop77
 	i32.load	$push75=, 0($pop76)
-	tee_local	$push74=, $8=, $pop75
+	tee_local	$push74=, $9=, $pop75
 	i32.eqz 	$push117=, $pop74
-	br_if   	1, $pop117      # 1: down to label5
+	br_if   	1, $pop117      # 1: down to label6
 # BB#4:                                 # %if.else
                                         #   in Loop: Header=BB0_3 Depth=2
 	i32.const	$push79=, 0
 	i32.store	xx($pop79), $2
-	i32.const	$push56=, 112
-	i32.add 	$push57=, $1, $pop56
-	copy_local	$7=, $pop57
 	block   	
 	block   	
 	block   	
 	i32.eqz 	$push118=, $3
-	br_if   	0, $pop118      # 0: down to label9
+	br_if   	0, $pop118      # 0: down to label10
 # BB#5:                                 # %while.body.i.preheader
                                         #   in Loop: Header=BB0_3 Depth=2
 	i32.const	$push62=, 112
 	i32.add 	$push63=, $1, $pop62
 	copy_local	$7=, $pop63
+	copy_local	$8=, $9
 .LBB0_6:                                # %while.body.i
                                         #   Parent Loop BB0_2 Depth=1
                                         #     Parent Loop BB0_3 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
-	loop    	                # label10:
+	loop    	                # label11:
 	block   	
 	block   	
 	i32.load	$push3=, 4($8)
 	i32.load	$push2=, 4($3)
 	i32.ge_u	$push4=, $pop3, $pop2
-	br_if   	0, $pop4        # 0: down to label12
+	br_if   	0, $pop4        # 0: down to label13
 # BB#7:                                 # %if.then.i
                                         #   in Loop: Header=BB0_6 Depth=3
 	i32.const	$push81=, 32
@@ -100,10 +99,10 @@ sort_pagelist:                          # @sort_pagelist
 	i32.load	$9=, 0($pop8)
 	copy_local	$10=, $3
 	copy_local	$7=, $8
-	br      	1               # 1: down to label11
+	br      	1               # 1: down to label12
 .LBB0_8:                                # %if.else.i
                                         #   in Loop: Header=BB0_6 Depth=3
-	end_block                       # label12:
+	end_block                       # label13:
 	i32.const	$push83=, 32
 	i32.add 	$push5=, $7, $pop83
 	i32.store	0($pop5), $3
@@ -114,34 +113,36 @@ sort_pagelist:                          # @sort_pagelist
 	copy_local	$7=, $3
 .LBB0_9:                                # %if.end.i
                                         #   in Loop: Header=BB0_6 Depth=3
-	end_block                       # label11:
+	end_block                       # label12:
 	block   	
 	i32.const	$push84=, 0
 	i32.load	$push9=, 0($2)
 	i32.load	$push10=, 0($pop9)
 	i32.store	vx($pop84), $pop10
 	i32.eqz 	$push119=, $9
-	br_if   	0, $pop119      # 0: down to label13
+	br_if   	0, $pop119      # 0: down to label14
 # BB#10:                                # %if.end.i
                                         #   in Loop: Header=BB0_6 Depth=3
 	copy_local	$3=, $10
 	copy_local	$8=, $9
-	br_if   	1, $10          # 1: up to label10
+	br_if   	1, $10          # 1: up to label11
 .LBB0_11:                               # %merge_pagelist.exit
                                         #   in Loop: Header=BB0_3 Depth=2
-	end_block                       # label13:
+	end_block                       # label14:
 	end_loop
-	br_if   	1, $9           # 1: down to label8
-	br      	2               # 2: down to label7
+	br_if   	1, $9           # 1: down to label9
+	br      	2               # 2: down to label8
 .LBB0_12:                               #   in Loop: Header=BB0_3 Depth=2
-	end_block                       # label9:
-	copy_local	$9=, $8
+	end_block                       # label10:
+	i32.const	$push56=, 112
+	i32.add 	$push57=, $1, $pop56
+	copy_local	$7=, $pop57
 .LBB0_13:                               # %merge_pagelist.exit.thread
                                         #   in Loop: Header=BB0_3 Depth=2
-	end_block                       # label8:
+	end_block                       # label9:
 	copy_local	$10=, $9
 .LBB0_14:                               #   in Loop: Header=BB0_3 Depth=2
-	end_block                       # label7:
+	end_block                       # label8:
 	i32.const	$push90=, 32
 	i32.add 	$push11=, $7, $pop90
 	i32.store	0($pop11), $10
@@ -153,13 +154,13 @@ sort_pagelist:                          # @sort_pagelist
 	tee_local	$push86=, $6=, $pop87
 	i32.const	$push85=, 24
 	i32.lt_s	$push12=, $pop86, $pop85
-	br_if   	0, $pop12       # 0: up to label6
+	br_if   	0, $pop12       # 0: up to label7
 # BB#15:                                # %for.end
                                         #   in Loop: Header=BB0_2 Depth=1
 	end_loop
 	i32.const	$push91=, 24
 	i32.ne  	$push13=, $6, $pop91
-	br_if   	3, $pop13       # 3: down to label2
+	br_if   	3, $pop13       # 3: down to label3
 # BB#16:                                # %if.then9
                                         #   in Loop: Header=BB0_2 Depth=1
 	i32.load	$8=, 0($5)
@@ -171,11 +172,11 @@ sort_pagelist:                          # @sort_pagelist
 	i32.add 	$push59=, $1, $pop58
 	copy_local	$7=, $pop59
 	i32.eqz 	$push120=, $3
-	br_if   	1, $pop120      # 1: down to label4
+	br_if   	1, $pop120      # 1: down to label5
 # BB#17:                                # %if.then9
                                         #   in Loop: Header=BB0_2 Depth=1
 	i32.eqz 	$push121=, $8
-	br_if   	1, $pop121      # 1: down to label4
+	br_if   	1, $pop121      # 1: down to label5
 # BB#18:                                # %while.body.i84.preheader
                                         #   in Loop: Header=BB0_2 Depth=1
 	i32.const	$push60=, 112
@@ -184,13 +185,13 @@ sort_pagelist:                          # @sort_pagelist
 .LBB0_19:                               # %while.body.i84
                                         #   Parent Loop BB0_2 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label14:
+	loop    	                # label15:
 	block   	
 	block   	
 	i32.load	$push16=, 4($8)
 	i32.load	$push15=, 4($3)
 	i32.ge_u	$push17=, $pop16, $pop15
-	br_if   	0, $pop17       # 0: down to label16
+	br_if   	0, $pop17       # 0: down to label17
 # BB#20:                                # %if.then.i86
                                         #   in Loop: Header=BB0_19 Depth=2
 	i32.const	$push95=, 32
@@ -201,10 +202,10 @@ sort_pagelist:                          # @sort_pagelist
 	i32.load	$9=, 0($pop21)
 	copy_local	$10=, $3
 	copy_local	$7=, $8
-	br      	1               # 1: down to label15
+	br      	1               # 1: down to label16
 .LBB0_21:                               # %if.else.i88
                                         #   in Loop: Header=BB0_19 Depth=2
-	end_block                       # label16:
+	end_block                       # label17:
 	i32.const	$push97=, 32
 	i32.add 	$push18=, $7, $pop97
 	i32.store	0($pop18), $3
@@ -215,7 +216,7 @@ sort_pagelist:                          # @sort_pagelist
 	copy_local	$7=, $3
 .LBB0_22:                               # %if.end.i95
                                         #   in Loop: Header=BB0_19 Depth=2
-	end_block                       # label15:
+	end_block                       # label16:
 	i32.const	$push99=, 0
 	i32.load	$push22=, 0($2)
 	i32.load	$push23=, 0($pop22)
@@ -223,26 +224,27 @@ sort_pagelist:                          # @sort_pagelist
 	i32.const	$push98=, 0
 	i32.ne  	$6=, $9, $pop98
 	i32.eqz 	$push122=, $9
-	br_if   	3, $pop122      # 3: down to label3
+	br_if   	3, $pop122      # 3: down to label4
 # BB#23:                                # %if.end.i95
                                         #   in Loop: Header=BB0_19 Depth=2
 	copy_local	$3=, $10
 	copy_local	$8=, $9
-	br_if   	0, $10          # 0: up to label14
-	br      	3               # 3: down to label3
+	br_if   	0, $10          # 0: up to label15
+	br      	3               # 3: down to label4
 .LBB0_24:                               # %for.end.thread
                                         #   in Loop: Header=BB0_2 Depth=1
 	end_loop
-	end_block                       # label5:
+	end_block                       # label6:
 	i32.store	0($4), $3
-	br      	2               # 2: down to label2
+	br_if   	4, $0           # 4: up to label1
+	br      	3               # 3: down to label2
 .LBB0_25:                               #   in Loop: Header=BB0_2 Depth=1
-	end_block                       # label4:
+	end_block                       # label5:
 	copy_local	$9=, $8
 	copy_local	$10=, $3
 .LBB0_26:                               # %merge_pagelist.exit102
                                         #   in Loop: Header=BB0_2 Depth=1
-	end_block                       # label3:
+	end_block                       # label4:
 	i32.const	$push100=, 32
 	i32.add 	$push25=, $7, $pop100
 	i32.select	$push24=, $9, $10, $6
@@ -251,9 +253,10 @@ sort_pagelist:                          # @sort_pagelist
 	i32.store	0($5), $pop26
 .LBB0_27:                               # %while.cond.backedge
                                         #   in Loop: Header=BB0_2 Depth=1
+	end_block                       # label3:
+	br_if   	1, $0           # 1: up to label1
+.LBB0_28:                               # %while.end.loopexit
 	end_block                       # label2:
-	br_if   	0, $0           # 0: up to label1
-# BB#28:                                # %while.end.loopexit
 	end_loop
 	i32.load	$3=, 0($1)
 .LBB0_29:                               # %while.end
@@ -266,7 +269,7 @@ sort_pagelist:                          # @sort_pagelist
 .LBB0_30:                               # %for.body17
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB0_33 Depth 2
-	loop    	                # label17:
+	loop    	                # label18:
 	i32.const	$push104=, 2
 	i32.shl 	$push27=, $4, $pop104
 	i32.add 	$push28=, $1, $pop27
@@ -281,11 +284,11 @@ sort_pagelist:                          # @sort_pagelist
 	block   	
 	block   	
 	i32.eqz 	$push123=, $3
-	br_if   	0, $pop123      # 0: down to label19
+	br_if   	0, $pop123      # 0: down to label20
 # BB#31:                                # %for.body17
                                         #   in Loop: Header=BB0_30 Depth=1
 	i32.eqz 	$push124=, $8
-	br_if   	0, $pop124      # 0: down to label19
+	br_if   	0, $pop124      # 0: down to label20
 # BB#32:                                # %while.body.i54.preheader
                                         #   in Loop: Header=BB0_30 Depth=1
 	i32.const	$push52=, 112
@@ -294,13 +297,13 @@ sort_pagelist:                          # @sort_pagelist
 .LBB0_33:                               # %while.body.i54
                                         #   Parent Loop BB0_30 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop    	                # label20:
+	loop    	                # label21:
 	block   	
 	block   	
 	i32.load	$push30=, 4($3)
 	i32.load	$push29=, 4($8)
 	i32.ge_u	$push31=, $pop30, $pop29
-	br_if   	0, $pop31       # 0: down to label22
+	br_if   	0, $pop31       # 0: down to label23
 # BB#34:                                # %if.then.i56
                                         #   in Loop: Header=BB0_33 Depth=2
 	i32.const	$push106=, 32
@@ -311,10 +314,10 @@ sort_pagelist:                          # @sort_pagelist
 	i32.load	$9=, 0($pop35)
 	copy_local	$10=, $8
 	copy_local	$7=, $3
-	br      	1               # 1: down to label21
+	br      	1               # 1: down to label22
 .LBB0_35:                               # %if.else.i58
                                         #   in Loop: Header=BB0_33 Depth=2
-	end_block                       # label22:
+	end_block                       # label23:
 	i32.const	$push108=, 32
 	i32.add 	$push32=, $7, $pop108
 	i32.store	0($pop32), $8
@@ -325,7 +328,7 @@ sort_pagelist:                          # @sort_pagelist
 	copy_local	$7=, $8
 .LBB0_36:                               # %if.end.i65
                                         #   in Loop: Header=BB0_33 Depth=2
-	end_block                       # label21:
+	end_block                       # label22:
 	i32.const	$push110=, 0
 	i32.load	$push36=, 0($2)
 	i32.load	$push37=, 0($pop36)
@@ -333,21 +336,21 @@ sort_pagelist:                          # @sort_pagelist
 	i32.const	$push109=, 0
 	i32.ne  	$6=, $9, $pop109
 	i32.eqz 	$push125=, $9
-	br_if   	2, $pop125      # 2: down to label18
+	br_if   	2, $pop125      # 2: down to label19
 # BB#37:                                # %if.end.i65
                                         #   in Loop: Header=BB0_33 Depth=2
 	copy_local	$8=, $10
 	copy_local	$3=, $9
-	br_if   	0, $10          # 0: up to label20
-	br      	2               # 2: down to label18
+	br_if   	0, $10          # 0: up to label21
+	br      	2               # 2: down to label19
 .LBB0_38:                               #   in Loop: Header=BB0_30 Depth=1
 	end_loop
-	end_block                       # label19:
+	end_block                       # label20:
 	copy_local	$9=, $3
 	copy_local	$10=, $8
 .LBB0_39:                               # %merge_pagelist.exit72
                                         #   in Loop: Header=BB0_30 Depth=1
-	end_block                       # label18:
+	end_block                       # label19:
 	i32.const	$push115=, 32
 	i32.add 	$push39=, $7, $pop115
 	i32.select	$push38=, $9, $10, $6
@@ -358,7 +361,7 @@ sort_pagelist:                          # @sort_pagelist
 	tee_local	$push112=, $4=, $pop113
 	i32.const	$push111=, 25
 	i32.ne  	$push40=, $pop112, $pop111
-	br_if   	0, $pop40       # 0: up to label17
+	br_if   	0, $pop40       # 0: up to label18
 # BB#40:                                # %for.end22
 	end_loop
 	i32.const	$push47=, 0
@@ -426,7 +429,7 @@ main:                                   # @main
 	i32.add 	$push24=, $0, $pop34
 	i32.load	$push25=, 0($pop24)
 	i32.eq  	$push26=, $pop35, $pop25
-	br_if   	0, $pop26       # 0: down to label23
+	br_if   	0, $pop26       # 0: down to label24
 # BB#1:                                 # %if.end
 	i32.const	$push33=, 0
 	i32.const	$push31=, 224
@@ -435,7 +438,7 @@ main:                                   # @main
 	i32.const	$push40=, 0
 	return  	$pop40
 .LBB1_2:                                # %if.then
-	end_block                       # label23:
+	end_block                       # label24:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -461,5 +464,5 @@ vx:
 	.size	vx, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr33870.c.s
+++ b/test/torture-s/pr33870.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr33870.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr33870.c"
 	.section	.text.sort_pagelist,"ax",@progbits
 	.hidden	sort_pagelist
 	.globl	sort_pagelist
@@ -7,22 +7,22 @@
 sort_pagelist:                          # @sort_pagelist
 	.param  	i32
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$push25=, 0
 	i32.const	$push22=, 0
 	i32.load	$push23=, __stack_pointer($pop22)
 	i32.const	$push24=, 144
 	i32.sub 	$push47=, $pop23, $pop24
-	tee_local	$push46=, $11=, $pop47
+	tee_local	$push46=, $10=, $pop47
 	i32.store	__stack_pointer($pop25), $pop46
 	i32.const	$4=, 0
 	i32.const	$push45=, 0
 	i32.const	$push0=, 100
-	i32.call	$1=, memset@FUNCTION, $11, $pop45, $pop0
+	i32.call	$1=, memset@FUNCTION, $10, $pop45, $pop0
 	block   	
-	i32.eqz 	$push103=, $0
-	br_if   	0, $pop103      # 0: down to label0
+	i32.eqz 	$push99=, $0
+	br_if   	0, $pop99       # 0: down to label0
 # BB#1:                                 # %while.body.lr.ph
 	i32.const	$push35=, 104
 	i32.add 	$push36=, $1, $pop35
@@ -55,36 +55,35 @@ sort_pagelist:                          # @sort_pagelist
 	block   	
 	block   	
 	block   	
-	loop    	                # label8:
+	block   	
+	loop    	                # label9:
 	i32.const	$push56=, 2
 	i32.shl 	$push1=, $7, $pop56
 	i32.add 	$push55=, $1, $pop1
 	tee_local	$push54=, $2=, $pop55
 	i32.load	$push53=, 0($pop54)
-	tee_local	$push52=, $4=, $pop53
-	i32.eqz 	$push104=, $pop52
-	br_if   	1, $pop104      # 1: down to label7
+	tee_local	$push52=, $10=, $pop53
+	i32.eqz 	$push100=, $pop52
+	br_if   	1, $pop100      # 1: down to label8
 # BB#4:                                 # %if.else
                                         #   in Loop: Header=BB0_3 Depth=2
-	i32.const	$push37=, 104
-	i32.add 	$push38=, $1, $pop37
-	copy_local	$10=, $pop38
 	block   	
 	block   	
-	i32.eqz 	$push105=, $8
-	br_if   	0, $pop105      # 0: down to label10
+	i32.eqz 	$push101=, $8
+	br_if   	0, $pop101      # 0: down to label11
 # BB#5:                                 # %while.body.lr.ph.i.preheader
                                         #   in Loop: Header=BB0_3 Depth=2
 	i32.const	$push43=, 104
 	i32.add 	$push44=, $1, $pop43
 	copy_local	$9=, $pop44
+	copy_local	$3=, $10
 .LBB0_6:                                # %while.body.lr.ph.i
                                         #   Parent Loop BB0_2 Depth=1
                                         #     Parent Loop BB0_3 Depth=2
                                         # =>    This Loop Header: Depth=3
                                         #         Child Loop BB0_7 Depth 4
-	loop    	                # label11:
-	copy_local	$push58=, $4
+	loop    	                # label12:
+	copy_local	$push58=, $3
 	tee_local	$push57=, $3=, $pop58
 	i32.load	$4=, 0($pop57)
 .LBB0_7:                                # %while.body.i
@@ -94,49 +93,51 @@ sort_pagelist:                          # @sort_pagelist
                                         # =>      This Inner Loop Header: Depth=4
 	block   	
 	block   	
-	loop    	                # label14:
+	loop    	                # label15:
 	copy_local	$push60=, $8
-	tee_local	$push59=, $11=, $pop60
+	tee_local	$push59=, $10=, $pop60
 	i32.load	$push2=, 0($pop59)
 	i32.lt_u	$push3=, $4, $pop2
-	br_if   	1, $pop3        # 1: down to label13
+	br_if   	1, $pop3        # 1: down to label14
 # BB#8:                                 # %if.else.i
                                         #   in Loop: Header=BB0_7 Depth=4
 	i32.const	$push63=, 28
 	i32.add 	$push4=, $9, $pop63
-	i32.store	0($pop4), $11
-	copy_local	$9=, $11
-	i32.load	$push62=, 28($11)
+	i32.store	0($pop4), $10
+	copy_local	$9=, $10
+	i32.load	$push62=, 28($10)
 	tee_local	$push61=, $8=, $pop62
-	br_if   	0, $pop61       # 0: up to label14
-	br      	2               # 2: down to label12
+	br_if   	0, $pop61       # 0: up to label15
+	br      	2               # 2: down to label13
 .LBB0_9:                                # %if.then.i
                                         #   in Loop: Header=BB0_6 Depth=3
 	end_loop
-	end_block                       # label13:
+	end_block                       # label14:
 	i32.const	$push66=, 28
 	i32.add 	$push5=, $9, $pop66
 	i32.store	0($pop5), $3
 	copy_local	$9=, $3
-	copy_local	$8=, $11
-	copy_local	$10=, $3
+	copy_local	$8=, $10
+	copy_local	$4=, $3
 	i32.load	$push65=, 28($3)
-	tee_local	$push64=, $4=, $pop65
-	br_if   	1, $pop64       # 1: up to label11
-	br      	3               # 3: down to label9
+	tee_local	$push64=, $3=, $pop65
+	br_if   	1, $pop64       # 1: up to label12
+	br      	3               # 3: down to label10
 .LBB0_10:                               #   in Loop: Header=BB0_3 Depth=2
-	end_block                       # label12:
+	end_block                       # label13:
 	end_loop
-	copy_local	$10=, $11
-	copy_local	$11=, $3
-	br      	1               # 1: down to label9
+	copy_local	$4=, $10
+	copy_local	$10=, $3
+	br      	1               # 1: down to label10
 .LBB0_11:                               #   in Loop: Header=BB0_3 Depth=2
-	end_block                       # label10:
-	copy_local	$11=, $4
+	end_block                       # label11:
+	i32.const	$push37=, 104
+	i32.add 	$push38=, $1, $pop37
+	copy_local	$4=, $pop38
 .LBB0_12:                               # %merge_pagelist.exit
                                         #   in Loop: Header=BB0_3 Depth=2
-	end_block                       # label9:
-	i32.store	28($10), $11
+	end_block                       # label10:
+	i32.store	28($4), $10
 	i32.load	$8=, 0($5)
 	i32.const	$push71=, 0
 	i32.store	0($2), $pop71
@@ -145,33 +146,32 @@ sort_pagelist:                          # @sort_pagelist
 	tee_local	$push68=, $7=, $pop69
 	i32.const	$push67=, 24
 	i32.lt_s	$push6=, $pop68, $pop67
-	br_if   	0, $pop6        # 0: up to label8
+	br_if   	0, $pop6        # 0: up to label9
 # BB#13:                                # %for.end
                                         #   in Loop: Header=BB0_2 Depth=1
 	end_loop
 	i32.const	$push72=, 24
 	i32.ne  	$push7=, $7, $pop72
-	br_if   	5, $pop7        # 5: down to label2
+	br_if   	5, $pop7        # 5: down to label3
 # BB#14:                                # %if.then7
                                         #   in Loop: Header=BB0_2 Depth=1
 	i32.load	$4=, 0($6)
-	i32.eqz 	$push106=, $8
-	br_if   	1, $pop106      # 1: down to label6
+	i32.eqz 	$push102=, $8
+	br_if   	1, $pop102      # 1: down to label7
 # BB#15:                                # %if.then7
                                         #   in Loop: Header=BB0_2 Depth=1
-	i32.eqz 	$push107=, $4
-	br_if   	1, $pop107      # 1: down to label6
+	i32.eqz 	$push103=, $4
+	br_if   	1, $pop103      # 1: down to label7
 # BB#16:                                # %while.body.lr.ph.i79.preheader
                                         #   in Loop: Header=BB0_2 Depth=1
 	i32.const	$push39=, 104
 	i32.add 	$push40=, $1, $pop39
 	copy_local	$9=, $pop40
-	copy_local	$11=, $8
 .LBB0_17:                               # %while.body.lr.ph.i79
                                         #   Parent Loop BB0_2 Depth=1
                                         # =>  This Loop Header: Depth=2
                                         #       Child Loop BB0_18 Depth 3
-	loop    	                # label15:
+	loop    	                # label16:
 	copy_local	$push74=, $4
 	tee_local	$push73=, $3=, $pop74
 	i32.load	$4=, 0($pop73)
@@ -180,186 +180,197 @@ sort_pagelist:                          # @sort_pagelist
                                         #     Parent Loop BB0_17 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
 	block   	
-	loop    	                # label17:
-	copy_local	$push76=, $11
-	tee_local	$push75=, $8=, $pop76
+	loop    	                # label18:
+	copy_local	$push76=, $8
+	tee_local	$push75=, $10=, $pop76
 	i32.load	$push9=, 0($pop75)
 	i32.lt_u	$push10=, $4, $pop9
-	br_if   	1, $pop10       # 1: down to label16
+	br_if   	1, $pop10       # 1: down to label17
 # BB#19:                                # %if.else.i91
                                         #   in Loop: Header=BB0_18 Depth=3
 	i32.const	$push79=, 28
 	i32.add 	$push11=, $9, $pop79
-	i32.store	0($pop11), $8
-	copy_local	$9=, $8
-	i32.load	$push78=, 28($8)
-	tee_local	$push77=, $11=, $pop78
-	br_if   	0, $pop77       # 0: up to label17
-	br      	5               # 5: down to label5
+	i32.store	0($pop11), $10
+	copy_local	$9=, $10
+	i32.load	$push78=, 28($10)
+	tee_local	$push77=, $8=, $pop78
+	br_if   	0, $pop77       # 0: up to label18
+	br      	5               # 5: down to label6
 .LBB0_20:                               # %if.then.i88
                                         #   in Loop: Header=BB0_17 Depth=2
 	end_loop
-	end_block                       # label16:
+	end_block                       # label17:
 	i32.const	$push82=, 28
 	i32.add 	$push12=, $9, $pop82
 	i32.store	0($pop12), $3
 	copy_local	$9=, $3
-	copy_local	$11=, $8
+	copy_local	$8=, $10
 	i32.load	$push81=, 28($3)
 	tee_local	$push80=, $4=, $pop81
-	br_if   	0, $pop80       # 0: up to label15
-	br      	5               # 5: down to label3
+	br_if   	0, $pop80       # 0: up to label16
+	br      	5               # 5: down to label4
 .LBB0_21:                               # %for.end.thread
                                         #   in Loop: Header=BB0_2 Depth=1
 	end_loop
-	end_block                       # label7:
+	end_block                       # label8:
 	i32.store	0($2), $8
-	br      	4               # 4: down to label2
+	br_if   	6, $0           # 6: up to label1
+	br      	5               # 5: down to label2
 .LBB0_22:                               # %while.end.i96
                                         #   in Loop: Header=BB0_2 Depth=1
-	end_block                       # label6:
+	end_block                       # label7:
 	i32.const	$push41=, 104
 	i32.add 	$push42=, $1, $pop41
-	copy_local	$push84=, $pop42
-	tee_local	$push83=, $11=, $pop84
-	copy_local	$3=, $pop83
-	br_if   	1, $4           # 1: down to label4
-	br      	2               # 2: down to label3
-.LBB0_23:                               #   in Loop: Header=BB0_2 Depth=1
+	copy_local	$3=, $pop42
+	block   	
+	br_if   	0, $4           # 0: down to label19
+# BB#23:                                #   in Loop: Header=BB0_2 Depth=1
+	copy_local	$10=, $8
+	br      	3               # 3: down to label4
+.LBB0_24:                               #   in Loop: Header=BB0_2 Depth=1
+	end_block                       # label19:
+	copy_local	$8=, $3
+	copy_local	$10=, $4
+	br      	1               # 1: down to label5
+.LBB0_25:                               #   in Loop: Header=BB0_2 Depth=1
+	end_block                       # label6:
+	copy_local	$8=, $10
+	copy_local	$10=, $3
+.LBB0_26:                               # %while.end.thread.i99
+                                        #   in Loop: Header=BB0_2 Depth=1
 	end_block                       # label5:
-	copy_local	$11=, $8
-	copy_local	$4=, $3
-.LBB0_24:                               # %while.end.thread.i99
+	copy_local	$3=, $8
+.LBB0_27:                               # %merge_pagelist.exit103
                                         #   in Loop: Header=BB0_2 Depth=1
 	end_block                       # label4:
-	copy_local	$3=, $11
-	copy_local	$8=, $4
-.LBB0_25:                               # %merge_pagelist.exit103
-                                        #   in Loop: Header=BB0_2 Depth=1
-	end_block                       # label3:
-	i32.store	28($3), $8
+	i32.store	28($3), $10
 	i32.load	$push13=, 0($5)
 	i32.store	0($6), $pop13
-.LBB0_26:                               # %while.cond.backedge
+.LBB0_28:                               # %while.cond.backedge
                                         #   in Loop: Header=BB0_2 Depth=1
+	end_block                       # label3:
+	br_if   	1, $0           # 1: up to label1
+.LBB0_29:                               # %while.end.loopexit
 	end_block                       # label2:
-	br_if   	0, $0           # 0: up to label1
-# BB#27:                                # %while.end.loopexit
 	end_loop
 	i32.load	$4=, 0($1)
-.LBB0_28:                               # %while.end
+.LBB0_30:                               # %while.end
 	end_block                       # label0:
-	i32.const	$10=, 1
-.LBB0_29:                               # %for.body15
+	i32.const	$7=, 1
+.LBB0_31:                               # %for.body15
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB0_32 Depth 2
-                                        #       Child Loop BB0_33 Depth 3
-	loop    	                # label18:
-	i32.const	$push85=, 2
-	i32.shl 	$push14=, $10, $pop85
+                                        #     Child Loop BB0_34 Depth 2
+                                        #       Child Loop BB0_35 Depth 3
+	loop    	                # label20:
+	i32.const	$push83=, 2
+	i32.shl 	$push14=, $7, $pop83
 	i32.add 	$push15=, $1, $pop14
-	i32.load	$11=, 0($pop15)
+	i32.load	$8=, 0($pop15)
 	block   	
 	block   	
 	block   	
 	block   	
-	i32.eqz 	$push108=, $4
-	br_if   	0, $pop108      # 0: down to label22
-# BB#30:                                # %for.body15
-                                        #   in Loop: Header=BB0_29 Depth=1
-	i32.eqz 	$push109=, $11
-	br_if   	0, $pop109      # 0: down to label22
-# BB#31:                                # %while.body.lr.ph.i47.preheader
-                                        #   in Loop: Header=BB0_29 Depth=1
+	i32.eqz 	$push104=, $4
+	br_if   	0, $pop104      # 0: down to label24
+# BB#32:                                # %for.body15
+                                        #   in Loop: Header=BB0_31 Depth=1
+	i32.eqz 	$push105=, $8
+	br_if   	0, $pop105      # 0: down to label24
+# BB#33:                                # %while.body.lr.ph.i47.preheader
+                                        #   in Loop: Header=BB0_31 Depth=1
 	i32.const	$push29=, 104
 	i32.add 	$push30=, $1, $pop29
 	copy_local	$9=, $pop30
-	copy_local	$8=, $11
-.LBB0_32:                               # %while.body.lr.ph.i47
-                                        #   Parent Loop BB0_29 Depth=1
+.LBB0_34:                               # %while.body.lr.ph.i47
+                                        #   Parent Loop BB0_31 Depth=1
                                         # =>  This Loop Header: Depth=2
-                                        #       Child Loop BB0_33 Depth 3
-	loop    	                # label23:
-	copy_local	$push87=, $4
-	tee_local	$push86=, $3=, $pop87
-	i32.load	$4=, 0($pop86)
-.LBB0_33:                               # %while.body.i53
-                                        #   Parent Loop BB0_29 Depth=1
-                                        #     Parent Loop BB0_32 Depth=2
+                                        #       Child Loop BB0_35 Depth 3
+	loop    	                # label25:
+	copy_local	$push85=, $4
+	tee_local	$push84=, $3=, $pop85
+	i32.load	$4=, 0($pop84)
+.LBB0_35:                               # %while.body.i53
+                                        #   Parent Loop BB0_31 Depth=1
+                                        #     Parent Loop BB0_34 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
 	block   	
-	loop    	                # label25:
-	copy_local	$push89=, $8
-	tee_local	$push88=, $11=, $pop89
-	i32.load	$push16=, 0($pop88)
+	loop    	                # label27:
+	copy_local	$push87=, $8
+	tee_local	$push86=, $10=, $pop87
+	i32.load	$push16=, 0($pop86)
 	i32.lt_u	$push17=, $4, $pop16
-	br_if   	1, $pop17       # 1: down to label24
-# BB#34:                                # %if.else.i59
-                                        #   in Loop: Header=BB0_33 Depth=3
-	i32.const	$push92=, 28
-	i32.add 	$push18=, $9, $pop92
-	i32.store	0($pop18), $11
-	copy_local	$9=, $11
-	i32.load	$push91=, 28($11)
-	tee_local	$push90=, $8=, $pop91
-	br_if   	0, $pop90       # 0: up to label25
-	br      	4               # 4: down to label21
-.LBB0_35:                               # %if.then.i56
-                                        #   in Loop: Header=BB0_32 Depth=2
+	br_if   	1, $pop17       # 1: down to label26
+# BB#36:                                # %if.else.i59
+                                        #   in Loop: Header=BB0_35 Depth=3
+	i32.const	$push90=, 28
+	i32.add 	$push18=, $9, $pop90
+	i32.store	0($pop18), $10
+	copy_local	$9=, $10
+	i32.load	$push89=, 28($10)
+	tee_local	$push88=, $8=, $pop89
+	br_if   	0, $pop88       # 0: up to label27
+	br      	4               # 4: down to label23
+.LBB0_37:                               # %if.then.i56
+                                        #   in Loop: Header=BB0_34 Depth=2
 	end_loop
-	end_block                       # label24:
-	i32.const	$push95=, 28
-	i32.add 	$push19=, $9, $pop95
+	end_block                       # label26:
+	i32.const	$push93=, 28
+	i32.add 	$push19=, $9, $pop93
 	i32.store	0($pop19), $3
 	copy_local	$9=, $3
-	copy_local	$8=, $11
-	i32.load	$push94=, 28($3)
-	tee_local	$push93=, $4=, $pop94
-	br_if   	0, $pop93       # 0: up to label23
-	br      	4               # 4: down to label19
-.LBB0_36:                               # %while.end.i64
-                                        #   in Loop: Header=BB0_29 Depth=1
+	copy_local	$8=, $10
+	i32.load	$push92=, 28($3)
+	tee_local	$push91=, $4=, $pop92
+	br_if   	0, $pop91       # 0: up to label25
+	br      	4               # 4: down to label21
+.LBB0_38:                               # %while.end.i64
+                                        #   in Loop: Header=BB0_31 Depth=1
 	end_loop
-	end_block                       # label22:
+	end_block                       # label24:
 	i32.const	$push33=, 104
 	i32.add 	$push34=, $1, $pop33
-	copy_local	$push97=, $pop34
-	tee_local	$push96=, $8=, $pop97
-	copy_local	$3=, $pop96
-	br_if   	1, $4           # 1: down to label20
-	br      	2               # 2: down to label19
-.LBB0_37:                               #   in Loop: Header=BB0_29 Depth=1
-	end_block                       # label21:
-	copy_local	$8=, $11
-	copy_local	$4=, $3
-.LBB0_38:                               # %while.end.thread.i67
-                                        #   in Loop: Header=BB0_29 Depth=1
-	end_block                       # label20:
+	copy_local	$3=, $pop34
+	block   	
+	br_if   	0, $4           # 0: down to label28
+# BB#39:                                #   in Loop: Header=BB0_31 Depth=1
+	copy_local	$10=, $8
+	br      	3               # 3: down to label21
+.LBB0_40:                               #   in Loop: Header=BB0_31 Depth=1
+	end_block                       # label28:
+	copy_local	$8=, $3
+	copy_local	$10=, $4
+	br      	1               # 1: down to label22
+.LBB0_41:                               #   in Loop: Header=BB0_31 Depth=1
+	end_block                       # label23:
+	copy_local	$8=, $10
+	copy_local	$10=, $3
+.LBB0_42:                               # %while.end.thread.i67
+                                        #   in Loop: Header=BB0_31 Depth=1
+	end_block                       # label22:
 	copy_local	$3=, $8
-	copy_local	$11=, $4
-.LBB0_39:                               # %merge_pagelist.exit71
-                                        #   in Loop: Header=BB0_29 Depth=1
-	end_block                       # label19:
-	i32.store	28($3), $11
+.LBB0_43:                               # %merge_pagelist.exit71
+                                        #   in Loop: Header=BB0_31 Depth=1
+	end_block                       # label21:
+	i32.store	28($3), $10
 	i32.const	$push31=, 104
 	i32.add 	$push32=, $1, $pop31
-	i32.const	$push102=, 28
-	i32.add 	$push21=, $pop32, $pop102
+	i32.const	$push98=, 28
+	i32.add 	$push21=, $pop32, $pop98
 	i32.load	$4=, 0($pop21)
-	i32.const	$push101=, 1
-	i32.add 	$push100=, $10, $pop101
-	tee_local	$push99=, $10=, $pop100
-	i32.const	$push98=, 25
-	i32.ne  	$push20=, $pop99, $pop98
-	br_if   	0, $pop20       # 0: up to label18
-# BB#40:                                # %for.end20
+	i32.const	$push97=, 1
+	i32.add 	$push96=, $7, $pop97
+	tee_local	$push95=, $7=, $pop96
+	i32.const	$push94=, 25
+	i32.ne  	$push20=, $pop95, $pop94
+	br_if   	0, $pop20       # 0: up to label20
+# BB#44:                                # %for.end20
 	end_loop
 	i32.const	$push28=, 0
 	i32.const	$push26=, 144
 	i32.add 	$push27=, $1, $pop26
 	i32.store	__stack_pointer($pop28), $pop27
-	copy_local	$push110=, $4
-                                        # fallthrough-return: $pop110
+	copy_local	$push106=, $4
+                                        # fallthrough-return: $pop106
 	.endfunc
 .Lfunc_end0:
 	.size	sort_pagelist, .Lfunc_end0-sort_pagelist
@@ -409,7 +420,7 @@ main:                                   # @main
 	tee_local	$push25=, $0=, $pop26
 	i32.load	$push16=, 28($0)
 	i32.eq  	$push17=, $pop25, $pop16
-	br_if   	0, $pop17       # 0: down to label26
+	br_if   	0, $pop17       # 0: down to label29
 # BB#1:                                 # %if.end
 	i32.const	$push24=, 0
 	i32.const	$push22=, 208
@@ -418,7 +429,7 @@ main:                                   # @main
 	i32.const	$push30=, 0
 	return  	$pop30
 .LBB1_2:                                # %if.then
-	end_block                       # label26:
+	end_block                       # label29:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -426,5 +437,5 @@ main:                                   # @main
 	.size	main, .Lfunc_end1-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr34176.c.s
+++ b/test/torture-s/pr34176.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr34176.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr34176.c"
 	.section	.text.hash_find_entry,"ax",@progbits
 	.hidden	hash_find_entry
 	.globl	hash_find_entry
@@ -67,18 +67,15 @@ main:                                   # @main
 	i32.call	$drop=, hash_find_entry@FUNCTION, $pop9
 .LBB2_1:                                # %if.end
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB2_3 Depth 2
+                                        #     Child Loop BB2_2 Depth 2
 	loop    	                # label1:
 	i32.load	$0=, 12($2)
-	i32.call	$drop=, foo@FUNCTION, $1
+	i32.call	$drop=, foo@FUNCTION, $0
 	i32.const	$1=, 0
 	block   	
 	i32.eqz 	$push18=, $0
 	br_if   	0, $pop18       # 0: down to label2
-# BB#2:                                 # %while.body.preheader
-                                        #   in Loop: Header=BB2_1 Depth=1
-	i32.const	$1=, 0
-.LBB2_3:                                # %while.body
+.LBB2_2:                                # %while.body
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	loop    	                # label3:
@@ -88,7 +85,7 @@ main:                                   # @main
 	i32.add 	$push15=, $0, $pop16
 	tee_local	$push14=, $0=, $pop15
 	br_if   	0, $pop14       # 0: up to label3
-.LBB2_4:                                # %cleanup.thread
+.LBB2_3:                                # %cleanup.thread
                                         #   in Loop: Header=BB2_1 Depth=1
 	end_loop
 	end_block                       # label2:
@@ -97,7 +94,7 @@ main:                                   # @main
 	i32.call	$drop=, hash_find_entry@FUNCTION, $pop11
 	i32.eqz 	$push19=, $1
 	br_if   	0, $pop19       # 0: up to label1
-# BB#5:                                 # %for.end
+# BB#4:                                 # %for.end
 	end_loop
 	i32.const	$push7=, 0
 	i32.const	$push5=, 16
@@ -117,5 +114,5 @@ foo.count:
 	.size	foo.count, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr34456.c.s
+++ b/test/torture-s/pr34456.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr34456.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr34456.c"
 	.section	.text.debug,"ax",@progbits
 	.hidden	debug
 	.globl	debug
@@ -63,7 +63,7 @@ compare:                                # @compare
 	br_if   	0, $pop10       # 0: down to label0
 # BB#1:                                 # %land.lhs.true
 	i32.load	$push0=, 0($0)
-	i32.call_indirect	$push1=, $2, $pop0
+	i32.call_indirect	$push1=, $pop0, $2
 	i32.eqz 	$push11=, $pop1
 	br_if   	0, $pop11       # 0: down to label0
 # BB#2:                                 # %if.then
@@ -75,7 +75,7 @@ compare:                                # @compare
 	i32.store	errors($pop2), $pop5
 .LBB3_3:                                # %if.end
 	end_block                       # label0:
-	i32.call_indirect	$push6=, $2, $1
+	i32.call_indirect	$push6=, $1, $2
                                         # fallthrough-return: $pop6
 	.endfunc
 .Lfunc_end3:
@@ -103,5 +103,5 @@ errors:
 	.size	errors, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	qsort, void, i32, i32, i32, i32

--- a/test/torture-s/pr36339.c.s
+++ b/test/torture-s/pr36339.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr36339.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr36339.c"
 	.section	.text.try_a,"ax",@progbits
 	.hidden	try_a
 	.globl	try_a
@@ -43,26 +43,23 @@ check_a:                                # @check_a
 	.result 	i32
 	.local  	i32
 # BB#0:                                 # %entry
-	block   	
-	block   	
-	i32.const	$push0=, -1
-	i32.add 	$push1=, $0, $pop0
-	i32.load	$push2=, 0($pop1)
-	i32.const	$push3=, 42
-	i32.ne  	$push4=, $pop2, $pop3
-	br_if   	0, $pop4        # 0: down to label1
-# BB#1:                                 # %land.lhs.true
-	i32.const	$1=, 0
-	i32.load	$push5=, 3($0)
-	i32.eqz 	$push6=, $pop5
-	br_if   	1, $pop6        # 1: down to label0
-.LBB1_2:                                # %if.end
-	end_block                       # label1:
 	i32.const	$1=, -1
+	block   	
+	i32.const	$push5=, -1
+	i32.add 	$push0=, $0, $pop5
+	i32.load	$push1=, 0($pop0)
+	i32.const	$push2=, 42
+	i32.ne  	$push3=, $pop1, $pop2
+	br_if   	0, $pop3        # 0: down to label0
+# BB#1:                                 # %land.lhs.true
+	i32.load	$push4=, 3($0)
+	br_if   	0, $pop4        # 0: down to label0
+# BB#2:
+	i32.const	$1=, 0
 .LBB1_3:                                # %cleanup
 	end_block                       # label0:
-	copy_local	$push7=, $1
-                                        # fallthrough-return: $pop7
+	copy_local	$push6=, $1
+                                        # fallthrough-return: $pop6
 	.endfunc
 .Lfunc_end1:
 	.size	check_a, .Lfunc_end1-check_a
@@ -79,12 +76,12 @@ main:                                   # @main
 	i32.call	$push1=, try_a@FUNCTION, $pop0
 	i32.const	$push2=, -1
 	i32.le_s	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label2
+	br_if   	0, $pop3        # 0: down to label1
 # BB#1:                                 # %if.end
 	i32.const	$push4=, 0
 	return  	$pop4
 .LBB2_2:                                # %if.then
-	end_block                       # label2:
+	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -92,5 +89,5 @@ main:                                   # @main
 	.size	main, .Lfunc_end2-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr38051.c.s
+++ b/test/torture-s/pr38051.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr38051.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr38051.c"
 	.section	.text.mymemcmp,"ax",@progbits
 	.hidden	mymemcmp
 	.globl	mymemcmp
@@ -9,10 +9,10 @@ mymemcmp:                               # @mymemcmp
 	.result 	i32
 	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push103=, 0
-	i32.load	$push104=, __stack_pointer($pop103)
-	i32.const	$push105=, 16
-	i32.sub 	$10=, $pop104, $pop105
+	i32.const	$push104=, 0
+	i32.load	$push105=, __stack_pointer($pop104)
+	i32.const	$push106=, 16
+	i32.sub 	$10=, $pop105, $pop106
 	i32.const	$push26=, 2
 	i32.shr_u	$2=, $2, $pop26
 	block   	
@@ -29,71 +29,72 @@ mymemcmp:                               # @mymemcmp
 	block   	
 	block   	
 	block   	
-	i32.const	$push146=, 3
-	i32.and 	$push27=, $0, $pop146
-	i32.eqz 	$push222=, $pop27
-	br_if   	0, $pop222      # 0: down to label13
+	block   	
+	i32.const	$push147=, 3
+	i32.and 	$push27=, $0, $pop147
+	i32.eqz 	$push223=, $pop27
+	br_if   	0, $pop223      # 0: down to label14
 # BB#1:                                 # %if.else
 	i32.const	$push28=, -4
 	i32.and 	$4=, $0, $pop28
 	i32.const	$push31=, 32
-	i32.const	$push152=, 3
-	i32.shl 	$push29=, $0, $pop152
+	i32.const	$push153=, 3
+	i32.shl 	$push29=, $0, $pop153
 	i32.const	$push30=, 24
-	i32.and 	$push151=, $pop29, $pop30
-	tee_local	$push150=, $0=, $pop151
-	i32.sub 	$3=, $pop31, $pop150
-	i32.const	$push149=, 3
-	i32.and 	$push148=, $2, $pop149
-	tee_local	$push147=, $5=, $pop148
-	i32.eqz 	$push223=, $pop147
-	br_if   	1, $pop223      # 1: down to label12
+	i32.and 	$push152=, $pop29, $pop30
+	tee_local	$push151=, $0=, $pop152
+	i32.sub 	$3=, $pop31, $pop151
+	i32.const	$push150=, 3
+	i32.and 	$push149=, $2, $pop150
+	tee_local	$push148=, $5=, $pop149
+	i32.eqz 	$push224=, $pop148
+	br_if   	1, $pop224      # 1: down to label13
 # BB#2:                                 # %if.else
 	i32.const	$push32=, 1
 	i32.eq  	$push33=, $5, $pop32
-	br_if   	2, $pop33       # 2: down to label11
+	br_if   	2, $pop33       # 2: down to label12
 # BB#3:                                 # %if.else
 	i32.const	$push34=, 3
 	i32.ne  	$push35=, $5, $pop34
-	br_if   	3, $pop35       # 3: down to label10
+	br_if   	3, $pop35       # 3: down to label11
 # BB#4:                                 # %sw.bb6.i
 	i32.const	$push40=, 1
 	i32.add 	$2=, $2, $pop40
 	i32.const	$push41=, -4
 	i32.add 	$8=, $1, $pop41
 	i32.load	$7=, 0($4)
-	br      	8               # 8: down to label5
+	br      	8               # 8: down to label6
 .LBB0_5:                                # %if.then
-	end_block                       # label13:
-	i32.const	$push155=, 3
-	i32.and 	$push154=, $2, $pop155
-	tee_local	$push153=, $4=, $pop154
-	i32.eqz 	$push224=, $pop153
-	br_if   	10, $pop224     # 10: down to label2
+	end_block                       # label14:
+	i32.const	$push156=, 3
+	i32.and 	$push155=, $2, $pop156
+	tee_local	$push154=, $4=, $pop155
+	i32.eqz 	$push225=, $pop154
+	br_if   	11, $pop225     # 11: down to label2
 # BB#6:                                 # %if.then
 	i32.const	$push70=, 1
 	i32.eq  	$push71=, $4, $pop70
-	br_if   	3, $pop71       # 3: down to label9
+	br_if   	3, $pop71       # 3: down to label10
 # BB#7:                                 # %if.then
 	i32.const	$push72=, 3
 	i32.ne  	$push73=, $4, $pop72
-	br_if   	4, $pop73       # 4: down to label8
+	br_if   	4, $pop73       # 4: down to label9
 # BB#8:                                 # %sw.bb3.i
 	i32.const	$push76=, 1
 	i32.add 	$2=, $2, $pop76
 	i32.const	$push77=, -4
 	i32.add 	$4=, $1, $pop77
-	i32.const	$push156=, -4
-	i32.add 	$3=, $0, $pop156
-	br      	11              # 11: down to label1
+	i32.const	$push157=, -4
+	i32.add 	$3=, $0, $pop157
+	br      	12              # 12: down to label1
 .LBB0_9:                                # %sw.bb12.i18
-	end_block                       # label12:
+	end_block                       # label13:
 	i32.const	$push39=, 4
 	i32.add 	$6=, $4, $pop39
 	i32.load	$5=, 0($4)
-	br      	5               # 5: down to label6
+	br      	5               # 5: down to label7
 .LBB0_10:                               # %sw.bb17.i
-	end_block                       # label11:
+	end_block                       # label12:
 	i32.const	$push36=, -1
 	i32.add 	$2=, $2, $pop36
 	i32.const	$push38=, 8
@@ -104,9 +105,9 @@ mymemcmp:                               # @mymemcmp
 	i32.const	$push37=, 4
 	i32.add 	$push14=, $1, $pop37
 	copy_local	$1=, $pop14
-	br      	3               # 3: down to label7
+	br      	3               # 3: down to label8
 .LBB0_11:                               # %sw.bb.i16
-	end_block                       # label10:
+	end_block                       # label11:
 	i32.const	$push42=, 2
 	i32.add 	$2=, $2, $pop42
 	i32.const	$push43=, -8
@@ -116,9 +117,9 @@ mymemcmp:                               # @mymemcmp
 	i32.const	$push45=, 4
 	i32.add 	$6=, $4, $pop45
 	i32.load	$5=, 0($4)
-	br      	5               # 5: down to label4
+	br      	5               # 5: down to label5
 .LBB0_12:                               # %sw.bb12.i
-	end_block                       # label9:
+	end_block                       # label10:
 	i32.const	$push74=, -1
 	i32.add 	$2=, $2, $pop74
 	i32.load	$5=, 0($1)
@@ -126,51 +127,57 @@ mymemcmp:                               # @mymemcmp
 	i32.const	$push75=, 4
 	i32.add 	$push0=, $0, $pop75
 	copy_local	$0=, $pop0
-	i32.const	$push157=, 4
-	i32.add 	$push1=, $1, $pop157
+	i32.const	$push158=, 4
+	i32.add 	$push1=, $1, $pop158
 	copy_local	$1=, $pop1
-	br      	5               # 5: down to label3
+	i32.eq  	$push84=, $6, $5
+	br_if   	5, $pop84       # 5: down to label4
+	br      	6               # 6: down to label3
 .LBB0_13:                               # %sw.bb.i
-	end_block                       # label8:
+	end_block                       # label9:
 	i32.const	$push78=, 2
 	i32.add 	$2=, $2, $pop78
 	i32.const	$push79=, -8
 	i32.add 	$4=, $1, $pop79
-	i32.const	$push158=, -8
-	i32.add 	$3=, $0, $pop158
+	i32.const	$push159=, -8
+	i32.add 	$3=, $0, $pop159
 # BB#14:
 	i32.const	$11=, 39
-	br      	7               # 7: down to label0
+	br      	8               # 8: down to label0
 .LBB0_15:
-	end_block                       # label7:
+	end_block                       # label8:
 	i32.const	$11=, 0
-	br      	6               # 6: down to label0
+	br      	7               # 7: down to label0
 .LBB0_16:
-	end_block                       # label6:
+	end_block                       # label7:
 	i32.const	$11=, 4
-	br      	5               # 5: down to label0
+	br      	6               # 6: down to label0
 .LBB0_17:
-	end_block                       # label5:
+	end_block                       # label6:
 	i32.const	$11=, 9
-	br      	4               # 4: down to label0
+	br      	5               # 5: down to label0
 .LBB0_18:
-	end_block                       # label4:
+	end_block                       # label5:
 	i32.const	$11=, 14
-	br      	3               # 3: down to label0
+	br      	4               # 4: down to label0
 .LBB0_19:
-	end_block                       # label3:
-	i32.const	$11=, 25
-	br      	2               # 2: down to label0
+	end_block                       # label4:
+	i32.const	$11=, 29
+	br      	3               # 3: down to label0
 .LBB0_20:
+	end_block                       # label3:
+	i32.const	$11=, 26
+	br      	2               # 2: down to label0
+.LBB0_21:
 	end_block                       # label2:
 	i32.const	$11=, 29
 	br      	1               # 1: down to label0
-.LBB0_21:
+.LBB0_22:
 	end_block                       # label1:
 	i32.const	$11=, 34
-.LBB0_22:                               # =>This Inner Loop Header: Depth=1
+.LBB0_23:                               # =>This Inner Loop Header: Depth=1
 	end_block                       # label0:
-	loop    	i32             # label14:
+	loop    	i32             # label15:
 	block   	
 	block   	
 	block   	
@@ -243,707 +250,699 @@ mymemcmp:                               # @mymemcmp
 	block   	
 	block   	
 	block   	
-	block   	
-	br_table 	$11, 27, 35, 36, 37, 28, 38, 39, 40, 29, 30, 41, 42, 43, 31, 24, 32, 33, 34, 25, 26, 44, 45, 46, 47, 48, 3, 11, 12, 13, 4, 14, 15, 16, 5, 6, 17, 18, 19, 7, 0, 8, 9, 10, 1, 2, 20, 21, 22, 23, 23 # 27: down to label60
+	br_table 	$11, 26, 34, 35, 36, 27, 37, 38, 39, 28, 29, 40, 41, 42, 30, 23, 31, 32, 33, 24, 25, 43, 44, 45, 46, 47, 2, 10, 11, 12, 3, 13, 14, 15, 4, 5, 16, 17, 18, 6, 0, 7, 8, 9, 1, 19, 20, 21, 22, 22 # 26: down to label61
+                                        # 34: down to label53
                                         # 35: down to label52
                                         # 36: down to label51
+                                        # 27: down to label60
                                         # 37: down to label50
-                                        # 28: down to label59
                                         # 38: down to label49
                                         # 39: down to label48
-                                        # 40: down to label47
+                                        # 28: down to label59
                                         # 29: down to label58
-                                        # 30: down to label57
+                                        # 40: down to label47
                                         # 41: down to label46
                                         # 42: down to label45
-                                        # 43: down to label44
+                                        # 30: down to label57
+                                        # 23: down to label64
                                         # 31: down to label56
-                                        # 24: down to label63
                                         # 32: down to label55
                                         # 33: down to label54
-                                        # 34: down to label53
+                                        # 24: down to label63
                                         # 25: down to label62
-                                        # 26: down to label61
+                                        # 43: down to label44
                                         # 44: down to label43
                                         # 45: down to label42
                                         # 46: down to label41
                                         # 47: down to label40
-                                        # 48: down to label39
-                                        # 3: down to label84
+                                        # 2: down to label85
+                                        # 10: down to label77
                                         # 11: down to label76
                                         # 12: down to label75
+                                        # 3: down to label84
                                         # 13: down to label74
-                                        # 4: down to label83
                                         # 14: down to label73
                                         # 15: down to label72
-                                        # 16: down to label71
+                                        # 4: down to label83
                                         # 5: down to label82
-                                        # 6: down to label81
+                                        # 16: down to label71
                                         # 17: down to label70
                                         # 18: down to label69
-                                        # 19: down to label68
-                                        # 7: down to label80
+                                        # 6: down to label81
                                         # 0: down to label87
+                                        # 7: down to label80
                                         # 8: down to label79
                                         # 9: down to label78
-                                        # 10: down to label77
                                         # 1: down to label86
-                                        # 2: down to label85
+                                        # 19: down to label68
                                         # 20: down to label67
                                         # 21: down to label66
                                         # 22: down to label65
-                                        # 23: down to label64
-.LBB0_23:                               # %do1.i
-                                        #   in Loop: Header=BB0_22 Depth=1
+.LBB0_24:                               # %do1.i
+                                        #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label87:
-	i32.load	$push162=, 0($0)
-	tee_local	$push161=, $0=, $pop162
-	i32.load	$push160=, 0($1)
-	tee_local	$push159=, $1=, $pop160
-	i32.ne  	$push80=, $pop161, $pop159
+	i32.load	$push163=, 0($0)
+	tee_local	$push162=, $0=, $pop163
+	i32.load	$push161=, 0($1)
+	tee_local	$push160=, $1=, $pop161
+	i32.ne  	$push80=, $pop162, $pop160
 	br_if   	68, $pop80      # 68: down to label18
-# BB#24:                                #   in Loop: Header=BB0_22 Depth=1
+# BB#25:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 43
-	br      	72              # 72: up to label14
-.LBB0_25:                               # %if.end37.i
-                                        #   in Loop: Header=BB0_22 Depth=1
+	br      	71              # 71: up to label15
+.LBB0_26:                               # %if.end37.i
+                                        #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label86:
 	i32.load	$5=, 12($4)
 	i32.load	$6=, 12($3)
 	i32.const	$push82=, -4
-	i32.add 	$push164=, $2, $pop82
-	tee_local	$push163=, $2=, $pop164
-	i32.eqz 	$push225=, $pop163
-	br_if   	69, $pop225     # 69: down to label16
-# BB#26:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 44
-	br      	71              # 71: up to label14
-.LBB0_27:                               #   in Loop: Header=BB0_22 Depth=1
+	i32.add 	$push165=, $2, $pop82
+	tee_local	$push164=, $2=, $pop165
+	i32.eqz 	$push226=, $pop164
+	br_if   	60, $pop226     # 60: down to label25
+# BB#27:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 25
+	br      	70              # 70: up to label15
+.LBB0_28:                               #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label85:
 	i32.const	$push83=, 16
 	i32.add 	$1=, $4, $pop83
-	i32.const	$push165=, 16
-	i32.add 	$0=, $3, $pop165
-# BB#28:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 25
-	br      	70              # 70: up to label14
-.LBB0_29:                               # %do.body.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label84:
-	i32.ne  	$push84=, $6, $5
-	br_if   	45, $pop84      # 45: down to label38
-# BB#30:                                #   in Loop: Header=BB0_22 Depth=1
+	i32.const	$push166=, 16
+	i32.add 	$0=, $3, $pop166
+	i32.ne  	$push85=, $6, $5
+	br_if   	45, $pop85      # 45: down to label39
+# BB#29:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 29
-	br      	69              # 69: up to label14
-.LBB0_31:                               # %do3.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label83:
-	i32.load	$push169=, 0($0)
-	tee_local	$push168=, $4=, $pop169
-	i32.load	$push167=, 0($1)
-	tee_local	$push166=, $3=, $pop167
-	i32.ne  	$push87=, $pop168, $pop166
-	br_if   	59, $pop87      # 59: down to label23
-# BB#32:                                #   in Loop: Header=BB0_22 Depth=1
+	br      	69              # 69: up to label15
+.LBB0_30:                               # %do3.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label84:
+	i32.load	$push170=, 0($0)
+	tee_local	$push169=, $4=, $pop170
+	i32.load	$push168=, 0($1)
+	tee_local	$push167=, $3=, $pop168
+	i32.ne  	$push88=, $pop169, $pop167
+	br_if   	60, $pop88      # 60: down to label23
+# BB#31:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 33
-	br      	68              # 68: up to label14
-.LBB0_33:                               #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label82:
+	br      	68              # 68: up to label15
+.LBB0_32:                               #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label83:
 	copy_local	$3=, $0
 	copy_local	$4=, $1
-	i32.const	$push86=, 4
-	i32.add 	$push4=, $0, $pop86
+	i32.const	$push87=, 4
+	i32.add 	$push4=, $0, $pop87
 	copy_local	$0=, $pop4
-	i32.const	$push170=, 4
-	i32.add 	$push5=, $1, $pop170
+	i32.const	$push171=, 4
+	i32.add 	$push5=, $1, $pop171
 	copy_local	$1=, $pop5
-# BB#34:                                #   in Loop: Header=BB0_22 Depth=1
+# BB#33:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 34
-	br      	67              # 67: up to label14
-.LBB0_35:                               # %do2.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label81:
-	i32.load	$push174=, 0($0)
-	tee_local	$push173=, $0=, $pop174
-	i32.load	$push172=, 0($1)
-	tee_local	$push171=, $1=, $pop172
-	i32.ne  	$push90=, $pop173, $pop171
-	br_if   	59, $pop90      # 59: down to label21
-# BB#36:                                #   in Loop: Header=BB0_22 Depth=1
+	br      	67              # 67: up to label15
+.LBB0_34:                               # %do2.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label82:
+	i32.load	$push175=, 0($0)
+	tee_local	$push174=, $0=, $pop175
+	i32.load	$push173=, 0($1)
+	tee_local	$push172=, $1=, $pop173
+	i32.ne  	$push91=, $pop174, $pop172
+	br_if   	60, $pop91      # 60: down to label21
+# BB#35:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 38
-	br      	66              # 66: up to label14
-.LBB0_37:                               #   in Loop: Header=BB0_22 Depth=1
+	br      	66              # 66: up to label15
+.LBB0_36:                               #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label81:
+	i32.const	$push90=, 8
+	i32.add 	$1=, $4, $pop90
+	i32.const	$push176=, 8
+	i32.add 	$0=, $3, $pop176
+	br      	61              # 61: down to label19
+.LBB0_37:                               # %if.then35.i
+                                        #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label80:
-	i32.const	$push89=, 8
-	i32.add 	$1=, $4, $pop89
-	i32.const	$push175=, 8
-	i32.add 	$0=, $3, $pop175
-	br      	60              # 60: down to label19
-.LBB0_38:                               # %if.then35.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label79:
 	i32.store	12($10), $0
 	i32.store	8($10), $1
-	i32.const	$push114=, 8
-	i32.add 	$push115=, $10, $pop114
-	copy_local	$1=, $pop115
-	i32.const	$push116=, 12
-	i32.add 	$push117=, $10, $pop116
-	copy_local	$10=, $pop117
-# BB#39:                                #   in Loop: Header=BB0_22 Depth=1
+	i32.const	$push115=, 8
+	i32.add 	$push116=, $10, $pop115
+	copy_local	$1=, $pop116
+	i32.const	$push117=, 12
+	i32.add 	$push118=, $10, $pop117
+	copy_local	$10=, $pop118
+# BB#38:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 41
-	br      	64              # 64: up to label14
-.LBB0_40:                               # %do.body.i116.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label78:
+	br      	64              # 64: up to label15
+.LBB0_39:                               # %do.body.i116.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label79:
 	i32.load8_u	$0=, 0($1)
 	i32.load8_u	$2=, 0($10)
-	i32.const	$push177=, 1
-	i32.add 	$push11=, $1, $pop177
+	i32.const	$push178=, 1
+	i32.add 	$push11=, $1, $pop178
 	copy_local	$1=, $pop11
-	i32.const	$push176=, 1
-	i32.add 	$push10=, $10, $pop176
+	i32.const	$push177=, 1
+	i32.add 	$push10=, $10, $pop177
 	copy_local	$10=, $pop10
 	i32.eq  	$push81=, $2, $0
-	br_if   	60, $pop81      # 60: down to label17
-# BB#41:                                #   in Loop: Header=BB0_22 Depth=1
+	br_if   	61, $pop81      # 61: down to label17
+# BB#40:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 42
-	br      	63              # 63: up to label14
-.LBB0_42:                               # %mymemcmp1.exit120.i
-	end_block                       # label77:
-	i32.sub 	$push99=, $2, $0
-	return  	$pop99
-.LBB0_43:                               # %if.then.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label76:
-	i32.store	12($10), $6
-	i32.store	8($10), $5
-	i32.const	$push110=, 8
-	i32.add 	$push111=, $10, $pop110
-	copy_local	$1=, $pop111
-	i32.const	$push112=, 12
-	i32.add 	$push113=, $10, $pop112
-	copy_local	$10=, $pop113
-# BB#44:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 27
-	br      	61              # 61: up to label14
-.LBB0_45:                               # %do.body.i.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label75:
-	i32.load8_u	$0=, 0($1)
-	i32.load8_u	$2=, 0($10)
-	i32.const	$push179=, 1
-	i32.add 	$push3=, $1, $pop179
-	copy_local	$1=, $pop3
-	i32.const	$push178=, 1
-	i32.add 	$push2=, $10, $pop178
-	copy_local	$10=, $pop2
-	i32.eq  	$push85=, $2, $0
-	br_if   	50, $pop85      # 50: down to label24
-# BB#46:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 28
-	br      	60              # 60: up to label14
-.LBB0_47:                               # %mymemcmp1.exit.i
-	end_block                       # label74:
-	i32.sub 	$push102=, $2, $0
-	return  	$pop102
-.LBB0_48:                               # %if.then23.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label73:
-	i32.store	12($10), $4
-	i32.store	8($10), $3
-	i32.const	$push122=, 8
-	i32.add 	$push123=, $10, $pop122
-	copy_local	$1=, $pop123
-	i32.const	$push124=, 12
-	i32.add 	$push125=, $10, $pop124
-	copy_local	$10=, $pop125
-# BB#49:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 31
-	br      	58              # 58: up to label14
-.LBB0_50:                               # %do.body.i140.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label72:
-	i32.load8_u	$0=, 0($1)
-	i32.load8_u	$2=, 0($10)
-	i32.const	$push181=, 1
-	i32.add 	$push7=, $1, $pop181
-	copy_local	$1=, $pop7
-	i32.const	$push180=, 1
-	i32.add 	$push6=, $10, $pop180
-	copy_local	$10=, $pop6
-	i32.eq  	$push88=, $2, $0
-	br_if   	49, $pop88      # 49: down to label22
-# BB#51:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 32
-	br      	57              # 57: up to label14
-.LBB0_52:                               # %mymemcmp1.exit144.i
-	end_block                       # label71:
-	i32.sub 	$push101=, $2, $0
-	return  	$pop101
-.LBB0_53:                               # %if.then29.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label70:
-	i32.store	12($10), $0
-	i32.store	8($10), $1
-	i32.const	$push118=, 8
-	i32.add 	$push119=, $10, $pop118
-	copy_local	$1=, $pop119
-	i32.const	$push120=, 12
-	i32.add 	$push121=, $10, $pop120
-	copy_local	$10=, $pop121
-# BB#54:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 36
-	br      	55              # 55: up to label14
-.LBB0_55:                               # %do.body.i128.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label69:
-	i32.load8_u	$0=, 0($1)
-	i32.load8_u	$2=, 0($10)
-	i32.const	$push183=, 1
-	i32.add 	$push9=, $1, $pop183
-	copy_local	$1=, $pop9
-	i32.const	$push182=, 1
-	i32.add 	$push8=, $10, $pop182
-	copy_local	$10=, $pop8
-	i32.eq  	$push91=, $2, $0
-	br_if   	48, $pop91      # 48: down to label20
-# BB#56:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 37
-	br      	54              # 54: up to label14
-.LBB0_57:                               # %mymemcmp1.exit132.i
-	end_block                       # label68:
+	br      	63              # 63: up to label15
+.LBB0_41:                               # %mymemcmp1.exit120.i
+	end_block                       # label78:
 	i32.sub 	$push100=, $2, $0
 	return  	$pop100
-.LBB0_58:                               # %do0.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label67:
-	i32.const	$1=, 0
-	i32.eq  	$push92=, $6, $5
-	br_if   	41, $pop92      # 41: down to label25
-# BB#59:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 46
-	br      	52              # 52: up to label14
-.LBB0_60:                               # %if.then43.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label66:
+.LBB0_42:                               # %if.then.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label77:
 	i32.store	12($10), $6
 	i32.store	8($10), $5
-	i32.const	$push106=, 8
-	i32.add 	$push107=, $10, $pop106
-	copy_local	$1=, $pop107
-	i32.const	$push108=, 12
-	i32.add 	$push109=, $10, $pop108
-	copy_local	$10=, $pop109
-# BB#61:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 47
-	br      	51              # 51: up to label14
-.LBB0_62:                               # %do.body.i104.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label65:
+	i32.const	$push111=, 8
+	i32.add 	$push112=, $10, $pop111
+	copy_local	$1=, $pop112
+	i32.const	$push113=, 12
+	i32.add 	$push114=, $10, $pop113
+	copy_local	$10=, $pop114
+# BB#43:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 27
+	br      	61              # 61: up to label15
+.LBB0_44:                               # %do.body.i.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label76:
 	i32.load8_u	$0=, 0($1)
 	i32.load8_u	$2=, 0($10)
-	i32.const	$push185=, 1
-	i32.add 	$push13=, $1, $pop185
-	copy_local	$1=, $pop13
+	i32.const	$push180=, 1
+	i32.add 	$push3=, $1, $pop180
+	copy_local	$1=, $pop3
+	i32.const	$push179=, 1
+	i32.add 	$push2=, $10, $pop179
+	copy_local	$10=, $pop2
+	i32.eq  	$push86=, $2, $0
+	br_if   	51, $pop86      # 51: down to label24
+# BB#45:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 28
+	br      	60              # 60: up to label15
+.LBB0_46:                               # %mymemcmp1.exit.i
+	end_block                       # label75:
+	i32.sub 	$push103=, $2, $0
+	return  	$pop103
+.LBB0_47:                               # %if.then23.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label74:
+	i32.store	12($10), $4
+	i32.store	8($10), $3
+	i32.const	$push123=, 8
+	i32.add 	$push124=, $10, $pop123
+	copy_local	$1=, $pop124
+	i32.const	$push125=, 12
+	i32.add 	$push126=, $10, $pop125
+	copy_local	$10=, $pop126
+# BB#48:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 31
+	br      	58              # 58: up to label15
+.LBB0_49:                               # %do.body.i140.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label73:
+	i32.load8_u	$0=, 0($1)
+	i32.load8_u	$2=, 0($10)
+	i32.const	$push182=, 1
+	i32.add 	$push7=, $1, $pop182
+	copy_local	$1=, $pop7
+	i32.const	$push181=, 1
+	i32.add 	$push6=, $10, $pop181
+	copy_local	$10=, $pop6
+	i32.eq  	$push89=, $2, $0
+	br_if   	50, $pop89      # 50: down to label22
+# BB#50:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 32
+	br      	57              # 57: up to label15
+.LBB0_51:                               # %mymemcmp1.exit144.i
+	end_block                       # label72:
+	i32.sub 	$push102=, $2, $0
+	return  	$pop102
+.LBB0_52:                               # %if.then29.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label71:
+	i32.store	12($10), $0
+	i32.store	8($10), $1
+	i32.const	$push119=, 8
+	i32.add 	$push120=, $10, $pop119
+	copy_local	$1=, $pop120
+	i32.const	$push121=, 12
+	i32.add 	$push122=, $10, $pop121
+	copy_local	$10=, $pop122
+# BB#53:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 36
+	br      	55              # 55: up to label15
+.LBB0_54:                               # %do.body.i128.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label70:
+	i32.load8_u	$0=, 0($1)
+	i32.load8_u	$2=, 0($10)
 	i32.const	$push184=, 1
-	i32.add 	$push12=, $10, $pop184
+	i32.add 	$push9=, $1, $pop184
+	copy_local	$1=, $pop9
+	i32.const	$push183=, 1
+	i32.add 	$push8=, $10, $pop183
+	copy_local	$10=, $pop8
+	i32.eq  	$push92=, $2, $0
+	br_if   	49, $pop92      # 49: down to label20
+# BB#55:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 37
+	br      	54              # 54: up to label15
+.LBB0_56:                               # %mymemcmp1.exit132.i
+	end_block                       # label69:
+	i32.sub 	$push101=, $2, $0
+	return  	$pop101
+.LBB0_57:                               # %do0.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label68:
+	i32.const	$1=, 0
+	i32.eq  	$push93=, $6, $5
+	br_if   	41, $pop93      # 41: down to label26
+# BB#58:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 45
+	br      	52              # 52: up to label15
+.LBB0_59:                               # %if.then43.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label67:
+	i32.store	12($10), $6
+	i32.store	8($10), $5
+	i32.const	$push107=, 8
+	i32.add 	$push108=, $10, $pop107
+	copy_local	$1=, $pop108
+	i32.const	$push109=, 12
+	i32.add 	$push110=, $10, $pop109
+	copy_local	$10=, $pop110
+# BB#60:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 46
+	br      	51              # 51: up to label15
+.LBB0_61:                               # %do.body.i104.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label66:
+	i32.load8_u	$0=, 0($1)
+	i32.load8_u	$2=, 0($10)
+	i32.const	$push186=, 1
+	i32.add 	$push13=, $1, $pop186
+	copy_local	$1=, $pop13
+	i32.const	$push185=, 1
+	i32.add 	$push12=, $10, $pop185
 	copy_local	$10=, $pop12
-	i32.eq  	$push93=, $2, $0
-	br_if   	49, $pop93      # 49: down to label15
-# BB#63:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 48
-	br      	50              # 50: up to label14
-.LBB0_64:                               # %mymemcmp1.exit108.i
+	i32.eq  	$push94=, $2, $0
+	br_if   	49, $pop94      # 49: down to label16
+# BB#62:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 47
+	br      	50              # 50: up to label15
+.LBB0_63:                               # %mymemcmp1.exit108.i
+	end_block                       # label65:
+	i32.sub 	$push99=, $2, $0
+	return  	$pop99
+.LBB0_64:                               # %do1.i56
+                                        #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label64:
-	i32.sub 	$push98=, $2, $0
-	return  	$pop98
-.LBB0_65:                               # %do1.i56
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label63:
-	i32.load	$push191=, 0($6)
-	tee_local	$push190=, $4=, $pop191
-	i32.shl 	$push47=, $pop190, $3
+	i32.load	$push192=, 0($6)
+	tee_local	$push191=, $4=, $pop192
+	i32.shl 	$push47=, $pop191, $3
 	i32.shr_u	$push46=, $5, $0
-	i32.or  	$push189=, $pop47, $pop46
-	tee_local	$push188=, $5=, $pop189
-	i32.load	$push187=, 0($1)
-	tee_local	$push186=, $1=, $pop187
-	i32.ne  	$push48=, $pop188, $pop186
-	br_if   	32, $pop48      # 32: down to label30
-# BB#66:                                #   in Loop: Header=BB0_22 Depth=1
+	i32.or  	$push190=, $pop47, $pop46
+	tee_local	$push189=, $5=, $pop190
+	i32.load	$push188=, 0($1)
+	tee_local	$push187=, $1=, $pop188
+	i32.ne  	$push48=, $pop189, $pop187
+	br_if   	32, $pop48      # 32: down to label31
+# BB#65:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 18
-	br      	48              # 48: up to label14
-.LBB0_67:                               # %if.end54.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label62:
+	br      	48              # 48: up to label15
+.LBB0_66:                               # %if.end54.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label63:
 	i32.load	$7=, 12($8)
 	i32.load	$5=, 12($9)
 	i32.const	$push50=, -4
-	i32.add 	$push193=, $2, $pop50
-	tee_local	$push192=, $2=, $pop193
-	i32.eqz 	$push226=, $pop192
-	br_if   	33, $pop226     # 33: down to label28
-# BB#68:                                #   in Loop: Header=BB0_22 Depth=1
+	i32.add 	$push194=, $2, $pop50
+	tee_local	$push193=, $2=, $pop194
+	i32.eqz 	$push227=, $pop193
+	br_if   	33, $pop227     # 33: down to label29
+# BB#67:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 19
-	br      	47              # 47: up to label14
-.LBB0_69:                               #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label61:
+	br      	47              # 47: up to label15
+.LBB0_68:                               #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label62:
 	i32.const	$push51=, 16
 	i32.add 	$1=, $8, $pop51
-	i32.const	$push194=, 16
-	i32.add 	$6=, $9, $pop194
-# BB#70:                                #   in Loop: Header=BB0_22 Depth=1
+	i32.const	$push195=, 16
+	i32.add 	$6=, $9, $pop195
+# BB#69:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 0
-	br      	46              # 46: up to label14
-.LBB0_71:                               # %do.body.i23
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label60:
+	br      	46              # 46: up to label15
+.LBB0_70:                               # %do.body.i23
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label61:
 	i32.shl 	$push53=, $5, $3
 	i32.shr_u	$push52=, $4, $0
-	i32.or  	$push196=, $pop53, $pop52
-	tee_local	$push195=, $4=, $pop196
-	i32.ne  	$push54=, $pop195, $7
-	br_if   	22, $pop54      # 22: down to label37
-# BB#72:                                #   in Loop: Header=BB0_22 Depth=1
+	i32.or  	$push197=, $pop53, $pop52
+	tee_local	$push196=, $4=, $pop197
+	i32.ne  	$push54=, $pop196, $7
+	br_if   	22, $pop54      # 22: down to label38
+# BB#71:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 4
-	br      	45              # 45: up to label14
-.LBB0_73:                               # %do3.i42
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label59:
-	i32.load	$push202=, 0($6)
-	tee_local	$push201=, $7=, $pop202
-	i32.shl 	$push57=, $pop201, $3
+	br      	45              # 45: up to label15
+.LBB0_72:                               # %do3.i42
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label60:
+	i32.load	$push203=, 0($6)
+	tee_local	$push202=, $7=, $pop203
+	i32.shl 	$push57=, $pop202, $3
 	i32.shr_u	$push56=, $5, $0
-	i32.or  	$push200=, $pop57, $pop56
-	tee_local	$push199=, $4=, $pop200
-	i32.load	$push198=, 0($1)
-	tee_local	$push197=, $5=, $pop198
-	i32.ne  	$push58=, $pop199, $pop197
-	br_if   	23, $pop58      # 23: down to label35
-# BB#74:                                #   in Loop: Header=BB0_22 Depth=1
+	i32.or  	$push201=, $pop57, $pop56
+	tee_local	$push200=, $4=, $pop201
+	i32.load	$push199=, 0($1)
+	tee_local	$push198=, $5=, $pop199
+	i32.ne  	$push58=, $pop200, $pop198
+	br_if   	23, $pop58      # 23: down to label36
+# BB#73:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 8
-	br      	44              # 44: up to label14
-.LBB0_75:                               #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label58:
+	br      	44              # 44: up to label15
+.LBB0_74:                               #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label59:
 	copy_local	$8=, $1
 	copy_local	$4=, $6
 	i32.const	$push59=, 4
 	i32.add 	$push17=, $1, $pop59
 	copy_local	$1=, $pop17
-# BB#76:                                #   in Loop: Header=BB0_22 Depth=1
+# BB#75:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 9
-	br      	43              # 43: up to label14
-.LBB0_77:                               # %do2.i50
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label57:
-	i32.load	$push208=, 4($4)
-	tee_local	$push207=, $5=, $pop208
-	i32.shl 	$push62=, $pop207, $3
+	br      	43              # 43: up to label15
+.LBB0_76:                               # %do2.i50
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label58:
+	i32.load	$push209=, 4($4)
+	tee_local	$push208=, $5=, $pop209
+	i32.shl 	$push62=, $pop208, $3
 	i32.shr_u	$push61=, $7, $0
-	i32.or  	$push206=, $pop62, $pop61
-	tee_local	$push205=, $6=, $pop206
-	i32.load	$push204=, 0($1)
-	tee_local	$push203=, $1=, $pop204
-	i32.ne  	$push63=, $pop205, $pop203
-	br_if   	23, $pop63      # 23: down to label33
-# BB#78:                                #   in Loop: Header=BB0_22 Depth=1
+	i32.or  	$push207=, $pop62, $pop61
+	tee_local	$push206=, $6=, $pop207
+	i32.load	$push205=, 0($1)
+	tee_local	$push204=, $1=, $pop205
+	i32.ne  	$push63=, $pop206, $pop204
+	br_if   	23, $pop63      # 23: down to label34
+# BB#77:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 13
-	br      	42              # 42: up to label14
-.LBB0_79:                               #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label56:
+	br      	42              # 42: up to label15
+.LBB0_78:                               #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label57:
 	i32.const	$push64=, 8
 	i32.add 	$1=, $8, $pop64
-	i32.const	$push209=, 8
-	i32.add 	$6=, $4, $pop209
+	i32.const	$push210=, 8
+	i32.add 	$6=, $4, $pop210
 	copy_local	$9=, $4
-	br      	24              # 24: down to label31
-.LBB0_80:                               # %if.then52.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label55:
+	br      	24              # 24: down to label32
+.LBB0_79:                               # %if.then52.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label56:
 	i32.store	12($10), $5
 	i32.store	8($10), $1
-	i32.const	$push134=, 8
-	i32.add 	$push135=, $10, $pop134
-	copy_local	$1=, $pop135
-	i32.const	$push136=, 12
-	i32.add 	$push137=, $10, $pop136
-	copy_local	$10=, $pop137
-# BB#81:                                #   in Loop: Header=BB0_22 Depth=1
+	i32.const	$push135=, 8
+	i32.add 	$push136=, $10, $pop135
+	copy_local	$1=, $pop136
+	i32.const	$push137=, 12
+	i32.add 	$push138=, $10, $pop137
+	copy_local	$10=, $pop138
+# BB#80:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 16
-	br      	40              # 40: up to label14
-.LBB0_82:                               # %do.body.i170.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label54:
+	br      	40              # 40: up to label15
+.LBB0_81:                               # %do.body.i170.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label55:
 	i32.load8_u	$0=, 0($1)
 	i32.load8_u	$2=, 0($10)
-	i32.const	$push211=, 1
-	i32.add 	$push23=, $1, $pop211
+	i32.const	$push212=, 1
+	i32.add 	$push23=, $1, $pop212
 	copy_local	$1=, $pop23
-	i32.const	$push210=, 1
-	i32.add 	$push22=, $10, $pop210
+	i32.const	$push211=, 1
+	i32.add 	$push22=, $10, $pop211
 	copy_local	$10=, $pop22
 	i32.eq  	$push49=, $2, $0
-	br_if   	24, $pop49      # 24: down to label29
-# BB#83:                                #   in Loop: Header=BB0_22 Depth=1
+	br_if   	24, $pop49      # 24: down to label30
+# BB#82:                                #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 17
-	br      	39              # 39: up to label14
-.LBB0_84:                               # %mymemcmp1.exit174.i
-	end_block                       # label53:
-	i32.sub 	$push94=, $2, $0
-	return  	$pop94
-.LBB0_85:                               # %if.then.i24
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label52:
-	i32.store	12($10), $4
-	i32.store	8($10), $7
-	i32.const	$push130=, 8
-	i32.add 	$push131=, $10, $pop130
-	copy_local	$1=, $pop131
-	i32.const	$push132=, 12
-	i32.add 	$push133=, $10, $pop132
-	copy_local	$10=, $pop133
-# BB#86:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 2
-	br      	37              # 37: up to label14
-.LBB0_87:                               # %do.body.i.i30
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label51:
-	i32.load8_u	$0=, 0($1)
-	i32.load8_u	$2=, 0($10)
-	i32.const	$push213=, 1
-	i32.add 	$push16=, $1, $pop213
-	copy_local	$1=, $pop16
-	i32.const	$push212=, 1
-	i32.add 	$push15=, $10, $pop212
-	copy_local	$10=, $pop15
-	i32.eq  	$push55=, $2, $0
-	br_if   	14, $pop55      # 14: down to label36
-# BB#88:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 3
-	br      	36              # 36: up to label14
-.LBB0_89:                               # %mymemcmp1.exit.i34
-	end_block                       # label50:
-	i32.sub 	$push97=, $2, $0
-	return  	$pop97
-.LBB0_90:                               # %if.then34.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label49:
-	i32.store	12($10), $4
-	i32.store	8($10), $5
-	i32.const	$push142=, 8
-	i32.add 	$push143=, $10, $pop142
-	copy_local	$1=, $pop143
-	i32.const	$push144=, 12
-	i32.add 	$push145=, $10, $pop144
-	copy_local	$10=, $pop145
-# BB#91:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 6
-	br      	34              # 34: up to label14
-.LBB0_92:                               # %do.body.i194.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label48:
-	i32.load8_u	$0=, 0($1)
-	i32.load8_u	$2=, 0($10)
-	i32.const	$push215=, 1
-	i32.add 	$push19=, $1, $pop215
-	copy_local	$1=, $pop19
-	i32.const	$push214=, 1
-	i32.add 	$push18=, $10, $pop214
-	copy_local	$10=, $pop18
-	i32.eq  	$push60=, $2, $0
-	br_if   	13, $pop60      # 13: down to label34
-# BB#93:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 7
-	br      	33              # 33: up to label14
-.LBB0_94:                               # %mymemcmp1.exit198.i
-	end_block                       # label47:
-	i32.sub 	$push96=, $2, $0
-	return  	$pop96
-.LBB0_95:                               # %if.then43.i51
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label46:
-	i32.store	12($10), $6
-	i32.store	8($10), $1
-	i32.const	$push138=, 8
-	i32.add 	$push139=, $10, $pop138
-	copy_local	$1=, $pop139
-	i32.const	$push140=, 12
-	i32.add 	$push141=, $10, $pop140
-	copy_local	$10=, $pop141
-# BB#96:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 11
-	br      	31              # 31: up to label14
-.LBB0_97:                               # %do.body.i182.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label45:
-	i32.load8_u	$0=, 0($1)
-	i32.load8_u	$2=, 0($10)
-	i32.const	$push217=, 1
-	i32.add 	$push21=, $1, $pop217
-	copy_local	$1=, $pop21
-	i32.const	$push216=, 1
-	i32.add 	$push20=, $10, $pop216
-	copy_local	$10=, $pop20
-	i32.eq  	$push65=, $2, $0
-	br_if   	12, $pop65      # 12: down to label32
-# BB#98:                                #   in Loop: Header=BB0_22 Depth=1
-	i32.const	$11=, 12
-	br      	30              # 30: up to label14
-.LBB0_99:                               # %mymemcmp1.exit186.i
-	end_block                       # label44:
+	br      	39              # 39: up to label15
+.LBB0_83:                               # %mymemcmp1.exit174.i
+	end_block                       # label54:
 	i32.sub 	$push95=, $2, $0
 	return  	$pop95
-.LBB0_100:                              # %do0.i57
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label43:
+.LBB0_84:                               # %if.then.i24
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label53:
+	i32.store	12($10), $4
+	i32.store	8($10), $7
+	i32.const	$push131=, 8
+	i32.add 	$push132=, $10, $pop131
+	copy_local	$1=, $pop132
+	i32.const	$push133=, 12
+	i32.add 	$push134=, $10, $pop133
+	copy_local	$10=, $pop134
+# BB#85:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 2
+	br      	37              # 37: up to label15
+.LBB0_86:                               # %do.body.i.i30
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label52:
+	i32.load8_u	$0=, 0($1)
+	i32.load8_u	$2=, 0($10)
+	i32.const	$push214=, 1
+	i32.add 	$push16=, $1, $pop214
+	copy_local	$1=, $pop16
+	i32.const	$push213=, 1
+	i32.add 	$push15=, $10, $pop213
+	copy_local	$10=, $pop15
+	i32.eq  	$push55=, $2, $0
+	br_if   	14, $pop55      # 14: down to label37
+# BB#87:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 3
+	br      	36              # 36: up to label15
+.LBB0_88:                               # %mymemcmp1.exit.i34
+	end_block                       # label51:
+	i32.sub 	$push98=, $2, $0
+	return  	$pop98
+.LBB0_89:                               # %if.then34.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label50:
+	i32.store	12($10), $4
+	i32.store	8($10), $5
+	i32.const	$push143=, 8
+	i32.add 	$push144=, $10, $pop143
+	copy_local	$1=, $pop144
+	i32.const	$push145=, 12
+	i32.add 	$push146=, $10, $pop145
+	copy_local	$10=, $pop146
+# BB#90:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 6
+	br      	34              # 34: up to label15
+.LBB0_91:                               # %do.body.i194.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label49:
+	i32.load8_u	$0=, 0($1)
+	i32.load8_u	$2=, 0($10)
+	i32.const	$push216=, 1
+	i32.add 	$push19=, $1, $pop216
+	copy_local	$1=, $pop19
+	i32.const	$push215=, 1
+	i32.add 	$push18=, $10, $pop215
+	copy_local	$10=, $pop18
+	i32.eq  	$push60=, $2, $0
+	br_if   	13, $pop60      # 13: down to label35
+# BB#92:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 7
+	br      	33              # 33: up to label15
+.LBB0_93:                               # %mymemcmp1.exit198.i
+	end_block                       # label48:
+	i32.sub 	$push97=, $2, $0
+	return  	$pop97
+.LBB0_94:                               # %if.then43.i51
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label47:
+	i32.store	12($10), $6
+	i32.store	8($10), $1
+	i32.const	$push139=, 8
+	i32.add 	$push140=, $10, $pop139
+	copy_local	$1=, $pop140
+	i32.const	$push141=, 12
+	i32.add 	$push142=, $10, $pop141
+	copy_local	$10=, $pop142
+# BB#95:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 11
+	br      	31              # 31: up to label15
+.LBB0_96:                               # %do.body.i182.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label46:
+	i32.load8_u	$0=, 0($1)
+	i32.load8_u	$2=, 0($10)
+	i32.const	$push218=, 1
+	i32.add 	$push21=, $1, $pop218
+	copy_local	$1=, $pop21
+	i32.const	$push217=, 1
+	i32.add 	$push20=, $10, $pop217
+	copy_local	$10=, $pop20
+	i32.eq  	$push65=, $2, $0
+	br_if   	12, $pop65      # 12: down to label33
+# BB#97:                                #   in Loop: Header=BB0_23 Depth=1
+	i32.const	$11=, 12
+	br      	30              # 30: up to label15
+.LBB0_98:                               # %mymemcmp1.exit186.i
+	end_block                       # label45:
+	i32.sub 	$push96=, $2, $0
+	return  	$pop96
+.LBB0_99:                               # %do0.i57
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label44:
 	i32.const	$1=, 0
 	i32.shl 	$push67=, $5, $3
 	i32.shr_u	$push66=, $4, $0
-	i32.or  	$push219=, $pop67, $pop66
-	tee_local	$push218=, $0=, $pop219
-	i32.eq  	$push68=, $pop218, $7
-	br_if   	15, $pop68      # 15: down to label27
-# BB#101:                               #   in Loop: Header=BB0_22 Depth=1
+	i32.or  	$push220=, $pop67, $pop66
+	tee_local	$push219=, $0=, $pop220
+	i32.eq  	$push68=, $pop219, $7
+	br_if   	15, $pop68      # 15: down to label28
+# BB#100:                               #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 21
-	br      	28              # 28: up to label14
-.LBB0_102:                              # %if.then63.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label42:
+	br      	28              # 28: up to label15
+.LBB0_101:                              # %if.then63.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label43:
 	i32.store	12($10), $0
 	i32.store	8($10), $7
-	i32.const	$push126=, 8
-	i32.add 	$push127=, $10, $pop126
-	copy_local	$1=, $pop127
-	i32.const	$push128=, 12
-	i32.add 	$push129=, $10, $pop128
-	copy_local	$10=, $pop129
-# BB#103:                               #   in Loop: Header=BB0_22 Depth=1
+	i32.const	$push127=, 8
+	i32.add 	$push128=, $10, $pop127
+	copy_local	$1=, $pop128
+	i32.const	$push129=, 12
+	i32.add 	$push130=, $10, $pop129
+	copy_local	$10=, $pop130
+# BB#102:                               #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 22
-	br      	27              # 27: up to label14
-.LBB0_104:                              # %do.body.i158.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label41:
+	br      	27              # 27: up to label15
+.LBB0_103:                              # %do.body.i158.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label42:
 	i32.load8_u	$0=, 0($1)
 	i32.load8_u	$2=, 0($10)
-	i32.const	$push221=, 1
-	i32.add 	$push25=, $1, $pop221
+	i32.const	$push222=, 1
+	i32.add 	$push25=, $1, $pop222
 	copy_local	$1=, $pop25
-	i32.const	$push220=, 1
-	i32.add 	$push24=, $10, $pop220
+	i32.const	$push221=, 1
+	i32.add 	$push24=, $10, $pop221
 	copy_local	$10=, $pop24
 	i32.eq  	$push69=, $2, $0
-	br_if   	14, $pop69      # 14: down to label26
-# BB#105:                               #   in Loop: Header=BB0_22 Depth=1
+	br_if   	14, $pop69      # 14: down to label27
+# BB#104:                               #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 23
-	br      	26              # 26: up to label14
-.LBB0_106:                              # %mymemcmp1.exit162.i
-                                        #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label40:
+	br      	26              # 26: up to label15
+.LBB0_105:                              # %mymemcmp1.exit162.i
+                                        #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label41:
 	i32.sub 	$1=, $2, $0
-# BB#107:                               #   in Loop: Header=BB0_22 Depth=1
+# BB#106:                               #   in Loop: Header=BB0_23 Depth=1
 	i32.const	$11=, 24
-	br      	25              # 25: up to label14
-.LBB0_108:                              # %cleanup
-	end_block                       # label39:
+	br      	25              # 25: up to label15
+.LBB0_107:                              # %cleanup
+	end_block                       # label40:
 	return  	$1
-.LBB0_109:                              #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label38:
+.LBB0_108:                              #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label39:
 	i32.const	$11=, 26
-	br      	23              # 23: up to label14
-.LBB0_110:                              #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label37:
+	br      	23              # 23: up to label15
+.LBB0_109:                              #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label38:
 	i32.const	$11=, 1
-	br      	22              # 22: up to label14
-.LBB0_111:                              #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label36:
+	br      	22              # 22: up to label15
+.LBB0_110:                              #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label37:
 	i32.const	$11=, 2
-	br      	21              # 21: up to label14
-.LBB0_112:                              #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label35:
+	br      	21              # 21: up to label15
+.LBB0_111:                              #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label36:
 	i32.const	$11=, 5
-	br      	20              # 20: up to label14
-.LBB0_113:                              #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label34:
+	br      	20              # 20: up to label15
+.LBB0_112:                              #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label35:
 	i32.const	$11=, 6
-	br      	19              # 19: up to label14
-.LBB0_114:                              #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label33:
+	br      	19              # 19: up to label15
+.LBB0_113:                              #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label34:
 	i32.const	$11=, 10
-	br      	18              # 18: up to label14
-.LBB0_115:                              #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label32:
+	br      	18              # 18: up to label15
+.LBB0_114:                              #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label33:
 	i32.const	$11=, 11
-	br      	17              # 17: up to label14
-.LBB0_116:                              #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label31:
+	br      	17              # 17: up to label15
+.LBB0_115:                              #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label32:
 	i32.const	$11=, 14
-	br      	16              # 16: up to label14
-.LBB0_117:                              #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label30:
+	br      	16              # 16: up to label15
+.LBB0_116:                              #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label31:
 	i32.const	$11=, 15
-	br      	15              # 15: up to label14
-.LBB0_118:                              #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label29:
+	br      	15              # 15: up to label15
+.LBB0_117:                              #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label30:
 	i32.const	$11=, 16
-	br      	14              # 14: up to label14
-.LBB0_119:                              #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label28:
+	br      	14              # 14: up to label15
+.LBB0_118:                              #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label29:
 	i32.const	$11=, 20
-	br      	13              # 13: up to label14
-.LBB0_120:                              #   in Loop: Header=BB0_22 Depth=1
+	br      	13              # 13: up to label15
+.LBB0_119:                              #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label28:
+	i32.const	$11=, 24
+	br      	12              # 12: up to label15
+.LBB0_120:                              #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label27:
-	i32.const	$11=, 24
-	br      	12              # 12: up to label14
-.LBB0_121:                              #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label26:
 	i32.const	$11=, 22
-	br      	11              # 11: up to label14
-.LBB0_122:                              #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label25:
+	br      	11              # 11: up to label15
+.LBB0_121:                              #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label26:
 	i32.const	$11=, 24
-	br      	10              # 10: up to label14
-.LBB0_123:                              #   in Loop: Header=BB0_22 Depth=1
+	br      	10              # 10: up to label15
+.LBB0_122:                              #   in Loop: Header=BB0_23 Depth=1
+	end_block                       # label25:
+	i32.const	$11=, 44
+	br      	9               # 9: up to label15
+.LBB0_123:                              #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label24:
 	i32.const	$11=, 27
-	br      	9               # 9: up to label14
-.LBB0_124:                              #   in Loop: Header=BB0_22 Depth=1
+	br      	8               # 8: up to label15
+.LBB0_124:                              #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label23:
 	i32.const	$11=, 30
-	br      	8               # 8: up to label14
-.LBB0_125:                              #   in Loop: Header=BB0_22 Depth=1
+	br      	7               # 7: up to label15
+.LBB0_125:                              #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label22:
 	i32.const	$11=, 31
-	br      	7               # 7: up to label14
-.LBB0_126:                              #   in Loop: Header=BB0_22 Depth=1
+	br      	6               # 6: up to label15
+.LBB0_126:                              #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label21:
 	i32.const	$11=, 35
-	br      	6               # 6: up to label14
-.LBB0_127:                              #   in Loop: Header=BB0_22 Depth=1
+	br      	5               # 5: up to label15
+.LBB0_127:                              #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label20:
 	i32.const	$11=, 36
-	br      	5               # 5: up to label14
-.LBB0_128:                              #   in Loop: Header=BB0_22 Depth=1
+	br      	4               # 4: up to label15
+.LBB0_128:                              #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label19:
 	i32.const	$11=, 39
-	br      	4               # 4: up to label14
-.LBB0_129:                              #   in Loop: Header=BB0_22 Depth=1
+	br      	3               # 3: up to label15
+.LBB0_129:                              #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label18:
 	i32.const	$11=, 40
-	br      	3               # 3: up to label14
-.LBB0_130:                              #   in Loop: Header=BB0_22 Depth=1
+	br      	2               # 2: up to label15
+.LBB0_130:                              #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label17:
 	i32.const	$11=, 41
-	br      	2               # 2: up to label14
-.LBB0_131:                              #   in Loop: Header=BB0_22 Depth=1
+	br      	1               # 1: up to label15
+.LBB0_131:                              #   in Loop: Header=BB0_23 Depth=1
 	end_block                       # label16:
-	i32.const	$11=, 45
-	br      	1               # 1: up to label14
-.LBB0_132:                              #   in Loop: Header=BB0_22 Depth=1
-	end_block                       # label15:
-	i32.const	$11=, 47
-	br      	0               # 0: up to label14
-.LBB0_133:
+	i32.const	$11=, 46
+	br      	0               # 0: up to label15
+.LBB0_132:
 	end_loop
 	.endfunc
 .Lfunc_end0:
@@ -1028,5 +1027,5 @@ buf:
 	.size	.L.str.1, 16
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr40022.c.s
+++ b/test/torture-s/pr40022.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr40022.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr40022.c"
 	.section	.text.foo,"ax",@progbits
 	.hidden	foo
 	.globl	foo
@@ -31,39 +31,38 @@ foo:                                    # @foo
 	.type	bar,@function
 bar:                                    # @bar
 	.param  	i32, i32, i32, i32
-	.local  	i32
 # BB#0:                                 # %entry
 	i32.call	$push2=, foo@FUNCTION, $1
 	tee_local	$push1=, $1=, $pop2
 	i32.store	0($0), $pop1
 	block   	
-	i32.eqz 	$push9=, $1
-	br_if   	0, $pop9        # 0: down to label0
+	i32.eqz 	$push13=, $1
+	br_if   	0, $pop13       # 0: down to label0
 .LBB1_1:                                # %while.cond.while.cond_crit_edge
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label1:
-	copy_local	$0=, $1
-	i32.load	$push4=, 0($1)
-	tee_local	$push3=, $4=, $pop4
-	copy_local	$1=, $pop3
-	br_if   	0, $4           # 0: up to label1
+	copy_local	$push6=, $1
+	tee_local	$push5=, $0=, $pop6
+	i32.load	$push4=, 0($pop5)
+	tee_local	$push3=, $1=, $pop4
+	br_if   	0, $pop3        # 0: up to label1
 .LBB1_2:                                # %while.end
 	end_loop
 	end_block                       # label0:
-	i32.call	$push6=, foo@FUNCTION, $2
-	tee_local	$push5=, $1=, $pop6
-	i32.store	0($0), $pop5
+	i32.call	$push8=, foo@FUNCTION, $2
+	tee_local	$push7=, $1=, $pop8
+	i32.store	0($0), $pop7
 	block   	
-	i32.eqz 	$push10=, $1
-	br_if   	0, $pop10       # 0: down to label2
+	i32.eqz 	$push14=, $1
+	br_if   	0, $pop14       # 0: down to label2
 .LBB1_3:                                # %while.cond2.while.cond2_crit_edge
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label3:
-	copy_local	$0=, $1
-	i32.load	$push8=, 0($1)
-	tee_local	$push7=, $4=, $pop8
-	copy_local	$1=, $pop7
-	br_if   	0, $4           # 0: up to label3
+	copy_local	$push12=, $1
+	tee_local	$push11=, $0=, $pop12
+	i32.load	$push10=, 0($pop11)
+	tee_local	$push9=, $1=, $pop10
+	br_if   	0, $pop9        # 0: up to label3
 .LBB1_4:                                # %while.end6
 	end_loop
 	end_block                       # label2:
@@ -157,5 +156,5 @@ e:
 	.size	e, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr42231.c.s
+++ b/test/torture-s/pr42231.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr42231.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr42231.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
@@ -42,22 +42,25 @@ CallFunctionRec:                        # @CallFunctionRec
 	.local  	i32
 # BB#0:                                 # %entry
 	call    	storemax@FUNCTION, $0
-	i32.const	$1=, 0
+	block   	
 	block   	
 	i32.eqz 	$push5=, $0
-	br_if   	0, $pop5        # 0: down to label2
+	br_if   	0, $pop5        # 0: down to label3
 # BB#1:                                 # %if.end
 	i32.const	$1=, 1
 	i32.const	$push0=, 9
 	i32.gt_s	$push1=, $0, $pop0
-	br_if   	0, $pop1        # 0: down to label2
+	br_if   	1, $pop1        # 1: down to label2
 # BB#2:                                 # %if.then1
 	i32.const	$push2=, 1
 	i32.add 	$push3=, $0, $pop2
 	i32.call	$drop=, CallFunctionRec@FUNCTION, $pop3
 	i32.const	$push4=, 1
 	return  	$pop4
-.LBB1_3:                                # %return
+.LBB1_3:
+	end_block                       # label3:
+	i32.const	$1=, 0
+.LBB1_4:                                # %return
 	end_block                       # label2:
 	copy_local	$push6=, $1
                                         # fallthrough-return: $pop6
@@ -74,12 +77,12 @@ storemax:                               # @storemax
 	i32.const	$push2=, 0
 	i32.load	$push0=, max($pop2)
 	i32.ge_s	$push1=, $pop0, $0
-	br_if   	0, $pop1        # 0: down to label3
+	br_if   	0, $pop1        # 0: down to label4
 # BB#1:                                 # %if.then
 	i32.const	$push3=, 0
 	i32.store	max($pop3), $0
 .LBB2_2:                                # %if.end
-	end_block                       # label3:
+	end_block                       # label4:
                                         # fallthrough-return
 	.endfunc
 .Lfunc_end2:
@@ -93,5 +96,5 @@ max:
 	.size	max, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr47538.c.s
+++ b/test/torture-s/pr47538.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr47538.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr47538.c"
 	.section	.text.foo,"ax",@progbits
 	.hidden	foo
 	.globl	foo
@@ -8,109 +8,111 @@ foo:                                    # @foo
 	.param  	i32, i32
 	.local  	i32, i32, f64, i32, i32, i32, f64, i32, f64, f64
 # BB#0:                                 # %entry
-	f64.load	$push32=, 0($1)
+	f64.load	$push34=, 0($1)
+	tee_local	$push33=, $11=, $pop34
+	f64.store	0($0), $pop33
+	f64.load	$push32=, 8($1)
 	tee_local	$push31=, $10=, $pop32
-	f64.store	0($0), $pop31
-	f64.load	$push30=, 8($1)
-	tee_local	$push29=, $8=, $pop30
-	f64.store	8($0), $pop29
+	f64.store	8($0), $pop31
 	i32.load	$5=, 16($0)
-	f64.const	$11=, 0x0p0
 	block   	
-	i32.load	$push28=, 20($1)
-	tee_local	$push27=, $2=, $pop28
-	i32.eqz 	$push53=, $pop27
-	br_if   	0, $pop53       # 0: down to label0
+	block   	
+	i32.load	$push30=, 20($1)
+	tee_local	$push29=, $2=, $pop30
+	i32.eqz 	$push55=, $pop29
+	br_if   	0, $pop55       # 0: down to label1
 # BB#1:                                 # %if.else
-	f64.sub 	$push1=, $8, $10
+	f64.sub 	$push1=, $10, $11
 	f64.const	$push2=, 0x1p-2
 	f64.mul 	$4=, $pop1, $pop2
 	i32.load	$6=, 16($1)
-	block   	
 	i32.const	$push0=, 1
-	i32.add 	$push34=, $2, $pop0
-	tee_local	$push33=, $3=, $pop34
+	i32.add 	$push36=, $2, $pop0
+	tee_local	$push35=, $3=, $pop36
 	i32.const	$push3=, 2
-	i32.ne  	$push4=, $pop33, $pop3
-	br_if   	0, $pop4        # 0: down to label1
+	i32.ne  	$push4=, $pop35, $pop3
+	br_if   	1, $pop4        # 1: down to label0
 # BB#2:                                 # %if.then6
 	f64.load	$push25=, 0($6)
-	f64.mul 	$push36=, $4, $pop25
-	tee_local	$push35=, $11=, $pop36
-	f64.store	8($5), $pop35
+	f64.mul 	$push38=, $4, $pop25
+	tee_local	$push37=, $11=, $pop38
+	f64.store	8($5), $pop37
 	f64.add 	$push26=, $11, $11
 	f64.store	0($5), $pop26
 	return
-.LBB0_3:                                # %for.cond.preheader
+.LBB0_3:
 	end_block                       # label1:
+	f64.const	$push27=, 0x0p0
+	f64.store	0($5), $pop27
+	return
+.LBB0_4:                                # %for.cond.preheader
+	end_block                       # label0:
 	block   	
 	block   	
 	i32.const	$push5=, -1
-	i32.add 	$push38=, $2, $pop5
-	tee_local	$push37=, $7=, $pop38
-	i32.eqz 	$push54=, $pop37
-	br_if   	0, $pop54       # 0: down to label3
-# BB#4:                                 # %for.body.preheader
-	i32.const	$push39=, 8
-	i32.add 	$0=, $5, $pop39
+	i32.add 	$push40=, $2, $pop5
+	tee_local	$push39=, $7=, $pop40
+	i32.eqz 	$push56=, $pop39
+	br_if   	0, $pop56       # 0: down to label3
+# BB#5:                                 # %for.body.preheader
+	i32.const	$push41=, 8
+	i32.add 	$0=, $5, $pop41
 	f64.const	$10=, 0x0p0
 	f64.const	$11=, 0x1p0
 	copy_local	$1=, $6
 	i32.const	$9=, 1
-.LBB0_5:                                # %for.body
+.LBB0_6:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label4:
 	f64.load	$push8=, 0($1)
-	i32.const	$push47=, 16
-	i32.add 	$push6=, $1, $pop47
+	i32.const	$push49=, 16
+	i32.add 	$push6=, $1, $pop49
 	f64.load	$push7=, 0($pop6)
 	f64.sub 	$push9=, $pop8, $pop7
 	f64.mul 	$push10=, $4, $pop9
 	f64.convert_u/i32	$push11=, $9
-	f64.div 	$push46=, $pop10, $pop11
-	tee_local	$push45=, $8=, $pop46
-	f64.store	0($0), $pop45
-	i32.const	$push44=, 8
-	i32.add 	$0=, $0, $pop44
-	i32.const	$push43=, 8
-	i32.add 	$1=, $1, $pop43
+	f64.div 	$push48=, $pop10, $pop11
+	tee_local	$push47=, $8=, $pop48
+	f64.store	0($0), $pop47
+	i32.const	$push46=, 8
+	i32.add 	$0=, $0, $pop46
+	i32.const	$push45=, 8
+	i32.add 	$1=, $1, $pop45
 	f64.mul 	$push12=, $11, $8
 	f64.add 	$10=, $10, $pop12
 	f64.neg 	$11=, $11
-	i32.const	$push42=, 1
-	i32.add 	$push41=, $9, $pop42
-	tee_local	$push40=, $9=, $pop41
-	i32.le_u	$push13=, $pop40, $7
+	i32.const	$push44=, 1
+	i32.add 	$push43=, $9, $pop44
+	tee_local	$push42=, $9=, $pop43
+	i32.le_u	$push13=, $pop42, $7
 	br_if   	0, $pop13       # 0: up to label4
 	br      	2               # 2: down to label2
-.LBB0_6:
+.LBB0_7:
 	end_loop
 	end_block                       # label3:
 	f64.const	$11=, 0x1p0
 	f64.const	$10=, 0x0p0
-.LBB0_7:                                # %for.end
+.LBB0_8:                                # %for.end
 	end_block                       # label2:
 	i32.const	$push17=, 3
 	i32.shl 	$push22=, $2, $pop17
 	i32.add 	$push23=, $5, $pop22
-	i32.const	$push52=, 3
-	i32.shl 	$push18=, $7, $pop52
+	i32.const	$push54=, 3
+	i32.shl 	$push18=, $7, $pop54
 	i32.add 	$push19=, $6, $pop18
 	f64.load	$push20=, 0($pop19)
 	f64.mul 	$push21=, $4, $pop20
 	f64.convert_u/i32	$push14=, $3
 	f64.const	$push15=, -0x1p0
 	f64.add 	$push16=, $pop14, $pop15
-	f64.div 	$push51=, $pop21, $pop16
-	tee_local	$push50=, $8=, $pop51
-	f64.store	0($pop23), $pop50
+	f64.div 	$push53=, $pop21, $pop16
+	tee_local	$push52=, $8=, $pop53
+	f64.store	0($pop23), $pop52
 	f64.mul 	$push24=, $11, $8
-	f64.add 	$push49=, $10, $pop24
-	tee_local	$push48=, $11=, $pop49
-	f64.add 	$11=, $pop48, $11
-.LBB0_8:                                # %if.end53
-	end_block                       # label0:
-	f64.store	0($5), $11
+	f64.add 	$push51=, $10, $pop24
+	tee_local	$push50=, $11=, $pop51
+	f64.add 	$push28=, $pop50, $11
+	f64.store	0($5), $pop28
                                         # fallthrough-return
 	.endfunc
 .Lfunc_end0:
@@ -389,5 +391,5 @@ main:                                   # @main
 	.size	.Lmain.e, 32
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr49390.c.s
+++ b/test/torture-s/pr49390.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr49390.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr49390.c"
 	.section	.text.foo,"ax",@progbits
 	.hidden	foo
 	.globl	foo
@@ -81,154 +81,158 @@ baz:                                    # @baz
 	.type	test,@function
 test:                                   # @test
 	.param  	i32
-	.local  	i32, i32, i32, i64, i32, i32, i32
+	.local  	i32, i32, i32, i32, i64, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push52=, 0
-	i32.const	$push49=, 0
-	i32.load	$push50=, __stack_pointer($pop49)
-	i32.const	$push51=, 16
-	i32.sub 	$push61=, $pop50, $pop51
-	tee_local	$push60=, $7=, $pop61
-	i32.store	__stack_pointer($pop52), $pop60
+	i32.const	$push53=, 0
+	i32.const	$push50=, 0
+	i32.load	$push51=, __stack_pointer($pop50)
+	i32.const	$push52=, 16
+	i32.sub 	$push62=, $pop51, $pop52
+	tee_local	$push61=, $7=, $pop62
+	i32.store	__stack_pointer($pop53), $pop61
 	i32.const	$push1=, 0
-	i64.load	$push59=, a($pop1)
-	tee_local	$push58=, $4=, $pop59
-	i64.store	8($7), $pop58
-	i32.const	$push56=, 8
-	i32.add 	$push57=, $7, $pop56
-	copy_local	$5=, $pop57
+	i64.load	$push60=, a($pop1)
+	tee_local	$push59=, $5=, $pop60
+	i64.store	8($7), $pop59
 	block   	
-	i32.eqz 	$push82=, $0
-	br_if   	0, $pop82       # 0: down to label1
+	block   	
+	block   	
+	block   	
+	i32.eqz 	$push83=, $0
+	br_if   	0, $pop83       # 0: down to label4
 # BB#1:                                 # %if.else
 	block   	
-	block   	
-	i32.load	$push65=, 4($0)
-	tee_local	$push64=, $6=, $pop65
+	i32.load	$push66=, 4($0)
+	tee_local	$push65=, $6=, $pop66
 	i32.const	$push5=, 8191
-	i32.and 	$push63=, $pop64, $pop5
-	tee_local	$push62=, $5=, $pop63
+	i32.and 	$push64=, $pop65, $pop5
+	tee_local	$push63=, $3=, $pop64
 	i32.const	$push7=, 16
-	i32.lt_u	$push8=, $pop62, $pop7
-	br_if   	0, $pop8        # 0: down to label3
+	i32.lt_u	$push8=, $pop63, $pop7
+	br_if   	0, $pop8        # 0: down to label5
 # BB#2:                                 # %if.else
 	i32.const	$push6=, 8192
-	i32.sub 	$push4=, $pop6, $5
+	i32.sub 	$push4=, $pop6, $3
 	i32.const	$push9=, 31
 	i32.gt_u	$push10=, $pop4, $pop9
-	br_if   	1, $pop10       # 1: down to label2
+	br_if   	2, $pop10       # 2: down to label3
 .LBB3_3:                                # %if.then5
-	end_block                       # label3:
+	end_block                       # label5:
 	i32.const	$push13=, 1
 	i32.const	$push12=, 0
 	i32.load	$push11=, 0($0)
 	call    	foo@FUNCTION, $pop13, $pop12, $pop11, $6
-.LBB3_4:                                # %if.end7
-	end_block                       # label2:
-	copy_local	$5=, $0
+	i32.call	$push14=, baz@FUNCTION, $0
+	br_if   	2, $pop14       # 2: down to label2
+	br      	3               # 3: down to label1
+.LBB3_4:
+	end_block                       # label4:
+	i32.const	$push57=, 8
+	i32.add 	$push58=, $7, $pop57
+	copy_local	$0=, $pop58
 .LBB3_5:                                # %if.end7
-	end_block                       # label1:
+	end_block                       # label3:
+	i32.call	$push15=, baz@FUNCTION, $0
+	i32.eqz 	$push84=, $pop15
+	br_if   	1, $pop84       # 1: down to label1
+.LBB3_6:                                # %if.end9
+	end_block                       # label2:
+	i32.const	$push22=, 32
+	i32.const	$push21=, 4
+	i32.const	$push16=, 0
+	i32.load	$push74=, b($pop16)
+	tee_local	$push73=, $1=, $pop74
+	i32.load16_u	$push72=, 2($pop73)
+	tee_local	$push71=, $2=, $pop72
+	i32.const	$push17=, 2
+	i32.and 	$push18=, $pop71, $pop17
+	i32.const	$push19=, 1
+	i32.shr_u	$push20=, $pop18, $pop19
+	i32.select	$3=, $pop22, $pop21, $pop20
 	block   	
-	i32.call	$push14=, baz@FUNCTION, $5
-	i32.eqz 	$push83=, $pop14
-	br_if   	0, $pop83       # 0: down to label4
-# BB#6:                                 # %if.end9
-	i32.const	$push21=, 32
-	i32.const	$push20=, 4
-	i32.const	$push15=, 0
-	i32.load	$push73=, b($pop15)
-	tee_local	$push72=, $1=, $pop73
-	i32.load16_u	$push71=, 2($pop72)
-	tee_local	$push70=, $2=, $pop71
-	i32.const	$push16=, 2
-	i32.and 	$push17=, $pop70, $pop16
-	i32.const	$push18=, 1
-	i32.shr_u	$push19=, $pop17, $pop18
-	i32.select	$0=, $pop21, $pop20, $pop19
 	block   	
-	block   	
-	i32.load	$push69=, 4($5)
-	tee_local	$push68=, $3=, $pop69
-	i32.const	$push22=, 8191
-	i32.and 	$push67=, $pop68, $pop22
-	tee_local	$push66=, $6=, $pop67
-	i32.eqz 	$push84=, $pop66
-	br_if   	0, $pop84       # 0: down to label6
-# BB#7:                                 # %if.else17
-	i32.ge_u	$push23=, $6, $0
-	br_if   	1, $pop23       # 1: down to label5
-# BB#8:                                 # %if.then20
-	i32.const	$push26=, 2
-	i32.const	$push25=, 0
-	i32.load	$push24=, 0($5)
-	call    	foo@FUNCTION, $pop26, $pop25, $pop24, $3
-	br      	2               # 2: down to label4
-.LBB3_9:                                # %if.then15
-	end_block                       # label6:
-	i64.const	$push2=, 32
-	i64.shr_u	$push3=, $4, $pop2
-	i32.wrap/i64	$push0=, $pop3
-	i32.add 	$push27=, $pop0, $0
-	i32.store	12($7), $pop27
-	copy_local	$6=, $0
-.LBB3_10:                               # %if.end24
-	end_block                       # label5:
-	block   	
-	i32.const	$push28=, 1
-	i32.and 	$push29=, $2, $pop28
-	i32.eqz 	$push85=, $pop29
+	i32.load	$push70=, 4($0)
+	tee_local	$push69=, $4=, $pop70
+	i32.const	$push23=, 8191
+	i32.and 	$push68=, $pop69, $pop23
+	tee_local	$push67=, $6=, $pop68
+	i32.eqz 	$push85=, $pop67
 	br_if   	0, $pop85       # 0: down to label7
-# BB#11:                                # %if.end24
-	i32.ne  	$push30=, $6, $0
-	br_if   	0, $pop30       # 0: down to label7
-# BB#12:                                # %if.then31
-	i64.load	$push42=, 0($5):p2align=2
-	i64.store	0($7):p2align=2, $pop42
-	call    	bar@FUNCTION, $7
-	i32.const	$push48=, 3
-	i32.const	$push47=, 0
-	i32.load	$push46=, 0($5)
-	i32.const	$push43=, 4
-	i32.add 	$push44=, $5, $pop43
-	i32.load	$push45=, 0($pop44)
-	call    	foo@FUNCTION, $pop48, $pop47, $pop46, $pop45
-	br      	1               # 1: down to label4
-.LBB3_13:                               # %if.end34
+# BB#7:                                 # %if.else17
+	i32.ge_u	$push24=, $6, $3
+	br_if   	1, $pop24       # 1: down to label6
+# BB#8:                                 # %if.then20
+	i32.const	$push27=, 2
+	i32.const	$push26=, 0
+	i32.load	$push25=, 0($0)
+	call    	foo@FUNCTION, $pop27, $pop26, $pop25, $4
+	br      	2               # 2: down to label1
+.LBB3_9:                                # %if.then15
 	end_block                       # label7:
-	i32.const	$push31=, 4
-	i32.add 	$push32=, $5, $pop31
-	i32.load	$push81=, 0($pop32)
-	tee_local	$push80=, $0=, $pop81
-	i32.const	$push33=, 8191
-	i32.and 	$push34=, $pop80, $pop33
-	i32.add 	$push79=, $1, $pop34
-	tee_local	$push78=, $6=, $pop79
-	i32.load	$push77=, 4($pop78)
-	tee_local	$push76=, $2=, $pop77
-	i32.load	$push75=, 0($5)
-	tee_local	$push74=, $5=, $pop75
-	i32.lt_u	$push35=, $pop76, $pop74
-	br_if   	0, $pop35       # 0: down to label4
+	i64.const	$push2=, 32
+	i64.shr_u	$push3=, $5, $pop2
+	i32.wrap/i64	$push0=, $pop3
+	i32.add 	$push28=, $pop0, $3
+	i32.store	12($7), $pop28
+	copy_local	$6=, $3
+.LBB3_10:                               # %if.end24
+	end_block                       # label6:
+	block   	
+	i32.const	$push29=, 1
+	i32.and 	$push30=, $2, $pop29
+	i32.eqz 	$push86=, $pop30
+	br_if   	0, $pop86       # 0: down to label8
+# BB#11:                                # %if.end24
+	i32.ne  	$push31=, $6, $3
+	br_if   	0, $pop31       # 0: down to label8
+# BB#12:                                # %if.then31
+	i64.load	$push43=, 0($0):p2align=2
+	i64.store	0($7):p2align=2, $pop43
+	call    	bar@FUNCTION, $7
+	i32.const	$push49=, 3
+	i32.const	$push48=, 0
+	i32.load	$push47=, 0($0)
+	i32.const	$push44=, 4
+	i32.add 	$push45=, $0, $pop44
+	i32.load	$push46=, 0($pop45)
+	call    	foo@FUNCTION, $pop49, $pop48, $pop47, $pop46
+	br      	1               # 1: down to label1
+.LBB3_13:                               # %if.end34
+	end_block                       # label8:
+	i32.const	$push32=, 4
+	i32.add 	$push33=, $0, $pop32
+	i32.load	$push82=, 0($pop33)
+	tee_local	$push81=, $3=, $pop82
+	i32.const	$push34=, 8191
+	i32.and 	$push35=, $pop81, $pop34
+	i32.add 	$push80=, $1, $pop35
+	tee_local	$push79=, $6=, $pop80
+	i32.load	$push78=, 4($pop79)
+	tee_local	$push77=, $2=, $pop78
+	i32.load	$push76=, 0($0)
+	tee_local	$push75=, $0=, $pop76
+	i32.lt_u	$push36=, $pop77, $pop75
+	br_if   	0, $pop36       # 0: down to label1
 # BB#14:                                # %land.lhs.true41
 	block   	
-	i32.ne  	$push36=, $2, $5
-	br_if   	0, $pop36       # 0: down to label8
+	i32.ne  	$push37=, $2, $0
+	br_if   	0, $pop37       # 0: down to label9
 # BB#15:                                # %lor.lhs.false47
-	i32.const	$push37=, 8
-	i32.add 	$push38=, $6, $pop37
-	i32.load	$push39=, 0($pop38)
-	i32.lt_u	$push40=, $pop39, $0
-	br_if   	1, $pop40       # 1: down to label4
+	i32.const	$push38=, 8
+	i32.add 	$push39=, $6, $pop38
+	i32.load	$push40=, 0($pop39)
+	i32.lt_u	$push41=, $pop40, $3
+	br_if   	1, $pop41       # 1: down to label1
 .LBB3_16:                               # %if.then53
-	end_block                       # label8:
-	i32.const	$push41=, 4
-	call    	foo@FUNCTION, $pop41, $6, $5, $0
+	end_block                       # label9:
+	i32.const	$push42=, 4
+	call    	foo@FUNCTION, $pop42, $6, $0, $3
 .LBB3_17:                               # %cleanup
-	end_block                       # label4:
-	i32.const	$push55=, 0
-	i32.const	$push53=, 16
-	i32.add 	$push54=, $7, $pop53
-	i32.store	__stack_pointer($pop55), $pop54
+	end_block                       # label1:
+	i32.const	$push56=, 0
+	i32.const	$push54=, 16
+	i32.add 	$push55=, $7, $pop54
+	i32.store	__stack_pointer($pop56), $pop55
                                         # fallthrough-return
 	.endfunc
 .Lfunc_end3:
@@ -258,12 +262,12 @@ main:                                   # @main
 	i32.load	$push2=, v($pop5)
 	i32.const	$push3=, 16384
 	i32.ne  	$push4=, $pop2, $pop3
-	br_if   	0, $pop4        # 0: down to label9
+	br_if   	0, $pop4        # 0: down to label10
 # BB#1:                                 # %if.end
 	i32.const	$push8=, 0
 	return  	$pop8
 .LBB4_2:                                # %if.then
-	end_block                       # label9:
+	end_block                       # label10:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -307,5 +311,5 @@ b:
 	.size	b, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr49419.c.s
+++ b/test/torture-s/pr49419.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr49419.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr49419.c"
 	.section	.text.foo,"ax",@progbits
 	.hidden	foo
 	.globl	foo
@@ -9,7 +9,6 @@ foo:                                    # @foo
 	.result 	i32
 	.local  	i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$6=, 0
 	block   	
 	block   	
 	i32.const	$push0=, -1
@@ -17,8 +16,8 @@ foo:                                    # @foo
 	br_if   	0, $pop1        # 0: down to label1
 # BB#1:                                 # %for.cond.preheader
 	i32.const	$5=, 0
-	i32.const	$push23=, 0
-	i32.load	$4=, t($pop23)
+	i32.const	$push25=, 0
+	i32.load	$4=, t($pop25)
 	block   	
 	i32.const	$push3=, 1
 	i32.lt_s	$push4=, $3, $pop3
@@ -36,20 +35,20 @@ foo:                                    # @foo
 .LBB0_4:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label3:
-	i32.const	$push26=, 1
-	i32.add 	$push25=, $5, $pop26
-	tee_local	$push24=, $5=, $pop25
-	i32.ge_s	$push10=, $pop24, $3
+	i32.const	$push28=, 1
+	i32.add 	$push27=, $5, $pop28
+	tee_local	$push26=, $5=, $pop27
+	i32.ge_s	$push10=, $pop26, $3
 	br_if   	1, $pop10       # 1: down to label2
 # BB#5:                                 # %for.body
                                         #   in Loop: Header=BB0_4 Depth=1
-	i32.const	$push30=, 12
-	i32.mul 	$push11=, $6, $pop30
+	i32.const	$push32=, 12
+	i32.mul 	$push11=, $6, $pop32
 	i32.add 	$push12=, $4, $pop11
-	i32.load	$push29=, 4($pop12)
-	tee_local	$push28=, $6=, $pop29
-	i32.const	$push27=, 12
-	i32.mul 	$push13=, $pop28, $pop27
+	i32.load	$push31=, 4($pop12)
+	tee_local	$push30=, $6=, $pop31
+	i32.const	$push29=, 12
+	i32.mul 	$push13=, $pop30, $pop29
 	i32.add 	$push14=, $4, $pop13
 	i32.load	$push9=, 0($pop14)
 	i32.eq  	$push15=, $pop9, $1
@@ -61,42 +60,44 @@ foo:                                    # @foo
 	br_if   	1, $pop16       # 1: down to label0
 # BB#7:                                 # %if.end7
 	block   	
-	i32.const	$push31=, 1
-	i32.lt_s	$push17=, $5, $pop31
+	i32.const	$push33=, 1
+	i32.lt_s	$push17=, $5, $pop33
 	br_if   	0, $pop17       # 0: down to label4
 # BB#8:                                 # %for.body10.preheader
-	i32.const	$push32=, 1
-	i32.add 	$3=, $5, $pop32
+	i32.const	$push34=, 1
+	i32.add 	$3=, $5, $pop34
 	i32.const	$push18=, 2
 	i32.shl 	$push19=, $5, $pop18
 	i32.add 	$6=, $2, $pop19
 .LBB0_9:                                # %for.body10
                                         # =>This Inner Loop Header: Depth=1
 	loop    	                # label5:
-	i32.const	$push40=, 12
-	i32.mul 	$push20=, $0, $pop40
-	i32.add 	$push39=, $4, $pop20
-	tee_local	$push38=, $0=, $pop39
-	i32.load	$push21=, 8($pop38)
+	i32.const	$push42=, 12
+	i32.mul 	$push20=, $0, $pop42
+	i32.add 	$push41=, $4, $pop20
+	tee_local	$push40=, $0=, $pop41
+	i32.load	$push21=, 8($pop40)
 	i32.store	0($6), $pop21
-	i32.const	$push37=, -4
-	i32.add 	$6=, $6, $pop37
+	i32.const	$push39=, -4
+	i32.add 	$6=, $6, $pop39
 	i32.load	$0=, 4($0)
-	i32.const	$push36=, -1
-	i32.add 	$push35=, $3, $pop36
-	tee_local	$push34=, $3=, $pop35
-	i32.const	$push33=, 1
-	i32.gt_s	$push22=, $pop34, $pop33
+	i32.const	$push38=, -1
+	i32.add 	$push37=, $3, $pop38
+	tee_local	$push36=, $3=, $pop37
+	i32.const	$push35=, 1
+	i32.gt_s	$push22=, $pop36, $pop35
 	br_if   	0, $pop22       # 0: up to label5
 .LBB0_10:                               # %for.end16
 	end_loop
 	end_block                       # label4:
-	i32.const	$push41=, 1
-	i32.add 	$6=, $5, $pop41
 	i32.store	0($2), $0
-.LBB0_11:                               # %cleanup
+	i32.const	$push43=, 1
+	i32.add 	$push24=, $5, $pop43
+	return  	$pop24
+.LBB0_11:
 	end_block                       # label1:
-	return  	$6
+	i32.const	$push23=, 0
+	return  	$pop23
 .LBB0_12:                               # %if.then6
 	end_block                       # label0:
 	call    	abort@FUNCTION
@@ -266,5 +267,5 @@ t:
 	.size	t, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr52209.c.s
+++ b/test/torture-s/pr52209.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr52209.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr52209.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
@@ -8,24 +8,22 @@ main:                                   # @main
 	.result 	i32
 	.local  	i32
 # BB#0:                                 # %entry
-	i32.const	$push11=, 0
-	i32.const	$push10=, 0
-	i32.load8_u	$push9=, c($pop10)
-	tee_local	$push8=, $0=, $pop9
-	i32.const	$push0=, 31
-	i32.shl 	$push1=, $pop8, $pop0
-	i32.const	$push7=, 31
-	i32.shr_s	$push2=, $pop1, $pop7
+	i32.const	$push9=, 0
+	i32.const	$push8=, 0
+	i32.const	$push7=, 0
+	i32.load8_u	$push0=, c($pop7)
+	i32.const	$push1=, 1
+	i32.and 	$push6=, $pop0, $pop1
+	tee_local	$push5=, $0=, $pop6
+	i32.sub 	$push2=, $pop8, $pop5
 	i32.const	$push3=, -1
 	i32.xor 	$push4=, $pop2, $pop3
-	i32.store	b($pop11), $pop4
+	i32.store	b($pop9), $pop4
 	block   	
-	i32.const	$push5=, 1
-	i32.and 	$push6=, $0, $pop5
-	br_if   	0, $pop6        # 0: down to label0
+	br_if   	0, $0           # 0: down to label0
 # BB#1:                                 # %if.end
-	i32.const	$push12=, 0
-	return  	$pop12
+	i32.const	$push10=, 0
+	return  	$pop10
 .LBB0_2:                                # %if.then
 	end_block                       # label0:
 	call    	abort@FUNCTION
@@ -53,5 +51,5 @@ b:
 	.size	b, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr54937.c.s
+++ b/test/torture-s/pr54937.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr54937.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr54937.c"
 	.section	.text.t,"ax",@progbits
 	.hidden	t
 	.globl	t
@@ -24,9 +24,9 @@ t:                                      # @t
 # BB#3:                                 # %if.then
                                         #   in Loop: Header=BB0_2 Depth=1
 	i32.const	$push5=, 0
-	i32.load	$push2=, terminate_me($pop5)
 	i32.const	$push4=, 0
-	call_indirect	$pop2, $pop4
+	i32.load	$push2=, terminate_me($pop4)
+	call_indirect	$pop5, $pop2
 .LBB0_4:                                # %if.end
                                         #   in Loop: Header=BB0_2 Depth=1
 	end_block                       # label2:
@@ -86,6 +86,6 @@ a:
 	.size	a, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	exit, void, i32
 	.functype	abort, void

--- a/test/torture-s/pr54985.c.s
+++ b/test/torture-s/pr54985.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr54985.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr54985.c"
 	.section	.text.foo,"ax",@progbits
 	.hidden	foo
 	.globl	foo
@@ -7,46 +7,41 @@
 foo:                                    # @foo
 	.param  	i32, i32
 	.result 	i32
-	.local  	i32, i32, i32
+	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
+	i32.const	$5=, 0
 	block   	
-	block   	
-	i32.eqz 	$push11=, $1
-	br_if   	0, $pop11       # 0: down to label1
+	i32.eqz 	$push8=, $1
+	br_if   	0, $pop8        # 0: down to label0
 # BB#1:                                 # %while.body.preheader
-	i32.const	$push3=, 4
-	i32.add 	$4=, $0, $pop3
+	i32.const	$push1=, 4
+	i32.add 	$4=, $0, $pop1
 	i32.load	$0=, 0($0)
 .LBB0_2:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
-	loop    	                # label2:
-	i32.const	$push6=, -1
-	i32.add 	$push5=, $1, $pop6
-	tee_local	$push4=, $1=, $pop5
-	i32.eqz 	$push12=, $pop4
-	br_if   	2, $pop12       # 2: down to label0
+	loop    	                # label1:
+	i32.const	$push4=, -1
+	i32.add 	$push3=, $1, $pop4
+	tee_local	$push2=, $1=, $pop3
+	i32.eqz 	$push9=, $pop2
+	br_if   	1, $pop9        # 1: down to label0
 # BB#3:                                 # %while.cond.while.body_crit_edge
                                         #   in Loop: Header=BB0_2 Depth=1
-	i32.load	$push9=, 0($4)
-	tee_local	$push8=, $2=, $pop9
-	i32.lt_s	$3=, $pop8, $0
-	i32.const	$push7=, 4
-	i32.add 	$push0=, $4, $pop7
+	i32.load	$push7=, 0($4)
+	tee_local	$push6=, $2=, $pop7
+	i32.lt_s	$3=, $pop6, $0
+	i32.const	$push5=, 4
+	i32.add 	$push0=, $4, $pop5
 	copy_local	$4=, $pop0
 	copy_local	$0=, $2
-	br_if   	0, $3           # 0: up to label2
-# BB#4:                                 # %cleanup
+	br_if   	0, $3           # 0: up to label1
+# BB#4:
 	end_loop
-	i32.const	$push10=, 1
-	return  	$pop10
-.LBB0_5:
-	end_block                       # label1:
-	i32.const	$push2=, 0
-	return  	$pop2
-.LBB0_6:
+	i32.const	$5=, 1
+.LBB0_5:                                # %cleanup
 	end_block                       # label0:
-	i32.const	$push1=, 0
-                                        # fallthrough-return: $pop1
+	copy_local	$push10=, $5
+                                        # fallthrough-return: $pop10
 	.endfunc
 .Lfunc_end0:
 	.size	foo, .Lfunc_end0-foo
@@ -73,7 +68,7 @@ main:                                   # @main
 	i32.add 	$push12=, $0, $pop11
 	i32.const	$push1=, 2
 	i32.call	$push2=, foo@FUNCTION, $pop12, $pop1
-	br_if   	0, $pop2        # 0: down to label3
+	br_if   	0, $pop2        # 0: down to label2
 # BB#1:                                 # %if.end
 	i32.const	$push10=, 0
 	i32.const	$push8=, 16
@@ -82,7 +77,7 @@ main:                                   # @main
 	i32.const	$push3=, 0
 	return  	$pop3
 .LBB1_2:                                # %if.then
-	end_block                       # label3:
+	end_block                       # label2:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -90,5 +85,5 @@ main:                                   # @main
 	.size	main, .Lfunc_end1-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr56799.c.s
+++ b/test/torture-s/pr56799.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr56799.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr56799.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
@@ -55,34 +55,38 @@ foo:                                    # @foo
 	.result 	i32
 	.local  	i32, i32
 # BB#0:                                 # %entry
-	i32.load	$1=, 4($0)
-	i32.const	$2=, 0
+	i32.load	$2=, 4($0)
+	block   	
 	block   	
 	i32.load	$push10=, 0($0)
-	tee_local	$push9=, $0=, $pop10
+	tee_local	$push9=, $1=, $pop10
 	i32.const	$push0=, 65535
 	i32.and 	$push1=, $pop9, $pop0
 	i32.eqz 	$push11=, $pop1
-	br_if   	0, $pop11       # 0: down to label1
+	br_if   	0, $pop11       # 0: down to label2
 # BB#1:                                 # %if.then
 	i32.const	$push3=, 0
 	i32.const	$push2=, 1
 	i32.store	lo($pop3), $pop2
-	copy_local	$2=, $1
-.LBB1_2:                                # %if.end
+	copy_local	$0=, $2
+	br      	1               # 1: down to label1
+.LBB1_2:
+	end_block                       # label2:
+	i32.const	$0=, 0
+.LBB1_3:                                # %if.end
 	end_block                       # label1:
 	block   	
 	i32.const	$push4=, 65536
-	i32.lt_u	$push5=, $0, $pop4
-	br_if   	0, $pop5        # 0: down to label2
-# BB#3:                                 # %if.then7
+	i32.lt_u	$push5=, $1, $pop4
+	br_if   	0, $pop5        # 0: down to label3
+# BB#4:                                 # %if.then7
 	i32.const	$push7=, 0
 	i32.const	$push6=, 1
 	i32.store	hi($pop7), $pop6
-	i32.add 	$2=, $2, $1
-.LBB1_4:                                # %if.end10
-	end_block                       # label2:
-	i32.add 	$push8=, $2, $1
+	i32.add 	$0=, $0, $2
+.LBB1_5:                                # %if.end10
+	end_block                       # label3:
+	i32.add 	$push8=, $0, $2
                                         # fallthrough-return: $pop8
 	.endfunc
 .Lfunc_end1:
@@ -107,6 +111,6 @@ lo:
 	.size	lo, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	exit, void, i32
 	.functype	abort, void

--- a/test/torture-s/pr57860.c.s
+++ b/test/torture-s/pr57860.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr57860.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr57860.c"
 	.section	.text.foo,"ax",@progbits
 	.hidden	foo
 	.globl	foo
@@ -7,63 +7,102 @@
 foo:                                    # @foo
 	.param  	i32
 	.result 	i32
-	.local  	i64, i32, i32, i32
+	.local  	i64, i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push12=, 0
-	i32.load	$4=, f($pop12)
-	i32.const	$push11=, 0
-	i32.load	$3=, h($pop11)
-	i32.const	$push10=, 0
-	i32.load	$2=, b($pop10)
-	i64.extend_s/i32	$1=, $0
-.LBB0_1:                                # %for.cond
-                                        # =>This Inner Loop Header: Depth=1
-	loop    	                # label0:
-	block   	
-	i32.const	$push15=, 0
-	i32.load	$push0=, c($pop15)
-	i32.eqz 	$push27=, $pop0
-	br_if   	0, $pop27       # 0: down to label1
-# BB#2:                                 # %for.inc.preheader
-                                        #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push17=, 0
-	i32.const	$push16=, 0
-	i32.store	c($pop17), $pop16
-.LBB0_3:                                # %for.end
-                                        #   in Loop: Header=BB0_1 Depth=1
-	end_block                       # label1:
-	block   	
-	i64.load32_s	$push3=, 0($2)
-	i32.const	$push26=, 0
-	i64.load32_s	$push1=, a($pop26)
-	i64.const	$push25=, 8589934591
-	i64.xor 	$push2=, $pop1, $pop25
-	i64.and 	$push4=, $pop3, $pop2
-	i64.gt_s	$push24=, $1, $pop4
-	tee_local	$push23=, $0=, $pop24
-	i32.store	0($3), $pop23
-	i32.store	0($4), $0
-	i32.const	$push22=, 0
-	i32.load	$push21=, g($pop22)
-	tee_local	$push20=, $0=, $pop21
-	i32.const	$push19=, 2
-	i32.shl 	$push5=, $pop20, $pop19
-	i32.const	$push18=, k
-	i32.add 	$push6=, $pop5, $pop18
-	i32.load	$push7=, 0($pop6)
-	br_if   	0, $pop7        # 0: down to label2
-# BB#4:                                 # %for.inc6
-                                        #   in Loop: Header=BB0_1 Depth=1
 	i32.const	$push14=, 0
-	i32.const	$push13=, 1
-	i32.add 	$push9=, $0, $pop13
-	i32.store	g($pop14), $pop9
-	br      	1               # 1: up to label0
-.LBB0_5:                                # %if.then
-	end_block                       # label2:
+	i32.load	$4=, f($pop14)
+	i32.const	$push13=, 0
+	i32.load	$3=, h($pop13)
+	i32.const	$push12=, 0
+	i32.load	$2=, b($pop12)
+	i64.extend_s/i32	$1=, $0
+	block   	
+	block   	
+	i32.const	$push11=, 0
+	i32.load	$push0=, c($pop11)
+	br_if   	0, $pop0        # 0: down to label1
+# BB#1:
+	i32.const	$5=, 1
+	br      	1               # 1: down to label0
+.LBB0_2:
+	end_block                       # label1:
+	i32.const	$5=, 0
+.LBB0_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label0:
+	loop    	i32             # label2:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$5, 1, 2, 3, 0, 0 # 1: down to label7
+                                        # 2: down to label6
+                                        # 3: down to label5
+                                        # 0: down to label8
+.LBB0_4:                                # %for.inc6
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label8:
+	i32.const	$push17=, 0
+	i32.const	$push16=, 1
+	i32.add 	$push10=, $0, $pop16
+	i32.store	g($pop17), $pop10
+	i32.const	$push15=, 0
+	i32.load	$push1=, c($pop15)
+	i32.eqz 	$push29=, $pop1
+	br_if   	3, $pop29       # 3: down to label4
+# BB#5:                                 #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$5=, 0
+	br      	5               # 5: up to label2
+.LBB0_6:                                # %for.inc.preheader
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label7:
+	i32.const	$push19=, 0
+	i32.const	$push18=, 0
+	i32.store	c($pop19), $pop18
+# BB#7:                                 #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$5=, 1
+	br      	4               # 4: up to label2
+.LBB0_8:                                # %for.end
+                                        #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label6:
+	i64.load32_s	$push4=, 0($2)
+	i32.const	$push28=, 0
+	i64.load32_s	$push2=, a($pop28)
+	i64.const	$push27=, 8589934591
+	i64.xor 	$push3=, $pop2, $pop27
+	i64.and 	$push5=, $pop4, $pop3
+	i64.gt_s	$push26=, $1, $pop5
+	tee_local	$push25=, $0=, $pop26
+	i32.store	0($3), $pop25
+	i32.store	0($4), $0
+	i32.const	$push24=, 0
+	i32.load	$push23=, g($pop24)
+	tee_local	$push22=, $0=, $pop23
+	i32.const	$push21=, 2
+	i32.shl 	$push6=, $pop22, $pop21
+	i32.const	$push20=, k
+	i32.add 	$push7=, $pop6, $pop20
+	i32.load	$push8=, 0($pop7)
+	i32.eqz 	$push30=, $pop8
+	br_if   	2, $pop30       # 2: down to label3
+# BB#9:                                 #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$5=, 2
+	br      	3               # 3: up to label2
+.LBB0_10:                               # %if.then
+	end_block                       # label5:
+	i32.const	$push9=, 0
+	return  	$pop9
+.LBB0_11:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label4:
+	i32.const	$5=, 1
+	br      	1               # 1: up to label2
+.LBB0_12:                               #   in Loop: Header=BB0_3 Depth=1
+	end_block                       # label3:
+	i32.const	$5=, 3
+	br      	0               # 0: up to label2
+.LBB0_13:
 	end_loop
-	i32.const	$push8=, 0
-                                        # fallthrough-return: $pop8
 	.endfunc
 .Lfunc_end0:
 	.size	foo, .Lfunc_end0-foo
@@ -74,74 +113,126 @@ foo:                                    # @foo
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push14=, 0
-	i32.load	$2=, f($pop14)
-	i32.const	$push13=, 0
-	i32.load	$1=, h($pop13)
-	i32.const	$push12=, 0
-	i32.load	$0=, b($pop12)
-.LBB1_1:                                # %for.cond.i
-                                        # =>This Inner Loop Header: Depth=1
-	loop    	                # label3:
-	block   	
-	i32.const	$push17=, 0
-	i32.load	$push0=, c($pop17)
-	i32.eqz 	$push32=, $pop0
-	br_if   	0, $pop32       # 0: down to label4
-# BB#2:                                 # %for.inc.preheader.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push19=, 0
-	i32.const	$push18=, 0
-	i32.store	c($pop19), $pop18
-.LBB1_3:                                # %for.end.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label4:
-	block   	
-	i64.load32_s	$push3=, 0($0)
-	i32.const	$push29=, 0
-	i64.load32_s	$push1=, a($pop29)
-	i64.const	$push28=, 8589934591
-	i64.xor 	$push2=, $pop1, $pop28
-	i64.and 	$push4=, $pop3, $pop2
-	i64.const	$push27=, 1
-	i64.lt_s	$push26=, $pop4, $pop27
-	tee_local	$push25=, $3=, $pop26
-	i32.store	0($1), $pop25
-	i32.store	0($2), $3
-	i32.const	$push24=, 0
-	i32.load	$push23=, g($pop24)
-	tee_local	$push22=, $3=, $pop23
-	i32.const	$push21=, 2
-	i32.shl 	$push5=, $pop22, $pop21
-	i32.const	$push20=, k
-	i32.add 	$push6=, $pop5, $pop20
-	i32.load	$push7=, 0($pop6)
-	br_if   	0, $pop7        # 0: down to label5
-# BB#4:                                 # %for.inc6.i
-                                        #   in Loop: Header=BB1_1 Depth=1
 	i32.const	$push16=, 0
-	i32.const	$push15=, 1
-	i32.add 	$push11=, $3, $pop15
-	i32.store	g($pop16), $pop11
-	br      	1               # 1: up to label3
-.LBB1_5:                                # %foo.exit
-	end_block                       # label5:
-	end_loop
+	i32.load	$2=, f($pop16)
+	i32.const	$push15=, 0
+	i32.load	$1=, h($pop15)
+	i32.const	$push14=, 0
+	i32.load	$0=, b($pop14)
 	block   	
-	i32.const	$push30=, 0
-	i32.load	$push8=, d($pop30)
-	i32.const	$push9=, 1
-	i32.ne  	$push10=, $pop8, $pop9
-	br_if   	0, $pop10       # 0: down to label6
-# BB#6:                                 # %if.end
+	block   	
+	i32.const	$push13=, 0
+	i32.load	$push0=, c($pop13)
+	br_if   	0, $pop0        # 0: down to label10
+# BB#1:
+	i32.const	$4=, 1
+	br      	1               # 1: down to label9
+.LBB1_2:
+	end_block                       # label10:
+	i32.const	$4=, 0
+.LBB1_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label9:
+	loop    	i32             # label11:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$4, 1, 2, 3, 5, 4, 0, 0 # 1: down to label19
+                                        # 2: down to label18
+                                        # 3: down to label17
+                                        # 5: down to label15
+                                        # 4: down to label16
+                                        # 0: down to label20
+.LBB1_4:                                # %for.inc6.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label20:
+	i32.const	$push19=, 0
+	i32.const	$push18=, 1
+	i32.add 	$push12=, $3, $pop18
+	i32.store	g($pop19), $pop12
+	i32.const	$push17=, 0
+	i32.load	$push1=, c($pop17)
+	i32.eqz 	$push34=, $pop1
+	br_if   	5, $pop34       # 5: down to label14
+# BB#5:                                 #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$4=, 0
+	br      	8               # 8: up to label11
+.LBB1_6:                                # %for.inc.preheader.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label19:
+	i32.const	$push21=, 0
+	i32.const	$push20=, 0
+	i32.store	c($pop21), $pop20
+# BB#7:                                 #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$4=, 1
+	br      	7               # 7: up to label11
+.LBB1_8:                                # %for.end.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label18:
+	i64.load32_s	$push4=, 0($0)
 	i32.const	$push31=, 0
-	return  	$pop31
-.LBB1_7:                                # %if.then
-	end_block                       # label6:
+	i64.load32_s	$push2=, a($pop31)
+	i64.const	$push30=, 8589934591
+	i64.xor 	$push3=, $pop2, $pop30
+	i64.and 	$push5=, $pop4, $pop3
+	i64.const	$push29=, 1
+	i64.lt_s	$push28=, $pop5, $pop29
+	tee_local	$push27=, $3=, $pop28
+	i32.store	0($1), $pop27
+	i32.store	0($2), $3
+	i32.const	$push26=, 0
+	i32.load	$push25=, g($pop26)
+	tee_local	$push24=, $3=, $pop25
+	i32.const	$push23=, 2
+	i32.shl 	$push6=, $pop24, $pop23
+	i32.const	$push22=, k
+	i32.add 	$push7=, $pop6, $pop22
+	i32.load	$push8=, 0($pop7)
+	i32.eqz 	$push35=, $pop8
+	br_if   	4, $pop35       # 4: down to label13
+# BB#9:                                 #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$4=, 2
+	br      	6               # 6: up to label11
+.LBB1_10:                               # %foo.exit
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label17:
+	i32.const	$push32=, 0
+	i32.load	$push9=, d($pop32)
+	i32.const	$push10=, 1
+	i32.ne  	$push11=, $pop9, $pop10
+	br_if   	4, $pop11       # 4: down to label12
+# BB#11:                                #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$4=, 4
+	br      	5               # 5: up to label11
+.LBB1_12:                               # %if.end
+	end_block                       # label16:
+	i32.const	$push33=, 0
+	return  	$pop33
+.LBB1_13:                               # %if.then
+	end_block                       # label15:
 	call    	abort@FUNCTION
 	unreachable
+.LBB1_14:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label14:
+	i32.const	$4=, 1
+	br      	2               # 2: up to label11
+.LBB1_15:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label13:
+	i32.const	$4=, 5
+	br      	1               # 1: up to label11
+.LBB1_16:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label12:
+	i32.const	$4=, 3
+	br      	0               # 0: up to label11
+.LBB1_17:
+	end_loop
 	.endfunc
 .Lfunc_end1:
 	.size	main, .Lfunc_end1-main
@@ -228,5 +319,5 @@ g:
 	.size	g, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr57876.c.s
+++ b/test/torture-s/pr57876.c.s
@@ -1,246 +1,336 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr57876.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr57876.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i64, i32
+	.local  	i64, i32, i32, i32, i32
 # BB#0:                                 # %for.body4.1
-	i32.const	$push45=, 0
-	i32.const	$push42=, 0
-	i32.load	$push43=, __stack_pointer($pop42)
-	i32.const	$push44=, 16
-	i32.sub 	$push170=, $pop43, $pop44
-	tee_local	$push169=, $4=, $pop170
-	i32.store	__stack_pointer($pop45), $pop169
-	i32.const	$push168=, 0
-	i32.load	$0=, d($pop168)
-	i32.const	$push167=, 0
-	i32.const	$push166=, 0
-	i32.store	f($pop167), $pop166
-	i32.const	$push165=, 0
-	i32.load	$push164=, 0($0)
-	tee_local	$push163=, $1=, $pop164
-	i32.store	j($pop165), $pop163
-	i32.const	$push162=, 0
+	i32.const	$push75=, 0
+	i32.const	$push72=, 0
+	i32.load	$push73=, __stack_pointer($pop72)
+	i32.const	$push74=, 16
+	i32.sub 	$push245=, $pop73, $pop74
+	tee_local	$push244=, $4=, $pop245
+	i32.store	__stack_pointer($pop75), $pop244
+	i32.const	$push243=, 0
+	i64.load32_s	$0=, b($pop243)
+	i32.const	$push242=, 0
+	i32.load	$1=, d($pop242)
+	i32.const	$push241=, 0
+	i32.const	$push240=, 0
+	i32.store	f($pop241), $pop240
+	i32.const	$push239=, 0
+	i32.load	$push238=, 0($1)
+	tee_local	$push237=, $2=, $pop238
+	i32.store	j($pop239), $pop237
+	i32.const	$push236=, 0
 	i32.const	$push0=, 1
-	i32.store	f($pop162), $pop0
-	i32.const	$push161=, 0
-	i32.const	$push160=, 0
-	i32.load	$push159=, a($pop160)
-	tee_local	$push158=, $2=, $pop159
-	i32.mul 	$push1=, $1, $pop158
+	i32.store	f($pop236), $pop0
+	i32.const	$push235=, 0
+	i32.const	$push234=, 0
+	i32.load	$push233=, a($pop234)
+	tee_local	$push232=, $3=, $pop233
+	i32.mul 	$push1=, $2, $pop232
 	i32.const	$push2=, -1
-	i32.add 	$push3=, $pop1, $pop2
-	i32.store	h($pop161), $pop3
-	i32.const	$push157=, 0
-	i32.load	$push156=, 0($0)
-	tee_local	$push155=, $1=, $pop156
-	i32.store	j($pop157), $pop155
+	i32.add 	$push231=, $pop1, $pop2
+	tee_local	$push230=, $2=, $pop231
+	i32.store	h($pop235), $pop230
+	i32.const	$push229=, 0
+	i32.eqz 	$push3=, $2
+	i64.extend_u/i32	$push4=, $pop3
+	i64.lt_s	$push5=, $pop4, $0
+	i32.store	e($pop229), $pop5
+	i32.const	$push228=, 0
+	i32.load	$push227=, 0($1)
+	tee_local	$push226=, $2=, $pop227
+	i32.store	j($pop228), $pop226
+	i32.const	$push225=, 0
+	i32.const	$push6=, 2
+	i32.store	f($pop225), $pop6
+	i32.const	$push224=, 0
+	i32.mul 	$push7=, $3, $2
+	i32.const	$push223=, -1
+	i32.add 	$push222=, $pop7, $pop223
+	tee_local	$push221=, $2=, $pop222
+	i32.store	h($pop224), $pop221
+	i32.const	$push220=, 0
+	i32.eqz 	$push8=, $2
+	i64.extend_u/i32	$push9=, $pop8
+	i64.lt_s	$push10=, $pop9, $0
+	i32.store	e($pop220), $pop10
+	i32.const	$push219=, 0
+	i32.load	$push218=, 0($1)
+	tee_local	$push217=, $2=, $pop218
+	i32.store	j($pop219), $pop217
+	i32.const	$push216=, 0
+	i32.const	$push11=, 3
+	i32.store	f($pop216), $pop11
+	i32.const	$push215=, 0
+	i32.mul 	$push12=, $3, $2
+	i32.const	$push214=, -1
+	i32.add 	$push213=, $pop12, $pop214
+	tee_local	$push212=, $2=, $pop213
+	i32.store	h($pop215), $pop212
+	i32.const	$push211=, 0
+	i32.eqz 	$push13=, $2
+	i64.extend_u/i32	$push14=, $pop13
+	i64.lt_s	$push15=, $pop14, $0
+	i32.store	e($pop211), $pop15
+	i32.const	$push210=, 0
+	i32.load	$push209=, 0($1)
+	tee_local	$push208=, $2=, $pop209
+	i32.store	j($pop210), $pop208
+	i32.const	$push207=, 0
+	i32.const	$push16=, 4
+	i32.store	f($pop207), $pop16
+	i32.const	$push206=, 0
+	i32.mul 	$push17=, $3, $2
+	i32.const	$push205=, -1
+	i32.add 	$push204=, $pop17, $pop205
+	tee_local	$push203=, $2=, $pop204
+	i32.store	h($pop206), $pop203
+	i32.const	$push202=, 0
+	i32.eqz 	$push18=, $2
+	i64.extend_u/i32	$push19=, $pop18
+	i64.lt_s	$push20=, $pop19, $0
+	i32.store	e($pop202), $pop20
+	i32.const	$push201=, 0
+	i32.load	$push200=, 0($1)
+	tee_local	$push199=, $2=, $pop200
+	i32.store	j($pop201), $pop199
+	i32.const	$push198=, 0
+	i32.const	$push21=, 5
+	i32.store	f($pop198), $pop21
+	i32.const	$push197=, 0
+	i32.mul 	$push22=, $3, $2
+	i32.const	$push196=, -1
+	i32.add 	$push195=, $pop22, $pop196
+	tee_local	$push194=, $2=, $pop195
+	i32.store	h($pop197), $pop194
+	i32.const	$push193=, 0
+	i32.eqz 	$push23=, $2
+	i64.extend_u/i32	$push24=, $pop23
+	i64.lt_s	$push25=, $pop24, $0
+	i32.store	e($pop193), $pop25
+	i32.const	$push192=, 0
+	i32.load	$push191=, 0($1)
+	tee_local	$push190=, $2=, $pop191
+	i32.store	j($pop192), $pop190
+	i32.const	$push189=, 0
+	i32.const	$push26=, 6
+	i32.store	f($pop189), $pop26
+	i32.const	$push188=, 0
+	i32.mul 	$push27=, $3, $2
+	i32.const	$push187=, -1
+	i32.add 	$push186=, $pop27, $pop187
+	tee_local	$push185=, $2=, $pop186
+	i32.store	h($pop188), $pop185
+	i32.const	$push184=, 0
+	i32.eqz 	$push28=, $2
+	i64.extend_u/i32	$push29=, $pop28
+	i64.lt_s	$push30=, $pop29, $0
+	i32.store	e($pop184), $pop30
+	i32.const	$push183=, 0
+	i32.load	$push182=, 0($1)
+	tee_local	$push181=, $2=, $pop182
+	i32.store	j($pop183), $pop181
+	i32.const	$push180=, 0
+	i32.const	$push31=, 7
+	i32.store	f($pop180), $pop31
+	i32.const	$push179=, 0
+	i32.mul 	$push32=, $3, $2
+	i32.const	$push178=, -1
+	i32.add 	$push177=, $pop32, $pop178
+	tee_local	$push176=, $2=, $pop177
+	i32.store	h($pop179), $pop176
+	i32.const	$push175=, 0
+	i32.eqz 	$push33=, $2
+	i64.extend_u/i32	$push34=, $pop33
+	i64.lt_s	$push35=, $pop34, $0
+	i32.store	e($pop175), $pop35
+	i32.const	$push174=, 0
+	i32.load	$push173=, 0($1)
+	tee_local	$push172=, $2=, $pop173
+	i32.store	j($pop174), $pop172
+	i32.const	$push171=, 0
+	i32.const	$push36=, 8
+	i32.store	f($pop171), $pop36
+	i32.const	$push170=, 0
+	i32.mul 	$push37=, $3, $2
+	i32.const	$push169=, -1
+	i32.add 	$push168=, $pop37, $pop169
+	tee_local	$push167=, $2=, $pop168
+	i32.store	h($pop170), $pop167
+	i32.const	$push166=, 0
+	i32.eqz 	$push38=, $2
+	i64.extend_u/i32	$push39=, $pop38
+	i64.lt_s	$push40=, $pop39, $0
+	i32.store	e($pop166), $pop40
+	i32.const	$push165=, 0
+	i32.const	$push164=, 0
+	i32.store	f($pop165), $pop164
+	i32.const	$push163=, 0
+	i32.load	$push162=, 0($1)
+	tee_local	$push161=, $2=, $pop162
+	i32.store	j($pop163), $pop161
+	i32.const	$push160=, 0
+	i32.const	$push159=, 1
+	i32.store	f($pop160), $pop159
+	i32.const	$push158=, 0
+	i32.mul 	$push41=, $3, $2
+	i32.const	$push157=, -1
+	i32.add 	$push156=, $pop41, $pop157
+	tee_local	$push155=, $2=, $pop156
+	i32.store	h($pop158), $pop155
 	i32.const	$push154=, 0
-	i32.const	$push4=, 2
-	i32.store	f($pop154), $pop4
+	i32.eqz 	$push42=, $2
+	i64.extend_u/i32	$push43=, $pop42
+	i64.lt_s	$push44=, $pop43, $0
+	i32.store	e($pop154), $pop44
 	i32.const	$push153=, 0
-	i32.mul 	$push5=, $2, $1
-	i32.const	$push152=, -1
-	i32.add 	$push6=, $pop5, $pop152
-	i32.store	h($pop153), $pop6
-	i32.const	$push151=, 0
-	i32.load	$push150=, 0($0)
-	tee_local	$push149=, $1=, $pop150
-	i32.store	j($pop151), $pop149
+	i32.load	$push152=, 0($1)
+	tee_local	$push151=, $2=, $pop152
+	i32.store	j($pop153), $pop151
+	i32.const	$push150=, 0
+	i32.const	$push149=, 2
+	i32.store	f($pop150), $pop149
 	i32.const	$push148=, 0
-	i32.const	$push7=, 3
-	i32.store	f($pop148), $pop7
-	i32.const	$push147=, 0
-	i32.mul 	$push8=, $2, $1
-	i32.const	$push146=, -1
-	i32.add 	$push9=, $pop8, $pop146
-	i32.store	h($pop147), $pop9
-	i32.const	$push145=, 0
-	i32.load	$push144=, 0($0)
-	tee_local	$push143=, $1=, $pop144
-	i32.store	j($pop145), $pop143
-	i32.const	$push142=, 0
-	i32.const	$push10=, 4
-	i32.store	f($pop142), $pop10
-	i32.const	$push141=, 0
-	i32.mul 	$push11=, $2, $1
-	i32.const	$push140=, -1
-	i32.add 	$push12=, $pop11, $pop140
-	i32.store	h($pop141), $pop12
-	i32.const	$push139=, 0
-	i32.load	$push138=, 0($0)
-	tee_local	$push137=, $1=, $pop138
-	i32.store	j($pop139), $pop137
-	i32.const	$push136=, 0
-	i32.const	$push13=, 5
-	i32.store	f($pop136), $pop13
-	i32.const	$push135=, 0
-	i32.mul 	$push14=, $2, $1
-	i32.const	$push134=, -1
-	i32.add 	$push15=, $pop14, $pop134
-	i32.store	h($pop135), $pop15
+	i32.mul 	$push45=, $3, $2
+	i32.const	$push147=, -1
+	i32.add 	$push146=, $pop45, $pop147
+	tee_local	$push145=, $2=, $pop146
+	i32.store	h($pop148), $pop145
+	i32.const	$push144=, 0
+	i32.eqz 	$push46=, $2
+	i64.extend_u/i32	$push47=, $pop46
+	i64.lt_s	$push48=, $pop47, $0
+	i32.store	e($pop144), $pop48
+	i32.const	$push143=, 0
+	i32.load	$push142=, 0($1)
+	tee_local	$push141=, $2=, $pop142
+	i32.store	j($pop143), $pop141
+	i32.const	$push140=, 0
+	i32.const	$push139=, 3
+	i32.store	f($pop140), $pop139
+	i32.const	$push138=, 0
+	i32.mul 	$push49=, $3, $2
+	i32.const	$push137=, -1
+	i32.add 	$push136=, $pop49, $pop137
+	tee_local	$push135=, $2=, $pop136
+	i32.store	h($pop138), $pop135
+	i32.const	$push134=, 0
+	i32.eqz 	$push50=, $2
+	i64.extend_u/i32	$push51=, $pop50
+	i64.lt_s	$push52=, $pop51, $0
+	i32.store	e($pop134), $pop52
 	i32.const	$push133=, 0
-	i32.load	$push132=, 0($0)
-	tee_local	$push131=, $1=, $pop132
+	i32.load	$push132=, 0($1)
+	tee_local	$push131=, $2=, $pop132
 	i32.store	j($pop133), $pop131
 	i32.const	$push130=, 0
-	i32.const	$push16=, 6
-	i32.store	f($pop130), $pop16
-	i32.const	$push129=, 0
-	i32.mul 	$push17=, $2, $1
-	i32.const	$push128=, -1
-	i32.add 	$push18=, $pop17, $pop128
-	i32.store	h($pop129), $pop18
-	i32.const	$push127=, 0
-	i32.load	$push126=, 0($0)
-	tee_local	$push125=, $1=, $pop126
-	i32.store	j($pop127), $pop125
+	i32.const	$push129=, 4
+	i32.store	f($pop130), $pop129
+	i32.const	$push128=, 0
+	i32.mul 	$push53=, $3, $2
+	i32.const	$push127=, -1
+	i32.add 	$push126=, $pop53, $pop127
+	tee_local	$push125=, $2=, $pop126
+	i32.store	h($pop128), $pop125
 	i32.const	$push124=, 0
-	i32.const	$push19=, 7
-	i32.store	f($pop124), $pop19
+	i32.eqz 	$push54=, $2
+	i64.extend_u/i32	$push55=, $pop54
+	i64.lt_s	$push56=, $pop55, $0
+	i32.store	e($pop124), $pop56
 	i32.const	$push123=, 0
-	i32.mul 	$push20=, $2, $1
-	i32.const	$push122=, -1
-	i32.add 	$push21=, $pop20, $pop122
-	i32.store	h($pop123), $pop21
-	i32.const	$push121=, 0
-	i32.load	$push120=, 0($0)
-	tee_local	$push119=, $1=, $pop120
-	i32.store	j($pop121), $pop119
+	i32.load	$push122=, 0($1)
+	tee_local	$push121=, $2=, $pop122
+	i32.store	j($pop123), $pop121
+	i32.const	$push120=, 0
+	i32.const	$push119=, 5
+	i32.store	f($pop120), $pop119
 	i32.const	$push118=, 0
-	i32.const	$push22=, 8
-	i32.store	f($pop118), $pop22
-	i32.const	$push117=, 0
-	i32.mul 	$push23=, $2, $1
-	i32.const	$push116=, -1
-	i32.add 	$push24=, $pop23, $pop116
-	i32.store	h($pop117), $pop24
-	i32.const	$push115=, 0
-	i64.load32_s	$3=, b($pop115)
+	i32.mul 	$push57=, $3, $2
+	i32.const	$push117=, -1
+	i32.add 	$push116=, $pop57, $pop117
+	tee_local	$push115=, $2=, $pop116
+	i32.store	h($pop118), $pop115
 	i32.const	$push114=, 0
+	i32.eqz 	$push58=, $2
+	i64.extend_u/i32	$push59=, $pop58
+	i64.lt_s	$push60=, $pop59, $0
+	i32.store	e($pop114), $pop60
 	i32.const	$push113=, 0
-	i32.store	f($pop114), $pop113
-	i32.const	$push112=, 0
-	i32.load	$push111=, 0($0)
-	tee_local	$push110=, $1=, $pop111
-	i32.store	j($pop112), $pop110
-	i32.const	$push109=, 0
-	i32.const	$push108=, 1
-	i32.store	f($pop109), $pop108
-	i32.const	$push107=, 0
-	i32.mul 	$push25=, $2, $1
-	i32.const	$push106=, -1
-	i32.add 	$push26=, $pop25, $pop106
-	i32.store	h($pop107), $pop26
-	i32.const	$push105=, 0
-	i32.load	$push104=, 0($0)
-	tee_local	$push103=, $1=, $pop104
-	i32.store	j($pop105), $pop103
-	i32.const	$push102=, 0
-	i32.const	$push101=, 2
-	i32.store	f($pop102), $pop101
+	i32.load	$push112=, 0($1)
+	tee_local	$push111=, $2=, $pop112
+	i32.store	j($pop113), $pop111
+	i32.const	$push110=, 0
+	i32.const	$push109=, 6
+	i32.store	f($pop110), $pop109
+	i32.const	$push108=, 0
+	i32.mul 	$push61=, $3, $2
+	i32.const	$push107=, -1
+	i32.add 	$push106=, $pop61, $pop107
+	tee_local	$push105=, $2=, $pop106
+	i32.store	h($pop108), $pop105
+	i32.const	$push104=, 0
+	i32.eqz 	$push62=, $2
+	i64.extend_u/i32	$push63=, $pop62
+	i64.lt_s	$push64=, $pop63, $0
+	i32.store	e($pop104), $pop64
+	i32.const	$push103=, 0
+	i32.load	$push102=, 0($1)
+	tee_local	$push101=, $2=, $pop102
+	i32.store	j($pop103), $pop101
 	i32.const	$push100=, 0
-	i32.mul 	$push27=, $2, $1
-	i32.const	$push99=, -1
-	i32.add 	$push28=, $pop27, $pop99
-	i32.store	h($pop100), $pop28
+	i32.const	$push99=, 7
+	i32.store	f($pop100), $pop99
 	i32.const	$push98=, 0
-	i32.load	$push97=, 0($0)
-	tee_local	$push96=, $1=, $pop97
-	i32.store	j($pop98), $pop96
-	i32.const	$push95=, 0
-	i32.const	$push94=, 3
-	i32.store	f($pop95), $pop94
+	i32.mul 	$push65=, $3, $2
+	i32.const	$push97=, -1
+	i32.add 	$push96=, $pop65, $pop97
+	tee_local	$push95=, $2=, $pop96
+	i32.store	h($pop98), $pop95
+	i32.const	$push94=, 0
+	i32.eqz 	$push66=, $2
+	i64.extend_u/i32	$push67=, $pop66
+	i64.lt_s	$push68=, $pop67, $0
+	i32.store	e($pop94), $pop68
 	i32.const	$push93=, 0
-	i32.mul 	$push29=, $2, $1
-	i32.const	$push92=, -1
-	i32.add 	$push30=, $pop29, $pop92
-	i32.store	h($pop93), $pop30
-	i32.const	$push91=, 0
-	i32.load	$push90=, 0($0)
-	tee_local	$push89=, $1=, $pop90
-	i32.store	j($pop91), $pop89
+	i32.load	$push92=, 0($1)
+	tee_local	$push91=, $1=, $pop92
+	i32.store	j($pop93), $pop91
+	i32.const	$push90=, 0
+	i32.const	$push89=, 8
+	i32.store	f($pop90), $pop89
 	i32.const	$push88=, 0
-	i32.const	$push87=, 4
-	i32.store	f($pop88), $pop87
-	i32.const	$push86=, 0
-	i32.mul 	$push31=, $2, $1
-	i32.const	$push85=, -1
-	i32.add 	$push32=, $pop31, $pop85
-	i32.store	h($pop86), $pop32
+	i32.mul 	$push69=, $3, $1
+	i32.const	$push87=, -1
+	i32.add 	$push86=, $pop69, $pop87
+	tee_local	$push85=, $1=, $pop86
+	i32.store	h($pop88), $pop85
 	i32.const	$push84=, 0
-	i32.load	$push83=, 0($0)
+	i32.eqz 	$push70=, $1
+	i64.extend_u/i32	$push71=, $pop70
+	i64.lt_s	$push83=, $pop71, $0
 	tee_local	$push82=, $1=, $pop83
-	i32.store	j($pop84), $pop82
+	i32.store	e($pop84), $pop82
 	i32.const	$push81=, 0
-	i32.const	$push80=, 5
-	i32.store	f($pop81), $pop80
-	i32.const	$push79=, 0
-	i32.mul 	$push33=, $2, $1
-	i32.const	$push78=, -1
-	i32.add 	$push34=, $pop33, $pop78
-	i32.store	h($pop79), $pop34
-	i32.const	$push77=, 0
-	i32.load	$push76=, 0($0)
-	tee_local	$push75=, $1=, $pop76
-	i32.store	j($pop77), $pop75
-	i32.const	$push74=, 0
-	i32.const	$push73=, 6
-	i32.store	f($pop74), $pop73
-	i32.const	$push72=, 0
-	i32.mul 	$push35=, $2, $1
-	i32.const	$push71=, -1
-	i32.add 	$push36=, $pop35, $pop71
-	i32.store	h($pop72), $pop36
-	i32.const	$push70=, 0
-	i32.load	$push69=, 0($0)
-	tee_local	$push68=, $1=, $pop69
-	i32.store	j($pop70), $pop68
-	i32.const	$push67=, 0
-	i32.const	$push66=, 7
-	i32.store	f($pop67), $pop66
-	i32.const	$push65=, 0
-	i32.mul 	$push37=, $2, $1
-	i32.const	$push64=, -1
-	i32.add 	$push38=, $pop37, $pop64
-	i32.store	h($pop65), $pop38
-	i32.const	$push63=, 0
-	i32.load	$push62=, 0($0)
-	tee_local	$push61=, $0=, $pop62
-	i32.store	j($pop63), $pop61
-	i32.const	$push60=, 0
-	i32.const	$push59=, 8
-	i32.store	f($pop60), $pop59
-	i32.const	$push58=, 0
-	i32.mul 	$push39=, $2, $0
-	i32.const	$push57=, -1
-	i32.add 	$push56=, $pop39, $pop57
-	tee_local	$push55=, $0=, $pop56
-	i32.store	h($pop58), $pop55
-	i32.const	$push54=, 0
-	i32.eqz 	$push40=, $0
-	i64.extend_u/i32	$push41=, $pop40
-	i64.lt_s	$push53=, $pop41, $3
-	tee_local	$push52=, $0=, $pop53
-	i32.store	e($pop54), $pop52
-	i32.const	$push51=, 0
-	i32.const	$push49=, 12
-	i32.add 	$push50=, $4, $pop49
-	i32.store	g($pop51), $pop50
+	i32.const	$push79=, 12
+	i32.add 	$push80=, $4, $pop79
+	i32.store	g($pop81), $pop80
 	block   	
-	i32.eqz 	$push172=, $0
-	br_if   	0, $pop172      # 0: down to label0
+	i32.eqz 	$push247=, $1
+	br_if   	0, $pop247      # 0: down to label0
 # BB#1:                                 # %if.end
-	i32.const	$push48=, 0
-	i32.const	$push46=, 16
-	i32.add 	$push47=, $4, $pop46
-	i32.store	__stack_pointer($pop48), $pop47
-	i32.const	$push171=, 0
-	return  	$pop171
+	i32.const	$push78=, 0
+	i32.const	$push76=, 16
+	i32.add 	$push77=, $4, $pop76
+	i32.store	__stack_pointer($pop78), $pop77
+	i32.const	$push246=, 0
+	return  	$pop246
 .LBB0_2:                                # %if.then
 	end_block                       # label0:
 	call    	abort@FUNCTION
@@ -329,5 +419,5 @@ g:
 	.size	g, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr58209.c.s
+++ b/test/torture-s/pr58209.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr58209.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr58209.c"
 	.section	.text.foo,"ax",@progbits
 	.hidden	foo
 	.globl	foo
@@ -33,21 +33,20 @@ foo:                                    # @foo
 bar:                                    # @bar
 	.param  	i32
 	.result 	i32
-	.local  	i32
 # BB#0:                                 # %entry
-	i32.const	$1=, buf
 	block   	
-	i32.eqz 	$push4=, $0
-	br_if   	0, $pop4        # 0: down to label1
+	i32.eqz 	$push6=, $0
+	br_if   	0, $pop6        # 0: down to label1
 # BB#1:                                 # %if.end
 	i32.const	$push0=, -1
 	i32.add 	$push1=, $0, $pop0
 	i32.call	$push2=, foo@FUNCTION, $pop1
 	i32.const	$push3=, 4
-	i32.add 	$1=, $pop2, $pop3
-.LBB1_2:                                # %return
+	i32.add 	$push4=, $pop2, $pop3
+	return  	$pop4
+.LBB1_2:
 	end_block                       # label1:
-	copy_local	$push5=, $1
+	i32.const	$push5=, buf
                                         # fallthrough-return: $pop5
 	.endfunc
 .Lfunc_end1:
@@ -59,7 +58,7 @@ bar:                                    # @bar
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32
+	.local  	i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$2=, 0
 	i32.const	$1=, buf-4
@@ -67,43 +66,47 @@ main:                                   # @main
                                         # =>This Inner Loop Header: Depth=1
 	block   	
 	loop    	                # label3:
-	i32.const	$push10=, 4
-	i32.add 	$push9=, $1, $pop10
-	tee_local	$push8=, $1=, $pop9
-	i32.call	$push7=, foo@FUNCTION, $2
-	tee_local	$push6=, $0=, $pop7
-	i32.ne  	$push0=, $pop8, $pop6
+	i32.const	$push13=, 4
+	i32.add 	$push12=, $1, $pop13
+	tee_local	$push11=, $1=, $pop12
+	i32.call	$push10=, foo@FUNCTION, $2
+	tee_local	$push9=, $0=, $pop10
+	i32.ne  	$push0=, $pop11, $pop9
 	br_if   	1, $pop0        # 1: down to label2
 # BB#2:                                 # %lor.lhs.false
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.const	$3=, buf
 	block   	
-	i32.eqz 	$push17=, $2
-	br_if   	0, $pop17       # 0: down to label4
+	block   	
+	i32.eqz 	$push20=, $2
+	br_if   	0, $pop20       # 0: down to label5
 # BB#3:                                 # %if.end.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.const	$push12=, -1
-	i32.add 	$push1=, $2, $pop12
+	i32.const	$push15=, -1
+	i32.add 	$push1=, $2, $pop15
 	i32.call	$push2=, foo@FUNCTION, $pop1
-	i32.const	$push11=, 4
-	i32.add 	$3=, $pop2, $pop11
-.LBB2_4:                                # %bar.exit
+	i32.const	$push14=, 4
+	i32.add 	$push7=, $pop2, $pop14
+	i32.eq  	$push3=, $pop7, $0
+	br_if   	1, $pop3        # 1: down to label4
+	br      	3               # 3: down to label2
+.LBB2_4:                                #   in Loop: Header=BB2_1 Depth=1
+	end_block                       # label5:
+	i32.const	$push8=, buf
+	i32.ne  	$push4=, $pop8, $0
+	br_if   	2, $pop4        # 2: down to label2
+.LBB2_5:                                # %for.cond
                                         #   in Loop: Header=BB2_1 Depth=1
 	end_block                       # label4:
-	i32.ne  	$push3=, $3, $0
-	br_if   	1, $pop3        # 1: down to label2
-# BB#5:                                 # %for.cond
-                                        #   in Loop: Header=BB2_1 Depth=1
-	i32.const	$push16=, 1
-	i32.add 	$push15=, $2, $pop16
-	tee_local	$push14=, $2=, $pop15
-	i32.const	$push13=, 26
-	i32.le_s	$push4=, $pop14, $pop13
-	br_if   	0, $pop4        # 0: up to label3
+	i32.const	$push19=, 1
+	i32.add 	$push18=, $2, $pop19
+	tee_local	$push17=, $2=, $pop18
+	i32.const	$push16=, 26
+	i32.le_s	$push5=, $pop17, $pop16
+	br_if   	0, $pop5        # 0: up to label3
 # BB#6:                                 # %for.end
 	end_loop
-	i32.const	$push5=, 0
-	return  	$pop5
+	i32.const	$push6=, 0
+	return  	$pop6
 .LBB2_7:                                # %if.then
 	end_block                       # label2:
 	call    	abort@FUNCTION
@@ -122,5 +125,5 @@ buf:
 	.size	buf, 4096
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/pr59358.c.s
+++ b/test/torture-s/pr59358.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr59358.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr59358.c"
 	.section	.text.foo,"ax",@progbits
 	.hidden	foo
 	.globl	foo
@@ -51,15 +51,15 @@ main:                                   # @main
 	.result 	i32
 	.local  	i32, i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push15=, 0
-	i32.const	$push12=, 0
-	i32.load	$push13=, __stack_pointer($pop12)
-	i32.const	$push14=, 16
-	i32.sub 	$push25=, $pop13, $pop14
-	tee_local	$push24=, $6=, $pop25
-	i32.store	__stack_pointer($pop15), $pop24
-	i32.const	$push23=, 1
-	i32.store	12($6), $pop23
+	i32.const	$push17=, 0
+	i32.const	$push14=, 0
+	i32.load	$push15=, __stack_pointer($pop14)
+	i32.const	$push16=, 16
+	i32.sub 	$push27=, $pop15, $pop16
+	tee_local	$push26=, $6=, $pop27
+	i32.store	__stack_pointer($pop17), $pop26
+	i32.const	$push25=, 1
+	i32.store	12($6), $pop25
 	i32.const	$0=, 2
 	i32.const	$1=, 2
 	i32.const	$2=, 1
@@ -67,96 +67,100 @@ main:                                   # @main
                                         # =>This Inner Loop Header: Depth=1
 	block   	
 	loop    	                # label4:
-	i32.const	$push19=, 12
-	i32.add 	$push20=, $6, $pop19
-	i32.const	$push31=, 16
-	i32.call	$4=, foo@FUNCTION, $pop20, $pop31
-	copy_local	$5=, $0
+	i32.const	$push21=, 12
+	i32.add 	$push22=, $6, $pop21
+	i32.const	$push33=, 16
+	i32.call	$5=, foo@FUNCTION, $pop22, $pop33
+	copy_local	$4=, $0
 	block   	
-	i32.const	$push30=, -1
-	i32.add 	$push29=, $1, $pop30
-	tee_local	$push28=, $3=, $pop29
-	i32.const	$push27=, -8
-	i32.and 	$push1=, $pop28, $pop27
-	i32.const	$push26=, 8
-	i32.eq  	$push2=, $pop1, $pop26
-	br_if   	0, $pop2        # 0: down to label5
+	block   	
+	i32.const	$push32=, -1
+	i32.add 	$push31=, $1, $pop32
+	tee_local	$push30=, $3=, $pop31
+	i32.const	$push29=, -8
+	i32.and 	$push1=, $pop30, $pop29
+	i32.const	$push28=, 8
+	i32.eq  	$push2=, $pop1, $pop28
+	br_if   	0, $pop2        # 0: down to label6
 # BB#2:                                 # %if.else
                                         #   in Loop: Header=BB1_1 Depth=1
 	block   	
-	i32.const	$push33=, -4
-	i32.and 	$push3=, $3, $pop33
-	i32.const	$push32=, 4
-	i32.ne  	$push4=, $pop3, $pop32
-	br_if   	0, $pop4        # 0: down to label6
+	i32.const	$push35=, -4
+	i32.and 	$push3=, $3, $pop35
+	i32.const	$push34=, 4
+	i32.ne  	$push4=, $pop3, $pop34
+	br_if   	0, $pop4        # 0: down to label7
 # BB#3:                                 # %if.then6
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push34=, 2
-	i32.shl 	$5=, $2, $pop34
-	br      	1               # 1: down to label5
+	i32.const	$push36=, 2
+	i32.shl 	$push13=, $2, $pop36
+	i32.eq  	$push6=, $5, $pop13
+	br_if   	2, $pop6        # 2: down to label5
+	br      	4               # 4: down to label3
 .LBB1_4:                                # %if.else10
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label6:
-	i32.const	$push37=, 24
-	i32.const	$push36=, 16
-	i32.const	$push35=, 4
-	i32.eq  	$push5=, $1, $pop35
-	i32.select	$5=, $pop37, $pop36, $pop5
+	end_block                       # label7:
+	i32.const	$push39=, 24
+	i32.const	$push38=, 16
+	i32.const	$push37=, 4
+	i32.eq  	$push5=, $1, $pop37
+	i32.select	$4=, $pop39, $pop38, $pop5
 .LBB1_5:                                # %if.end15
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label5:
-	i32.ne  	$push6=, $4, $5
-	br_if   	1, $pop6        # 1: down to label3
-# BB#6:                                 # %if.end18
+	end_block                       # label6:
+	i32.ne  	$push7=, $5, $4
+	br_if   	2, $pop7        # 2: down to label3
+.LBB1_6:                                # %if.end18
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push21=, 12
-	i32.add 	$push22=, $6, $pop21
-	i32.const	$push39=, 7
-	i32.call	$4=, foo@FUNCTION, $pop22, $pop39
+	end_block                       # label5:
+	i32.const	$push23=, 12
+	i32.add 	$push24=, $6, $pop23
+	i32.const	$push41=, 7
+	i32.call	$4=, foo@FUNCTION, $pop24, $pop41
 	copy_local	$5=, $2
 	block   	
-	i32.const	$push38=, 6
-	i32.gt_s	$push7=, $3, $pop38
-	br_if   	0, $pop7        # 0: down to label7
+	i32.const	$push40=, 6
+	i32.gt_s	$push8=, $3, $pop40
+	br_if   	0, $pop8        # 0: down to label8
 # BB#7:                                 # %if.else22
                                         #   in Loop: Header=BB1_1 Depth=1
 	copy_local	$5=, $0
-	i32.const	$push40=, 3
-	i32.gt_s	$push8=, $3, $pop40
-	br_if   	0, $pop8        # 0: down to label7
+	i32.const	$push42=, 3
+	i32.gt_s	$push9=, $3, $pop42
+	br_if   	0, $pop9        # 0: down to label8
 # BB#8:                                 # %if.else28
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push43=, 12
-	i32.const	$push42=, 8
-	i32.const	$push41=, 4
-	i32.eq  	$push9=, $1, $pop41
-	i32.select	$5=, $pop43, $pop42, $pop9
+	i32.const	$push45=, 12
+	i32.const	$push44=, 8
+	i32.const	$push43=, 4
+	i32.eq  	$push10=, $1, $pop43
+	i32.select	$5=, $pop45, $pop44, $pop10
 .LBB1_9:                                # %if.end34
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label7:
-	i32.ne  	$push10=, $4, $5
-	br_if   	1, $pop10       # 1: down to label3
+	end_block                       # label8:
+	i32.ne  	$push11=, $4, $5
+	br_if   	1, $pop11       # 1: down to label3
 # BB#10:                                # %if.end37
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push47=, 2
-	i32.add 	$0=, $0, $pop47
-	i32.const	$push46=, 1
-	i32.add 	$2=, $2, $pop46
+	i32.const	$push49=, 2
+	i32.add 	$0=, $0, $pop49
+	i32.const	$push48=, 1
+	i32.add 	$2=, $2, $pop48
 	i32.store	12($6), $1
-	i32.const	$push45=, 17
-	i32.lt_s	$3=, $1, $pop45
-	i32.const	$push44=, 1
-	i32.add 	$push0=, $1, $pop44
+	i32.const	$push47=, 17
+	i32.lt_s	$3=, $1, $pop47
+	i32.const	$push46=, 1
+	i32.add 	$push0=, $1, $pop46
 	copy_local	$1=, $pop0
 	br_if   	0, $3           # 0: up to label4
 # BB#11:                                # %for.end
 	end_loop
-	i32.const	$push18=, 0
-	i32.const	$push16=, 16
-	i32.add 	$push17=, $6, $pop16
-	i32.store	__stack_pointer($pop18), $pop17
-	i32.const	$push11=, 0
-	return  	$pop11
+	i32.const	$push20=, 0
+	i32.const	$push18=, 16
+	i32.add 	$push19=, $6, $pop18
+	i32.store	__stack_pointer($pop20), $pop19
+	i32.const	$push12=, 0
+	return  	$pop12
 .LBB1_12:                               # %if.then36
 	end_block                       # label3:
 	call    	abort@FUNCTION
@@ -166,5 +170,5 @@ main:                                   # @main
 	.size	main, .Lfunc_end1-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void

--- a/test/torture-s/strcmp-1.c.s
+++ b/test/torture-s/strcmp-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/strcmp-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/strcmp-1.c"
 	.section	.text.test,"ax",@progbits
 	.hidden	test
 	.globl	test
@@ -74,183 +74,195 @@ main:                                   # @main
                                         #     Parent Loop BB1_2 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
 	loop    	                # label8:
-	i32.const	$5=, u1
 	block   	
-	i32.eqz 	$push77=, $0
-	br_if   	0, $pop77       # 0: down to label9
+	block   	
+	block   	
+	i32.eqz 	$push83=, $0
+	br_if   	0, $pop83       # 0: down to label11
 # BB#4:                                 # %for.body9.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push26=, u1
-	i32.const	$push25=, 0
-	i32.call	$drop=, memset@FUNCTION, $pop26, $pop25, $0
-	copy_local	$5=, $1
-.LBB1_5:                                # %for.cond10.preheader
+	i32.const	$push28=, u1
+	i32.const	$push27=, 0
+	i32.call	$drop=, memset@FUNCTION, $pop28, $pop27, $0
+	copy_local	$push26=, $1
+	tee_local	$push25=, $5=, $pop26
+	copy_local	$6=, $pop25
+	br_if   	1, $4           # 1: down to label10
+	br      	2               # 2: down to label9
+.LBB1_5:                                #   in Loop: Header=BB1_3 Depth=3
+	end_block                       # label11:
+	i32.const	$5=, u1
+	i32.const	$push29=, u1
+	copy_local	$6=, $pop29
+	i32.eqz 	$push84=, $4
+	br_if   	1, $pop84       # 1: down to label9
+.LBB1_6:                                # %for.body12.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	end_block                       # label9:
-	copy_local	$6=, $5
-	block   	
-	i32.eqz 	$push78=, $4
-	br_if   	0, $pop78       # 0: down to label10
-# BB#6:                                 # %for.body12.preheader
-                                        #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push27=, 97
-	i32.call	$push0=, memset@FUNCTION, $5, $pop27, $4
+	end_block                       # label10:
+	i32.const	$push30=, 97
+	i32.call	$push0=, memset@FUNCTION, $5, $pop30, $4
 	i32.add 	$6=, $pop0, $4
 .LBB1_7:                                # %for.cond17.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	end_block                       # label10:
-	i64.const	$push30=, 8680820740569200760
-	i64.store	0($6):p2align=0, $pop30
-	i32.const	$push29=, 8
-	i32.add 	$push2=, $6, $pop29
-	i32.const	$push28=, 30840
-	i32.store16	0($pop2):p2align=0, $pop28
-	i32.const	$7=, u2
+	end_block                       # label9:
+	i64.const	$push33=, 8680820740569200760
+	i64.store	0($6):p2align=0, $pop33
+	i32.const	$push32=, 8
+	i32.add 	$push2=, $6, $pop32
+	i32.const	$push31=, 30840
+	i32.store16	0($pop2):p2align=0, $pop31
 	block   	
-	i32.eqz 	$push79=, $2
-	br_if   	0, $pop79       # 0: down to label11
+	block   	
+	block   	
+	i32.eqz 	$push85=, $2
+	br_if   	0, $pop85       # 0: down to label14
 # BB#8:                                 # %for.body26.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push32=, u2
-	i32.const	$push31=, 0
-	i32.call	$drop=, memset@FUNCTION, $pop32, $pop31, $2
-	copy_local	$7=, $3
-.LBB1_9:                                # %for.cond31.preheader
+	i32.const	$push37=, u2
+	i32.const	$push36=, 0
+	i32.call	$drop=, memset@FUNCTION, $pop37, $pop36, $2
+	copy_local	$push35=, $3
+	tee_local	$push34=, $7=, $pop35
+	copy_local	$8=, $pop34
+	br_if   	1, $4           # 1: down to label13
+	br      	2               # 2: down to label12
+.LBB1_9:                                #   in Loop: Header=BB1_3 Depth=3
+	end_block                       # label14:
+	i32.const	$7=, u2
+	i32.const	$push38=, u2
+	copy_local	$8=, $pop38
+	i32.eqz 	$push86=, $4
+	br_if   	1, $pop86       # 1: down to label12
+.LBB1_10:                               # %for.body33.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	end_block                       # label11:
-	copy_local	$8=, $7
-	block   	
-	i32.eqz 	$push80=, $4
-	br_if   	0, $pop80       # 0: down to label12
-# BB#10:                                # %for.body33.preheader
-                                        #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push33=, 97
-	i32.call	$push1=, memset@FUNCTION, $7, $pop33, $4
+	end_block                       # label13:
+	i32.const	$push39=, 97
+	i32.call	$push1=, memset@FUNCTION, $7, $pop39, $4
 	i32.add 	$8=, $pop1, $4
 .LBB1_11:                               # %for.cond38.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
 	end_block                       # label12:
-	i64.const	$push38=, 8680820740569200760
-	i64.store	1($8):p2align=0, $pop38
-	i32.const	$push37=, 9
-	i32.add 	$push3=, $8, $pop37
-	i32.const	$push36=, 120
-	i32.store8	0($pop3), $pop36
-	i32.const	$push35=, 0
-	i32.store8	0($6), $pop35
-	i32.const	$push34=, 0
-	i32.store8	0($8), $pop34
+	i64.const	$push44=, 8680820740569200760
+	i64.store	1($8):p2align=0, $pop44
+	i32.const	$push43=, 9
+	i32.add 	$push3=, $8, $pop43
+	i32.const	$push42=, 120
+	i32.store8	0($pop3), $pop42
+	i32.const	$push41=, 0
+	i32.store8	0($6), $pop41
+	i32.const	$push40=, 0
+	i32.store8	0($8), $pop40
 	i32.call	$push4=, strcmp@FUNCTION, $5, $7
 	br_if   	3, $pop4        # 3: down to label5
 # BB#12:                                # %test.exit
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push41=, 97
-	i32.store16	0($6):p2align=0, $pop41
-	i32.const	$push40=, 0
-	i32.store8	0($8), $pop40
+	i32.const	$push47=, 97
+	i32.store16	0($6):p2align=0, $pop47
+	i32.const	$push46=, 0
+	i32.store8	0($8), $pop46
 	i32.call	$push5=, strcmp@FUNCTION, $5, $7
-	i32.const	$push39=, 0
-	i32.le_s	$push6=, $pop5, $pop39
+	i32.const	$push45=, 0
+	i32.le_s	$push6=, $pop5, $pop45
 	br_if   	3, $pop6        # 3: down to label5
 # BB#13:                                # %test.exit157
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push44=, 0
-	i32.store8	0($6), $pop44
-	i32.const	$push43=, 97
-	i32.store16	0($8):p2align=0, $pop43
+	i32.const	$push50=, 0
+	i32.store8	0($6), $pop50
+	i32.const	$push49=, 97
+	i32.store16	0($8):p2align=0, $pop49
 	i32.call	$push7=, strcmp@FUNCTION, $5, $7
-	i32.const	$push42=, 0
-	i32.ge_s	$push8=, $pop7, $pop42
+	i32.const	$push48=, 0
+	i32.ge_s	$push8=, $pop7, $pop48
 	br_if   	3, $pop8        # 3: down to label5
 # BB#14:                                # %test.exit162
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push47=, 98
-	i32.store16	0($6):p2align=0, $pop47
-	i32.const	$push46=, 99
-	i32.store16	0($8):p2align=0, $pop46
+	i32.const	$push53=, 98
+	i32.store16	0($6):p2align=0, $pop53
+	i32.const	$push52=, 99
+	i32.store16	0($8):p2align=0, $pop52
 	i32.call	$push9=, strcmp@FUNCTION, $5, $7
-	i32.const	$push45=, 0
-	i32.ge_s	$push10=, $pop9, $pop45
+	i32.const	$push51=, 0
+	i32.ge_s	$push10=, $pop9, $pop51
 	br_if   	3, $pop10       # 3: down to label5
 # BB#15:                                # %test.exit168
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push50=, 99
-	i32.store16	0($6):p2align=0, $pop50
-	i32.const	$push49=, 98
-	i32.store16	0($8):p2align=0, $pop49
-	i32.call	$push11=, strcmp@FUNCTION, $5, $7
-	i32.const	$push48=, 0
-	i32.le_s	$push12=, $pop11, $pop48
-	br_if   	3, $pop12       # 3: down to label5
-# BB#16:                                # %test.exit174
-                                        #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push53=, 98
-	i32.store16	0($6):p2align=0, $pop53
-	i32.const	$push52=, 169
-	i32.store16	0($8):p2align=0, $pop52
-	i32.call	$push13=, strcmp@FUNCTION, $5, $7
-	i32.const	$push51=, 0
-	i32.ge_s	$push14=, $pop13, $pop51
-	br_if   	3, $pop14       # 3: down to label5
-# BB#17:                                # %test.exit180
-                                        #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push56=, 169
+	i32.const	$push56=, 99
 	i32.store16	0($6):p2align=0, $pop56
 	i32.const	$push55=, 98
 	i32.store16	0($8):p2align=0, $pop55
-	i32.call	$push15=, strcmp@FUNCTION, $5, $7
+	i32.call	$push11=, strcmp@FUNCTION, $5, $7
 	i32.const	$push54=, 0
-	i32.le_s	$push16=, $pop15, $pop54
+	i32.le_s	$push12=, $pop11, $pop54
+	br_if   	3, $pop12       # 3: down to label5
+# BB#16:                                # %test.exit174
+                                        #   in Loop: Header=BB1_3 Depth=3
+	i32.const	$push59=, 98
+	i32.store16	0($6):p2align=0, $pop59
+	i32.const	$push58=, 169
+	i32.store16	0($8):p2align=0, $pop58
+	i32.call	$push13=, strcmp@FUNCTION, $5, $7
+	i32.const	$push57=, 0
+	i32.ge_s	$push14=, $pop13, $pop57
+	br_if   	3, $pop14       # 3: down to label5
+# BB#17:                                # %test.exit180
+                                        #   in Loop: Header=BB1_3 Depth=3
+	i32.const	$push62=, 169
+	i32.store16	0($6):p2align=0, $pop62
+	i32.const	$push61=, 98
+	i32.store16	0($8):p2align=0, $pop61
+	i32.call	$push15=, strcmp@FUNCTION, $5, $7
+	i32.const	$push60=, 0
+	i32.le_s	$push16=, $pop15, $pop60
 	br_if   	3, $pop16       # 3: down to label5
 # BB#18:                                # %test.exit186
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push59=, 169
-	i32.store16	0($6):p2align=0, $pop59
-	i32.const	$push58=, 170
-	i32.store16	0($8):p2align=0, $pop58
+	i32.const	$push65=, 169
+	i32.store16	0($6):p2align=0, $pop65
+	i32.const	$push64=, 170
+	i32.store16	0($8):p2align=0, $pop64
 	i32.call	$push17=, strcmp@FUNCTION, $5, $7
-	i32.const	$push57=, 0
-	i32.ge_s	$push18=, $pop17, $pop57
+	i32.const	$push63=, 0
+	i32.ge_s	$push18=, $pop17, $pop63
 	br_if   	3, $pop18       # 3: down to label5
 # BB#19:                                # %test.exit192
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push62=, 170
-	i32.store16	0($6):p2align=0, $pop62
-	i32.const	$push61=, 169
-	i32.store16	0($8):p2align=0, $pop61
+	i32.const	$push68=, 170
+	i32.store16	0($6):p2align=0, $pop68
+	i32.const	$push67=, 169
+	i32.store16	0($8):p2align=0, $pop67
 	i32.call	$push19=, strcmp@FUNCTION, $5, $7
-	i32.const	$push60=, 0
-	i32.le_s	$push20=, $pop19, $pop60
+	i32.const	$push66=, 0
+	i32.le_s	$push20=, $pop19, $pop66
 	br_if   	4, $pop20       # 4: down to label4
 # BB#20:                                # %for.cond4
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push66=, 1
-	i32.add 	$push65=, $4, $pop66
-	tee_local	$push64=, $4=, $pop65
-	i32.const	$push63=, 63
-	i32.le_u	$push21=, $pop64, $pop63
+	i32.const	$push72=, 1
+	i32.add 	$push71=, $4, $pop72
+	tee_local	$push70=, $4=, $pop71
+	i32.const	$push69=, 63
+	i32.le_u	$push21=, $pop70, $pop69
 	br_if   	0, $pop21       # 0: up to label8
 # BB#21:                                # %for.inc79
                                         #   in Loop: Header=BB1_2 Depth=2
 	end_loop
-	i32.const	$push71=, 1
-	i32.add 	$3=, $3, $pop71
-	i32.const	$push70=, 1
-	i32.add 	$push69=, $2, $pop70
-	tee_local	$push68=, $2=, $pop69
-	i32.const	$push67=, 8
-	i32.lt_u	$push22=, $pop68, $pop67
+	i32.const	$push77=, 1
+	i32.add 	$3=, $3, $pop77
+	i32.const	$push76=, 1
+	i32.add 	$push75=, $2, $pop76
+	tee_local	$push74=, $2=, $pop75
+	i32.const	$push73=, 8
+	i32.lt_u	$push22=, $pop74, $pop73
 	br_if   	0, $pop22       # 0: up to label7
 # BB#22:                                # %for.inc82
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_loop
-	i32.const	$push76=, 1
-	i32.add 	$1=, $1, $pop76
-	i32.const	$push75=, 1
-	i32.add 	$push74=, $0, $pop75
-	tee_local	$push73=, $0=, $pop74
-	i32.const	$push72=, 8
-	i32.lt_u	$push23=, $pop73, $pop72
+	i32.const	$push82=, 1
+	i32.add 	$1=, $1, $pop82
+	i32.const	$push81=, 1
+	i32.add 	$push80=, $0, $pop81
+	tee_local	$push79=, $0=, $pop80
+	i32.const	$push78=, 8
+	i32.lt_u	$push23=, $pop79, $pop78
 	br_if   	0, $pop23       # 0: up to label6
 # BB#23:                                # %for.end84
 	end_loop
@@ -284,7 +296,7 @@ u2:
 	.size	u2, 96
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	strcmp, i32, i32, i32
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/strcpy-1.c.s
+++ b/test/torture-s/strcpy-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/strcpy-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/strcpy-1.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
@@ -15,10 +15,11 @@ main:                                   # @main
                                         #       Child Loop BB0_3 Depth 3
                                         #         Child Loop BB0_4 Depth 4
                                         #         Child Loop BB0_8 Depth 4
-                                        #         Child Loop BB0_12 Depth 4
+                                        #         Child Loop BB0_13 Depth 4
 	block   	
 	block   	
-	loop    	                # label2:
+	block   	
+	loop    	                # label3:
 	i32.const	$push52=, u1
 	i32.add 	$1=, $0, $pop52
 	i32.const	$2=, 0
@@ -28,8 +29,8 @@ main:                                   # @main
                                         #       Child Loop BB0_3 Depth 3
                                         #         Child Loop BB0_4 Depth 4
                                         #         Child Loop BB0_8 Depth 4
-                                        #         Child Loop BB0_12 Depth 4
-	loop    	                # label3:
+                                        #         Child Loop BB0_13 Depth 4
+	loop    	                # label4:
 	i32.const	$push54=, 65
 	i32.add 	$4=, $2, $pop54
 	i32.const	$push53=, u2
@@ -41,8 +42,8 @@ main:                                   # @main
                                         # =>    This Loop Header: Depth=3
                                         #         Child Loop BB0_4 Depth 4
                                         #         Child Loop BB0_8 Depth 4
-                                        #         Child Loop BB0_12 Depth 4
-	loop    	                # label4:
+                                        #         Child Loop BB0_13 Depth 4
+	loop    	                # label5:
 	i32.const	$push57=, u1
 	i32.const	$push56=, 97
 	i32.const	$push55=, 97
@@ -54,7 +55,7 @@ main:                                   # @main
                                         #     Parent Loop BB0_2 Depth=2
                                         #       Parent Loop BB0_3 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	loop    	                # label5:
+	loop    	                # label6:
 	i32.const	$push68=, u2+97
 	i32.add 	$push3=, $7, $pop68
 	i32.const	$push67=, 65
@@ -72,7 +73,7 @@ main:                                   # @main
 	i32.const	$push60=, 1
 	i32.add 	$push59=, $7, $pop60
 	tee_local	$push58=, $7=, $pop59
-	br_if   	0, $pop58       # 0: up to label5
+	br_if   	0, $pop58       # 0: up to label6
 # BB#5:                                 # %for.end
                                         #   in Loop: Header=BB0_3 Depth=3
 	end_loop
@@ -83,14 +84,14 @@ main:                                   # @main
 	i32.store8	0($pop5), $pop69
 	i32.call	$push6=, strcpy@FUNCTION, $1, $3
 	i32.ne  	$push7=, $pop6, $1
-	br_if   	3, $pop7        # 3: down to label1
+	br_if   	5, $pop7        # 5: down to label0
 # BB#6:                                 # %for.cond21.preheader
                                         #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$8=, u1
+	block   	
 	block   	
 	i32.const	$push71=, 1
 	i32.lt_s	$push8=, $0, $pop71
-	br_if   	0, $pop8        # 0: down to label6
+	br_if   	0, $pop8        # 0: down to label8
 # BB#7:                                 # %for.body24.preheader
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$9=, 0
@@ -99,35 +100,39 @@ main:                                   # @main
                                         #     Parent Loop BB0_2 Depth=2
                                         #       Parent Loop BB0_3 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	loop    	                # label7:
+	loop    	                # label9:
 	i32.add 	$push9=, $9, $10
 	i32.load8_u	$push10=, 0($pop9)
 	i32.const	$push72=, 97
 	i32.ne  	$push11=, $pop10, $pop72
-	br_if   	5, $pop11       # 5: down to label1
+	br_if   	6, $pop11       # 6: down to label2
 # BB#9:                                 # %for.inc30
                                         #   in Loop: Header=BB0_8 Depth=4
 	i32.const	$push75=, 1
 	i32.add 	$push74=, $9, $pop75
 	tee_local	$push73=, $9=, $pop74
 	i32.lt_s	$push12=, $pop73, $0
-	br_if   	0, $pop12       # 0: up to label7
+	br_if   	0, $pop12       # 0: up to label9
 # BB#10:                                # %for.body38.preheader.loopexit
                                         #   in Loop: Header=BB0_3 Depth=3
 	end_loop
 	i32.add 	$8=, $9, $10
-.LBB0_11:                               # %for.body38.preheader
+	br      	1               # 1: down to label7
+.LBB0_11:                               #   in Loop: Header=BB0_3 Depth=3
+	end_block                       # label8:
+	i32.const	$8=, u1
+.LBB0_12:                               # %for.body38.preheader
                                         #   in Loop: Header=BB0_3 Depth=3
-	end_block                       # label6:
+	end_block                       # label7:
 	i32.load8_u	$9=, 0($8)
 	i32.const	$10=, 0
 	copy_local	$7=, $4
-.LBB0_12:                               # %for.body38
+.LBB0_13:                               # %for.body38
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         #       Parent Loop BB0_3 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	loop    	                # label8:
+	loop    	                # label10:
 	i32.const	$push81=, 255
 	i32.and 	$push13=, $9, $pop81
 	i32.const	$push80=, 65
@@ -141,9 +146,9 @@ main:                                   # @main
 	i32.const	$push76=, 255
 	i32.and 	$push18=, $pop17, $pop76
 	i32.ne  	$push19=, $pop13, $pop18
-	br_if   	4, $pop19       # 4: down to label1
-# BB#13:                                # %for.inc50
-                                        #   in Loop: Header=BB0_12 Depth=4
+	br_if   	4, $pop19       # 4: down to label2
+# BB#14:                                # %for.inc50
+                                        #   in Loop: Header=BB0_13 Depth=4
 	i32.const	$push86=, 1
 	i32.add 	$7=, $9, $pop86
 	i32.add 	$push21=, $8, $10
@@ -155,14 +160,14 @@ main:                                   # @main
 	tee_local	$push82=, $6=, $pop83
 	copy_local	$10=, $pop82
 	i32.lt_s	$push20=, $6, $5
-	br_if   	0, $pop20       # 0: up to label8
-# BB#14:                                # %for.end54
+	br_if   	0, $pop20       # 0: up to label10
+# BB#15:                                # %for.end54
                                         #   in Loop: Header=BB0_3 Depth=3
 	end_loop
 	i32.const	$push87=, 255
 	i32.and 	$push23=, $9, $pop87
-	br_if   	3, $pop23       # 3: down to label1
-# BB#15:                                # %for.cond61.preheader
+	br_if   	3, $pop23       # 3: down to label2
+# BB#16:                                # %for.cond61.preheader
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.add 	$push91=, $8, $6
 	tee_local	$push90=, $9=, $pop91
@@ -171,72 +176,72 @@ main:                                   # @main
 	i32.load8_u	$push25=, 0($pop24)
 	i32.const	$push88=, 97
 	i32.ne  	$push26=, $pop25, $pop88
-	br_if   	4, $pop26       # 4: down to label0
-# BB#16:                                # %for.cond61
+	br_if   	4, $pop26       # 4: down to label1
+# BB#17:                                # %for.cond61
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push93=, 2
 	i32.add 	$push27=, $9, $pop93
 	i32.load8_u	$push28=, 0($pop27)
 	i32.const	$push92=, 97
 	i32.ne  	$push29=, $pop28, $pop92
-	br_if   	4, $pop29       # 4: down to label0
-# BB#17:                                # %for.cond61.1
+	br_if   	4, $pop29       # 4: down to label1
+# BB#18:                                # %for.cond61.1
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push95=, 3
 	i32.add 	$push30=, $9, $pop95
 	i32.load8_u	$push31=, 0($pop30)
 	i32.const	$push94=, 97
 	i32.ne  	$push32=, $pop31, $pop94
-	br_if   	4, $pop32       # 4: down to label0
-# BB#18:                                # %for.cond61.2
+	br_if   	4, $pop32       # 4: down to label1
+# BB#19:                                # %for.cond61.2
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push97=, 4
 	i32.add 	$push33=, $9, $pop97
 	i32.load8_u	$push34=, 0($pop33)
 	i32.const	$push96=, 97
 	i32.ne  	$push35=, $pop34, $pop96
-	br_if   	4, $pop35       # 4: down to label0
-# BB#19:                                # %for.cond61.3
+	br_if   	4, $pop35       # 4: down to label1
+# BB#20:                                # %for.cond61.3
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push99=, 5
 	i32.add 	$push36=, $9, $pop99
 	i32.load8_u	$push37=, 0($pop36)
 	i32.const	$push98=, 97
 	i32.ne  	$push38=, $pop37, $pop98
-	br_if   	4, $pop38       # 4: down to label0
-# BB#20:                                # %for.cond61.4
+	br_if   	4, $pop38       # 4: down to label1
+# BB#21:                                # %for.cond61.4
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push101=, 6
 	i32.add 	$push39=, $9, $pop101
 	i32.load8_u	$push40=, 0($pop39)
 	i32.const	$push100=, 97
 	i32.ne  	$push41=, $pop40, $pop100
-	br_if   	4, $pop41       # 4: down to label0
-# BB#21:                                # %for.cond61.5
+	br_if   	4, $pop41       # 4: down to label1
+# BB#22:                                # %for.cond61.5
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push103=, 7
 	i32.add 	$push42=, $9, $pop103
 	i32.load8_u	$push43=, 0($pop42)
 	i32.const	$push102=, 97
 	i32.ne  	$push44=, $pop43, $pop102
-	br_if   	4, $pop44       # 4: down to label0
-# BB#22:                                # %for.cond61.6
+	br_if   	4, $pop44       # 4: down to label1
+# BB#23:                                # %for.cond61.6
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push105=, 8
 	i32.add 	$push45=, $9, $pop105
 	i32.load8_u	$push46=, 0($pop45)
 	i32.const	$push104=, 97
 	i32.ne  	$push47=, $pop46, $pop104
-	br_if   	4, $pop47       # 4: down to label0
-# BB#23:                                # %for.cond61.7
+	br_if   	4, $pop47       # 4: down to label1
+# BB#24:                                # %for.cond61.7
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$push109=, 1
 	i32.add 	$push108=, $5, $pop109
 	tee_local	$push107=, $5=, $pop108
 	i32.const	$push106=, 80
 	i32.lt_u	$push48=, $pop107, $pop106
-	br_if   	0, $pop48       # 0: up to label4
-# BB#24:                                # %for.inc77
+	br_if   	0, $pop48       # 0: up to label5
+# BB#25:                                # %for.inc77
                                         #   in Loop: Header=BB0_2 Depth=2
 	end_loop
 	i32.const	$push113=, 1
@@ -244,8 +249,8 @@ main:                                   # @main
 	tee_local	$push111=, $2=, $pop112
 	i32.const	$push110=, 8
 	i32.lt_u	$push49=, $pop111, $pop110
-	br_if   	0, $pop49       # 0: up to label3
-# BB#25:                                # %for.inc80
+	br_if   	0, $pop49       # 0: up to label4
+# BB#26:                                # %for.inc80
                                         #   in Loop: Header=BB0_1 Depth=1
 	end_loop
 	i32.const	$push117=, 1
@@ -253,17 +258,21 @@ main:                                   # @main
 	tee_local	$push115=, $0=, $pop116
 	i32.const	$push114=, 8
 	i32.lt_u	$push50=, $pop115, $pop114
-	br_if   	0, $pop50       # 0: up to label2
-# BB#26:                                # %for.end82
+	br_if   	0, $pop50       # 0: up to label3
+# BB#27:                                # %for.end82
 	end_loop
 	i32.const	$push51=, 0
 	call    	exit@FUNCTION, $pop51
 	unreachable
-.LBB0_27:                               # %if.then59
+.LBB0_28:                               # %if.then59
+	end_block                       # label2:
+	call    	abort@FUNCTION
+	unreachable
+.LBB0_29:                               # %if.then68
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
-.LBB0_28:                               # %if.then68
+.LBB0_30:                               # %if.then19
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -286,7 +295,7 @@ u2:
 	.size	u2, 112
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	strcpy, i32, i32, i32
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/strlen-1.c.s
+++ b/test/torture-s/strlen-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/strlen-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/strlen-1.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
@@ -22,30 +22,33 @@ main:                                   # @main
                                         #   Parent Loop BB0_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	loop    	                # label2:
-	i32.const	$4=, u
+	block   	
+	block   	
 	block   	
 	i32.eqz 	$push23=, $1
-	br_if   	0, $pop23       # 0: down to label3
+	br_if   	0, $pop23       # 0: down to label5
 # BB#3:                                 # %for.body6.preheader
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push9=, u
 	i32.const	$push8=, 0
 	i32.call	$drop=, memset@FUNCTION, $pop9, $pop8, $1
 	copy_local	$4=, $2
-.LBB0_4:                                # %for.cond7.preheader
-                                        #   in Loop: Header=BB0_2 Depth=2
-	end_block                       # label3:
-	block   	
+	br_if   	1, $3           # 1: down to label4
+	br      	2               # 2: down to label3
+.LBB0_4:                                #   in Loop: Header=BB0_2 Depth=2
+	end_block                       # label5:
+	i32.const	$4=, u
 	i32.eqz 	$push24=, $3
-	br_if   	0, $pop24       # 0: down to label4
-# BB#5:                                 # %for.body9.preheader
+	br_if   	1, $pop24       # 1: down to label3
+.LBB0_5:                                # %for.body9.preheader
                                         #   in Loop: Header=BB0_2 Depth=2
+	end_block                       # label4:
 	i32.const	$push10=, 97
 	i32.call	$push0=, memset@FUNCTION, $4, $pop10, $3
 	i32.add 	$4=, $pop0, $3
 .LBB0_6:                                # %for.end13
                                         #   in Loop: Header=BB0_2 Depth=2
-	end_block                       # label4:
+	end_block                       # label3:
 	i32.const	$push13=, 0
 	i32.store8	0($4), $pop13
 	i32.const	$push12=, 1
@@ -95,7 +98,7 @@ u:
 	.size	u, 96
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	strlen, i32, i32
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/strncmp-1.c.s
+++ b/test/torture-s/strncmp-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/strncmp-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/strncmp-1.c"
 	.section	.text.test,"ax",@progbits
 	.hidden	test
 	.globl	test
@@ -74,66 +74,78 @@ main:                                   # @main
                                         #     Parent Loop BB1_2 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
 	loop    	                # label8:
-	i32.const	$5=, u1
 	block   	
-	i32.eqz 	$push89=, $0
-	br_if   	0, $pop89       # 0: down to label9
+	block   	
+	block   	
+	i32.eqz 	$push95=, $0
+	br_if   	0, $pop95       # 0: down to label11
 # BB#4:                                 # %for.body9.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push33=, u1
-	i32.const	$push32=, 0
-	i32.call	$drop=, memset@FUNCTION, $pop33, $pop32, $0
-	copy_local	$5=, $1
-.LBB1_5:                                # %for.cond10.preheader
+	i32.const	$push35=, u1
+	i32.const	$push34=, 0
+	i32.call	$drop=, memset@FUNCTION, $pop35, $pop34, $0
+	copy_local	$push33=, $1
+	tee_local	$push32=, $5=, $pop33
+	copy_local	$6=, $pop32
+	br_if   	1, $4           # 1: down to label10
+	br      	2               # 2: down to label9
+.LBB1_5:                                #   in Loop: Header=BB1_3 Depth=3
+	end_block                       # label11:
+	i32.const	$5=, u1
+	i32.const	$push36=, u1
+	copy_local	$6=, $pop36
+	i32.eqz 	$push96=, $4
+	br_if   	1, $pop96       # 1: down to label9
+.LBB1_6:                                # %for.body12.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	end_block                       # label9:
-	copy_local	$6=, $5
-	block   	
-	i32.eqz 	$push90=, $4
-	br_if   	0, $pop90       # 0: down to label10
-# BB#6:                                 # %for.body12.preheader
-                                        #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push34=, 97
-	i32.call	$push0=, memset@FUNCTION, $5, $pop34, $4
+	end_block                       # label10:
+	i32.const	$push37=, 97
+	i32.call	$push0=, memset@FUNCTION, $5, $pop37, $4
 	i32.add 	$6=, $pop0, $4
 .LBB1_7:                                # %for.cond17.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	end_block                       # label10:
-	i64.const	$push35=, 8680820740569200760
-	i64.store	0($6):p2align=0, $pop35
-	i32.const	$7=, u2
+	end_block                       # label9:
+	i64.const	$push38=, 8680820740569200760
+	i64.store	0($6):p2align=0, $pop38
 	block   	
-	i32.eqz 	$push91=, $2
-	br_if   	0, $pop91       # 0: down to label11
+	block   	
+	block   	
+	i32.eqz 	$push97=, $2
+	br_if   	0, $pop97       # 0: down to label14
 # BB#8:                                 # %for.body26.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push37=, u2
-	i32.const	$push36=, 0
-	i32.call	$drop=, memset@FUNCTION, $pop37, $pop36, $2
-	copy_local	$7=, $3
-.LBB1_9:                                # %for.cond31.preheader
+	i32.const	$push42=, u2
+	i32.const	$push41=, 0
+	i32.call	$drop=, memset@FUNCTION, $pop42, $pop41, $2
+	copy_local	$push40=, $3
+	tee_local	$push39=, $7=, $pop40
+	copy_local	$8=, $pop39
+	br_if   	1, $4           # 1: down to label13
+	br      	2               # 2: down to label12
+.LBB1_9:                                #   in Loop: Header=BB1_3 Depth=3
+	end_block                       # label14:
+	i32.const	$7=, u2
+	i32.const	$push43=, u2
+	copy_local	$8=, $pop43
+	i32.eqz 	$push98=, $4
+	br_if   	1, $pop98       # 1: down to label12
+.LBB1_10:                               # %for.body33.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	end_block                       # label11:
-	copy_local	$8=, $7
-	block   	
-	i32.eqz 	$push92=, $4
-	br_if   	0, $pop92       # 0: down to label12
-# BB#10:                                # %for.body33.preheader
-                                        #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push38=, 97
-	i32.call	$push1=, memset@FUNCTION, $7, $pop38, $4
+	end_block                       # label13:
+	i32.const	$push44=, 97
+	i32.call	$push1=, memset@FUNCTION, $7, $pop44, $4
 	i32.add 	$8=, $pop1, $4
 .LBB1_11:                               # %for.cond38.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
 	end_block                       # label12:
-	i64.const	$push42=, 8680820740569200760
-	i64.store	0($8):p2align=0, $pop42
-	i32.const	$push41=, 0
-	i32.store8	0($6), $pop41
-	i32.const	$push40=, 0
-	i32.store8	0($8), $pop40
-	i32.const	$push39=, 80
-	i32.call	$push2=, strncmp@FUNCTION, $5, $7, $pop39
+	i64.const	$push48=, 8680820740569200760
+	i64.store	0($8):p2align=0, $pop48
+	i32.const	$push47=, 0
+	i32.store8	0($6), $pop47
+	i32.const	$push46=, 0
+	i32.store8	0($8), $pop46
+	i32.const	$push45=, 80
+	i32.call	$push2=, strncmp@FUNCTION, $5, $7, $pop45
 	br_if   	3, $pop2        # 3: down to label5
 # BB#12:                                # %test.exit
                                         #   in Loop: Header=BB1_3 Depth=3
@@ -141,14 +153,14 @@ main:                                   # @main
 	br_if   	3, $pop3        # 3: down to label5
 # BB#13:                                # %test.exit185
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push46=, 97
-	i32.store16	0($6):p2align=0, $pop46
-	i32.const	$push45=, 0
-	i32.store8	0($8), $pop45
-	i32.const	$push44=, 80
-	i32.call	$push4=, strncmp@FUNCTION, $5, $7, $pop44
-	i32.const	$push43=, 0
-	i32.le_s	$push5=, $pop4, $pop43
+	i32.const	$push52=, 97
+	i32.store16	0($6):p2align=0, $pop52
+	i32.const	$push51=, 0
+	i32.store8	0($8), $pop51
+	i32.const	$push50=, 80
+	i32.call	$push4=, strncmp@FUNCTION, $5, $7, $pop50
+	i32.const	$push49=, 0
+	i32.le_s	$push5=, $pop4, $pop49
 	br_if   	3, $pop5        # 3: down to label5
 # BB#14:                                # %test.exit190
                                         #   in Loop: Header=BB1_3 Depth=3
@@ -156,14 +168,14 @@ main:                                   # @main
 	br_if   	3, $pop6        # 3: down to label5
 # BB#15:                                # %test.exit196
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push50=, 0
-	i32.store8	0($6), $pop50
-	i32.const	$push49=, 97
-	i32.store16	0($8):p2align=0, $pop49
-	i32.const	$push48=, 80
-	i32.call	$push7=, strncmp@FUNCTION, $5, $7, $pop48
-	i32.const	$push47=, 0
-	i32.ge_s	$push8=, $pop7, $pop47
+	i32.const	$push56=, 0
+	i32.store8	0($6), $pop56
+	i32.const	$push55=, 97
+	i32.store16	0($8):p2align=0, $pop55
+	i32.const	$push54=, 80
+	i32.call	$push7=, strncmp@FUNCTION, $5, $7, $pop54
+	i32.const	$push53=, 0
+	i32.ge_s	$push8=, $pop7, $pop53
 	br_if   	3, $pop8        # 3: down to label5
 # BB#16:                                # %test.exit201
                                         #   in Loop: Header=BB1_3 Depth=3
@@ -171,14 +183,14 @@ main:                                   # @main
 	br_if   	3, $pop9        # 3: down to label5
 # BB#17:                                # %test.exit207
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push54=, 98
-	i32.store16	0($6):p2align=0, $pop54
-	i32.const	$push53=, 99
-	i32.store16	0($8):p2align=0, $pop53
-	i32.const	$push52=, 80
-	i32.call	$push10=, strncmp@FUNCTION, $5, $7, $pop52
-	i32.const	$push51=, 0
-	i32.ge_s	$push11=, $pop10, $pop51
+	i32.const	$push60=, 98
+	i32.store16	0($6):p2align=0, $pop60
+	i32.const	$push59=, 99
+	i32.store16	0($8):p2align=0, $pop59
+	i32.const	$push58=, 80
+	i32.call	$push10=, strncmp@FUNCTION, $5, $7, $pop58
+	i32.const	$push57=, 0
+	i32.ge_s	$push11=, $pop10, $pop57
 	br_if   	3, $pop11       # 3: down to label5
 # BB#18:                                # %test.exit213
                                         #   in Loop: Header=BB1_3 Depth=3
@@ -186,14 +198,14 @@ main:                                   # @main
 	br_if   	3, $pop12       # 3: down to label5
 # BB#19:                                # %test.exit219
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push58=, 99
-	i32.store16	0($6):p2align=0, $pop58
-	i32.const	$push57=, 98
-	i32.store16	0($8):p2align=0, $pop57
-	i32.const	$push56=, 80
-	i32.call	$push13=, strncmp@FUNCTION, $5, $7, $pop56
-	i32.const	$push55=, 0
-	i32.le_s	$push14=, $pop13, $pop55
+	i32.const	$push64=, 99
+	i32.store16	0($6):p2align=0, $pop64
+	i32.const	$push63=, 98
+	i32.store16	0($8):p2align=0, $pop63
+	i32.const	$push62=, 80
+	i32.call	$push13=, strncmp@FUNCTION, $5, $7, $pop62
+	i32.const	$push61=, 0
+	i32.le_s	$push14=, $pop13, $pop61
 	br_if   	3, $pop14       # 3: down to label5
 # BB#20:                                # %test.exit225
                                         #   in Loop: Header=BB1_3 Depth=3
@@ -201,14 +213,14 @@ main:                                   # @main
 	br_if   	3, $pop15       # 3: down to label5
 # BB#21:                                # %test.exit231
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push62=, 98
-	i32.store16	0($6):p2align=0, $pop62
-	i32.const	$push61=, 169
-	i32.store16	0($8):p2align=0, $pop61
-	i32.const	$push60=, 80
-	i32.call	$push16=, strncmp@FUNCTION, $5, $7, $pop60
-	i32.const	$push59=, 0
-	i32.ge_s	$push17=, $pop16, $pop59
+	i32.const	$push68=, 98
+	i32.store16	0($6):p2align=0, $pop68
+	i32.const	$push67=, 169
+	i32.store16	0($8):p2align=0, $pop67
+	i32.const	$push66=, 80
+	i32.call	$push16=, strncmp@FUNCTION, $5, $7, $pop66
+	i32.const	$push65=, 0
+	i32.ge_s	$push17=, $pop16, $pop65
 	br_if   	3, $pop17       # 3: down to label5
 # BB#22:                                # %test.exit237
                                         #   in Loop: Header=BB1_3 Depth=3
@@ -216,14 +228,14 @@ main:                                   # @main
 	br_if   	3, $pop18       # 3: down to label5
 # BB#23:                                # %test.exit243
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push66=, 169
-	i32.store16	0($6):p2align=0, $pop66
-	i32.const	$push65=, 98
-	i32.store16	0($8):p2align=0, $pop65
-	i32.const	$push64=, 80
-	i32.call	$push19=, strncmp@FUNCTION, $5, $7, $pop64
-	i32.const	$push63=, 0
-	i32.le_s	$push20=, $pop19, $pop63
+	i32.const	$push72=, 169
+	i32.store16	0($6):p2align=0, $pop72
+	i32.const	$push71=, 98
+	i32.store16	0($8):p2align=0, $pop71
+	i32.const	$push70=, 80
+	i32.call	$push19=, strncmp@FUNCTION, $5, $7, $pop70
+	i32.const	$push69=, 0
+	i32.le_s	$push20=, $pop19, $pop69
 	br_if   	3, $pop20       # 3: down to label5
 # BB#24:                                # %test.exit249
                                         #   in Loop: Header=BB1_3 Depth=3
@@ -231,14 +243,14 @@ main:                                   # @main
 	br_if   	3, $pop21       # 3: down to label5
 # BB#25:                                # %test.exit255
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push70=, 169
-	i32.store16	0($6):p2align=0, $pop70
-	i32.const	$push69=, 170
-	i32.store16	0($8):p2align=0, $pop69
-	i32.const	$push68=, 80
-	i32.call	$push22=, strncmp@FUNCTION, $5, $7, $pop68
-	i32.const	$push67=, 0
-	i32.ge_s	$push23=, $pop22, $pop67
+	i32.const	$push76=, 169
+	i32.store16	0($6):p2align=0, $pop76
+	i32.const	$push75=, 170
+	i32.store16	0($8):p2align=0, $pop75
+	i32.const	$push74=, 80
+	i32.call	$push22=, strncmp@FUNCTION, $5, $7, $pop74
+	i32.const	$push73=, 0
+	i32.ge_s	$push23=, $pop22, $pop73
 	br_if   	3, $pop23       # 3: down to label5
 # BB#26:                                # %test.exit261
                                         #   in Loop: Header=BB1_3 Depth=3
@@ -246,14 +258,14 @@ main:                                   # @main
 	br_if   	3, $pop24       # 3: down to label5
 # BB#27:                                # %test.exit267
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push74=, 170
-	i32.store16	0($6):p2align=0, $pop74
-	i32.const	$push73=, 169
-	i32.store16	0($8):p2align=0, $pop73
-	i32.const	$push72=, 80
-	i32.call	$push25=, strncmp@FUNCTION, $5, $7, $pop72
-	i32.const	$push71=, 0
-	i32.le_s	$push26=, $pop25, $pop71
+	i32.const	$push80=, 170
+	i32.store16	0($6):p2align=0, $pop80
+	i32.const	$push79=, 169
+	i32.store16	0($8):p2align=0, $pop79
+	i32.const	$push78=, 80
+	i32.call	$push25=, strncmp@FUNCTION, $5, $7, $pop78
+	i32.const	$push77=, 0
+	i32.le_s	$push26=, $pop25, $pop77
 	br_if   	3, $pop26       # 3: down to label5
 # BB#28:                                # %test.exit273
                                         #   in Loop: Header=BB1_3 Depth=3
@@ -261,33 +273,33 @@ main:                                   # @main
 	br_if   	4, $pop27       # 4: down to label4
 # BB#29:                                # %for.cond4
                                         #   in Loop: Header=BB1_3 Depth=3
-	i32.const	$push78=, 1
-	i32.add 	$push77=, $4, $pop78
-	tee_local	$push76=, $4=, $pop77
-	i32.const	$push75=, 63
-	i32.le_u	$push28=, $pop76, $pop75
+	i32.const	$push84=, 1
+	i32.add 	$push83=, $4, $pop84
+	tee_local	$push82=, $4=, $pop83
+	i32.const	$push81=, 63
+	i32.le_u	$push28=, $pop82, $pop81
 	br_if   	0, $pop28       # 0: up to label8
 # BB#30:                                # %for.inc79
                                         #   in Loop: Header=BB1_2 Depth=2
 	end_loop
-	i32.const	$push83=, 1
-	i32.add 	$3=, $3, $pop83
-	i32.const	$push82=, 1
-	i32.add 	$push81=, $2, $pop82
-	tee_local	$push80=, $2=, $pop81
-	i32.const	$push79=, 8
-	i32.lt_u	$push29=, $pop80, $pop79
+	i32.const	$push89=, 1
+	i32.add 	$3=, $3, $pop89
+	i32.const	$push88=, 1
+	i32.add 	$push87=, $2, $pop88
+	tee_local	$push86=, $2=, $pop87
+	i32.const	$push85=, 8
+	i32.lt_u	$push29=, $pop86, $pop85
 	br_if   	0, $pop29       # 0: up to label7
 # BB#31:                                # %for.inc82
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_loop
-	i32.const	$push88=, 1
-	i32.add 	$1=, $1, $pop88
-	i32.const	$push87=, 1
-	i32.add 	$push86=, $0, $pop87
-	tee_local	$push85=, $0=, $pop86
-	i32.const	$push84=, 8
-	i32.lt_u	$push30=, $pop85, $pop84
+	i32.const	$push94=, 1
+	i32.add 	$1=, $1, $pop94
+	i32.const	$push93=, 1
+	i32.add 	$push92=, $0, $pop93
+	tee_local	$push91=, $0=, $pop92
+	i32.const	$push90=, 8
+	i32.lt_u	$push30=, $pop91, $pop90
 	br_if   	0, $pop30       # 0: up to label6
 # BB#32:                                # %for.end84
 	end_loop
@@ -321,7 +333,7 @@ u2:
 	.size	u2, 80
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	strncmp, i32, i32, i32, i32
 	.functype	abort, void
 	.functype	exit, void, i32

--- a/test/torture-s/struct-ret-1.c.s
+++ b/test/torture-s/struct-ret-1.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/struct-ret-1.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/struct-ret-1.c"
 	.section	.text.f,"ax",@progbits
 	.hidden	f
 	.globl	f
@@ -195,7 +195,7 @@ main:                                   # @main
 	i32.add 	$push54=, $8, $pop53
 	i32.const	$push55=, 24
 	i32.add 	$push56=, $8, $pop55
-	call_indirect	$3, $pop54, $pop56, $2, $0, $8
+	call_indirect	$pop54, $pop56, $2, $0, $8, $3
 	block   	
 	i32.const	$push57=, 144
 	i32.add 	$push58=, $8, $pop57
@@ -420,7 +420,7 @@ fp:
 	.size	fp, 4
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	sprintf, i32, i32, i32
 	.functype	strcpy, i32, i32, i32
 	.functype	strcmp, i32, i32, i32

--- a/test/torture-s/va-arg-24.c.s
+++ b/test/torture-s/va-arg-24.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/va-arg-24.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/va-arg-24.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
@@ -171,22 +171,22 @@ main:                                   # @main
 	.type	varargs0,@function
 varargs0:                               # @varargs0
 	.param  	i32, i32
-	.local  	i32, i32, i32
+	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push21=, 0
-	i32.const	$push18=, 0
-	i32.load	$push19=, __stack_pointer($pop18)
-	i32.const	$push20=, 64
-	i32.sub 	$push33=, $pop19, $pop20
-	tee_local	$push32=, $4=, $pop33
-	i32.store	__stack_pointer($pop21), $pop32
+	i32.const	$push22=, 0
+	i32.const	$push19=, 0
+	i32.load	$push20=, __stack_pointer($pop19)
+	i32.const	$push21=, 64
+	i32.sub 	$push36=, $pop20, $pop21
+	tee_local	$push35=, $4=, $pop36
+	i32.store	__stack_pointer($pop22), $pop35
 	i32.store	60($4), $1
-	i32.const	$push31=, 0
-	i32.store	16($4), $pop31
-	i32.load	$push30=, 60($4)
-	tee_local	$push29=, $1=, $pop30
-	i32.const	$push28=, 4
-	i32.add 	$push1=, $pop29, $pop28
+	i32.const	$push34=, 0
+	i32.store	16($4), $pop34
+	i32.load	$push33=, 60($4)
+	tee_local	$push32=, $1=, $pop33
+	i32.const	$push31=, 4
+	i32.add 	$push1=, $pop32, $pop31
 	i32.store	60($4), $pop1
 	i32.load	$push2=, 4($1)
 	i32.store	24($4), $pop2
@@ -211,57 +211,97 @@ varargs0:                               # @varargs0
 	i32.store	60($4), $pop12
 	i32.load	$push13=, 36($1)
 	i32.store	56($4), $pop13
-	i32.const	$push25=, 16
-	i32.add 	$push26=, $4, $pop25
-	i32.const	$push27=, 4
-	i32.or  	$2=, $pop26, $pop27
+	i32.const	$push26=, 16
+	i32.add 	$push27=, $4, $pop26
+	i32.const	$push30=, 4
+	i32.or  	$2=, $pop27, $pop30
 	i32.const	$3=, 0
 	i32.const	$1=, 0
-.LBB1_1:                                # %for.body.i
-                                        # =>This Inner Loop Header: Depth=1
-	loop    	                # label1:
 	block   	
-	i32.eq  	$push14=, $1, $3
+	block   	
+	i32.const	$push29=, 0
+	i32.const	$push28=, 0
+	i32.ne  	$push14=, $pop29, $pop28
 	br_if   	0, $pop14       # 0: down to label2
-# BB#2:                                 # %if.then.i
-                                        #   in Loop: Header=BB1_1 Depth=1
+# BB#1:
+	i32.const	$5=, 1
+	br      	1               # 1: down to label1
+.LBB1_2:
+	end_block                       # label2:
+	i32.const	$5=, 0
+.LBB1_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label1:
+	loop    	                # label3:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$5, 1, 2, 0, 3, 3 # 1: down to label8
+                                        # 2: down to label7
+                                        # 0: down to label9
+                                        # 3: down to label6
+.LBB1_4:                                # %for.inc.i.for.body.i_crit_edge
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label9:
+	i32.load	$3=, 0($2)
+	i32.const	$push40=, 4
+	i32.add 	$push0=, $2, $pop40
+	copy_local	$2=, $pop0
+	i32.const	$push39=, 1
+	i32.add 	$push38=, $1, $pop39
+	tee_local	$push37=, $1=, $pop38
+	i32.eq  	$push15=, $3, $pop37
+	br_if   	3, $pop15       # 3: down to label5
+# BB#5:                                 #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$5=, 0
+	br      	5               # 5: up to label3
+.LBB1_6:                                # %if.then.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label8:
 	i32.store	12($4), $1
 	i32.store	8($4), $3
 	i32.store	4($4), $1
-	i32.const	$push40=, .L.str
-	i32.store	0($4), $pop40
-	i32.const	$push39=, .L.str.1
-	i32.call	$drop=, printf@FUNCTION, $pop39, $4
-	i32.const	$push38=, 0
-	i32.const	$push37=, 0
-	i32.load	$push15=, errors($pop37)
-	i32.const	$push36=, 1
-	i32.add 	$push16=, $pop15, $pop36
-	i32.store	errors($pop38), $pop16
-.LBB1_3:                                # %for.inc.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label2:
-	block   	
-	i32.const	$push41=, 10
-	i32.eq  	$push17=, $1, $pop41
-	br_if   	0, $pop17       # 0: down to label3
-# BB#4:                                 # %for.inc.i.for.body.i_crit_edge
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push35=, 1
-	i32.add 	$1=, $1, $pop35
-	i32.load	$3=, 0($2)
-	i32.const	$push34=, 4
-	i32.add 	$push0=, $2, $pop34
-	copy_local	$2=, $pop0
-	br      	1               # 1: up to label1
-.LBB1_5:                                # %verify.exit
-	end_block                       # label3:
+	i32.const	$push45=, .L.str
+	i32.store	0($4), $pop45
+	i32.const	$push44=, .L.str.1
+	i32.call	$drop=, printf@FUNCTION, $pop44, $4
+	i32.const	$push43=, 0
+	i32.const	$push42=, 0
+	i32.load	$push16=, errors($pop42)
+	i32.const	$push41=, 1
+	i32.add 	$push17=, $pop16, $pop41
+	i32.store	errors($pop43), $pop17
+# BB#7:                                 #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$5=, 1
+	br      	4               # 4: up to label3
+.LBB1_8:                                # %for.inc.i
+                                        #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label7:
+	i32.const	$push46=, 10
+	i32.ne  	$push18=, $1, $pop46
+	br_if   	2, $pop18       # 2: down to label4
+# BB#9:                                 #   in Loop: Header=BB1_3 Depth=1
+	i32.const	$5=, 3
+	br      	3               # 3: up to label3
+.LBB1_10:                               # %verify.exit
+	end_block                       # label6:
+	i32.const	$push25=, 0
+	i32.const	$push23=, 64
+	i32.add 	$push24=, $4, $pop23
+	i32.store	__stack_pointer($pop25), $pop24
+	return
+.LBB1_11:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label5:
+	i32.const	$5=, 1
+	br      	1               # 1: up to label3
+.LBB1_12:                               #   in Loop: Header=BB1_3 Depth=1
+	end_block                       # label4:
+	i32.const	$5=, 2
+	br      	0               # 0: up to label3
+.LBB1_13:
 	end_loop
-	i32.const	$push24=, 0
-	i32.const	$push22=, 64
-	i32.add 	$push23=, $4, $pop22
-	i32.store	__stack_pointer($pop24), $pop23
-                                        # fallthrough-return
 	.endfunc
 .Lfunc_end1:
 	.size	varargs0, .Lfunc_end1-varargs0
@@ -270,22 +310,22 @@ varargs0:                               # @varargs0
 	.type	varargs1,@function
 varargs1:                               # @varargs1
 	.param  	i32, i32, i32
-	.local  	i32, i32, i32
+	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push21=, 0
-	i32.const	$push18=, 0
-	i32.load	$push19=, __stack_pointer($pop18)
-	i32.const	$push20=, 64
-	i32.sub 	$push32=, $pop19, $pop20
-	tee_local	$push31=, $5=, $pop32
-	i32.store	__stack_pointer($pop21), $pop31
+	i32.const	$push22=, 0
+	i32.const	$push19=, 0
+	i32.load	$push20=, __stack_pointer($pop19)
+	i32.const	$push21=, 64
+	i32.sub 	$push35=, $pop20, $pop21
+	tee_local	$push34=, $5=, $pop35
+	i32.store	__stack_pointer($pop22), $pop34
 	i32.store	60($5), $2
 	i64.const	$push1=, 4294967296
 	i64.store	16($5), $pop1
-	i32.load	$push30=, 60($5)
-	tee_local	$push29=, $2=, $pop30
-	i32.const	$push28=, 4
-	i32.add 	$push2=, $pop29, $pop28
+	i32.load	$push33=, 60($5)
+	tee_local	$push32=, $2=, $pop33
+	i32.const	$push31=, 4
+	i32.add 	$push2=, $pop32, $pop31
 	i32.store	60($5), $pop2
 	i32.load	$push3=, 0($2)
 	i32.store	24($5), $pop3
@@ -308,57 +348,97 @@ varargs1:                               # @varargs1
 	i32.store	60($5), $pop12
 	i32.load	$push13=, 32($2)
 	i32.store	56($5), $pop13
-	i32.const	$push25=, 16
-	i32.add 	$push26=, $5, $pop25
-	i32.const	$push27=, 4
-	i32.or  	$3=, $pop26, $pop27
+	i32.const	$push26=, 16
+	i32.add 	$push27=, $5, $pop26
+	i32.const	$push30=, 4
+	i32.or  	$3=, $pop27, $pop30
 	i32.const	$4=, 0
 	i32.const	$2=, 0
-.LBB2_1:                                # %for.body.i
-                                        # =>This Inner Loop Header: Depth=1
-	loop    	                # label4:
 	block   	
-	i32.eq  	$push14=, $2, $4
-	br_if   	0, $pop14       # 0: down to label5
-# BB#2:                                 # %if.then.i
-                                        #   in Loop: Header=BB2_1 Depth=1
+	block   	
+	i32.const	$push29=, 0
+	i32.const	$push28=, 0
+	i32.ne  	$push14=, $pop29, $pop28
+	br_if   	0, $pop14       # 0: down to label11
+# BB#1:
+	i32.const	$6=, 1
+	br      	1               # 1: down to label10
+.LBB2_2:
+	end_block                       # label11:
+	i32.const	$6=, 0
+.LBB2_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label10:
+	loop    	                # label12:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$6, 1, 2, 0, 3, 3 # 1: down to label17
+                                        # 2: down to label16
+                                        # 0: down to label18
+                                        # 3: down to label15
+.LBB2_4:                                # %for.inc.i.for.body.i_crit_edge
+                                        #   in Loop: Header=BB2_3 Depth=1
+	end_block                       # label18:
+	i32.load	$4=, 0($3)
+	i32.const	$push39=, 4
+	i32.add 	$push0=, $3, $pop39
+	copy_local	$3=, $pop0
+	i32.const	$push38=, 1
+	i32.add 	$push37=, $2, $pop38
+	tee_local	$push36=, $2=, $pop37
+	i32.eq  	$push15=, $4, $pop36
+	br_if   	3, $pop15       # 3: down to label14
+# BB#5:                                 #   in Loop: Header=BB2_3 Depth=1
+	i32.const	$6=, 0
+	br      	5               # 5: up to label12
+.LBB2_6:                                # %if.then.i
+                                        #   in Loop: Header=BB2_3 Depth=1
+	end_block                       # label17:
 	i32.store	12($5), $2
 	i32.store	8($5), $4
 	i32.store	4($5), $2
-	i32.const	$push39=, .L.str.2
-	i32.store	0($5), $pop39
-	i32.const	$push38=, .L.str.1
-	i32.call	$drop=, printf@FUNCTION, $pop38, $5
-	i32.const	$push37=, 0
-	i32.const	$push36=, 0
-	i32.load	$push15=, errors($pop36)
-	i32.const	$push35=, 1
-	i32.add 	$push16=, $pop15, $pop35
-	i32.store	errors($pop37), $pop16
-.LBB2_3:                                # %for.inc.i
-                                        #   in Loop: Header=BB2_1 Depth=1
-	end_block                       # label5:
-	block   	
-	i32.const	$push40=, 10
-	i32.eq  	$push17=, $2, $pop40
-	br_if   	0, $pop17       # 0: down to label6
-# BB#4:                                 # %for.inc.i.for.body.i_crit_edge
-                                        #   in Loop: Header=BB2_1 Depth=1
-	i32.const	$push34=, 1
-	i32.add 	$2=, $2, $pop34
-	i32.load	$4=, 0($3)
-	i32.const	$push33=, 4
-	i32.add 	$push0=, $3, $pop33
-	copy_local	$3=, $pop0
-	br      	1               # 1: up to label4
-.LBB2_5:                                # %verify.exit
-	end_block                       # label6:
+	i32.const	$push44=, .L.str.2
+	i32.store	0($5), $pop44
+	i32.const	$push43=, .L.str.1
+	i32.call	$drop=, printf@FUNCTION, $pop43, $5
+	i32.const	$push42=, 0
+	i32.const	$push41=, 0
+	i32.load	$push16=, errors($pop41)
+	i32.const	$push40=, 1
+	i32.add 	$push17=, $pop16, $pop40
+	i32.store	errors($pop42), $pop17
+# BB#7:                                 #   in Loop: Header=BB2_3 Depth=1
+	i32.const	$6=, 1
+	br      	4               # 4: up to label12
+.LBB2_8:                                # %for.inc.i
+                                        #   in Loop: Header=BB2_3 Depth=1
+	end_block                       # label16:
+	i32.const	$push45=, 10
+	i32.ne  	$push18=, $2, $pop45
+	br_if   	2, $pop18       # 2: down to label13
+# BB#9:                                 #   in Loop: Header=BB2_3 Depth=1
+	i32.const	$6=, 3
+	br      	3               # 3: up to label12
+.LBB2_10:                               # %verify.exit
+	end_block                       # label15:
+	i32.const	$push25=, 0
+	i32.const	$push23=, 64
+	i32.add 	$push24=, $5, $pop23
+	i32.store	__stack_pointer($pop25), $pop24
+	return
+.LBB2_11:                               #   in Loop: Header=BB2_3 Depth=1
+	end_block                       # label14:
+	i32.const	$6=, 1
+	br      	1               # 1: up to label12
+.LBB2_12:                               #   in Loop: Header=BB2_3 Depth=1
+	end_block                       # label13:
+	i32.const	$6=, 2
+	br      	0               # 0: up to label12
+.LBB2_13:
 	end_loop
-	i32.const	$push24=, 0
-	i32.const	$push22=, 64
-	i32.add 	$push23=, $5, $pop22
-	i32.store	__stack_pointer($pop24), $pop23
-                                        # fallthrough-return
 	.endfunc
 .Lfunc_end2:
 	.size	varargs1, .Lfunc_end2-varargs1
@@ -367,22 +447,22 @@ varargs1:                               # @varargs1
 	.type	varargs2,@function
 varargs2:                               # @varargs2
 	.param  	i32, i32, i32, i32
-	.local  	i32, i32, i32
+	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push21=, 0
-	i32.const	$push18=, 0
-	i32.load	$push19=, __stack_pointer($pop18)
-	i32.const	$push20=, 64
-	i32.sub 	$push32=, $pop19, $pop20
-	tee_local	$push31=, $6=, $pop32
-	i32.store	__stack_pointer($pop21), $pop31
+	i32.const	$push22=, 0
+	i32.const	$push19=, 0
+	i32.load	$push20=, __stack_pointer($pop19)
+	i32.const	$push21=, 64
+	i32.sub 	$push35=, $pop20, $pop21
+	tee_local	$push34=, $6=, $pop35
+	i32.store	__stack_pointer($pop22), $pop34
 	i32.store	60($6), $3
 	i64.const	$push1=, 4294967296
 	i64.store	16($6), $pop1
-	i32.load	$push30=, 60($6)
-	tee_local	$push29=, $3=, $pop30
-	i32.const	$push28=, 4
-	i32.add 	$push2=, $pop29, $pop28
+	i32.load	$push33=, 60($6)
+	tee_local	$push32=, $3=, $pop33
+	i32.const	$push31=, 4
+	i32.add 	$push2=, $pop32, $pop31
 	i32.store	60($6), $pop2
 	i32.const	$push3=, 2
 	i32.store	24($6), $pop3
@@ -405,57 +485,97 @@ varargs2:                               # @varargs2
 	i32.store	60($6), $pop12
 	i32.load	$push13=, 28($3)
 	i32.store	56($6), $pop13
-	i32.const	$push25=, 16
-	i32.add 	$push26=, $6, $pop25
-	i32.const	$push27=, 4
-	i32.or  	$4=, $pop26, $pop27
+	i32.const	$push26=, 16
+	i32.add 	$push27=, $6, $pop26
+	i32.const	$push30=, 4
+	i32.or  	$4=, $pop27, $pop30
 	i32.const	$5=, 0
 	i32.const	$3=, 0
-.LBB3_1:                                # %for.body.i
-                                        # =>This Inner Loop Header: Depth=1
-	loop    	                # label7:
 	block   	
-	i32.eq  	$push14=, $3, $5
-	br_if   	0, $pop14       # 0: down to label8
-# BB#2:                                 # %if.then.i
-                                        #   in Loop: Header=BB3_1 Depth=1
+	block   	
+	i32.const	$push29=, 0
+	i32.const	$push28=, 0
+	i32.ne  	$push14=, $pop29, $pop28
+	br_if   	0, $pop14       # 0: down to label20
+# BB#1:
+	i32.const	$7=, 1
+	br      	1               # 1: down to label19
+.LBB3_2:
+	end_block                       # label20:
+	i32.const	$7=, 0
+.LBB3_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label19:
+	loop    	                # label21:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$7, 1, 2, 0, 3, 3 # 1: down to label26
+                                        # 2: down to label25
+                                        # 0: down to label27
+                                        # 3: down to label24
+.LBB3_4:                                # %for.inc.i.for.body.i_crit_edge
+                                        #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label27:
+	i32.load	$5=, 0($4)
+	i32.const	$push39=, 4
+	i32.add 	$push0=, $4, $pop39
+	copy_local	$4=, $pop0
+	i32.const	$push38=, 1
+	i32.add 	$push37=, $3, $pop38
+	tee_local	$push36=, $3=, $pop37
+	i32.eq  	$push15=, $5, $pop36
+	br_if   	3, $pop15       # 3: down to label23
+# BB#5:                                 #   in Loop: Header=BB3_3 Depth=1
+	i32.const	$7=, 0
+	br      	5               # 5: up to label21
+.LBB3_6:                                # %if.then.i
+                                        #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label26:
 	i32.store	12($6), $3
 	i32.store	8($6), $5
 	i32.store	4($6), $3
-	i32.const	$push39=, .L.str.3
-	i32.store	0($6), $pop39
-	i32.const	$push38=, .L.str.1
-	i32.call	$drop=, printf@FUNCTION, $pop38, $6
-	i32.const	$push37=, 0
-	i32.const	$push36=, 0
-	i32.load	$push15=, errors($pop36)
-	i32.const	$push35=, 1
-	i32.add 	$push16=, $pop15, $pop35
-	i32.store	errors($pop37), $pop16
-.LBB3_3:                                # %for.inc.i
-                                        #   in Loop: Header=BB3_1 Depth=1
-	end_block                       # label8:
-	block   	
-	i32.const	$push40=, 10
-	i32.eq  	$push17=, $3, $pop40
-	br_if   	0, $pop17       # 0: down to label9
-# BB#4:                                 # %for.inc.i.for.body.i_crit_edge
-                                        #   in Loop: Header=BB3_1 Depth=1
-	i32.const	$push34=, 1
-	i32.add 	$3=, $3, $pop34
-	i32.load	$5=, 0($4)
-	i32.const	$push33=, 4
-	i32.add 	$push0=, $4, $pop33
-	copy_local	$4=, $pop0
-	br      	1               # 1: up to label7
-.LBB3_5:                                # %verify.exit
-	end_block                       # label9:
+	i32.const	$push44=, .L.str.3
+	i32.store	0($6), $pop44
+	i32.const	$push43=, .L.str.1
+	i32.call	$drop=, printf@FUNCTION, $pop43, $6
+	i32.const	$push42=, 0
+	i32.const	$push41=, 0
+	i32.load	$push16=, errors($pop41)
+	i32.const	$push40=, 1
+	i32.add 	$push17=, $pop16, $pop40
+	i32.store	errors($pop42), $pop17
+# BB#7:                                 #   in Loop: Header=BB3_3 Depth=1
+	i32.const	$7=, 1
+	br      	4               # 4: up to label21
+.LBB3_8:                                # %for.inc.i
+                                        #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label25:
+	i32.const	$push45=, 10
+	i32.ne  	$push18=, $3, $pop45
+	br_if   	2, $pop18       # 2: down to label22
+# BB#9:                                 #   in Loop: Header=BB3_3 Depth=1
+	i32.const	$7=, 3
+	br      	3               # 3: up to label21
+.LBB3_10:                               # %verify.exit
+	end_block                       # label24:
+	i32.const	$push25=, 0
+	i32.const	$push23=, 64
+	i32.add 	$push24=, $6, $pop23
+	i32.store	__stack_pointer($pop25), $pop24
+	return
+.LBB3_11:                               #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label23:
+	i32.const	$7=, 1
+	br      	1               # 1: up to label21
+.LBB3_12:                               #   in Loop: Header=BB3_3 Depth=1
+	end_block                       # label22:
+	i32.const	$7=, 2
+	br      	0               # 0: up to label21
+.LBB3_13:
 	end_loop
-	i32.const	$push24=, 0
-	i32.const	$push22=, 64
-	i32.add 	$push23=, $6, $pop22
-	i32.store	__stack_pointer($pop24), $pop23
-                                        # fallthrough-return
 	.endfunc
 .Lfunc_end3:
 	.size	varargs2, .Lfunc_end3-varargs2
@@ -464,22 +584,22 @@ varargs2:                               # @varargs2
 	.type	varargs3,@function
 varargs3:                               # @varargs3
 	.param  	i32, i32, i32, i32, i32
-	.local  	i32, i32, i32
+	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push21=, 0
-	i32.const	$push18=, 0
-	i32.load	$push19=, __stack_pointer($pop18)
-	i32.const	$push20=, 64
-	i32.sub 	$push32=, $pop19, $pop20
-	tee_local	$push31=, $7=, $pop32
-	i32.store	__stack_pointer($pop21), $pop31
+	i32.const	$push22=, 0
+	i32.const	$push19=, 0
+	i32.load	$push20=, __stack_pointer($pop19)
+	i32.const	$push21=, 64
+	i32.sub 	$push35=, $pop20, $pop21
+	tee_local	$push34=, $7=, $pop35
+	i32.store	__stack_pointer($pop22), $pop34
 	i32.store	60($7), $4
 	i64.const	$push1=, 4294967296
 	i64.store	16($7), $pop1
-	i32.load	$push30=, 60($7)
-	tee_local	$push29=, $4=, $pop30
-	i32.const	$push28=, 4
-	i32.add 	$push2=, $pop29, $pop28
+	i32.load	$push33=, 60($7)
+	tee_local	$push32=, $4=, $pop33
+	i32.const	$push31=, 4
+	i32.add 	$push2=, $pop32, $pop31
 	i32.store	60($7), $pop2
 	i32.const	$push3=, 2
 	i32.store	24($7), $pop3
@@ -502,57 +622,97 @@ varargs3:                               # @varargs3
 	i32.store	60($7), $pop12
 	i32.load	$push13=, 24($4)
 	i32.store	56($7), $pop13
-	i32.const	$push25=, 16
-	i32.add 	$push26=, $7, $pop25
-	i32.const	$push27=, 4
-	i32.or  	$5=, $pop26, $pop27
+	i32.const	$push26=, 16
+	i32.add 	$push27=, $7, $pop26
+	i32.const	$push30=, 4
+	i32.or  	$5=, $pop27, $pop30
 	i32.const	$6=, 0
 	i32.const	$4=, 0
-.LBB4_1:                                # %for.body.i
-                                        # =>This Inner Loop Header: Depth=1
-	loop    	                # label10:
 	block   	
-	i32.eq  	$push14=, $4, $6
-	br_if   	0, $pop14       # 0: down to label11
-# BB#2:                                 # %if.then.i
-                                        #   in Loop: Header=BB4_1 Depth=1
+	block   	
+	i32.const	$push29=, 0
+	i32.const	$push28=, 0
+	i32.ne  	$push14=, $pop29, $pop28
+	br_if   	0, $pop14       # 0: down to label29
+# BB#1:
+	i32.const	$8=, 1
+	br      	1               # 1: down to label28
+.LBB4_2:
+	end_block                       # label29:
+	i32.const	$8=, 0
+.LBB4_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label28:
+	loop    	                # label30:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$8, 1, 2, 0, 3, 3 # 1: down to label35
+                                        # 2: down to label34
+                                        # 0: down to label36
+                                        # 3: down to label33
+.LBB4_4:                                # %for.inc.i.for.body.i_crit_edge
+                                        #   in Loop: Header=BB4_3 Depth=1
+	end_block                       # label36:
+	i32.load	$6=, 0($5)
+	i32.const	$push39=, 4
+	i32.add 	$push0=, $5, $pop39
+	copy_local	$5=, $pop0
+	i32.const	$push38=, 1
+	i32.add 	$push37=, $4, $pop38
+	tee_local	$push36=, $4=, $pop37
+	i32.eq  	$push15=, $6, $pop36
+	br_if   	3, $pop15       # 3: down to label32
+# BB#5:                                 #   in Loop: Header=BB4_3 Depth=1
+	i32.const	$8=, 0
+	br      	5               # 5: up to label30
+.LBB4_6:                                # %if.then.i
+                                        #   in Loop: Header=BB4_3 Depth=1
+	end_block                       # label35:
 	i32.store	12($7), $4
 	i32.store	8($7), $6
 	i32.store	4($7), $4
-	i32.const	$push39=, .L.str.4
-	i32.store	0($7), $pop39
-	i32.const	$push38=, .L.str.1
-	i32.call	$drop=, printf@FUNCTION, $pop38, $7
-	i32.const	$push37=, 0
-	i32.const	$push36=, 0
-	i32.load	$push15=, errors($pop36)
-	i32.const	$push35=, 1
-	i32.add 	$push16=, $pop15, $pop35
-	i32.store	errors($pop37), $pop16
-.LBB4_3:                                # %for.inc.i
-                                        #   in Loop: Header=BB4_1 Depth=1
-	end_block                       # label11:
-	block   	
-	i32.const	$push40=, 10
-	i32.eq  	$push17=, $4, $pop40
-	br_if   	0, $pop17       # 0: down to label12
-# BB#4:                                 # %for.inc.i.for.body.i_crit_edge
-                                        #   in Loop: Header=BB4_1 Depth=1
-	i32.const	$push34=, 1
-	i32.add 	$4=, $4, $pop34
-	i32.load	$6=, 0($5)
-	i32.const	$push33=, 4
-	i32.add 	$push0=, $5, $pop33
-	copy_local	$5=, $pop0
-	br      	1               # 1: up to label10
-.LBB4_5:                                # %verify.exit
-	end_block                       # label12:
+	i32.const	$push44=, .L.str.4
+	i32.store	0($7), $pop44
+	i32.const	$push43=, .L.str.1
+	i32.call	$drop=, printf@FUNCTION, $pop43, $7
+	i32.const	$push42=, 0
+	i32.const	$push41=, 0
+	i32.load	$push16=, errors($pop41)
+	i32.const	$push40=, 1
+	i32.add 	$push17=, $pop16, $pop40
+	i32.store	errors($pop42), $pop17
+# BB#7:                                 #   in Loop: Header=BB4_3 Depth=1
+	i32.const	$8=, 1
+	br      	4               # 4: up to label30
+.LBB4_8:                                # %for.inc.i
+                                        #   in Loop: Header=BB4_3 Depth=1
+	end_block                       # label34:
+	i32.const	$push45=, 10
+	i32.ne  	$push18=, $4, $pop45
+	br_if   	2, $pop18       # 2: down to label31
+# BB#9:                                 #   in Loop: Header=BB4_3 Depth=1
+	i32.const	$8=, 3
+	br      	3               # 3: up to label30
+.LBB4_10:                               # %verify.exit
+	end_block                       # label33:
+	i32.const	$push25=, 0
+	i32.const	$push23=, 64
+	i32.add 	$push24=, $7, $pop23
+	i32.store	__stack_pointer($pop25), $pop24
+	return
+.LBB4_11:                               #   in Loop: Header=BB4_3 Depth=1
+	end_block                       # label32:
+	i32.const	$8=, 1
+	br      	1               # 1: up to label30
+.LBB4_12:                               #   in Loop: Header=BB4_3 Depth=1
+	end_block                       # label31:
+	i32.const	$8=, 2
+	br      	0               # 0: up to label30
+.LBB4_13:
 	end_loop
-	i32.const	$push24=, 0
-	i32.const	$push22=, 64
-	i32.add 	$push23=, $7, $pop22
-	i32.store	__stack_pointer($pop24), $pop23
-                                        # fallthrough-return
 	.endfunc
 .Lfunc_end4:
 	.size	varargs3, .Lfunc_end4-varargs3
@@ -561,24 +721,24 @@ varargs3:                               # @varargs3
 	.type	varargs4,@function
 varargs4:                               # @varargs4
 	.param  	i32, i32, i32, i32, i32, i32
-	.local  	i32, i32, i32
+	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push19=, 0
-	i32.const	$push16=, 0
-	i32.load	$push17=, __stack_pointer($pop16)
-	i32.const	$push18=, 64
-	i32.sub 	$push31=, $pop17, $pop18
-	tee_local	$push30=, $8=, $pop31
-	i32.store	__stack_pointer($pop19), $pop30
+	i32.const	$push20=, 0
+	i32.const	$push17=, 0
+	i32.load	$push18=, __stack_pointer($pop17)
+	i32.const	$push19=, 64
+	i32.sub 	$push34=, $pop18, $pop19
+	tee_local	$push33=, $8=, $pop34
+	i32.store	__stack_pointer($pop20), $pop33
 	i32.store	60($8), $5
 	i64.const	$push1=, 4294967296
 	i64.store	16($8), $pop1
+	i32.const	$push32=, 4
+	i32.store	32($8), $pop32
+	i32.load	$push31=, 60($8)
+	tee_local	$push30=, $5=, $pop31
 	i32.const	$push29=, 4
-	i32.store	32($8), $pop29
-	i32.load	$push28=, 60($8)
-	tee_local	$push27=, $5=, $pop28
-	i32.const	$push26=, 4
-	i32.add 	$push2=, $pop27, $pop26
+	i32.add 	$push2=, $pop30, $pop29
 	i32.store	60($8), $pop2
 	i64.const	$push3=, 12884901890
 	i64.store	24($8), $pop3
@@ -597,57 +757,97 @@ varargs4:                               # @varargs4
 	i32.store	60($8), $pop10
 	i32.load	$push11=, 20($5)
 	i32.store	56($8), $pop11
-	i32.const	$push23=, 16
-	i32.add 	$push24=, $8, $pop23
-	i32.const	$push25=, 4
-	i32.or  	$6=, $pop24, $pop25
+	i32.const	$push24=, 16
+	i32.add 	$push25=, $8, $pop24
+	i32.const	$push28=, 4
+	i32.or  	$6=, $pop25, $pop28
 	i32.const	$7=, 0
 	i32.const	$5=, 0
-.LBB5_1:                                # %for.body.i
-                                        # =>This Inner Loop Header: Depth=1
-	loop    	                # label13:
 	block   	
-	i32.eq  	$push12=, $5, $7
-	br_if   	0, $pop12       # 0: down to label14
-# BB#2:                                 # %if.then.i
-                                        #   in Loop: Header=BB5_1 Depth=1
+	block   	
+	i32.const	$push27=, 0
+	i32.const	$push26=, 0
+	i32.ne  	$push12=, $pop27, $pop26
+	br_if   	0, $pop12       # 0: down to label38
+# BB#1:
+	i32.const	$9=, 1
+	br      	1               # 1: down to label37
+.LBB5_2:
+	end_block                       # label38:
+	i32.const	$9=, 0
+.LBB5_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label37:
+	loop    	                # label39:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$9, 1, 2, 0, 3, 3 # 1: down to label44
+                                        # 2: down to label43
+                                        # 0: down to label45
+                                        # 3: down to label42
+.LBB5_4:                                # %for.inc.i.for.body.i_crit_edge
+                                        #   in Loop: Header=BB5_3 Depth=1
+	end_block                       # label45:
+	i32.load	$7=, 0($6)
+	i32.const	$push38=, 4
+	i32.add 	$push0=, $6, $pop38
+	copy_local	$6=, $pop0
+	i32.const	$push37=, 1
+	i32.add 	$push36=, $5, $pop37
+	tee_local	$push35=, $5=, $pop36
+	i32.eq  	$push13=, $7, $pop35
+	br_if   	3, $pop13       # 3: down to label41
+# BB#5:                                 #   in Loop: Header=BB5_3 Depth=1
+	i32.const	$9=, 0
+	br      	5               # 5: up to label39
+.LBB5_6:                                # %if.then.i
+                                        #   in Loop: Header=BB5_3 Depth=1
+	end_block                       # label44:
 	i32.store	12($8), $5
 	i32.store	8($8), $7
 	i32.store	4($8), $5
-	i32.const	$push38=, .L.str.5
-	i32.store	0($8), $pop38
-	i32.const	$push37=, .L.str.1
-	i32.call	$drop=, printf@FUNCTION, $pop37, $8
-	i32.const	$push36=, 0
-	i32.const	$push35=, 0
-	i32.load	$push13=, errors($pop35)
-	i32.const	$push34=, 1
-	i32.add 	$push14=, $pop13, $pop34
-	i32.store	errors($pop36), $pop14
-.LBB5_3:                                # %for.inc.i
-                                        #   in Loop: Header=BB5_1 Depth=1
-	end_block                       # label14:
-	block   	
-	i32.const	$push39=, 10
-	i32.eq  	$push15=, $5, $pop39
-	br_if   	0, $pop15       # 0: down to label15
-# BB#4:                                 # %for.inc.i.for.body.i_crit_edge
-                                        #   in Loop: Header=BB5_1 Depth=1
-	i32.const	$push33=, 1
-	i32.add 	$5=, $5, $pop33
-	i32.load	$7=, 0($6)
-	i32.const	$push32=, 4
-	i32.add 	$push0=, $6, $pop32
-	copy_local	$6=, $pop0
-	br      	1               # 1: up to label13
-.LBB5_5:                                # %verify.exit
-	end_block                       # label15:
+	i32.const	$push43=, .L.str.5
+	i32.store	0($8), $pop43
+	i32.const	$push42=, .L.str.1
+	i32.call	$drop=, printf@FUNCTION, $pop42, $8
+	i32.const	$push41=, 0
+	i32.const	$push40=, 0
+	i32.load	$push14=, errors($pop40)
+	i32.const	$push39=, 1
+	i32.add 	$push15=, $pop14, $pop39
+	i32.store	errors($pop41), $pop15
+# BB#7:                                 #   in Loop: Header=BB5_3 Depth=1
+	i32.const	$9=, 1
+	br      	4               # 4: up to label39
+.LBB5_8:                                # %for.inc.i
+                                        #   in Loop: Header=BB5_3 Depth=1
+	end_block                       # label43:
+	i32.const	$push44=, 10
+	i32.ne  	$push16=, $5, $pop44
+	br_if   	2, $pop16       # 2: down to label40
+# BB#9:                                 #   in Loop: Header=BB5_3 Depth=1
+	i32.const	$9=, 3
+	br      	3               # 3: up to label39
+.LBB5_10:                               # %verify.exit
+	end_block                       # label42:
+	i32.const	$push23=, 0
+	i32.const	$push21=, 64
+	i32.add 	$push22=, $8, $pop21
+	i32.store	__stack_pointer($pop23), $pop22
+	return
+.LBB5_11:                               #   in Loop: Header=BB5_3 Depth=1
+	end_block                       # label41:
+	i32.const	$9=, 1
+	br      	1               # 1: up to label39
+.LBB5_12:                               #   in Loop: Header=BB5_3 Depth=1
+	end_block                       # label40:
+	i32.const	$9=, 2
+	br      	0               # 0: up to label39
+.LBB5_13:
 	end_loop
-	i32.const	$push22=, 0
-	i32.const	$push20=, 64
-	i32.add 	$push21=, $8, $pop20
-	i32.store	__stack_pointer($pop22), $pop21
-                                        # fallthrough-return
 	.endfunc
 .Lfunc_end5:
 	.size	varargs4, .Lfunc_end5-varargs4
@@ -656,22 +856,22 @@ varargs4:                               # @varargs4
 	.type	varargs5,@function
 varargs5:                               # @varargs5
 	.param  	i32, i32, i32, i32, i32, i32, i32
-	.local  	i32, i32, i32
+	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push19=, 0
-	i32.const	$push16=, 0
-	i32.load	$push17=, __stack_pointer($pop16)
-	i32.const	$push18=, 64
-	i32.sub 	$push30=, $pop17, $pop18
-	tee_local	$push29=, $9=, $pop30
-	i32.store	__stack_pointer($pop19), $pop29
+	i32.const	$push20=, 0
+	i32.const	$push17=, 0
+	i32.load	$push18=, __stack_pointer($pop17)
+	i32.const	$push19=, 64
+	i32.sub 	$push33=, $pop18, $pop19
+	tee_local	$push32=, $9=, $pop33
+	i32.store	__stack_pointer($pop20), $pop32
 	i32.store	60($9), $6
 	i64.const	$push1=, 4294967296
 	i64.store	16($9), $pop1
-	i32.load	$push28=, 60($9)
-	tee_local	$push27=, $6=, $pop28
-	i32.const	$push26=, 4
-	i32.add 	$push2=, $pop27, $pop26
+	i32.load	$push31=, 60($9)
+	tee_local	$push30=, $6=, $pop31
+	i32.const	$push29=, 4
+	i32.add 	$push2=, $pop30, $pop29
 	i32.store	60($9), $pop2
 	i64.const	$push3=, 12884901890
 	i64.store	24($9), $pop3
@@ -690,57 +890,97 @@ varargs5:                               # @varargs5
 	i32.store	60($9), $pop10
 	i32.load	$push11=, 16($6)
 	i32.store	56($9), $pop11
-	i32.const	$push23=, 16
-	i32.add 	$push24=, $9, $pop23
-	i32.const	$push25=, 4
-	i32.or  	$7=, $pop24, $pop25
+	i32.const	$push24=, 16
+	i32.add 	$push25=, $9, $pop24
+	i32.const	$push28=, 4
+	i32.or  	$7=, $pop25, $pop28
 	i32.const	$8=, 0
 	i32.const	$6=, 0
-.LBB6_1:                                # %for.body.i
-                                        # =>This Inner Loop Header: Depth=1
-	loop    	                # label16:
 	block   	
-	i32.eq  	$push12=, $6, $8
-	br_if   	0, $pop12       # 0: down to label17
-# BB#2:                                 # %if.then.i
-                                        #   in Loop: Header=BB6_1 Depth=1
+	block   	
+	i32.const	$push27=, 0
+	i32.const	$push26=, 0
+	i32.ne  	$push12=, $pop27, $pop26
+	br_if   	0, $pop12       # 0: down to label47
+# BB#1:
+	i32.const	$10=, 1
+	br      	1               # 1: down to label46
+.LBB6_2:
+	end_block                       # label47:
+	i32.const	$10=, 0
+.LBB6_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label46:
+	loop    	                # label48:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$10, 1, 2, 0, 3, 3 # 1: down to label53
+                                        # 2: down to label52
+                                        # 0: down to label54
+                                        # 3: down to label51
+.LBB6_4:                                # %for.inc.i.for.body.i_crit_edge
+                                        #   in Loop: Header=BB6_3 Depth=1
+	end_block                       # label54:
+	i32.load	$8=, 0($7)
+	i32.const	$push37=, 4
+	i32.add 	$push0=, $7, $pop37
+	copy_local	$7=, $pop0
+	i32.const	$push36=, 1
+	i32.add 	$push35=, $6, $pop36
+	tee_local	$push34=, $6=, $pop35
+	i32.eq  	$push13=, $8, $pop34
+	br_if   	3, $pop13       # 3: down to label50
+# BB#5:                                 #   in Loop: Header=BB6_3 Depth=1
+	i32.const	$10=, 0
+	br      	5               # 5: up to label48
+.LBB6_6:                                # %if.then.i
+                                        #   in Loop: Header=BB6_3 Depth=1
+	end_block                       # label53:
 	i32.store	12($9), $6
 	i32.store	8($9), $8
 	i32.store	4($9), $6
-	i32.const	$push37=, .L.str.6
-	i32.store	0($9), $pop37
-	i32.const	$push36=, .L.str.1
-	i32.call	$drop=, printf@FUNCTION, $pop36, $9
-	i32.const	$push35=, 0
-	i32.const	$push34=, 0
-	i32.load	$push13=, errors($pop34)
-	i32.const	$push33=, 1
-	i32.add 	$push14=, $pop13, $pop33
-	i32.store	errors($pop35), $pop14
-.LBB6_3:                                # %for.inc.i
-                                        #   in Loop: Header=BB6_1 Depth=1
-	end_block                       # label17:
-	block   	
-	i32.const	$push38=, 10
-	i32.eq  	$push15=, $6, $pop38
-	br_if   	0, $pop15       # 0: down to label18
-# BB#4:                                 # %for.inc.i.for.body.i_crit_edge
-                                        #   in Loop: Header=BB6_1 Depth=1
-	i32.const	$push32=, 1
-	i32.add 	$6=, $6, $pop32
-	i32.load	$8=, 0($7)
-	i32.const	$push31=, 4
-	i32.add 	$push0=, $7, $pop31
-	copy_local	$7=, $pop0
-	br      	1               # 1: up to label16
-.LBB6_5:                                # %verify.exit
-	end_block                       # label18:
+	i32.const	$push42=, .L.str.6
+	i32.store	0($9), $pop42
+	i32.const	$push41=, .L.str.1
+	i32.call	$drop=, printf@FUNCTION, $pop41, $9
+	i32.const	$push40=, 0
+	i32.const	$push39=, 0
+	i32.load	$push14=, errors($pop39)
+	i32.const	$push38=, 1
+	i32.add 	$push15=, $pop14, $pop38
+	i32.store	errors($pop40), $pop15
+# BB#7:                                 #   in Loop: Header=BB6_3 Depth=1
+	i32.const	$10=, 1
+	br      	4               # 4: up to label48
+.LBB6_8:                                # %for.inc.i
+                                        #   in Loop: Header=BB6_3 Depth=1
+	end_block                       # label52:
+	i32.const	$push43=, 10
+	i32.ne  	$push16=, $6, $pop43
+	br_if   	2, $pop16       # 2: down to label49
+# BB#9:                                 #   in Loop: Header=BB6_3 Depth=1
+	i32.const	$10=, 3
+	br      	3               # 3: up to label48
+.LBB6_10:                               # %verify.exit
+	end_block                       # label51:
+	i32.const	$push23=, 0
+	i32.const	$push21=, 64
+	i32.add 	$push22=, $9, $pop21
+	i32.store	__stack_pointer($pop23), $pop22
+	return
+.LBB6_11:                               #   in Loop: Header=BB6_3 Depth=1
+	end_block                       # label50:
+	i32.const	$10=, 1
+	br      	1               # 1: up to label48
+.LBB6_12:                               #   in Loop: Header=BB6_3 Depth=1
+	end_block                       # label49:
+	i32.const	$10=, 2
+	br      	0               # 0: up to label48
+.LBB6_13:
 	end_loop
-	i32.const	$push22=, 0
-	i32.const	$push20=, 64
-	i32.add 	$push21=, $9, $pop20
-	i32.store	__stack_pointer($pop22), $pop21
-                                        # fallthrough-return
 	.endfunc
 .Lfunc_end6:
 	.size	varargs5, .Lfunc_end6-varargs5
@@ -749,22 +989,22 @@ varargs5:                               # @varargs5
 	.type	varargs6,@function
 varargs6:                               # @varargs6
 	.param  	i32, i32, i32, i32, i32, i32, i32, i32
-	.local  	i32, i32, i32
+	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push19=, 0
-	i32.const	$push16=, 0
-	i32.load	$push17=, __stack_pointer($pop16)
-	i32.const	$push18=, 64
-	i32.sub 	$push30=, $pop17, $pop18
-	tee_local	$push29=, $10=, $pop30
-	i32.store	__stack_pointer($pop19), $pop29
+	i32.const	$push20=, 0
+	i32.const	$push17=, 0
+	i32.load	$push18=, __stack_pointer($pop17)
+	i32.const	$push19=, 64
+	i32.sub 	$push33=, $pop18, $pop19
+	tee_local	$push32=, $10=, $pop33
+	i32.store	__stack_pointer($pop20), $pop32
 	i32.store	60($10), $7
 	i64.const	$push1=, 4294967296
 	i64.store	16($10), $pop1
-	i32.load	$push28=, 60($10)
-	tee_local	$push27=, $7=, $pop28
-	i32.const	$push26=, 4
-	i32.add 	$push2=, $pop27, $pop26
+	i32.load	$push31=, 60($10)
+	tee_local	$push30=, $7=, $pop31
+	i32.const	$push29=, 4
+	i32.add 	$push2=, $pop30, $pop29
 	i32.store	60($10), $pop2
 	i64.const	$push3=, 12884901890
 	i64.store	24($10), $pop3
@@ -783,57 +1023,97 @@ varargs6:                               # @varargs6
 	i32.store	52($10), $pop10
 	i32.load	$push11=, 12($7)
 	i32.store	56($10), $pop11
-	i32.const	$push23=, 16
-	i32.add 	$push24=, $10, $pop23
-	i32.const	$push25=, 4
-	i32.or  	$8=, $pop24, $pop25
+	i32.const	$push24=, 16
+	i32.add 	$push25=, $10, $pop24
+	i32.const	$push28=, 4
+	i32.or  	$8=, $pop25, $pop28
 	i32.const	$9=, 0
 	i32.const	$7=, 0
-.LBB7_1:                                # %for.body.i
-                                        # =>This Inner Loop Header: Depth=1
-	loop    	                # label19:
 	block   	
-	i32.eq  	$push12=, $7, $9
-	br_if   	0, $pop12       # 0: down to label20
-# BB#2:                                 # %if.then.i
-                                        #   in Loop: Header=BB7_1 Depth=1
+	block   	
+	i32.const	$push27=, 0
+	i32.const	$push26=, 0
+	i32.ne  	$push12=, $pop27, $pop26
+	br_if   	0, $pop12       # 0: down to label56
+# BB#1:
+	i32.const	$11=, 1
+	br      	1               # 1: down to label55
+.LBB7_2:
+	end_block                       # label56:
+	i32.const	$11=, 0
+.LBB7_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label55:
+	loop    	                # label57:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$11, 1, 2, 0, 3, 3 # 1: down to label62
+                                        # 2: down to label61
+                                        # 0: down to label63
+                                        # 3: down to label60
+.LBB7_4:                                # %for.inc.i.for.body.i_crit_edge
+                                        #   in Loop: Header=BB7_3 Depth=1
+	end_block                       # label63:
+	i32.load	$9=, 0($8)
+	i32.const	$push37=, 4
+	i32.add 	$push0=, $8, $pop37
+	copy_local	$8=, $pop0
+	i32.const	$push36=, 1
+	i32.add 	$push35=, $7, $pop36
+	tee_local	$push34=, $7=, $pop35
+	i32.eq  	$push13=, $9, $pop34
+	br_if   	3, $pop13       # 3: down to label59
+# BB#5:                                 #   in Loop: Header=BB7_3 Depth=1
+	i32.const	$11=, 0
+	br      	5               # 5: up to label57
+.LBB7_6:                                # %if.then.i
+                                        #   in Loop: Header=BB7_3 Depth=1
+	end_block                       # label62:
 	i32.store	12($10), $7
 	i32.store	8($10), $9
 	i32.store	4($10), $7
-	i32.const	$push37=, .L.str.7
-	i32.store	0($10), $pop37
-	i32.const	$push36=, .L.str.1
-	i32.call	$drop=, printf@FUNCTION, $pop36, $10
-	i32.const	$push35=, 0
-	i32.const	$push34=, 0
-	i32.load	$push13=, errors($pop34)
-	i32.const	$push33=, 1
-	i32.add 	$push14=, $pop13, $pop33
-	i32.store	errors($pop35), $pop14
-.LBB7_3:                                # %for.inc.i
-                                        #   in Loop: Header=BB7_1 Depth=1
-	end_block                       # label20:
-	block   	
-	i32.const	$push38=, 10
-	i32.eq  	$push15=, $7, $pop38
-	br_if   	0, $pop15       # 0: down to label21
-# BB#4:                                 # %for.inc.i.for.body.i_crit_edge
-                                        #   in Loop: Header=BB7_1 Depth=1
-	i32.const	$push32=, 1
-	i32.add 	$7=, $7, $pop32
-	i32.load	$9=, 0($8)
-	i32.const	$push31=, 4
-	i32.add 	$push0=, $8, $pop31
-	copy_local	$8=, $pop0
-	br      	1               # 1: up to label19
-.LBB7_5:                                # %verify.exit
-	end_block                       # label21:
+	i32.const	$push42=, .L.str.7
+	i32.store	0($10), $pop42
+	i32.const	$push41=, .L.str.1
+	i32.call	$drop=, printf@FUNCTION, $pop41, $10
+	i32.const	$push40=, 0
+	i32.const	$push39=, 0
+	i32.load	$push14=, errors($pop39)
+	i32.const	$push38=, 1
+	i32.add 	$push15=, $pop14, $pop38
+	i32.store	errors($pop40), $pop15
+# BB#7:                                 #   in Loop: Header=BB7_3 Depth=1
+	i32.const	$11=, 1
+	br      	4               # 4: up to label57
+.LBB7_8:                                # %for.inc.i
+                                        #   in Loop: Header=BB7_3 Depth=1
+	end_block                       # label61:
+	i32.const	$push43=, 10
+	i32.ne  	$push16=, $7, $pop43
+	br_if   	2, $pop16       # 2: down to label58
+# BB#9:                                 #   in Loop: Header=BB7_3 Depth=1
+	i32.const	$11=, 3
+	br      	3               # 3: up to label57
+.LBB7_10:                               # %verify.exit
+	end_block                       # label60:
+	i32.const	$push23=, 0
+	i32.const	$push21=, 64
+	i32.add 	$push22=, $10, $pop21
+	i32.store	__stack_pointer($pop23), $pop22
+	return
+.LBB7_11:                               #   in Loop: Header=BB7_3 Depth=1
+	end_block                       # label59:
+	i32.const	$11=, 1
+	br      	1               # 1: up to label57
+.LBB7_12:                               #   in Loop: Header=BB7_3 Depth=1
+	end_block                       # label58:
+	i32.const	$11=, 2
+	br      	0               # 0: up to label57
+.LBB7_13:
 	end_loop
-	i32.const	$push22=, 0
-	i32.const	$push20=, 64
-	i32.add 	$push21=, $10, $pop20
-	i32.store	__stack_pointer($pop22), $pop21
-                                        # fallthrough-return
 	.endfunc
 .Lfunc_end7:
 	.size	varargs6, .Lfunc_end7-varargs6
@@ -842,22 +1122,22 @@ varargs6:                               # @varargs6
 	.type	varargs7,@function
 varargs7:                               # @varargs7
 	.param  	i32, i32, i32, i32, i32, i32, i32, i32, i32
-	.local  	i32, i32, i32
+	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push18=, 0
-	i32.const	$push15=, 0
-	i32.load	$push16=, __stack_pointer($pop15)
-	i32.const	$push17=, 64
-	i32.sub 	$push29=, $pop16, $pop17
-	tee_local	$push28=, $11=, $pop29
-	i32.store	__stack_pointer($pop18), $pop28
+	i32.const	$push19=, 0
+	i32.const	$push16=, 0
+	i32.load	$push17=, __stack_pointer($pop16)
+	i32.const	$push18=, 64
+	i32.sub 	$push32=, $pop17, $pop18
+	tee_local	$push31=, $11=, $pop32
+	i32.store	__stack_pointer($pop19), $pop31
 	i32.store	60($11), $8
 	i64.const	$push1=, 4294967296
 	i64.store	16($11), $pop1
-	i32.load	$push27=, 60($11)
-	tee_local	$push26=, $8=, $pop27
-	i32.const	$push25=, 4
-	i32.add 	$push2=, $pop26, $pop25
+	i32.load	$push30=, 60($11)
+	tee_local	$push29=, $8=, $pop30
+	i32.const	$push28=, 4
+	i32.add 	$push2=, $pop29, $pop28
 	i32.store	60($11), $pop2
 	i64.const	$push3=, 12884901890
 	i64.store	24($11), $pop3
@@ -874,57 +1154,97 @@ varargs7:                               # @varargs7
 	i32.store	52($11), $pop9
 	i32.load	$push10=, 8($8)
 	i32.store	56($11), $pop10
-	i32.const	$push22=, 16
-	i32.add 	$push23=, $11, $pop22
-	i32.const	$push24=, 4
-	i32.or  	$9=, $pop23, $pop24
+	i32.const	$push23=, 16
+	i32.add 	$push24=, $11, $pop23
+	i32.const	$push27=, 4
+	i32.or  	$9=, $pop24, $pop27
 	i32.const	$10=, 0
 	i32.const	$8=, 0
-.LBB8_1:                                # %for.body.i
-                                        # =>This Inner Loop Header: Depth=1
-	loop    	                # label22:
 	block   	
-	i32.eq  	$push11=, $8, $10
-	br_if   	0, $pop11       # 0: down to label23
-# BB#2:                                 # %if.then.i
-                                        #   in Loop: Header=BB8_1 Depth=1
+	block   	
+	i32.const	$push26=, 0
+	i32.const	$push25=, 0
+	i32.ne  	$push11=, $pop26, $pop25
+	br_if   	0, $pop11       # 0: down to label65
+# BB#1:
+	i32.const	$12=, 1
+	br      	1               # 1: down to label64
+.LBB8_2:
+	end_block                       # label65:
+	i32.const	$12=, 0
+.LBB8_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label64:
+	loop    	                # label66:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$12, 1, 2, 0, 3, 3 # 1: down to label71
+                                        # 2: down to label70
+                                        # 0: down to label72
+                                        # 3: down to label69
+.LBB8_4:                                # %for.inc.i.for.body.i_crit_edge
+                                        #   in Loop: Header=BB8_3 Depth=1
+	end_block                       # label72:
+	i32.load	$10=, 0($9)
+	i32.const	$push36=, 4
+	i32.add 	$push0=, $9, $pop36
+	copy_local	$9=, $pop0
+	i32.const	$push35=, 1
+	i32.add 	$push34=, $8, $pop35
+	tee_local	$push33=, $8=, $pop34
+	i32.eq  	$push12=, $10, $pop33
+	br_if   	3, $pop12       # 3: down to label68
+# BB#5:                                 #   in Loop: Header=BB8_3 Depth=1
+	i32.const	$12=, 0
+	br      	5               # 5: up to label66
+.LBB8_6:                                # %if.then.i
+                                        #   in Loop: Header=BB8_3 Depth=1
+	end_block                       # label71:
 	i32.store	12($11), $8
 	i32.store	8($11), $10
 	i32.store	4($11), $8
-	i32.const	$push36=, .L.str.8
-	i32.store	0($11), $pop36
-	i32.const	$push35=, .L.str.1
-	i32.call	$drop=, printf@FUNCTION, $pop35, $11
-	i32.const	$push34=, 0
-	i32.const	$push33=, 0
-	i32.load	$push12=, errors($pop33)
-	i32.const	$push32=, 1
-	i32.add 	$push13=, $pop12, $pop32
-	i32.store	errors($pop34), $pop13
-.LBB8_3:                                # %for.inc.i
-                                        #   in Loop: Header=BB8_1 Depth=1
-	end_block                       # label23:
-	block   	
-	i32.const	$push37=, 10
-	i32.eq  	$push14=, $8, $pop37
-	br_if   	0, $pop14       # 0: down to label24
-# BB#4:                                 # %for.inc.i.for.body.i_crit_edge
-                                        #   in Loop: Header=BB8_1 Depth=1
-	i32.const	$push31=, 1
-	i32.add 	$8=, $8, $pop31
-	i32.load	$10=, 0($9)
-	i32.const	$push30=, 4
-	i32.add 	$push0=, $9, $pop30
-	copy_local	$9=, $pop0
-	br      	1               # 1: up to label22
-.LBB8_5:                                # %verify.exit
-	end_block                       # label24:
+	i32.const	$push41=, .L.str.8
+	i32.store	0($11), $pop41
+	i32.const	$push40=, .L.str.1
+	i32.call	$drop=, printf@FUNCTION, $pop40, $11
+	i32.const	$push39=, 0
+	i32.const	$push38=, 0
+	i32.load	$push13=, errors($pop38)
+	i32.const	$push37=, 1
+	i32.add 	$push14=, $pop13, $pop37
+	i32.store	errors($pop39), $pop14
+# BB#7:                                 #   in Loop: Header=BB8_3 Depth=1
+	i32.const	$12=, 1
+	br      	4               # 4: up to label66
+.LBB8_8:                                # %for.inc.i
+                                        #   in Loop: Header=BB8_3 Depth=1
+	end_block                       # label70:
+	i32.const	$push42=, 10
+	i32.ne  	$push15=, $8, $pop42
+	br_if   	2, $pop15       # 2: down to label67
+# BB#9:                                 #   in Loop: Header=BB8_3 Depth=1
+	i32.const	$12=, 3
+	br      	3               # 3: up to label66
+.LBB8_10:                               # %verify.exit
+	end_block                       # label69:
+	i32.const	$push22=, 0
+	i32.const	$push20=, 64
+	i32.add 	$push21=, $11, $pop20
+	i32.store	__stack_pointer($pop22), $pop21
+	return
+.LBB8_11:                               #   in Loop: Header=BB8_3 Depth=1
+	end_block                       # label68:
+	i32.const	$12=, 1
+	br      	1               # 1: up to label66
+.LBB8_12:                               #   in Loop: Header=BB8_3 Depth=1
+	end_block                       # label67:
+	i32.const	$12=, 2
+	br      	0               # 0: up to label66
+.LBB8_13:
 	end_loop
-	i32.const	$push21=, 0
-	i32.const	$push19=, 64
-	i32.add 	$push20=, $11, $pop19
-	i32.store	__stack_pointer($pop21), $pop20
-                                        # fallthrough-return
 	.endfunc
 .Lfunc_end8:
 	.size	varargs7, .Lfunc_end8-varargs7
@@ -933,15 +1253,15 @@ varargs7:                               # @varargs7
 	.type	varargs8,@function
 varargs8:                               # @varargs8
 	.param  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
-	.local  	i32, i32, i32
+	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push16=, 0
-	i32.const	$push13=, 0
-	i32.load	$push14=, __stack_pointer($pop13)
-	i32.const	$push15=, 64
-	i32.sub 	$push28=, $pop14, $pop15
-	tee_local	$push27=, $12=, $pop28
-	i32.store	__stack_pointer($pop16), $pop27
+	i32.const	$push17=, 0
+	i32.const	$push14=, 0
+	i32.load	$push15=, __stack_pointer($pop14)
+	i32.const	$push16=, 64
+	i32.sub 	$push31=, $pop15, $pop16
+	tee_local	$push30=, $12=, $pop31
+	i32.store	__stack_pointer($pop17), $pop30
 	i32.store	60($12), $9
 	i64.const	$push1=, 4294967296
 	i64.store	16($12), $pop1
@@ -951,71 +1271,111 @@ varargs8:                               # @varargs8
 	i64.store	32($12), $pop3
 	i64.const	$push4=, 30064771078
 	i64.store	40($12), $pop4
-	i32.load	$push26=, 60($12)
-	tee_local	$push25=, $9=, $pop26
-	i32.const	$push24=, 4
-	i32.add 	$push5=, $pop25, $pop24
+	i32.load	$push29=, 60($12)
+	tee_local	$push28=, $9=, $pop29
+	i32.const	$push27=, 4
+	i32.add 	$push5=, $pop28, $pop27
 	i32.store	60($12), $pop5
 	i32.const	$push6=, 8
 	i32.store	48($12), $pop6
 	i32.load	$10=, 0($9)
-	i32.const	$push23=, 8
-	i32.add 	$push7=, $9, $pop23
+	i32.const	$push26=, 8
+	i32.add 	$push7=, $9, $pop26
 	i32.store	60($12), $pop7
 	i32.store	52($12), $10
 	i32.load	$push8=, 4($9)
 	i32.store	56($12), $pop8
-	i32.const	$push20=, 16
-	i32.add 	$push21=, $12, $pop20
-	i32.const	$push22=, 4
-	i32.or  	$10=, $pop21, $pop22
+	i32.const	$push21=, 16
+	i32.add 	$push22=, $12, $pop21
+	i32.const	$push25=, 4
+	i32.or  	$10=, $pop22, $pop25
 	i32.const	$11=, 0
 	i32.const	$9=, 0
-.LBB9_1:                                # %for.body.i
-                                        # =>This Inner Loop Header: Depth=1
-	loop    	                # label25:
 	block   	
-	i32.eq  	$push9=, $9, $11
-	br_if   	0, $pop9        # 0: down to label26
-# BB#2:                                 # %if.then.i
-                                        #   in Loop: Header=BB9_1 Depth=1
+	block   	
+	i32.const	$push24=, 0
+	i32.const	$push23=, 0
+	i32.ne  	$push9=, $pop24, $pop23
+	br_if   	0, $pop9        # 0: down to label74
+# BB#1:
+	i32.const	$13=, 1
+	br      	1               # 1: down to label73
+.LBB9_2:
+	end_block                       # label74:
+	i32.const	$13=, 0
+.LBB9_3:                                # =>This Inner Loop Header: Depth=1
+	end_block                       # label73:
+	loop    	                # label75:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$13, 1, 2, 0, 3, 3 # 1: down to label80
+                                        # 2: down to label79
+                                        # 0: down to label81
+                                        # 3: down to label78
+.LBB9_4:                                # %for.inc.i.for.body.i_crit_edge
+                                        #   in Loop: Header=BB9_3 Depth=1
+	end_block                       # label81:
+	i32.load	$11=, 0($10)
+	i32.const	$push35=, 4
+	i32.add 	$push0=, $10, $pop35
+	copy_local	$10=, $pop0
+	i32.const	$push34=, 1
+	i32.add 	$push33=, $9, $pop34
+	tee_local	$push32=, $9=, $pop33
+	i32.eq  	$push10=, $11, $pop32
+	br_if   	3, $pop10       # 3: down to label77
+# BB#5:                                 #   in Loop: Header=BB9_3 Depth=1
+	i32.const	$13=, 0
+	br      	5               # 5: up to label75
+.LBB9_6:                                # %if.then.i
+                                        #   in Loop: Header=BB9_3 Depth=1
+	end_block                       # label80:
 	i32.store	12($12), $9
 	i32.store	8($12), $11
 	i32.store	4($12), $9
-	i32.const	$push35=, .L.str.9
-	i32.store	0($12), $pop35
-	i32.const	$push34=, .L.str.1
-	i32.call	$drop=, printf@FUNCTION, $pop34, $12
-	i32.const	$push33=, 0
-	i32.const	$push32=, 0
-	i32.load	$push10=, errors($pop32)
-	i32.const	$push31=, 1
-	i32.add 	$push11=, $pop10, $pop31
-	i32.store	errors($pop33), $pop11
-.LBB9_3:                                # %for.inc.i
-                                        #   in Loop: Header=BB9_1 Depth=1
-	end_block                       # label26:
-	block   	
-	i32.const	$push36=, 10
-	i32.eq  	$push12=, $9, $pop36
-	br_if   	0, $pop12       # 0: down to label27
-# BB#4:                                 # %for.inc.i.for.body.i_crit_edge
-                                        #   in Loop: Header=BB9_1 Depth=1
-	i32.const	$push30=, 1
-	i32.add 	$9=, $9, $pop30
-	i32.load	$11=, 0($10)
-	i32.const	$push29=, 4
-	i32.add 	$push0=, $10, $pop29
-	copy_local	$10=, $pop0
-	br      	1               # 1: up to label25
-.LBB9_5:                                # %verify.exit
-	end_block                       # label27:
+	i32.const	$push40=, .L.str.9
+	i32.store	0($12), $pop40
+	i32.const	$push39=, .L.str.1
+	i32.call	$drop=, printf@FUNCTION, $pop39, $12
+	i32.const	$push38=, 0
+	i32.const	$push37=, 0
+	i32.load	$push11=, errors($pop37)
+	i32.const	$push36=, 1
+	i32.add 	$push12=, $pop11, $pop36
+	i32.store	errors($pop38), $pop12
+# BB#7:                                 #   in Loop: Header=BB9_3 Depth=1
+	i32.const	$13=, 1
+	br      	4               # 4: up to label75
+.LBB9_8:                                # %for.inc.i
+                                        #   in Loop: Header=BB9_3 Depth=1
+	end_block                       # label79:
+	i32.const	$push41=, 10
+	i32.ne  	$push13=, $9, $pop41
+	br_if   	2, $pop13       # 2: down to label76
+# BB#9:                                 #   in Loop: Header=BB9_3 Depth=1
+	i32.const	$13=, 3
+	br      	3               # 3: up to label75
+.LBB9_10:                               # %verify.exit
+	end_block                       # label78:
+	i32.const	$push20=, 0
+	i32.const	$push18=, 64
+	i32.add 	$push19=, $12, $pop18
+	i32.store	__stack_pointer($pop20), $pop19
+	return
+.LBB9_11:                               #   in Loop: Header=BB9_3 Depth=1
+	end_block                       # label77:
+	i32.const	$13=, 1
+	br      	1               # 1: up to label75
+.LBB9_12:                               #   in Loop: Header=BB9_3 Depth=1
+	end_block                       # label76:
+	i32.const	$13=, 2
+	br      	0               # 0: up to label75
+.LBB9_13:
 	end_loop
-	i32.const	$push19=, 0
-	i32.const	$push17=, 64
-	i32.add 	$push18=, $12, $pop17
-	i32.store	__stack_pointer($pop19), $pop18
-                                        # fallthrough-return
 	.endfunc
 .Lfunc_end9:
 	.size	varargs8, .Lfunc_end9-varargs8
@@ -1024,15 +1384,15 @@ varargs8:                               # @varargs8
 	.type	varargs9,@function
 varargs9:                               # @varargs9
 	.param  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
-	.local  	i32, i32, i32
+	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push15=, 0
-	i32.const	$push12=, 0
-	i32.load	$push13=, __stack_pointer($pop12)
-	i32.const	$push14=, 64
-	i32.sub 	$push26=, $pop13, $pop14
-	tee_local	$push25=, $13=, $pop26
-	i32.store	__stack_pointer($pop15), $pop25
+	i32.const	$push16=, 0
+	i32.const	$push13=, 0
+	i32.load	$push14=, __stack_pointer($pop13)
+	i32.const	$push15=, 64
+	i32.sub 	$push29=, $pop14, $pop15
+	tee_local	$push28=, $13=, $pop29
+	i32.store	__stack_pointer($pop16), $pop28
 	i32.store	60($13), $10
 	i64.const	$push1=, 4294967296
 	i64.store	16($13), $pop1
@@ -1044,64 +1404,104 @@ varargs9:                               # @varargs9
 	i64.store	40($13), $pop4
 	i64.const	$push5=, 38654705672
 	i64.store	48($13), $pop5
-	i32.load	$push24=, 60($13)
-	tee_local	$push23=, $10=, $pop24
-	i32.const	$push22=, 4
-	i32.add 	$push6=, $pop23, $pop22
+	i32.load	$push27=, 60($13)
+	tee_local	$push26=, $10=, $pop27
+	i32.const	$push25=, 4
+	i32.add 	$push6=, $pop26, $pop25
 	i32.store	60($13), $pop6
 	i32.load	$push7=, 0($10)
 	i32.store	56($13), $pop7
-	i32.const	$push19=, 16
-	i32.add 	$push20=, $13, $pop19
-	i32.const	$push21=, 4
-	i32.or  	$11=, $pop20, $pop21
+	i32.const	$push20=, 16
+	i32.add 	$push21=, $13, $pop20
+	i32.const	$push24=, 4
+	i32.or  	$11=, $pop21, $pop24
 	i32.const	$12=, 0
 	i32.const	$10=, 0
-.LBB10_1:                               # %for.body.i
-                                        # =>This Inner Loop Header: Depth=1
-	loop    	                # label28:
 	block   	
-	i32.eq  	$push8=, $10, $12
-	br_if   	0, $pop8        # 0: down to label29
-# BB#2:                                 # %if.then.i
-                                        #   in Loop: Header=BB10_1 Depth=1
+	block   	
+	i32.const	$push23=, 0
+	i32.const	$push22=, 0
+	i32.ne  	$push8=, $pop23, $pop22
+	br_if   	0, $pop8        # 0: down to label83
+# BB#1:
+	i32.const	$14=, 1
+	br      	1               # 1: down to label82
+.LBB10_2:
+	end_block                       # label83:
+	i32.const	$14=, 0
+.LBB10_3:                               # =>This Inner Loop Header: Depth=1
+	end_block                       # label82:
+	loop    	                # label84:
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	block   	
+	br_table 	$14, 1, 2, 0, 3, 3 # 1: down to label89
+                                        # 2: down to label88
+                                        # 0: down to label90
+                                        # 3: down to label87
+.LBB10_4:                               # %for.inc.i.for.body.i_crit_edge
+                                        #   in Loop: Header=BB10_3 Depth=1
+	end_block                       # label90:
+	i32.load	$12=, 0($11)
+	i32.const	$push33=, 4
+	i32.add 	$push0=, $11, $pop33
+	copy_local	$11=, $pop0
+	i32.const	$push32=, 1
+	i32.add 	$push31=, $10, $pop32
+	tee_local	$push30=, $10=, $pop31
+	i32.eq  	$push9=, $12, $pop30
+	br_if   	3, $pop9        # 3: down to label86
+# BB#5:                                 #   in Loop: Header=BB10_3 Depth=1
+	i32.const	$14=, 0
+	br      	5               # 5: up to label84
+.LBB10_6:                               # %if.then.i
+                                        #   in Loop: Header=BB10_3 Depth=1
+	end_block                       # label89:
 	i32.store	12($13), $10
 	i32.store	8($13), $12
 	i32.store	4($13), $10
-	i32.const	$push33=, .L.str.10
-	i32.store	0($13), $pop33
-	i32.const	$push32=, .L.str.1
-	i32.call	$drop=, printf@FUNCTION, $pop32, $13
-	i32.const	$push31=, 0
-	i32.const	$push30=, 0
-	i32.load	$push9=, errors($pop30)
-	i32.const	$push29=, 1
-	i32.add 	$push10=, $pop9, $pop29
-	i32.store	errors($pop31), $pop10
-.LBB10_3:                               # %for.inc.i
-                                        #   in Loop: Header=BB10_1 Depth=1
-	end_block                       # label29:
-	block   	
-	i32.const	$push34=, 10
-	i32.eq  	$push11=, $10, $pop34
-	br_if   	0, $pop11       # 0: down to label30
-# BB#4:                                 # %for.inc.i.for.body.i_crit_edge
-                                        #   in Loop: Header=BB10_1 Depth=1
-	i32.const	$push28=, 1
-	i32.add 	$10=, $10, $pop28
-	i32.load	$12=, 0($11)
-	i32.const	$push27=, 4
-	i32.add 	$push0=, $11, $pop27
-	copy_local	$11=, $pop0
-	br      	1               # 1: up to label28
-.LBB10_5:                               # %verify.exit
-	end_block                       # label30:
+	i32.const	$push38=, .L.str.10
+	i32.store	0($13), $pop38
+	i32.const	$push37=, .L.str.1
+	i32.call	$drop=, printf@FUNCTION, $pop37, $13
+	i32.const	$push36=, 0
+	i32.const	$push35=, 0
+	i32.load	$push10=, errors($pop35)
+	i32.const	$push34=, 1
+	i32.add 	$push11=, $pop10, $pop34
+	i32.store	errors($pop36), $pop11
+# BB#7:                                 #   in Loop: Header=BB10_3 Depth=1
+	i32.const	$14=, 1
+	br      	4               # 4: up to label84
+.LBB10_8:                               # %for.inc.i
+                                        #   in Loop: Header=BB10_3 Depth=1
+	end_block                       # label88:
+	i32.const	$push39=, 10
+	i32.ne  	$push12=, $10, $pop39
+	br_if   	2, $pop12       # 2: down to label85
+# BB#9:                                 #   in Loop: Header=BB10_3 Depth=1
+	i32.const	$14=, 3
+	br      	3               # 3: up to label84
+.LBB10_10:                              # %verify.exit
+	end_block                       # label87:
+	i32.const	$push19=, 0
+	i32.const	$push17=, 64
+	i32.add 	$push18=, $13, $pop17
+	i32.store	__stack_pointer($pop19), $pop18
+	return
+.LBB10_11:                              #   in Loop: Header=BB10_3 Depth=1
+	end_block                       # label86:
+	i32.const	$14=, 1
+	br      	1               # 1: up to label84
+.LBB10_12:                              #   in Loop: Header=BB10_3 Depth=1
+	end_block                       # label85:
+	i32.const	$14=, 2
+	br      	0               # 0: up to label84
+.LBB10_13:
 	end_loop
-	i32.const	$push18=, 0
-	i32.const	$push16=, 64
-	i32.add 	$push17=, $13, $pop16
-	i32.store	__stack_pointer($pop18), $pop17
-                                        # fallthrough-return
 	.endfunc
 .Lfunc_end10:
 	.size	varargs9, .Lfunc_end10-varargs9
@@ -1170,7 +1570,7 @@ errors:
 	.size	.L.str.10, 9
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "
 	.functype	abort, void
 	.functype	exit, void, i32
 	.functype	printf, i32, i32

--- a/test/torture-s/zerolen-2.c.s
+++ b/test/torture-s/zerolen-2.c.s
@@ -1,5 +1,5 @@
 	.text
-	.file	"/usr/local/google/home/dschuff/s/wasm-waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/zerolen-2.c"
+	.file	"/usr/local/google/home/jgravelle/code/wasm/waterfall/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/zerolen-2.c"
 	.section	.text.main,"ax",@progbits
 	.hidden	main
 	.globl	main
@@ -14,4 +14,4 @@ main:                                   # @main
 	.size	main, .Lfunc_end0-main
 
 
-	.ident	"clang version 4.0.0 (trunk 283460) (llvm/trunk 283507)"
+	.ident	"clang version 4.0.0 "


### PR DESCRIPTION
https://reviews.llvm.org/D25708 fixed call_indirect for 0xc by
reordering the operands. s2wasm needs to be aware of that too.