### PR TITLE
Code pushing

### DIFF
--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -102,10 +102,10 @@ struct DirectCallGraphAnalyzer : public PostWalker<DirectCallGraphAnalyzer, Visi
 struct EffectAnalyzer : public PostWalker<EffectAnalyzer, Visitor<EffectAnalyzer>> {
   EffectAnalyzer() {}
   EffectAnalyzer(Expression *ast) {
-    scan(ast);
+    analyze(ast);
   }
 
-  void scan(Expression *ast) {
+  void analyze(Expression *ast) {
     breakNames.clear();
     walk(ast);
     // if we are left with breaks, they are external

--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -102,6 +102,11 @@ struct DirectCallGraphAnalyzer : public PostWalker<DirectCallGraphAnalyzer, Visi
 struct EffectAnalyzer : public PostWalker<EffectAnalyzer, Visitor<EffectAnalyzer>> {
   EffectAnalyzer() {}
   EffectAnalyzer(Expression *ast) {
+    scan(ast);
+  }
+
+  void scan(Expression *ast) {
+    breakNames.clear();
     walk(ast);
     // if we are left with breaks, they are external
     if (breakNames.size() > 0) branches = true;
@@ -149,6 +154,17 @@ struct EffectAnalyzer : public PostWalker<EffectAnalyzer, Visitor<EffectAnalyzer
       if (other.globalsWritten.count(global)) return true;
     }
     return false;
+  }
+
+  void mergeIn(EffectAnalyzer& other) {
+    branches = branches || other.branches;
+    calls = calls || other.calls;
+    readsMemory = readsMemory || other.readsMemory;
+    writesMemory = writesMemory || other.writesMemory;
+    for (auto i : other.localsRead) localsRead.insert(i);
+    for (auto i : other.localsWritten) localsWritten.insert(i);
+    for (auto i : other.globalsRead) globalsRead.insert(i);
+    for (auto i : other.globalsWritten) globalsWritten.insert(i);
   }
 
   // the checks above happen after the node's children were processed, in the order of execution

--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -1,6 +1,7 @@
 SET(passes_SOURCES
   pass.cpp
   CoalesceLocals.cpp
+  CodePushing.cpp
   DeadCodeElimination.cpp
   DuplicateFunctionElimination.cpp
   ExtractFunction.cpp

--- a/src/passes/CodePushing.cpp
+++ b/src/passes/CodePushing.cpp
@@ -165,6 +165,9 @@ private:
           // no point in looking further
           break;
         }
+      } else {
+        // something that can't be pushed, so it might block further pushing
+        cumulativeEffects.analyze(list[i]);
       }
       assert(i > 0);
       i--;

--- a/src/passes/CodePushing.cpp
+++ b/src/passes/CodePushing.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Pushes code "forward" as much as possible, potentially into
+// a location behind a condition, where it might not always execute.
+//
+
+#include <wasm.h>
+#include <pass.h>
+#include <ast_utils.h>
+#include <wasm-builder.h>
+
+namespace wasm {
+
+//
+// Analyzers some useful local properties: # of sets and gets, and SFA.
+//
+// Single First Assignment (SFA) form: the local has a single set_local, is
+// not a parameter, and has no get_locals before the set_local in postorder.
+// This is a much weaker property than SSA, obviously, but together with
+// our implicit dominance properties in the structured AST is quite useful.
+//
+struct LocalAnalyzer : public PostWalker<LocalAnalyzer, Visitor<LocalAnalyzer>> {
+  std::vector<bool> sfa;
+  std::vector<Index> numSets;
+  std::vector<Index> numGets;
+
+  void scan(Function* func) {
+    auto num = func->getNumLocals();
+    numSets.resize(num);
+    std::fill(numSets.begin(), numSets.end(), 0);
+    numGets.resize(num);
+    std::fill(numGets.begin(), numGets.end(), 0);
+    sfa.resize(num);
+    std::fill(sfa.begin(), sfa.begin() + func->getNumParams(), false);
+    std::fill(sfa.begin() + func->getNumParams(), sfa.end(), true);
+    walk(func->body);
+    for (Index i = 0; i < num; i++) {
+      if (numSets[i] == 0) sfa[i] = false;
+    }
+  }
+
+  bool isSFA(Index i) {
+    return sfa[i];
+  }
+
+  Index getNumGets(Index i) {
+    return numGets[i];
+  }
+
+  void visitGetLocal(GetLocal *curr) {
+    if (numSets[curr->index] == 0) {
+      sfa[curr->index] = false;
+    }
+    numGets[curr->index]++;
+  }
+
+  void visitSetLocal(SetLocal *curr) {
+    numSets[curr->index]++;
+    if (numSets[curr->index] > 1) {
+      sfa[curr->index] = false;
+    }
+  }
+};
+
+// Implement core optimization logic in a struct, used and then discarded entirely
+// for each block
+class Pusher {
+  ExpressionList& list;
+  SFAAnalyzer& analyzer;
+  std::vector<Index>& numGetsSoFar;
+
+public:
+  Pusher(Block* block, SFAAnalyzer& analyzer, std::vector<Index>& numGetsSoFar) : list(block->list), analyzer(analyzer), numGetsSoFar(numGetsSoFar), {
+    // Find an optimization segment: from the first pushable thing, to the first
+    // point past which we want to push. We then push in that range before
+    // continuing forward.
+    Index relevant = list.size() - 1; // we never need to push past a final element, as
+                                      // we couldn't be used after it.
+    Index i = 0;
+    Index firstPushable = -1;
+    while (i < relevant) {
+      if (firstPushable == -1 && isPushable(list[i])) {
+        firstPushable = i;
+        i++;
+        continue;
+      }
+      if (firstPushable != -1 && isPushPoint(list[i])) {
+        // optimize this segment, and proceed from where it tells us
+        i = optimizeSegment(firstPushable, i);
+        firstPushable = -1;
+        continue;
+      }
+      i++;
+    }
+  }
+
+private:
+  SetLocal* isPushable(Expression* curr) {
+    auto* set = curr->dynCast<SetLocal>();
+    if (!set) return nullptr;
+    auto index = set->index;
+    return analyzer.isSFA(index) && numGetsSoFar[index] == analyzer.getNumGets(index) ? set : nullptr;
+  }
+
+  // Push past conditional control flow.
+  // TODO: push into ifs as well
+  bool isPushPoint(Expression* curr) {
+    // look through drops
+    if (auto* drop = curr->dynCast<Drop>()) {
+      curr = drop->value;
+    }
+    if (curr->is<If>()) return true;
+    if (auto* br = curr->dynCast<Break>()) {
+      return !!br->condition;
+    }
+    return false;
+  }
+
+  Index optimizeSegment(Index firstPushable, Index pushPoint) {
+    // The interesting part. Starting at firstPushable, try to push
+    // code past pushPoint. We start at the end since we are pushing
+    // forward, that way we can push later things out of the way
+    // of earlier ones. Once we know all we can push, we push it all
+    // in one pass, keeping the order of the pushables intact.
+    assert(firstPushable != -1 && pushPoint != -1 && firstPushable < pushPoint);
+    EffectAnalyzer cumulativeEffects; // everything that matters if you want
+                                      // to be pushed past the pushPoint
+    cumulativeEffects.scan(list[pushPoint]);
+    cumulativeEffects.branches = false; // it is ok to ignore the branching here,
+                                        // that is the crucial point of this opt
+    std::vector<SetLocal*> toPush;
+    Index i = pushPoint - 1;
+    while (1) {
+      auto* pushable = isPushable(list[i]);
+      if (pushable) {
+        auto* iter = pushableEffects.find(pushable);
+        if (iter == pushableEffects.end()) {
+          pushableEffects.emplace(pushable, pushable);
+        }
+        auto& effects = pushableEffects[pushable];
+        if (cumulativeEffects.invalidates(effects)) {
+          // we can't push this, so further pushables must pass it
+          cumulativeEffects.mergeIn(effects);
+        } else {
+          // we can push this, great!
+          toPush.push_back(pushable);
+        }
+        if (i == firstPushable) {
+          // no point in looking further
+          break;
+        }
+      }
+      assert(i > 0);
+      i--;
+    }
+    if (toPush.size() == 0) {
+      // nothing to do, can only continue after the push point
+      return pushPoint + 1;
+    }
+    // we have work to do!
+    Index last = toPush.size() - 1;
+    Index skip = 0;
+    for (Index i = firstPushable; i <= pushPoint; i++) {
+      // we see the first elements at the end of toPush
+      if (list[i] == toPush[last - skip]) {
+        // this is one of our elements to push, skip it
+        skip++;
+      }
+      if (skip) {
+        list[i] = list[i + skip];
+      }
+    }
+  }
+
+  // Pushables may need to be scanned more than once, so cache their effects.
+  set::unordered_map<SetLocal*, EffectAnalyzer> pushableEffects;
+};
+
+struct CodePushing : public WalkerPass<PostWalker<CodePushing, Visitor<CodePushing>>> {
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new CodePushing; }
+
+  LocalAnalyzer analyzer;
+
+  // gets seen so far in the main traversal
+  std::vector<Index> numGetsSoFar;
+
+  void doWalkFunction(Function* func) {
+    // pre-scan to find which vars are sfa, and also count their gets&sets
+    analyzer.scan(func);
+    // prepare to walk
+    numGetsSoFar.resize(func->getNumLocals());
+    std::fill(numGetsSoFar.begin(), numGetsSoFar.end(), 0);
+    // walk and optimize
+    walk(func->body);
+  }
+
+  void visitGetLocal(GetLocal *curr) {
+    numGetsSoFar[curr->index]++;
+  }
+
+  void visitBlock(Block* curr) {
+    // Pushing code only makes sense if we are size 3 or above: we need
+    // one element to push, an element to push it past, and an element to use
+    // what we pushed.
+    if (curr->list.size() < 3) return;
+    // At this point in the postorder traversal we have gone through all our children.
+    // Therefore any variable whose gets seen so far is equal to the total gets must
+    // have no further users after this block. And therefore when we see an SFA
+    // variable defined here, we know it isn't used before it either, and has just this
+    // one assign. So we can push it forward while we don't hit a non-control-flow
+    // ordering invalidation issue, since if this isn't a loop, it's fine (we're not
+    // used outside), and if it is, we hit the assign before any use (as we can't
+    // push it past a use).
+    Pusher pusher(curr, analyzer, numGetsSoFar);
+  }
+};
+
+Pass *createCodePushingPass() {
+  return new CodePushing();
+}
+
+} // namespace wasm
+

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -107,6 +107,7 @@ void PassRunner::addDefaultFunctionOptimizationPasses() {
   add("remove-unused-names");
   add("optimize-instructions");
   add("precompute");
+  add("code-pushing");
   add("simplify-locals");
   add("vacuum"); // previous pass creates garbage
   add("reorder-locals");

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -107,7 +107,9 @@ void PassRunner::addDefaultFunctionOptimizationPasses() {
   add("remove-unused-names");
   add("optimize-instructions");
   add("precompute");
-  add("code-pushing");
+  if (optimizeLevel >= 2 || shrinkLevel >= 2) {
+    add("code-pushing");
+  }
   add("simplify-locals");
   add("vacuum"); // previous pass creates garbage
   add("reorder-locals");

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -65,6 +65,7 @@ std::string PassRegistry::getPassDescription(std::string name) {
 void PassRegistry::registerPasses() {
   registerPass("coalesce-locals", "reduce # of locals by coalescing", createCoalesceLocalsPass);
   registerPass("coalesce-locals-learning", "reduce # of locals by coalescing and learning", createCoalesceLocalsWithLearningPass);
+  registerPass("code-pushing", "push code forward, potentially making it not always execute", createCodePushingPass);
   registerPass("dce", "removes unreachable code", createDeadCodeEliminationPass);
   registerPass("duplicate-function-elimination", "removes duplicate functions", createDuplicateFunctionEliminationPass);
   registerPass("extract-function", "leaves just one function (useful for debugging)", createExtractFunctionPass);

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -107,7 +107,7 @@ void PassRunner::addDefaultFunctionOptimizationPasses() {
   add("remove-unused-names");
   add("optimize-instructions");
   add("precompute");
-  if (optimizeLevel >= 2 || shrinkLevel >= 2) {
+  if (options.optimizeLevel >= 2 || options.shrinkLevel >= 2) {
     add("code-pushing");
   }
   add("simplify-locals");

--- a/src/passes/passes.h
+++ b/src/passes/passes.h
@@ -24,6 +24,7 @@ class Pass;
 // All passes:
 Pass *createCoalesceLocalsPass();
 Pass *createCoalesceLocalsWithLearningPass();
+Pass *createCodePushingPass();
 Pass *createDeadCodeEliminationPass();
 Pass *createDuplicateFunctionEliminationPass();
 Pass *createExtractFunctionPass();

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -8237,23 +8237,20 @@
           (i32.const 5)
         )
         (block
-          (set_local $4
-            (tee_local $3
-              (i32.load
-                (tee_local $5
-                  (i32.add
-                    (get_local $2)
-                    (i32.const 20)
-                  )
-                )
-              )
-            )
-          )
           (if
             (i32.lt_u
               (i32.sub
                 (get_local $6)
-                (get_local $3)
+                (tee_local $3
+                  (i32.load
+                    (tee_local $5
+                      (i32.add
+                        (get_local $2)
+                        (i32.const 20)
+                      )
+                    )
+                  )
+                )
               )
               (get_local $1)
             )
@@ -8276,6 +8273,9 @@
               )
               (br $label$break$L5)
             )
+          )
+          (set_local $4
+            (get_local $3)
           )
           (set_local $1
             (block $label$break$L10 i32
@@ -9124,7 +9124,6 @@
     (local $3 i32)
     (local $4 i32)
     (local $5 i32)
-    (local $6 i32)
     (set_local $4
       (i32.add
         (get_local $0)
@@ -9137,36 +9136,10 @@
         (i32.const 20)
       )
       (block
-        (set_local $5
-          (i32.or
-            (i32.or
-              (i32.or
-                (tee_local $1
-                  (i32.and
-                    (get_local $1)
-                    (i32.const 255)
-                  )
-                )
-                (i32.shl
-                  (get_local $1)
-                  (i32.const 8)
-                )
-              )
-              (i32.shl
-                (get_local $1)
-                (i32.const 16)
-              )
-            )
-            (i32.shl
-              (get_local $1)
-              (i32.const 24)
-            )
-          )
-        )
-        (set_local $6
+        (set_local $1
           (i32.and
-            (get_local $4)
-            (i32.const -4)
+            (get_local $1)
+            (i32.const 255)
           )
         )
         (if
@@ -9209,16 +9182,43 @@
             )
           )
         )
+        (set_local $3
+          (i32.or
+            (i32.or
+              (i32.or
+                (get_local $1)
+                (i32.shl
+                  (get_local $1)
+                  (i32.const 8)
+                )
+              )
+              (i32.shl
+                (get_local $1)
+                (i32.const 16)
+              )
+            )
+            (i32.shl
+              (get_local $1)
+              (i32.const 24)
+            )
+          )
+        )
+        (set_local $5
+          (i32.and
+            (get_local $4)
+            (i32.const -4)
+          )
+        )
         (loop $while-in1
           (if
             (i32.lt_s
               (get_local $0)
-              (get_local $6)
+              (get_local $5)
             )
             (block
               (i32.store
                 (get_local $0)
-                (get_local $5)
+                (get_local $3)
               )
               (set_local $0
                 (i32.add

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -8235,23 +8235,20 @@
           (i32.const 5)
         )
         (block
-          (set_local $4
-            (tee_local $3
-              (i32.load
-                (tee_local $5
-                  (i32.add
-                    (get_local $2)
-                    (i32.const 20)
-                  )
-                )
-              )
-            )
-          )
           (if
             (i32.lt_u
               (i32.sub
                 (get_local $6)
-                (get_local $3)
+                (tee_local $3
+                  (i32.load
+                    (tee_local $5
+                      (i32.add
+                        (get_local $2)
+                        (i32.const 20)
+                      )
+                    )
+                  )
+                )
               )
               (get_local $1)
             )
@@ -8274,6 +8271,9 @@
               )
               (br $label$break$L5)
             )
+          )
+          (set_local $4
+            (get_local $3)
           )
           (set_local $1
             (block $label$break$L10 i32
@@ -9122,7 +9122,6 @@
     (local $3 i32)
     (local $4 i32)
     (local $5 i32)
-    (local $6 i32)
     (set_local $4
       (i32.add
         (get_local $0)
@@ -9135,36 +9134,10 @@
         (i32.const 20)
       )
       (block
-        (set_local $5
-          (i32.or
-            (i32.or
-              (i32.or
-                (tee_local $1
-                  (i32.and
-                    (get_local $1)
-                    (i32.const 255)
-                  )
-                )
-                (i32.shl
-                  (get_local $1)
-                  (i32.const 8)
-                )
-              )
-              (i32.shl
-                (get_local $1)
-                (i32.const 16)
-              )
-            )
-            (i32.shl
-              (get_local $1)
-              (i32.const 24)
-            )
-          )
-        )
-        (set_local $6
+        (set_local $1
           (i32.and
-            (get_local $4)
-            (i32.const -4)
+            (get_local $1)
+            (i32.const 255)
           )
         )
         (if
@@ -9207,16 +9180,43 @@
             )
           )
         )
+        (set_local $3
+          (i32.or
+            (i32.or
+              (i32.or
+                (get_local $1)
+                (i32.shl
+                  (get_local $1)
+                  (i32.const 8)
+                )
+              )
+              (i32.shl
+                (get_local $1)
+                (i32.const 16)
+              )
+            )
+            (i32.shl
+              (get_local $1)
+              (i32.const 24)
+            )
+          )
+        )
+        (set_local $5
+          (i32.and
+            (get_local $4)
+            (i32.const -4)
+          )
+        )
         (loop $while-in1
           (if
             (i32.lt_s
               (get_local $0)
-              (get_local $6)
+              (get_local $5)
             )
             (block
               (i32.store
                 (get_local $0)
-                (get_local $5)
+                (get_local $3)
               )
               (set_local $0
                 (i32.add

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -798,7 +798,8 @@
     (local $12 i32)
     (local $13 i32)
     (local $14 i32)
-    (set_local $7
+    (local $15 i32)
+    (set_local $8
       (get_global $STACKTOP)
     )
     (set_global $STACKTOP
@@ -814,25 +815,25 @@
       )
       (call $abort)
     )
-    (set_local $8
+    (set_local $9
       (i32.add
-        (get_local $7)
+        (get_local $8)
         (i32.const 16)
       )
     )
-    (set_local $9
-      (get_local $7)
+    (set_local $10
+      (get_local $8)
     )
     (i32.store
       (tee_local $3
         (i32.add
-          (get_local $7)
+          (get_local $8)
           (i32.const 32)
         )
       )
-      (tee_local $5
+      (tee_local $4
         (i32.load
-          (tee_local $6
+          (tee_local $7
             (i32.add
               (get_local $0)
               (i32.const 28)
@@ -843,17 +844,17 @@
     )
     (i32.store offset=4
       (get_local $3)
-      (tee_local $4
+      (tee_local $6
         (i32.sub
           (i32.load
-            (tee_local $10
+            (tee_local $11
               (i32.add
                 (get_local $0)
                 (i32.const 20)
               )
             )
           )
-          (get_local $5)
+          (get_local $4)
         )
       )
     )
@@ -865,13 +866,13 @@
       (get_local $3)
       (get_local $2)
     )
-    (set_local $13
+    (set_local $14
       (i32.add
         (get_local $0)
         (i32.const 60)
       )
     )
-    (set_local $14
+    (set_local $15
       (i32.add
         (get_local $0)
         (i32.const 44)
@@ -880,12 +881,12 @@
     (set_local $1
       (get_local $3)
     )
-    (set_local $5
+    (set_local $4
       (i32.const 2)
     )
-    (set_local $11
+    (set_local $12
       (i32.add
-        (get_local $4)
+        (get_local $6)
         (get_local $2)
       )
     )
@@ -896,8 +897,8 @@
             (loop $while-in
               (br_if $jumpthreading$inner$0
                 (i32.eq
-                  (get_local $11)
-                  (tee_local $4
+                  (get_local $12)
+                  (tee_local $5
                     (if i32
                       (i32.load
                         (i32.const 16)
@@ -908,24 +909,24 @@
                           (get_local $0)
                         )
                         (i32.store
-                          (get_local $9)
+                          (get_local $10)
                           (i32.load
-                            (get_local $13)
+                            (get_local $14)
                           )
                         )
                         (i32.store offset=4
-                          (get_local $9)
+                          (get_local $10)
                           (get_local $1)
                         )
                         (i32.store offset=8
-                          (get_local $9)
-                          (get_local $5)
+                          (get_local $10)
+                          (get_local $4)
                         )
                         (set_local $3
                           (call $___syscall_ret
                             (call $___syscall146
                               (i32.const 146)
-                              (get_local $9)
+                              (get_local $10)
                             )
                           )
                         )
@@ -936,23 +937,23 @@
                       )
                       (block i32
                         (i32.store
-                          (get_local $8)
+                          (get_local $9)
                           (i32.load
-                            (get_local $13)
+                            (get_local $14)
                           )
                         )
                         (i32.store offset=4
-                          (get_local $8)
+                          (get_local $9)
                           (get_local $1)
                         )
                         (i32.store offset=8
-                          (get_local $8)
-                          (get_local $5)
+                          (get_local $9)
+                          (get_local $4)
                         )
                         (call $___syscall_ret
                           (call $___syscall146
                             (i32.const 146)
-                            (get_local $8)
+                            (get_local $9)
                           )
                         )
                       )
@@ -962,22 +963,16 @@
               )
               (br_if $jumpthreading$inner$1
                 (i32.lt_s
-                  (get_local $4)
+                  (get_local $5)
                   (i32.const 0)
                 )
               )
               (block
-                (set_local $11
-                  (i32.sub
-                    (get_local $11)
-                    (get_local $4)
-                  )
-                )
                 (set_local $1
                   (if i32
                     (i32.gt_u
-                      (get_local $4)
-                      (tee_local $12
+                      (get_local $5)
+                      (tee_local $13
                         (i32.load offset=4
                           (get_local $1)
                         )
@@ -985,21 +980,21 @@
                     )
                     (block i32
                       (i32.store
-                        (get_local $6)
+                        (get_local $7)
                         (tee_local $3
                           (i32.load
-                            (get_local $14)
+                            (get_local $15)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $10)
+                        (get_local $11)
                         (get_local $3)
                       )
-                      (set_local $4
+                      (set_local $6
                         (i32.sub
-                          (get_local $4)
-                          (get_local $12)
+                          (get_local $5)
+                          (get_local $13)
                         )
                       )
                       (set_local $3
@@ -1008,9 +1003,9 @@
                           (i32.const 8)
                         )
                       )
-                      (set_local $5
+                      (set_local $4
                         (i32.add
-                          (get_local $5)
+                          (get_local $4)
                           (i32.const -1)
                         )
                       )
@@ -1020,32 +1015,38 @@
                     )
                     (if i32
                       (i32.eq
-                        (get_local $5)
+                        (get_local $4)
                         (i32.const 2)
                       )
                       (block i32
                         (i32.store
-                          (get_local $6)
+                          (get_local $7)
                           (i32.add
                             (i32.load
-                              (get_local $6)
+                              (get_local $7)
                             )
-                            (get_local $4)
+                            (get_local $5)
                           )
                         )
+                        (set_local $6
+                          (get_local $5)
+                        )
                         (set_local $3
                           (get_local $1)
                         )
-                        (set_local $5
+                        (set_local $4
                           (i32.const 2)
                         )
-                        (get_local $12)
+                        (get_local $13)
                       )
                       (block i32
+                        (set_local $6
+                          (get_local $5)
+                        )
                         (set_local $3
                           (get_local $1)
                         )
-                        (get_local $12)
+                        (get_local $13)
                       )
                     )
                   )
@@ -1056,18 +1057,24 @@
                     (i32.load
                       (get_local $3)
                     )
-                    (get_local $4)
+                    (get_local $6)
                   )
                 )
                 (i32.store offset=4
                   (get_local $3)
                   (i32.sub
                     (get_local $1)
-                    (get_local $4)
+                    (get_local $6)
                   )
                 )
                 (set_local $1
                   (get_local $3)
+                )
+                (set_local $12
+                  (i32.sub
+                    (get_local $12)
+                    (get_local $5)
+                  )
                 )
                 (br $while-in)
               )
@@ -1078,7 +1085,7 @@
             (i32.add
               (tee_local $1
                 (i32.load
-                  (get_local $14)
+                  (get_local $15)
                 )
               )
               (i32.load offset=48
@@ -1087,13 +1094,13 @@
             )
           )
           (i32.store
-            (get_local $6)
+            (get_local $7)
             (tee_local $0
               (get_local $1)
             )
           )
           (i32.store
-            (get_local $10)
+            (get_local $11)
             (get_local $0)
           )
           (br $jumpthreading$outer$1
@@ -1105,11 +1112,11 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $6)
+          (get_local $7)
           (i32.const 0)
         )
         (i32.store
-          (get_local $10)
+          (get_local $11)
           (i32.const 0)
         )
         (i32.store
@@ -1130,14 +1137,14 @@
             )
           )
           (i32.eq
-            (get_local $5)
+            (get_local $4)
             (i32.const 2)
           )
         )
       )
     )
     (set_global $STACKTOP
-      (get_local $7)
+      (get_local $8)
     )
     (get_local $0)
   )
@@ -1235,7 +1242,7 @@
         )
         (i32.const -1)
         (block i32
-          (set_local $14
+          (set_local $4
             (if i32
               (i32.gt_s
                 (i32.load offset=76
@@ -1249,14 +1256,9 @@
               (i32.const 0)
             )
           )
-          (set_local $4
-            (i32.and
-              (tee_local $2
-                (i32.load
-                  (get_local $0)
-                )
-              )
-              (i32.const 32)
+          (set_local $10
+            (i32.load
+              (get_local $0)
             )
           )
           (if
@@ -1269,166 +1271,169 @@
             (i32.store
               (get_local $0)
               (i32.and
-                (get_local $2)
+                (get_local $10)
                 (i32.const -33)
               )
             )
           )
-          (set_local $1
-            (select
-              (i32.const -1)
-              (if i32
-                (i32.load
-                  (tee_local $10
-                    (i32.add
-                      (get_local $0)
-                      (i32.const 48)
-                    )
-                  )
-                )
-                (call $_printf_core
-                  (get_local $0)
-                  (get_local $1)
-                  (get_local $5)
-                  (get_local $7)
-                  (get_local $8)
-                )
-                (block i32
-                  (set_local $12
-                    (i32.load
-                      (tee_local $11
-                        (i32.add
-                          (get_local $0)
-                          (i32.const 44)
-                        )
-                      )
-                    )
-                  )
-                  (i32.store
-                    (get_local $11)
-                    (get_local $6)
-                  )
-                  (i32.store
-                    (tee_local $9
-                      (i32.add
-                        (get_local $0)
-                        (i32.const 28)
-                      )
-                    )
-                    (get_local $6)
-                  )
-                  (i32.store
-                    (tee_local $13
-                      (i32.add
-                        (get_local $0)
-                        (i32.const 20)
-                      )
-                    )
-                    (get_local $6)
-                  )
-                  (i32.store
-                    (get_local $10)
-                    (i32.const 80)
-                  )
-                  (i32.store
-                    (tee_local $2
-                      (i32.add
-                        (get_local $0)
-                        (i32.const 16)
-                      )
-                    )
-                    (i32.add
-                      (get_local $6)
-                      (i32.const 80)
-                    )
-                  )
-                  (set_local $1
-                    (call $_printf_core
-                      (get_local $0)
-                      (get_local $1)
-                      (get_local $5)
-                      (get_local $7)
-                      (get_local $8)
-                    )
-                  )
-                  (if i32
-                    (get_local $12)
-                    (block i32
-                      (drop
-                        (call_indirect $FUNCSIG$iiii
-                          (get_local $0)
-                          (i32.const 0)
-                          (i32.const 0)
-                          (i32.add
-                            (i32.and
-                              (i32.load offset=36
-                                (get_local $0)
-                              )
-                              (i32.const 7)
-                            )
-                            (i32.const 2)
-                          )
-                        )
-                      )
-                      (set_local $1
-                        (select
-                          (get_local $1)
-                          (i32.const -1)
-                          (i32.load
-                            (get_local $13)
-                          )
-                        )
-                      )
-                      (i32.store
-                        (get_local $11)
-                        (get_local $12)
-                      )
-                      (i32.store
-                        (get_local $10)
-                        (i32.const 0)
-                      )
-                      (i32.store
-                        (get_local $2)
-                        (i32.const 0)
-                      )
-                      (i32.store
-                        (get_local $9)
-                        (i32.const 0)
-                      )
-                      (i32.store
-                        (get_local $13)
-                        (i32.const 0)
-                      )
-                      (get_local $1)
-                    )
-                    (get_local $1)
+          (set_local $2
+            (if i32
+              (i32.load
+                (tee_local $11
+                  (i32.add
+                    (get_local $0)
+                    (i32.const 48)
                   )
                 )
               )
-              (i32.and
-                (tee_local $2
+              (call $_printf_core
+                (get_local $0)
+                (get_local $1)
+                (get_local $5)
+                (get_local $7)
+                (get_local $8)
+              )
+              (block i32
+                (set_local $13
                   (i32.load
-                    (get_local $0)
+                    (tee_local $12
+                      (i32.add
+                        (get_local $0)
+                        (i32.const 44)
+                      )
+                    )
                   )
                 )
-                (i32.const 32)
+                (i32.store
+                  (get_local $12)
+                  (get_local $6)
+                )
+                (i32.store
+                  (tee_local $9
+                    (i32.add
+                      (get_local $0)
+                      (i32.const 28)
+                    )
+                  )
+                  (get_local $6)
+                )
+                (i32.store
+                  (tee_local $14
+                    (i32.add
+                      (get_local $0)
+                      (i32.const 20)
+                    )
+                  )
+                  (get_local $6)
+                )
+                (i32.store
+                  (get_local $11)
+                  (i32.const 80)
+                )
+                (i32.store
+                  (tee_local $2
+                    (i32.add
+                      (get_local $0)
+                      (i32.const 16)
+                    )
+                  )
+                  (i32.add
+                    (get_local $6)
+                    (i32.const 80)
+                  )
+                )
+                (set_local $1
+                  (call $_printf_core
+                    (get_local $0)
+                    (get_local $1)
+                    (get_local $5)
+                    (get_local $7)
+                    (get_local $8)
+                  )
+                )
+                (if i32
+                  (get_local $13)
+                  (block i32
+                    (drop
+                      (call_indirect $FUNCSIG$iiii
+                        (get_local $0)
+                        (i32.const 0)
+                        (i32.const 0)
+                        (i32.add
+                          (i32.and
+                            (i32.load offset=36
+                              (get_local $0)
+                            )
+                            (i32.const 7)
+                          )
+                          (i32.const 2)
+                        )
+                      )
+                    )
+                    (set_local $1
+                      (select
+                        (get_local $1)
+                        (i32.const -1)
+                        (i32.load
+                          (get_local $14)
+                        )
+                      )
+                    )
+                    (i32.store
+                      (get_local $12)
+                      (get_local $13)
+                    )
+                    (i32.store
+                      (get_local $11)
+                      (i32.const 0)
+                    )
+                    (i32.store
+                      (get_local $2)
+                      (i32.const 0)
+                    )
+                    (i32.store
+                      (get_local $9)
+                      (i32.const 0)
+                    )
+                    (i32.store
+                      (get_local $14)
+                      (i32.const 0)
+                    )
+                    (get_local $1)
+                  )
+                  (get_local $1)
+                )
               )
             )
           )
           (i32.store
             (get_local $0)
             (i32.or
-              (get_local $2)
-              (get_local $4)
+              (tee_local $1
+                (i32.load
+                  (get_local $0)
+                )
+              )
+              (i32.and
+                (get_local $10)
+                (i32.const 32)
+              )
             )
           )
           (if
-            (get_local $14)
+            (get_local $4)
             (call $___unlockfile
               (get_local $0)
             )
           )
-          (get_local $1)
+          (select
+            (i32.const -1)
+            (get_local $2)
+            (i32.and
+              (get_local $1)
+              (i32.const 32)
+            )
+          )
         )
       )
     )
@@ -1474,23 +1479,20 @@
         )
         (br $label$break$L5)
       )
-      (set_local $6
-        (tee_local $4
-          (i32.load
-            (tee_local $5
-              (i32.add
-                (get_local $2)
-                (i32.const 20)
-              )
-            )
-          )
-        )
-      )
       (if
         (i32.lt_u
           (i32.sub
             (get_local $3)
-            (get_local $4)
+            (tee_local $6
+              (i32.load
+                (tee_local $5
+                  (i32.add
+                    (get_local $2)
+                    (i32.const 20)
+                  )
+                )
+              )
+            )
           )
           (get_local $1)
         )
@@ -2353,7 +2355,8 @@
     (local $53 i32)
     (local $54 i32)
     (local $55 i32)
-    (set_local $25
+    (local $56 i32)
+    (set_local $26
       (get_global $STACKTOP)
     )
     (set_global $STACKTOP
@@ -2371,31 +2374,31 @@
     )
     (set_local $20
       (i32.add
-        (get_local $25)
+        (get_local $26)
         (i32.const 16)
       )
     )
     (set_local $18
-      (get_local $25)
+      (get_local $26)
     )
-    (set_local $41
+    (set_local $40
       (i32.add
-        (get_local $25)
+        (get_local $26)
         (i32.const 528)
       )
     )
-    (set_local $32
+    (set_local $31
       (i32.ne
         (get_local $0)
         (i32.const 0)
       )
     )
-    (set_local $45
+    (set_local $44
       (tee_local $23
         (i32.add
           (tee_local $9
             (i32.add
-              (get_local $25)
+              (get_local $26)
               (i32.const 536)
             )
           )
@@ -2403,87 +2406,87 @@
         )
       )
     )
-    (set_local $46
+    (set_local $45
       (i32.add
         (get_local $9)
         (i32.const 39)
       )
     )
-    (set_local $50
+    (set_local $49
       (i32.add
-        (tee_local $47
+        (tee_local $46
           (i32.add
-            (get_local $25)
+            (get_local $26)
             (i32.const 8)
           )
         )
         (i32.const 4)
       )
     )
-    (set_local $38
+    (set_local $37
       (i32.add
         (tee_local $9
           (i32.add
-            (get_local $25)
+            (get_local $26)
             (i32.const 576)
           )
         )
         (i32.const 12)
       )
     )
-    (set_local $48
+    (set_local $47
       (i32.add
         (get_local $9)
         (i32.const 11)
       )
     )
-    (set_local $51
+    (set_local $50
       (i32.sub
         (tee_local $30
-          (get_local $38)
+          (get_local $37)
         )
-        (tee_local $42
+        (tee_local $41
           (tee_local $24
             (i32.add
-              (get_local $25)
+              (get_local $26)
               (i32.const 588)
             )
           )
         )
       )
     )
-    (set_local $52
+    (set_local $51
       (i32.sub
         (i32.const -2)
-        (get_local $42)
+        (get_local $41)
       )
     )
-    (set_local $53
+    (set_local $52
       (i32.add
         (get_local $30)
         (i32.const 2)
       )
     )
-    (set_local $55
+    (set_local $54
       (i32.add
-        (tee_local $54
+        (tee_local $53
           (i32.add
-            (get_local $25)
+            (get_local $26)
             (i32.const 24)
           )
         )
         (i32.const 288)
       )
     )
-    (set_local $49
-      (tee_local $33
+    (set_local $48
+      (tee_local $32
         (i32.add
           (get_local $24)
           (i32.const 9)
         )
       )
     )
-    (set_local $39
+    (set_local $38
       (i32.add
         (get_local $24)
         (i32.const 8)
@@ -2538,7 +2541,7 @@
               (i32.eqz
                 (i32.shr_s
                   (i32.shl
-                    (tee_local $7
+                    (tee_local $6
                       (i32.load8_s
                         (get_local $9)
                       )
@@ -2561,7 +2564,7 @@
                         (i32.sub
                           (i32.shr_s
                             (i32.shl
-                              (get_local $7)
+                              (get_local $6)
                               (i32.const 24)
                             )
                             (i32.const 24)
@@ -2570,26 +2573,26 @@
                         )
                       )
                     )
-                    (set_local $40
+                    (set_local $39
                       (get_local $5)
                     )
-                    (set_local $43
+                    (set_local $42
                       (get_local $5)
                     )
-                    (set_local $26
+                    (set_local $27
                       (i32.const 9)
                     )
                     (br $label$break$L9)
                   )
-                  (set_local $27
+                  (set_local $28
                     (get_local $5)
                   )
-                  (set_local $34
+                  (set_local $33
                     (get_local $5)
                   )
                   (br $label$break$L9)
                 )
-                (set_local $7
+                (set_local $6
                   (i32.load8_s
                     (tee_local $5
                       (i32.add
@@ -2605,42 +2608,42 @@
             (block $label$break$L12
               (if
                 (i32.eq
-                  (get_local $26)
+                  (get_local $27)
                   (i32.const 9)
                 )
                 (loop $while-in
-                  (set_local $26
+                  (set_local $27
                     (i32.const 0)
                   )
                   (if
                     (i32.ne
                       (i32.load8_s offset=1
-                        (get_local $40)
+                        (get_local $39)
                       )
                       (i32.const 37)
                     )
                     (block
-                      (set_local $27
-                        (get_local $40)
+                      (set_local $28
+                        (get_local $39)
                       )
-                      (set_local $34
-                        (get_local $43)
+                      (set_local $33
+                        (get_local $42)
                       )
                       (br $label$break$L12)
                     )
                   )
-                  (set_local $34
+                  (set_local $33
                     (i32.add
-                      (get_local $43)
+                      (get_local $42)
                       (i32.const 1)
                     )
                   )
                   (if
                     (i32.eq
                       (i32.load8_s
-                        (tee_local $27
+                        (tee_local $28
                           (i32.add
-                            (get_local $40)
+                            (get_local $39)
                             (i32.const 2)
                           )
                         )
@@ -2648,11 +2651,11 @@
                       (i32.const 37)
                     )
                     (block
-                      (set_local $40
-                        (get_local $27)
+                      (set_local $39
+                        (get_local $28)
                       )
-                      (set_local $43
-                        (get_local $34)
+                      (set_local $42
+                        (get_local $33)
                       )
                       (br $while-in)
                     )
@@ -2660,14 +2663,14 @@
                 )
               )
             )
-            (set_local $7
+            (set_local $6
               (i32.sub
-                (get_local $34)
+                (get_local $33)
                 (get_local $9)
               )
             )
             (if
-              (get_local $32)
+              (get_local $31)
               (if
                 (i32.eqz
                   (i32.and
@@ -2680,7 +2683,7 @@
                 (drop
                   (call $___fwritex
                     (get_local $9)
-                    (get_local $7)
+                    (get_local $6)
                     (get_local $0)
                   )
                 )
@@ -2688,15 +2691,15 @@
             )
             (if
               (i32.ne
-                (get_local $34)
+                (get_local $33)
                 (get_local $9)
               )
               (block
                 (set_local $9
-                  (get_local $27)
+                  (get_local $28)
                 )
                 (set_local $5
-                  (get_local $7)
+                  (get_local $6)
                 )
                 (br $label$continue$L1)
               )
@@ -2708,11 +2711,11 @@
                     (i32.add
                       (i32.shr_s
                         (i32.shl
-                          (tee_local $6
+                          (tee_local $7
                             (i32.load8_s
                               (tee_local $5
                                 (i32.add
-                                  (get_local $27)
+                                  (get_local $28)
                                   (i32.const 1)
                                 )
                               )
@@ -2728,19 +2731,19 @@
                   (i32.const 10)
                 )
                 (block i32
-                  (set_local $6
+                  (set_local $7
                     (i32.load8_s
                       (tee_local $5
                         (select
                           (i32.add
-                            (get_local $27)
+                            (get_local $28)
                             (i32.const 3)
                           )
                           (get_local $5)
                           (tee_local $12
                             (i32.eq
                               (i32.load8_s offset=2
-                                (get_local $27)
+                                (get_local $28)
                               )
                               (i32.const 36)
                             )
@@ -2777,7 +2780,7 @@
                     (tee_local $12
                       (i32.shr_s
                         (i32.shl
-                          (get_local $6)
+                          (get_local $7)
                           (i32.const 24)
                         )
                         (i32.const 24)
@@ -2789,9 +2792,9 @@
                 )
                 (block
                   (set_local $1
-                    (get_local $6)
+                    (get_local $7)
                   )
-                  (set_local $6
+                  (set_local $7
                     (i32.const 0)
                   )
                   (loop $while-in4
@@ -2809,7 +2812,7 @@
                         )
                       )
                     )
-                    (set_local $6
+                    (set_local $7
                       (i32.or
                         (i32.shl
                           (i32.const 1)
@@ -2824,7 +2827,7 @@
                             (i32.const -32)
                           )
                         )
-                        (get_local $6)
+                        (get_local $7)
                       )
                     )
                     (br_if $while-in4
@@ -2857,9 +2860,9 @@
                 )
                 (block
                   (set_local $1
-                    (get_local $6)
+                    (get_local $7)
                   )
-                  (set_local $6
+                  (set_local $7
                     (i32.const 0)
                   )
                 )
@@ -2946,7 +2949,7 @@
                           (i32.const 1)
                         )
                       )
-                      (set_local $26
+                      (set_local $27
                         (i32.const 0)
                       )
                       (if
@@ -2960,11 +2963,11 @@
                       )
                       (if
                         (i32.eqz
-                          (get_local $32)
+                          (get_local $31)
                         )
                         (block
                           (set_local $12
-                            (get_local $6)
+                            (get_local $7)
                           )
                           (set_local $5
                             (get_local $1)
@@ -3020,11 +3023,11 @@
                           )
                         )
                         (i32.or
-                          (get_local $6)
+                          (get_local $7)
                           (i32.const 8192)
                         )
                       )
-                      (get_local $6)
+                      (get_local $7)
                     )
                   )
                 )
@@ -3102,7 +3105,7 @@
                       )
                       (block
                         (set_local $12
-                          (get_local $6)
+                          (get_local $7)
                         )
                         (set_local $1
                           (get_local $8)
@@ -3112,7 +3115,7 @@
                   )
                   (block
                     (set_local $12
-                      (get_local $6)
+                      (get_local $7)
                     )
                     (set_local $1
                       (get_local $8)
@@ -3138,7 +3141,7 @@
                       (i32.ne
                         (i32.shr_s
                           (i32.shl
-                            (tee_local $6
+                            (tee_local $7
                               (i32.load8_s
                                 (tee_local $8
                                   (i32.add
@@ -3157,11 +3160,11 @@
                       (block
                         (if
                           (i32.lt_u
-                            (tee_local $6
+                            (tee_local $7
                               (i32.add
                                 (i32.shr_s
                                   (i32.shl
-                                    (get_local $6)
+                                    (get_local $7)
                                     (i32.const 24)
                                   )
                                   (i32.const 24)
@@ -3180,7 +3183,7 @@
                             )
                           )
                           (block
-                            (set_local $6
+                            (set_local $7
                               (i32.const 0)
                             )
                             (br $label$break$L46
@@ -3189,13 +3192,13 @@
                           )
                         )
                         (loop $while-in11
-                          (set_local $6
+                          (set_local $7
                             (i32.add
                               (i32.mul
                                 (get_local $8)
                                 (i32.const 10)
                               )
-                              (get_local $6)
+                              (get_local $7)
                             )
                           )
                           (if
@@ -3217,9 +3220,9 @@
                             )
                             (block
                               (set_local $8
-                                (get_local $6)
+                                (get_local $7)
                               )
-                              (set_local $6
+                              (set_local $7
                                 (get_local $10)
                               )
                               (br $while-in11)
@@ -3233,7 +3236,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (tee_local $6
+                        (tee_local $7
                           (i32.add
                             (i32.load8_s
                               (tee_local $8
@@ -3260,13 +3263,13 @@
                             (i32.add
                               (get_local $4)
                               (i32.shl
-                                (get_local $6)
+                                (get_local $7)
                                 (i32.const 2)
                               )
                             )
                             (i32.const 10)
                           )
-                          (set_local $6
+                          (set_local $7
                             (i32.add
                               (get_local $3)
                               (i32.shl
@@ -3280,9 +3283,9 @@
                               )
                             )
                           )
-                          (set_local $6
+                          (set_local $7
                             (i32.load
-                              (get_local $6)
+                              (get_local $7)
                             )
                           )
                           (br $label$break$L46
@@ -3304,9 +3307,9 @@
                       )
                     )
                     (if i32
-                      (get_local $32)
+                      (get_local $31)
                       (block i32
-                        (set_local $6
+                        (set_local $7
                           (i32.load
                             (tee_local $5
                               (i32.and
@@ -3331,7 +3334,7 @@
                         (get_local $8)
                       )
                       (block i32
-                        (set_local $6
+                        (set_local $7
                           (i32.const 0)
                         )
                         (get_local $8)
@@ -3339,7 +3342,7 @@
                     )
                   )
                   (block i32
-                    (set_local $6
+                    (set_local $7
                       (i32.const -1)
                     )
                     (get_local $5)
@@ -3506,7 +3509,7 @@
                     )
                     (if
                       (i32.eqz
-                        (get_local $32)
+                        (get_local $31)
                       )
                       (block
                         (set_local $16
@@ -3524,19 +3527,19 @@
                 )
                 (br $jumpthreading$outer$1)
               )
-              (set_local $26
+              (set_local $27
                 (i32.const 0)
               )
               (if
                 (i32.eqz
-                  (get_local $32)
+                  (get_local $31)
                 )
                 (block
                   (set_local $9
                     (get_local $5)
                   )
                   (set_local $5
-                    (get_local $7)
+                    (get_local $6)
                   )
                   (br $label$continue$L1)
                 )
@@ -3579,7 +3582,7 @@
                                                   (block $switch-case27
                                                     (br_table $switch-case42 $switch-default120 $switch-case40 $switch-default120 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case29 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case42 $switch-default120 $switch-case37 $switch-case34 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-case34 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case29 $switch-default120
                                                       (i32.sub
-                                                        (tee_local $17
+                                                        (tee_local $13
                                                           (select
                                                             (i32.and
                                                               (tee_local $11
@@ -3634,7 +3637,7 @@
                                                                   (get_local $5)
                                                                 )
                                                                 (set_local $5
-                                                                  (get_local $7)
+                                                                  (get_local $6)
                                                                 )
                                                                 (br $label$continue$L1)
                                                               )
@@ -3648,7 +3651,7 @@
                                                                 (get_local $5)
                                                               )
                                                               (set_local $5
-                                                                (get_local $7)
+                                                                (get_local $6)
                                                               )
                                                               (br $label$continue$L1)
                                                             )
@@ -3677,7 +3680,7 @@
                                                               (get_local $5)
                                                             )
                                                             (set_local $5
-                                                              (get_local $7)
+                                                              (get_local $6)
                                                             )
                                                             (br $label$continue$L1)
                                                           )
@@ -3691,7 +3694,7 @@
                                                             (get_local $5)
                                                           )
                                                           (set_local $5
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                           )
                                                           (br $label$continue$L1)
                                                         )
@@ -3705,7 +3708,7 @@
                                                           (get_local $5)
                                                         )
                                                         (set_local $5
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                         )
                                                         (br $label$continue$L1)
                                                       )
@@ -3719,7 +3722,7 @@
                                                         (get_local $5)
                                                       )
                                                       (set_local $5
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                       )
                                                       (br $label$continue$L1)
                                                     )
@@ -3748,7 +3751,7 @@
                                                       (get_local $5)
                                                     )
                                                     (set_local $5
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                     )
                                                     (br $label$continue$L1)
                                                   )
@@ -3756,7 +3759,7 @@
                                                     (get_local $5)
                                                   )
                                                   (set_local $5
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (br $label$continue$L1)
                                                 )
@@ -3766,17 +3769,17 @@
                                                     (i32.const 8)
                                                   )
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (select
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const 8)
                                                     (i32.gt_u
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.const 8)
                                                     )
                                                   )
                                                 )
-                                                (set_local $17
+                                                (set_local $13
                                                   (i32.const 120)
                                                 )
                                                 (br $jumpthreading$inner$2)
@@ -3789,7 +3792,7 @@
                                             (if
                                               (i32.and
                                                 (i32.eqz
-                                                  (tee_local $7
+                                                  (tee_local $6
                                                     (i32.load
                                                       (tee_local $9
                                                         (get_local $18)
@@ -3810,9 +3813,9 @@
                                               )
                                               (block
                                                 (set_local $9
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
-                                                (set_local $7
+                                                (set_local $6
                                                   (get_local $8)
                                                 )
                                                 (set_local $8
@@ -3841,13 +3844,13 @@
                                                           (tee_local $9
                                                             (call $_bitshift64Lshr
                                                               (get_local $9)
-                                                              (get_local $7)
+                                                              (get_local $6)
                                                               (i32.const 3)
                                                             )
                                                           )
                                                         )
                                                         (i32.eqz
-                                                          (tee_local $7
+                                                          (tee_local $6
                                                             (get_global $tempRet0)
                                                           )
                                                         )
@@ -3863,26 +3866,26 @@
                                                 (i32.const 8)
                                               )
                                               (block
-                                                (set_local $7
+                                                (set_local $6
                                                   (get_local $8)
                                                 )
                                                 (set_local $9
                                                   (get_local $12)
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (select
                                                     (tee_local $12
                                                       (i32.add
                                                         (i32.sub
-                                                          (get_local $45)
+                                                          (get_local $44)
                                                           (get_local $8)
                                                         )
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.lt_s
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (get_local $12)
                                                     )
                                                   )
@@ -3896,7 +3899,7 @@
                                                 (br $jumpthreading$inner$7)
                                               )
                                               (block
-                                                (set_local $7
+                                                (set_local $6
                                                   (get_local $8)
                                                 )
                                                 (set_local $9
@@ -3914,16 +3917,16 @@
                                           )
                                           (set_local $9
                                             (i32.load
-                                              (tee_local $7
+                                              (tee_local $6
                                                 (get_local $18)
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_s
-                                              (tee_local $7
+                                              (tee_local $6
                                                 (i32.load offset=4
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                               (i32.const 0)
@@ -3938,13 +3941,13 @@
                                                     (i32.const 0)
                                                     (i32.const 0)
                                                     (get_local $9)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                 )
                                               )
                                               (i32.store offset=4
                                                 (get_local $8)
-                                                (tee_local $7
+                                                (tee_local $6
                                                   (get_global $tempRet0)
                                                 )
                                               )
@@ -3993,14 +3996,14 @@
                                         )
                                         (set_local $9
                                           (i32.load
-                                            (tee_local $7
+                                            (tee_local $6
                                               (get_local $18)
                                             )
                                           )
                                         )
-                                        (set_local $7
+                                        (set_local $6
                                           (i32.load offset=4
-                                            (get_local $7)
+                                            (get_local $6)
                                           )
                                         )
                                         (set_local $8
@@ -4015,13 +4018,13 @@
                                         (get_local $18)
                                       )
                                       (i32.store8
-                                        (get_local $46)
+                                        (get_local $45)
                                         (i32.load
                                           (get_local $9)
                                         )
                                       )
-                                      (set_local $7
-                                        (get_local $46)
+                                      (set_local $6
+                                        (get_local $45)
                                       )
                                       (set_local $12
                                         (get_local $8)
@@ -4069,18 +4072,18 @@
                                   (get_local $18)
                                 )
                                 (i32.store
-                                  (get_local $47)
+                                  (get_local $46)
                                   (i32.load
                                     (get_local $9)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $50)
+                                  (get_local $49)
                                   (i32.const 0)
                                 )
                                 (i32.store
                                   (get_local $18)
-                                  (get_local $47)
+                                  (get_local $46)
                                 )
                                 (set_local $8
                                   (i32.const -1)
@@ -4088,10 +4091,10 @@
                                 (br $jumpthreading$inner$5)
                               )
                               (if
-                                (get_local $6)
+                                (get_local $7)
                                 (block
                                   (set_local $8
-                                    (get_local $6)
+                                    (get_local $7)
                                   )
                                   (br $jumpthreading$inner$5)
                                 )
@@ -4103,7 +4106,7 @@
                                     (i32.const 0)
                                     (get_local $12)
                                   )
-                                  (set_local $7
+                                  (set_local $6
                                     (i32.const 0)
                                   )
                                   (br $jumpthreading$inner$6)
@@ -4123,7 +4126,7 @@
                               (get_global $tempDoublePtr)
                               (get_local $15)
                             )
-                            (set_local $35
+                            (set_local $34
                               (if i32
                                 (i32.lt_s
                                   (i32.load offset=4
@@ -4132,7 +4135,7 @@
                                   (i32.const 0)
                                 )
                                 (block i32
-                                  (set_local $28
+                                  (set_local $29
                                     (i32.const 1)
                                   )
                                   (set_local $15
@@ -4148,13 +4151,13 @@
                                     (i32.const 2048)
                                   )
                                   (block i32
-                                    (set_local $28
+                                    (set_local $29
                                       (i32.const 1)
                                     )
                                     (i32.const 4111)
                                   )
                                   (block i32
-                                    (set_local $28
+                                    (set_local $29
                                       (tee_local $9
                                         (i32.and
                                           (get_local $12)
@@ -4229,9 +4232,9 @@
                                     )
                                     (if
                                       (i32.eq
-                                        (tee_local $13
+                                        (tee_local $17
                                           (i32.or
-                                            (get_local $17)
+                                            (get_local $13)
                                             (i32.const 32)
                                           )
                                         )
@@ -4241,36 +4244,30 @@
                                         (set_local $10
                                           (select
                                             (i32.add
-                                              (get_local $35)
+                                              (get_local $34)
                                               (i32.const 9)
                                             )
-                                            (get_local $35)
-                                            (tee_local $13
+                                            (get_local $34)
+                                            (tee_local $17
                                               (i32.and
-                                                (get_local $17)
+                                                (get_local $13)
                                                 (i32.const 32)
                                               )
                                             )
-                                          )
-                                        )
-                                        (set_local $11
-                                          (i32.or
-                                            (get_local $28)
-                                            (i32.const 2)
                                           )
                                         )
                                         (set_local $15
                                           (if f64
                                             (i32.or
                                               (i32.gt_u
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (i32.const 11)
                                               )
                                               (i32.eqz
                                                 (tee_local $5
                                                   (i32.sub
                                                     (i32.const 12)
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                 )
                                               )
@@ -4325,14 +4322,20 @@
                                             )
                                           )
                                         )
+                                        (set_local $11
+                                          (i32.or
+                                            (get_local $29)
+                                            (i32.const 2)
+                                          )
+                                        )
                                         (i32.store8
                                           (i32.add
-                                            (tee_local $7
+                                            (tee_local $6
                                               (if i32
                                                 (i32.eq
-                                                  (tee_local $7
+                                                  (tee_local $6
                                                     (call $_fmt_u
-                                                      (tee_local $7
+                                                      (tee_local $6
                                                         (select
                                                           (i32.sub
                                                             (i32.const 0)
@@ -4352,26 +4355,26 @@
                                                       (i32.shr_s
                                                         (i32.shl
                                                           (i32.lt_s
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                             (i32.const 0)
                                                           )
                                                           (i32.const 31)
                                                         )
                                                         (i32.const 31)
                                                       )
-                                                      (get_local $38)
+                                                      (get_local $37)
                                                     )
                                                   )
-                                                  (get_local $38)
+                                                  (get_local $37)
                                                 )
                                                 (block i32
                                                   (i32.store8
-                                                    (get_local $48)
+                                                    (get_local $47)
                                                     (i32.const 48)
                                                   )
-                                                  (get_local $48)
+                                                  (get_local $47)
                                                 )
-                                                (get_local $7)
+                                                (get_local $6)
                                               )
                                             )
                                             (i32.const -1)
@@ -4388,20 +4391,20 @@
                                           )
                                         )
                                         (i32.store8
-                                          (tee_local $7
+                                          (tee_local $6
                                             (i32.add
-                                              (get_local $7)
+                                              (get_local $6)
                                               (i32.const -2)
                                             )
                                           )
                                           (i32.add
-                                            (get_local $17)
+                                            (get_local $13)
                                             (i32.const 15)
                                           )
                                         )
-                                        (set_local $17
+                                        (set_local $13
                                           (i32.lt_s
-                                            (get_local $6)
+                                            (get_local $7)
                                             (i32.const 1)
                                           )
                                         )
@@ -4430,7 +4433,7 @@
                                                   (i32.const 4075)
                                                 )
                                               )
-                                              (get_local $13)
+                                              (get_local $17)
                                             )
                                           )
                                           (set_local $15
@@ -4455,7 +4458,7 @@
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (get_local $42)
+                                                    (get_local $41)
                                                   )
                                                   (i32.const 1)
                                                 )
@@ -4466,7 +4469,7 @@
                                                       (i32.and
                                                         (get_local $19)
                                                         (i32.and
-                                                          (get_local $17)
+                                                          (get_local $13)
                                                           (f64.eq
                                                             (get_local $15)
                                                             (f64.const 0)
@@ -4499,35 +4502,35 @@
                                           (get_local $0)
                                           (i32.const 32)
                                           (get_local $14)
-                                          (tee_local $6
+                                          (tee_local $7
                                             (i32.add
                                               (tee_local $8
                                                 (select
                                                   (i32.sub
                                                     (i32.add
-                                                      (get_local $53)
-                                                      (get_local $6)
+                                                      (get_local $52)
+                                                      (get_local $7)
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (i32.add
                                                     (i32.sub
-                                                      (get_local $51)
-                                                      (get_local $7)
+                                                      (get_local $50)
+                                                      (get_local $6)
                                                     )
                                                     (get_local $5)
                                                   )
                                                   (i32.and
                                                     (i32.ne
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.const 0)
                                                     )
                                                     (i32.lt_s
                                                       (i32.add
-                                                        (get_local $52)
+                                                        (get_local $51)
                                                         (get_local $5)
                                                       )
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                     )
                                                   )
                                                 )
@@ -4558,7 +4561,7 @@
                                           (get_local $0)
                                           (i32.const 48)
                                           (get_local $14)
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.xor
                                             (get_local $12)
                                             (i32.const 65536)
@@ -4567,7 +4570,7 @@
                                         (set_local $5
                                           (i32.sub
                                             (get_local $5)
-                                            (get_local $42)
+                                            (get_local $41)
                                           )
                                         )
                                         (if
@@ -4597,7 +4600,7 @@
                                               (tee_local $5
                                                 (i32.sub
                                                   (get_local $30)
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -4616,7 +4619,7 @@
                                           )
                                           (drop
                                             (call $___fwritex
-                                              (get_local $7)
+                                              (get_local $6)
                                               (get_local $5)
                                               (get_local $0)
                                             )
@@ -4626,7 +4629,7 @@
                                           (get_local $0)
                                           (i32.const 32)
                                           (get_local $14)
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.xor
                                             (get_local $12)
                                             (i32.const 8192)
@@ -4635,64 +4638,52 @@
                                         (br $do-once49
                                           (select
                                             (get_local $14)
-                                            (get_local $6)
+                                            (get_local $7)
                                             (i32.lt_s
-                                              (get_local $6)
+                                              (get_local $7)
                                               (get_local $14)
                                             )
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $19
+                                    (set_local $8
                                       (select
-                                        (i32.const 6)
-                                        (get_local $6)
+                                        (get_local $53)
+                                        (get_local $54)
                                         (i32.lt_s
-                                          (get_local $6)
-                                          (i32.const 0)
-                                        )
-                                      )
-                                    )
-                                    (set_local $31
-                                      (tee_local $8
-                                        (select
-                                          (get_local $54)
-                                          (get_local $55)
-                                          (i32.lt_s
-                                            (if i32
-                                              (get_local $5)
-                                              (block i32
-                                                (i32.store
-                                                  (get_local $20)
-                                                  (tee_local $5
-                                                    (i32.add
-                                                      (i32.load
-                                                        (get_local $20)
-                                                      )
-                                                      (i32.const -28)
+                                          (if i32
+                                            (get_local $5)
+                                            (block i32
+                                              (i32.store
+                                                (get_local $20)
+                                                (tee_local $5
+                                                  (i32.add
+                                                    (i32.load
+                                                      (get_local $20)
                                                     )
+                                                    (i32.const -28)
                                                   )
                                                 )
-                                                (set_local $15
-                                                  (f64.mul
-                                                    (get_local $21)
-                                                    (f64.const 268435456)
-                                                  )
-                                                )
-                                                (get_local $5)
                                               )
-                                              (block i32
-                                                (set_local $15
+                                              (set_local $15
+                                                (f64.mul
                                                   (get_local $21)
+                                                  (f64.const 268435456)
                                                 )
-                                                (i32.load
-                                                  (get_local $20)
-                                                )
+                                              )
+                                              (get_local $5)
+                                            )
+                                            (block i32
+                                              (set_local $15
+                                                (get_local $21)
+                                              )
+                                              (i32.load
+                                                (get_local $20)
                                               )
                                             )
-                                            (i32.const 0)
                                           )
+                                          (i32.const 0)
                                         )
                                       )
                                     )
@@ -4702,7 +4693,7 @@
                                     (loop $while-in60
                                       (i32.store
                                         (get_local $5)
-                                        (tee_local $7
+                                        (tee_local $6
                                           (call $f64-to-int
                                             (get_local $15)
                                           )
@@ -4721,7 +4712,7 @@
                                               (f64.sub
                                                 (get_local $15)
                                                 (f64.convert_u/i32
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                               (f64.const 1e9)
@@ -4733,7 +4724,7 @@
                                     )
                                     (if
                                       (i32.gt_s
-                                        (tee_local $6
+                                        (tee_local $10
                                           (i32.load
                                             (get_local $20)
                                           )
@@ -4741,51 +4732,51 @@
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $7
+                                        (set_local $6
                                           (get_local $8)
                                         )
                                         (loop $while-in62
-                                          (set_local $11
+                                          (set_local $19
                                             (select
                                               (i32.const 29)
-                                              (get_local $6)
+                                              (get_local $10)
                                               (i32.gt_s
-                                                (get_local $6)
+                                                (get_local $10)
                                                 (i32.const 29)
                                               )
                                             )
                                           )
-                                          (set_local $7
+                                          (set_local $6
                                             (block $do-once63 i32
                                               (if i32
                                                 (i32.lt_u
-                                                  (tee_local $6
+                                                  (tee_local $10
                                                     (i32.add
                                                       (get_local $5)
                                                       (i32.const -4)
                                                     )
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (block i32
-                                                  (set_local $10
+                                                  (set_local $11
                                                     (i32.const 0)
                                                   )
                                                   (loop $while-in66
-                                                    (set_local $29
+                                                    (set_local $25
                                                       (call $___uremdi3
-                                                        (tee_local $10
+                                                        (tee_local $11
                                                           (call $_i64Add
                                                             (call $_bitshift64Shl
                                                               (i32.load
-                                                                (get_local $6)
+                                                                (get_local $10)
                                                               )
                                                               (i32.const 0)
-                                                              (get_local $11)
+                                                              (get_local $19)
                                                             )
                                                             (get_global $tempRet0)
-                                                            (get_local $10)
+                                                            (get_local $11)
                                                             (i32.const 0)
                                                           )
                                                         )
@@ -4797,12 +4788,12 @@
                                                       )
                                                     )
                                                     (i32.store
-                                                      (get_local $6)
-                                                      (get_local $29)
+                                                      (get_local $10)
+                                                      (get_local $25)
                                                     )
-                                                    (set_local $10
+                                                    (set_local $11
                                                       (call $___udivdi3
-                                                        (get_local $10)
+                                                        (get_local $11)
                                                         (get_local $22)
                                                         (i32.const 1000000000)
                                                         (i32.const 0)
@@ -4810,34 +4801,34 @@
                                                     )
                                                     (br_if $while-in66
                                                       (i32.ge_u
-                                                        (tee_local $6
+                                                        (tee_local $10
                                                           (i32.add
-                                                            (get_local $6)
+                                                            (get_local $10)
                                                             (i32.const -4)
                                                           )
                                                         )
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                       )
                                                     )
                                                   )
                                                   (drop
                                                     (br_if $do-once63
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.eqz
-                                                        (get_local $10)
+                                                        (get_local $11)
                                                       )
                                                     )
                                                   )
                                                   (i32.store
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const -4)
                                                       )
                                                     )
-                                                    (get_local $10)
+                                                    (get_local $11)
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -4847,13 +4838,13 @@
                                               (br_if $while-out67
                                                 (i32.le_u
                                                   (get_local $5)
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                               (if
                                                 (i32.eqz
                                                   (i32.load
-                                                    (tee_local $6
+                                                    (tee_local $10
                                                       (i32.add
                                                         (get_local $5)
                                                         (i32.const -4)
@@ -4863,7 +4854,7 @@
                                                 )
                                                 (block
                                                   (set_local $5
-                                                    (get_local $6)
+                                                    (get_local $10)
                                                   )
                                                   (br $while-in68)
                                                 )
@@ -4872,46 +4863,56 @@
                                           )
                                           (i32.store
                                             (get_local $20)
-                                            (tee_local $6
+                                            (tee_local $10
                                               (i32.sub
                                                 (i32.load
                                                   (get_local $20)
                                                 )
-                                                (get_local $11)
+                                                (get_local $19)
                                               )
                                             )
                                           )
                                           (br_if $while-in62
                                             (i32.gt_s
-                                              (get_local $6)
+                                              (get_local $10)
                                               (i32.const 0)
                                             )
                                           )
                                           (block
-                                            (set_local $10
-                                              (get_local $6)
+                                            (set_local $11
+                                              (get_local $10)
                                             )
-                                            (set_local $6
+                                            (set_local $10
                                               (get_local $5)
                                             )
                                           )
                                         )
                                       )
                                       (block
-                                        (set_local $10
-                                          (get_local $6)
-                                        )
-                                        (set_local $7
-                                          (get_local $8)
+                                        (set_local $11
+                                          (get_local $10)
                                         )
                                         (set_local $6
+                                          (get_local $8)
+                                        )
+                                        (set_local $10
                                           (get_local $5)
+                                        )
+                                      )
+                                    )
+                                    (set_local $19
+                                      (select
+                                        (i32.const 6)
+                                        (get_local $7)
+                                        (i32.lt_s
+                                          (get_local $7)
+                                          (i32.const 0)
                                         )
                                       )
                                     )
                                     (if
                                       (i32.lt_s
-                                        (get_local $10)
+                                        (get_local $11)
                                         (i32.const 0)
                                       )
                                       (block
@@ -4927,46 +4928,46 @@
                                             (i32.const 1)
                                           )
                                         )
-                                        (set_local $29
+                                        (set_local $25
                                           (i32.eq
-                                            (get_local $13)
+                                            (get_local $17)
                                             (i32.const 102)
                                           )
                                         )
                                         (set_local $5
-                                          (get_local $6)
+                                          (get_local $10)
                                         )
                                         (loop $while-in70
                                           (set_local $11
                                             (select
                                               (i32.const 9)
-                                              (tee_local $6
+                                              (tee_local $7
                                                 (i32.sub
                                                   (i32.const 0)
-                                                  (get_local $10)
+                                                  (get_local $11)
                                                 )
                                               )
                                               (i32.gt_s
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (i32.const 9)
                                               )
                                             )
                                           )
-                                          (set_local $6
+                                          (set_local $10
                                             (select
                                               (i32.add
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (select
                                                     (get_local $8)
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (block $do-once71 i32
                                                         (if i32
                                                           (i32.lt_u
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                             (get_local $5)
                                                           )
                                                           (block i32
-                                                            (set_local $36
+                                                            (set_local $35
                                                               (i32.add
                                                                 (i32.shl
                                                                   (i32.const 1)
@@ -4975,7 +4976,7 @@
                                                                 (i32.const -1)
                                                               )
                                                             )
-                                                            (set_local $37
+                                                            (set_local $43
                                                               (i32.shr_u
                                                                 (i32.const 1000000000)
                                                                 (get_local $11)
@@ -4984,17 +4985,17 @@
                                                             (set_local $10
                                                               (i32.const 0)
                                                             )
-                                                            (set_local $6
-                                                              (get_local $7)
+                                                            (set_local $7
+                                                              (get_local $6)
                                                             )
                                                             (loop $while-in74
                                                               (i32.store
-                                                                (get_local $6)
+                                                                (get_local $7)
                                                                 (i32.add
                                                                   (i32.shr_u
-                                                                    (tee_local $44
+                                                                    (tee_local $36
                                                                       (i32.load
-                                                                        (get_local $6)
+                                                                        (get_local $7)
                                                                       )
                                                                     )
                                                                     (get_local $11)
@@ -5005,17 +5006,17 @@
                                                               (set_local $10
                                                                 (i32.mul
                                                                   (i32.and
-                                                                    (get_local $44)
                                                                     (get_local $36)
+                                                                    (get_local $35)
                                                                   )
-                                                                  (get_local $37)
+                                                                  (get_local $43)
                                                                 )
                                                               )
                                                               (br_if $while-in74
                                                                 (i32.lt_u
-                                                                  (tee_local $6
+                                                                  (tee_local $7
                                                                     (i32.add
-                                                                      (get_local $6)
+                                                                      (get_local $7)
                                                                       (i32.const 4)
                                                                     )
                                                                   )
@@ -5023,21 +5024,21 @@
                                                                 )
                                                               )
                                                             )
-                                                            (set_local $7
+                                                            (set_local $6
                                                               (select
-                                                                (get_local $7)
+                                                                (get_local $6)
                                                                 (i32.add
-                                                                  (get_local $7)
+                                                                  (get_local $6)
                                                                   (i32.const 4)
                                                                 )
                                                                 (i32.load
-                                                                  (get_local $7)
+                                                                  (get_local $6)
                                                                 )
                                                               )
                                                             )
                                                             (drop
                                                               (br_if $do-once71
-                                                                (get_local $7)
+                                                                (get_local $6)
                                                                 (i32.eqz
                                                                   (get_local $10)
                                                                 )
@@ -5053,22 +5054,22 @@
                                                                 (i32.const 4)
                                                               )
                                                             )
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                           )
                                                           (select
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                             (i32.add
-                                                              (get_local $7)
+                                                              (get_local $6)
                                                               (i32.const 4)
                                                             )
                                                             (i32.load
-                                                              (get_local $7)
+                                                              (get_local $6)
                                                             )
                                                           )
                                                         )
                                                       )
                                                     )
-                                                    (get_local $29)
+                                                    (get_local $25)
                                                   )
                                                 )
                                                 (i32.shl
@@ -5081,7 +5082,7 @@
                                                 (i32.shr_s
                                                   (i32.sub
                                                     (get_local $5)
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (i32.const 2)
                                                 )
@@ -5091,7 +5092,7 @@
                                           )
                                           (i32.store
                                             (get_local $20)
-                                            (tee_local $10
+                                            (tee_local $11
                                               (i32.add
                                                 (i32.load
                                                   (get_local $20)
@@ -5102,34 +5103,27 @@
                                           )
                                           (if
                                             (i32.lt_s
-                                              (get_local $10)
+                                              (get_local $11)
                                               (i32.const 0)
                                             )
                                             (block
                                               (set_local $5
-                                                (get_local $6)
+                                                (get_local $10)
                                               )
                                               (br $while-in70)
                                             )
-                                            (block
-                                              (set_local $5
-                                                (get_local $7)
-                                              )
-                                              (set_local $10
-                                                (get_local $6)
-                                              )
+                                            (set_local $5
+                                              (get_local $6)
                                             )
                                           )
                                         )
                                       )
-                                      (block
-                                        (set_local $5
-                                          (get_local $7)
-                                        )
-                                        (set_local $10
-                                          (get_local $6)
-                                        )
+                                      (set_local $5
+                                        (get_local $6)
                                       )
+                                    )
+                                    (set_local $22
+                                      (get_local $8)
                                     )
                                     (block $do-once75
                                       (if
@@ -5138,11 +5132,11 @@
                                           (get_local $10)
                                         )
                                         (block
-                                          (set_local $7
+                                          (set_local $6
                                             (i32.mul
                                               (i32.shr_s
                                                 (i32.sub
-                                                  (get_local $31)
+                                                  (get_local $22)
                                                   (get_local $5)
                                                 )
                                                 (i32.const 2)
@@ -5160,22 +5154,22 @@
                                               (i32.const 10)
                                             )
                                           )
-                                          (set_local $6
+                                          (set_local $7
                                             (i32.const 10)
                                           )
                                           (loop $while-in78
-                                            (set_local $7
+                                            (set_local $6
                                               (i32.add
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (i32.const 1)
                                               )
                                             )
                                             (br_if $while-in78
                                               (i32.ge_u
                                                 (get_local $11)
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (i32.mul
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const 10)
                                                   )
                                                 )
@@ -5183,23 +5177,23 @@
                                             )
                                           )
                                         )
-                                        (set_local $7
+                                        (set_local $6
                                           (i32.const 0)
                                         )
                                       )
                                     )
-                                    (set_local $13
+                                    (set_local $17
                                       (if i32
                                         (i32.lt_s
-                                          (tee_local $6
+                                          (tee_local $7
                                             (i32.add
                                               (i32.sub
                                                 (get_local $19)
                                                 (select
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (i32.const 0)
                                                   (i32.ne
-                                                    (get_local $13)
+                                                    (get_local $17)
                                                     (i32.const 102)
                                                   )
                                                 )
@@ -5207,15 +5201,15 @@
                                               (i32.shr_s
                                                 (i32.shl
                                                   (i32.and
-                                                    (tee_local $29
+                                                    (tee_local $35
                                                       (i32.ne
                                                         (get_local $19)
                                                         (i32.const 0)
                                                       )
                                                     )
-                                                    (tee_local $36
+                                                    (tee_local $43
                                                       (i32.eq
-                                                        (get_local $13)
+                                                        (get_local $17)
                                                         (i32.const 103)
                                                       )
                                                     )
@@ -5231,7 +5225,7 @@
                                               (i32.shr_s
                                                 (i32.sub
                                                   (get_local $10)
-                                                  (get_local $31)
+                                                  (get_local $22)
                                                 )
                                                 (i32.const 2)
                                               )
@@ -5241,35 +5235,23 @@
                                           )
                                         )
                                         (block i32
-                                          (set_local $6
-                                            (i32.add
-                                              (i32.add
-                                                (get_local $8)
-                                                (i32.const 4)
-                                              )
-                                              (i32.shl
+                                          (set_local $17
+                                            (call $i32s-div
+                                              (tee_local $7
                                                 (i32.add
-                                                  (call $i32s-div
-                                                    (tee_local $11
-                                                      (i32.add
-                                                        (get_local $6)
-                                                        (i32.const 9216)
-                                                      )
-                                                    )
-                                                    (i32.const 9)
-                                                  )
-                                                  (i32.const -1024)
+                                                  (get_local $7)
+                                                  (i32.const 9216)
                                                 )
-                                                (i32.const 2)
                                               )
+                                              (i32.const 9)
                                             )
                                           )
                                           (if
                                             (i32.lt_s
-                                              (tee_local $11
+                                              (tee_local $7
                                                 (i32.add
                                                   (call $i32s-rem
-                                                    (get_local $11)
+                                                    (get_local $7)
                                                     (i32.const 9)
                                                   )
                                                   (i32.const 1)
@@ -5278,21 +5260,21 @@
                                               (i32.const 9)
                                             )
                                             (block
-                                              (set_local $13
+                                              (set_local $11
                                                 (i32.const 10)
                                               )
                                               (loop $while-in80
-                                                (set_local $13
+                                                (set_local $11
                                                   (i32.mul
-                                                    (get_local $13)
+                                                    (get_local $11)
                                                     (i32.const 10)
                                                   )
                                                 )
                                                 (br_if $while-in80
                                                   (i32.ne
-                                                    (tee_local $11
+                                                    (tee_local $7
                                                       (i32.add
-                                                        (get_local $11)
+                                                        (get_local $7)
                                                         (i32.const 1)
                                                       )
                                                     )
@@ -5301,58 +5283,66 @@
                                                 )
                                               )
                                             )
-                                            (set_local $13
+                                            (set_local $11
                                               (i32.const 10)
+                                            )
+                                          )
+                                          (set_local $17
+                                            (call $i32u-rem
+                                              (tee_local $25
+                                                (i32.load
+                                                  (tee_local $7
+                                                    (i32.add
+                                                      (i32.add
+                                                        (get_local $8)
+                                                        (i32.const 4)
+                                                      )
+                                                      (i32.shl
+                                                        (i32.add
+                                                          (get_local $17)
+                                                          (i32.const -1024)
+                                                        )
+                                                        (i32.const 2)
+                                                      )
+                                                    )
+                                                  )
+                                                )
+                                              )
+                                              (get_local $11)
                                             )
                                           )
                                           (block $do-once81
                                             (if
                                               (i32.eqz
                                                 (i32.and
-                                                  (tee_local $37
+                                                  (tee_local $36
                                                     (i32.eq
                                                       (i32.add
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const 4)
                                                       )
                                                       (get_local $10)
                                                     )
                                                   )
                                                   (i32.eqz
-                                                    (tee_local $11
-                                                      (call $i32u-rem
-                                                        (tee_local $22
-                                                          (i32.load
-                                                            (get_local $6)
-                                                          )
-                                                        )
-                                                        (get_local $13)
-                                                      )
-                                                    )
+                                                    (get_local $17)
                                                   )
                                                 )
                                               )
                                               (block
-                                                (set_local $21
-                                                  (select
-                                                    (f64.const 9007199254740994)
-                                                    (f64.const 9007199254740992)
-                                                    (i32.and
-                                                      (call $i32u-div
-                                                        (get_local $22)
-                                                        (get_local $13)
-                                                      )
-                                                      (i32.const 1)
-                                                    )
+                                                (set_local $55
+                                                  (call $i32u-div
+                                                    (get_local $25)
+                                                    (get_local $11)
                                                   )
                                                 )
                                                 (set_local $15
                                                   (if f64
                                                     (i32.lt_u
-                                                      (get_local $11)
-                                                      (tee_local $44
+                                                      (get_local $17)
+                                                      (tee_local $56
                                                         (call $i32s-div
-                                                          (get_local $13)
+                                                          (get_local $11)
                                                           (i32.const 2)
                                                         )
                                                       )
@@ -5362,26 +5352,36 @@
                                                       (f64.const 1)
                                                       (f64.const 1.5)
                                                       (i32.and
-                                                        (get_local $37)
+                                                        (get_local $36)
                                                         (i32.eq
-                                                          (get_local $11)
-                                                          (get_local $44)
+                                                          (get_local $17)
+                                                          (get_local $56)
                                                         )
                                                       )
                                                     )
                                                   )
                                                 )
                                                 (set_local $21
+                                                  (select
+                                                    (f64.const 9007199254740994)
+                                                    (f64.const 9007199254740992)
+                                                    (i32.and
+                                                      (get_local $55)
+                                                      (i32.const 1)
+                                                    )
+                                                  )
+                                                )
+                                                (set_local $21
                                                   (block $do-once83 f64
                                                     (if f64
-                                                      (get_local $28)
+                                                      (get_local $29)
                                                       (block f64
                                                         (drop
                                                           (br_if $do-once83
                                                             (get_local $21)
                                                             (i32.ne
                                                               (i32.load8_s
-                                                                (get_local $35)
+                                                                (get_local $34)
                                                               )
                                                               (i32.const 45)
                                                             )
@@ -5401,11 +5401,11 @@
                                                   )
                                                 )
                                                 (i32.store
-                                                  (get_local $6)
-                                                  (tee_local $11
+                                                  (get_local $7)
+                                                  (tee_local $17
                                                     (i32.sub
-                                                      (get_local $22)
-                                                      (get_local $11)
+                                                      (get_local $25)
+                                                      (get_local $17)
                                                     )
                                                   )
                                                 )
@@ -5419,30 +5419,30 @@
                                                   )
                                                 )
                                                 (i32.store
-                                                  (get_local $6)
-                                                  (tee_local $7
+                                                  (get_local $7)
+                                                  (tee_local $6
                                                     (i32.add
+                                                      (get_local $17)
                                                       (get_local $11)
-                                                      (get_local $13)
                                                     )
                                                   )
                                                 )
                                                 (if
                                                   (i32.gt_u
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 999999999)
                                                   )
                                                   (loop $while-in86
                                                     (i32.store
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.const 0)
                                                     )
                                                     (set_local $5
                                                       (if i32
                                                         (i32.lt_u
-                                                          (tee_local $6
+                                                          (tee_local $7
                                                             (i32.add
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                               (i32.const -4)
                                                             )
                                                           )
@@ -5464,11 +5464,11 @@
                                                       )
                                                     )
                                                     (i32.store
-                                                      (get_local $6)
-                                                      (tee_local $7
+                                                      (get_local $7)
+                                                      (tee_local $6
                                                         (i32.add
                                                           (i32.load
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                           )
                                                           (i32.const 1)
                                                         )
@@ -5476,17 +5476,17 @@
                                                     )
                                                     (br_if $while-in86
                                                       (i32.gt_u
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const 999999999)
                                                       )
                                                     )
                                                   )
                                                 )
-                                                (set_local $7
+                                                (set_local $6
                                                   (i32.mul
                                                     (i32.shr_s
                                                       (i32.sub
-                                                        (get_local $31)
+                                                        (get_local $22)
                                                         (get_local $5)
                                                       )
                                                       (i32.const 2)
@@ -5496,7 +5496,7 @@
                                                 )
                                                 (br_if $do-once81
                                                   (i32.lt_u
-                                                    (tee_local $13
+                                                    (tee_local $17
                                                       (i32.load
                                                         (get_local $5)
                                                       )
@@ -5508,15 +5508,15 @@
                                                   (i32.const 10)
                                                 )
                                                 (loop $while-in88
-                                                  (set_local $7
+                                                  (set_local $6
                                                     (i32.add
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 1)
                                                     )
                                                   )
                                                   (br_if $while-in88
                                                     (i32.ge_u
-                                                      (get_local $13)
+                                                      (get_local $17)
                                                       (tee_local $11
                                                         (i32.mul
                                                           (get_local $11)
@@ -5530,20 +5530,20 @@
                                             )
                                           )
                                           (set_local $11
-                                            (get_local $7)
+                                            (get_local $6)
                                           )
                                           (set_local $10
                                             (select
-                                              (tee_local $7
+                                              (tee_local $6
                                                 (i32.add
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (i32.const 4)
                                                 )
                                               )
                                               (get_local $10)
                                               (i32.gt_u
                                                 (get_local $10)
-                                                (get_local $7)
+                                                (get_local $6)
                                               )
                                             )
                                           )
@@ -5551,13 +5551,13 @@
                                         )
                                         (block i32
                                           (set_local $11
-                                            (get_local $7)
+                                            (get_local $6)
                                           )
                                           (get_local $5)
                                         )
                                       )
                                     )
-                                    (set_local $37
+                                    (set_local $36
                                       (i32.sub
                                         (i32.const 0)
                                         (get_local $11)
@@ -5571,10 +5571,10 @@
                                         (if
                                           (i32.le_u
                                             (get_local $5)
-                                            (get_local $13)
+                                            (get_local $17)
                                           )
                                           (block
-                                            (set_local $22
+                                            (set_local $25
                                               (i32.const 0)
                                             )
                                             (set_local $10
@@ -5585,7 +5585,7 @@
                                         )
                                         (if
                                           (i32.load
-                                            (tee_local $7
+                                            (tee_local $6
                                               (i32.add
                                                 (get_local $5)
                                                 (i32.const -4)
@@ -5593,7 +5593,7 @@
                                             )
                                           )
                                           (block
-                                            (set_local $22
+                                            (set_local $25
                                               (i32.const 1)
                                             )
                                             (set_local $10
@@ -5602,19 +5602,19 @@
                                           )
                                           (block
                                             (set_local $5
-                                              (get_local $7)
+                                              (get_local $6)
                                             )
                                             (br $while-in90)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $17
+                                    (set_local $13
                                       (block $do-once91 i32
                                         (if i32
-                                          (get_local $36)
+                                          (get_local $43)
                                           (block i32
-                                            (set_local $17
+                                            (set_local $13
                                               (if i32
                                                 (i32.and
                                                   (i32.gt_s
@@ -5622,7 +5622,7 @@
                                                       (i32.add
                                                         (i32.xor
                                                           (i32.and
-                                                            (get_local $29)
+                                                            (get_local $35)
                                                             (i32.const 1)
                                                           )
                                                           (i32.const 1)
@@ -5638,9 +5638,9 @@
                                                   )
                                                 )
                                                 (block i32
-                                                  (set_local $7
+                                                  (set_local $6
                                                     (i32.add
-                                                      (get_local $17)
+                                                      (get_local $13)
                                                       (i32.const -1)
                                                     )
                                                   )
@@ -5653,9 +5653,9 @@
                                                   )
                                                 )
                                                 (block i32
-                                                  (set_local $7
+                                                  (set_local $6
                                                     (i32.add
-                                                      (get_local $17)
+                                                      (get_local $13)
                                                       (i32.const -2)
                                                     )
                                                   )
@@ -5667,7 +5667,7 @@
                                               )
                                             )
                                             (if
-                                              (tee_local $6
+                                              (tee_local $7
                                                 (i32.and
                                                   (get_local $12)
                                                   (i32.const 8)
@@ -5675,16 +5675,16 @@
                                               )
                                               (block
                                                 (set_local $5
-                                                  (get_local $17)
+                                                  (get_local $13)
                                                 )
                                                 (br $do-once91
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                             )
                                             (block $do-once93
                                               (if
-                                                (get_local $22)
+                                                (get_local $25)
                                                 (block
                                                   (if
                                                     (i32.eqz
@@ -5716,7 +5716,7 @@
                                                       (br $do-once93)
                                                     )
                                                     (block
-                                                      (set_local $6
+                                                      (set_local $7
                                                         (i32.const 10)
                                                       )
                                                       (set_local $5
@@ -5735,9 +5735,9 @@
                                                       (i32.eqz
                                                         (call $i32u-rem
                                                           (get_local $19)
-                                                          (tee_local $6
+                                                          (tee_local $7
                                                             (i32.mul
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                               (i32.const 10)
                                                             )
                                                           )
@@ -5751,13 +5751,13 @@
                                                 )
                                               )
                                             )
-                                            (set_local $6
+                                            (set_local $7
                                               (i32.add
                                                 (i32.mul
                                                   (i32.shr_s
                                                     (i32.sub
                                                       (get_local $10)
-                                                      (get_local $31)
+                                                      (get_local $22)
                                                     )
                                                     (i32.const 2)
                                                   )
@@ -5769,7 +5769,7 @@
                                             (if i32
                                               (i32.eq
                                                 (i32.or
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (i32.const 32)
                                                 )
                                                 (i32.const 102)
@@ -5777,13 +5777,13 @@
                                               (block i32
                                                 (set_local $5
                                                   (select
-                                                    (get_local $17)
+                                                    (get_local $13)
                                                     (tee_local $5
                                                       (select
                                                         (i32.const 0)
                                                         (tee_local $5
                                                           (i32.sub
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                             (get_local $5)
                                                           )
                                                         )
@@ -5794,7 +5794,7 @@
                                                       )
                                                     )
                                                     (i32.lt_s
-                                                      (get_local $17)
+                                                      (get_local $13)
                                                       (get_local $5)
                                                     )
                                                   )
@@ -5804,14 +5804,14 @@
                                               (block i32
                                                 (set_local $5
                                                   (select
-                                                    (get_local $17)
+                                                    (get_local $13)
                                                     (tee_local $5
                                                       (select
                                                         (i32.const 0)
                                                         (tee_local $5
                                                           (i32.sub
                                                             (i32.add
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                               (get_local $11)
                                                             )
                                                             (get_local $5)
@@ -5824,7 +5824,7 @@
                                                       )
                                                     )
                                                     (i32.lt_s
-                                                      (get_local $17)
+                                                      (get_local $13)
                                                       (get_local $5)
                                                     )
                                                   )
@@ -5837,8 +5837,8 @@
                                             (set_local $5
                                               (get_local $19)
                                             )
-                                            (set_local $7
-                                              (get_local $17)
+                                            (set_local $6
+                                              (get_local $13)
                                             )
                                             (i32.and
                                               (get_local $12)
@@ -5848,30 +5848,19 @@
                                         )
                                       )
                                     )
-                                    (set_local $29
-                                      (i32.ne
-                                        (tee_local $31
-                                          (i32.or
-                                            (get_local $5)
-                                            (get_local $17)
-                                          )
-                                        )
-                                        (i32.const 0)
-                                      )
-                                    )
                                     (set_local $19
                                       (if i32
-                                        (tee_local $36
+                                        (tee_local $22
                                           (i32.eq
                                             (i32.or
-                                              (get_local $7)
+                                              (get_local $6)
                                               (i32.const 32)
                                             )
                                             (i32.const 102)
                                           )
                                         )
                                         (block i32
-                                          (set_local $7
+                                          (set_local $6
                                             (select
                                               (get_local $11)
                                               (i32.const 0)
@@ -5888,11 +5877,11 @@
                                             (i32.lt_s
                                               (i32.sub
                                                 (get_local $30)
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (call $_fmt_u
-                                                    (tee_local $6
+                                                    (tee_local $7
                                                       (select
-                                                        (get_local $37)
+                                                        (get_local $36)
                                                         (get_local $11)
                                                         (i32.lt_s
                                                           (get_local $11)
@@ -5903,14 +5892,14 @@
                                                     (i32.shr_s
                                                       (i32.shl
                                                         (i32.lt_s
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                           (i32.const 0)
                                                         )
                                                         (i32.const 31)
                                                       )
                                                       (i32.const 31)
                                                     )
-                                                    (get_local $38)
+                                                    (get_local $37)
                                                   )
                                                 )
                                               )
@@ -5918,9 +5907,9 @@
                                             )
                                             (loop $while-in98
                                               (i32.store8
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (i32.add
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const -1)
                                                   )
                                                 )
@@ -5930,7 +5919,7 @@
                                                 (i32.lt_s
                                                   (i32.sub
                                                     (get_local $30)
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (i32.const 2)
                                                 )
@@ -5939,7 +5928,7 @@
                                           )
                                           (i32.store8
                                             (i32.add
-                                              (get_local $6)
+                                              (get_local $7)
                                               (i32.const -1)
                                             )
                                             (i32.add
@@ -5954,21 +5943,21 @@
                                             )
                                           )
                                           (i32.store8
-                                            (tee_local $6
+                                            (tee_local $7
                                               (i32.add
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (i32.const -2)
                                               )
                                             )
-                                            (get_local $7)
+                                            (get_local $6)
                                           )
-                                          (set_local $7
+                                          (set_local $6
                                             (i32.sub
                                               (get_local $30)
-                                              (get_local $6)
+                                              (get_local $7)
                                             )
                                           )
-                                          (get_local $6)
+                                          (get_local $7)
                                         )
                                       )
                                     )
@@ -5981,14 +5970,22 @@
                                           (i32.add
                                             (i32.add
                                               (i32.add
-                                                (get_local $28)
+                                                (get_local $29)
                                                 (i32.const 1)
                                               )
                                               (get_local $5)
                                             )
-                                            (get_local $29)
+                                            (i32.ne
+                                              (tee_local $35
+                                                (i32.or
+                                                  (get_local $5)
+                                                  (get_local $13)
+                                                )
+                                              )
+                                              (i32.const 0)
+                                            )
                                           )
-                                          (get_local $7)
+                                          (get_local $6)
                                         )
                                       )
                                       (get_local $12)
@@ -6004,8 +6001,8 @@
                                       )
                                       (drop
                                         (call $___fwritex
-                                          (get_local $35)
-                                          (get_local $28)
+                                          (get_local $34)
+                                          (get_local $29)
                                           (get_local $0)
                                         )
                                       )
@@ -6022,63 +6019,63 @@
                                     )
                                     (block $do-once99
                                       (if
-                                        (get_local $36)
+                                        (get_local $22)
                                         (block
-                                          (set_local $6
+                                          (set_local $7
                                             (tee_local $13
                                               (select
                                                 (get_local $8)
-                                                (get_local $13)
+                                                (get_local $17)
                                                 (i32.gt_u
-                                                  (get_local $13)
+                                                  (get_local $17)
                                                   (get_local $8)
                                                 )
                                               )
                                             )
                                           )
                                           (loop $while-in102
-                                            (set_local $7
+                                            (set_local $6
                                               (call $_fmt_u
                                                 (i32.load
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                                 (i32.const 0)
-                                                (get_local $33)
+                                                (get_local $32)
                                               )
                                             )
                                             (block $do-once103
                                               (if
                                                 (i32.eq
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (get_local $13)
                                                 )
                                                 (block
                                                   (br_if $do-once103
                                                     (i32.ne
-                                                      (get_local $7)
-                                                      (get_local $33)
+                                                      (get_local $6)
+                                                      (get_local $32)
                                                     )
                                                   )
                                                   (i32.store8
-                                                    (get_local $39)
+                                                    (get_local $38)
                                                     (i32.const 48)
                                                   )
-                                                  (set_local $7
-                                                    (get_local $39)
+                                                  (set_local $6
+                                                    (get_local $38)
                                                   )
                                                 )
                                                 (block
                                                   (br_if $do-once103
                                                     (i32.le_u
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (get_local $24)
                                                     )
                                                   )
                                                   (loop $while-in106
                                                     (i32.store8
-                                                      (tee_local $7
+                                                      (tee_local $6
                                                         (i32.add
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                           (i32.const -1)
                                                         )
                                                       )
@@ -6086,7 +6083,7 @@
                                                     )
                                                     (br_if $while-in106
                                                       (i32.gt_u
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (get_local $24)
                                                       )
                                                     )
@@ -6105,10 +6102,10 @@
                                               )
                                               (drop
                                                 (call $___fwritex
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (i32.sub
-                                                    (get_local $49)
-                                                    (get_local $7)
+                                                    (get_local $48)
+                                                    (get_local $6)
                                                   )
                                                   (get_local $0)
                                                 )
@@ -6116,17 +6113,17 @@
                                             )
                                             (if
                                               (i32.le_u
-                                                (tee_local $7
+                                                (tee_local $6
                                                   (i32.add
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const 4)
                                                   )
                                                 )
                                                 (get_local $8)
                                               )
                                               (block
-                                                (set_local $6
-                                                  (get_local $7)
+                                                (set_local $7
+                                                  (get_local $6)
                                                 )
                                                 (br $while-in102)
                                               )
@@ -6134,7 +6131,7 @@
                                           )
                                           (block $do-once107
                                             (if
-                                              (get_local $31)
+                                              (get_local $35)
                                               (block
                                                 (br_if $do-once107
                                                   (i32.and
@@ -6161,29 +6158,29 @@
                                                 (i32.const 0)
                                               )
                                               (i32.lt_u
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (get_local $10)
                                               )
                                             )
                                             (loop $while-in110
                                               (if
                                                 (i32.gt_u
-                                                  (tee_local $6
+                                                  (tee_local $7
                                                     (call $_fmt_u
                                                       (i32.load
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                       )
                                                       (i32.const 0)
-                                                      (get_local $33)
+                                                      (get_local $32)
                                                     )
                                                   )
                                                   (get_local $24)
                                                 )
                                                 (loop $while-in112
                                                   (i32.store8
-                                                    (tee_local $6
+                                                    (tee_local $7
                                                       (i32.add
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const -1)
                                                       )
                                                     )
@@ -6191,7 +6188,7 @@
                                                   )
                                                   (br_if $while-in112
                                                     (i32.gt_u
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (get_local $24)
                                                     )
                                                   )
@@ -6208,7 +6205,7 @@
                                                 )
                                                 (drop
                                                   (call $___fwritex
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (select
                                                       (i32.const 9)
                                                       (get_local $5)
@@ -6221,7 +6218,7 @@
                                                   )
                                                 )
                                               )
-                                              (set_local $6
+                                              (set_local $7
                                                 (i32.add
                                                   (get_local $5)
                                                   (i32.const -9)
@@ -6234,9 +6231,9 @@
                                                     (i32.const 9)
                                                   )
                                                   (i32.lt_u
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const 4)
                                                       )
                                                     )
@@ -6245,12 +6242,12 @@
                                                 )
                                                 (block
                                                   (set_local $5
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (br $while-in110)
                                                 )
                                                 (set_local $5
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                             )
@@ -6271,10 +6268,10 @@
                                             (select
                                               (get_local $10)
                                               (i32.add
-                                                (get_local $13)
+                                                (get_local $17)
                                                 (i32.const 4)
                                               )
-                                              (get_local $22)
+                                              (get_local $25)
                                             )
                                           )
                                           (if
@@ -6283,38 +6280,38 @@
                                               (i32.const -1)
                                             )
                                             (block
-                                              (set_local $17
+                                              (set_local $13
                                                 (i32.eqz
-                                                  (get_local $17)
+                                                  (get_local $13)
                                                 )
                                               )
-                                              (set_local $6
-                                                (get_local $13)
-                                              )
                                               (set_local $7
+                                                (get_local $17)
+                                              )
+                                              (set_local $6
                                                 (get_local $5)
                                               )
                                               (loop $while-in114
-                                                (set_local $8
+                                                (set_local $5
                                                   (if i32
                                                     (i32.eq
                                                       (tee_local $5
                                                         (call $_fmt_u
                                                           (i32.load
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                           )
                                                           (i32.const 0)
-                                                          (get_local $33)
+                                                          (get_local $32)
                                                         )
                                                       )
-                                                      (get_local $33)
+                                                      (get_local $32)
                                                     )
                                                     (block i32
                                                       (i32.store8
-                                                        (get_local $39)
+                                                        (get_local $38)
                                                         (i32.const 48)
                                                       )
-                                                      (get_local $39)
+                                                      (get_local $38)
                                                     )
                                                     (get_local $5)
                                                   )
@@ -6322,16 +6319,10 @@
                                                 (block $do-once115
                                                   (if
                                                     (i32.eq
-                                                      (get_local $6)
-                                                      (get_local $13)
+                                                      (get_local $7)
+                                                      (get_local $17)
                                                     )
                                                     (block
-                                                      (set_local $5
-                                                        (i32.add
-                                                          (get_local $8)
-                                                          (i32.const 1)
-                                                        )
-                                                      )
                                                       (if
                                                         (i32.eqz
                                                           (i32.and
@@ -6343,17 +6334,23 @@
                                                         )
                                                         (drop
                                                           (call $___fwritex
-                                                            (get_local $8)
+                                                            (get_local $5)
                                                             (i32.const 1)
                                                             (get_local $0)
                                                           )
                                                         )
                                                       )
+                                                      (set_local $5
+                                                        (i32.add
+                                                          (get_local $5)
+                                                          (i32.const 1)
+                                                        )
+                                                      )
                                                       (br_if $do-once115
                                                         (i32.and
-                                                          (get_local $17)
+                                                          (get_local $13)
                                                           (i32.lt_s
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                             (i32.const 1)
                                                           )
                                                         )
@@ -6375,19 +6372,10 @@
                                                       )
                                                     )
                                                     (block
-                                                      (if
-                                                        (i32.gt_u
-                                                          (get_local $8)
+                                                      (br_if $do-once115
+                                                        (i32.le_u
+                                                          (get_local $5)
                                                           (get_local $24)
-                                                        )
-                                                        (set_local $5
-                                                          (get_local $8)
-                                                        )
-                                                        (block
-                                                          (set_local $5
-                                                            (get_local $8)
-                                                          )
-                                                          (br $do-once115)
                                                         )
                                                       )
                                                       (loop $while-in118
@@ -6412,7 +6400,7 @@
                                                 )
                                                 (set_local $8
                                                   (i32.sub
-                                                    (get_local $49)
+                                                    (get_local $48)
                                                     (get_local $5)
                                                   )
                                                 )
@@ -6430,9 +6418,9 @@
                                                       (get_local $5)
                                                       (select
                                                         (get_local $8)
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.gt_s
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                           (get_local $8)
                                                         )
                                                       )
@@ -6443,18 +6431,18 @@
                                                 (br_if $while-in114
                                                   (i32.and
                                                     (i32.lt_u
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (i32.add
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                           (i32.const 4)
                                                         )
                                                       )
                                                       (get_local $10)
                                                     )
                                                     (i32.gt_s
-                                                      (tee_local $7
+                                                      (tee_local $6
                                                         (i32.sub
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                           (get_local $8)
                                                         )
                                                       )
@@ -6463,7 +6451,7 @@
                                                   )
                                                 )
                                                 (set_local $5
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -6519,30 +6507,41 @@
                                     )
                                   )
                                   (block i32
-                                    (set_local $7
-                                      (select
-                                        (i32.const 0)
-                                        (get_local $28)
-                                        (tee_local $5
-                                          (i32.or
-                                            (f64.ne
-                                              (get_local $15)
-                                              (get_local $15)
+                                    (call $_pad
+                                      (get_local $0)
+                                      (i32.const 32)
+                                      (get_local $14)
+                                      (tee_local $5
+                                        (i32.add
+                                          (tee_local $7
+                                            (select
+                                              (i32.const 0)
+                                              (get_local $29)
+                                              (tee_local $6
+                                                (i32.or
+                                                  (f64.ne
+                                                    (get_local $15)
+                                                    (get_local $15)
+                                                  )
+                                                  (i32.const 0)
+                                                )
+                                              )
                                             )
-                                            (i32.const 0)
                                           )
+                                          (i32.const 3)
                                         )
                                       )
+                                      (get_local $8)
                                     )
                                     (set_local $6
                                       (select
                                         (select
                                           (i32.const 4135)
                                           (i32.const 4139)
-                                          (tee_local $6
+                                          (tee_local $8
                                             (i32.ne
                                               (i32.and
-                                                (get_local $17)
+                                                (get_local $13)
                                                 (i32.const 32)
                                               )
                                               (i32.const 0)
@@ -6552,22 +6551,10 @@
                                         (select
                                           (i32.const 4127)
                                           (i32.const 4131)
-                                          (get_local $6)
+                                          (get_local $8)
                                         )
-                                        (get_local $5)
+                                        (get_local $6)
                                       )
-                                    )
-                                    (call $_pad
-                                      (get_local $0)
-                                      (i32.const 32)
-                                      (get_local $14)
-                                      (tee_local $5
-                                        (i32.add
-                                          (get_local $7)
-                                          (i32.const 3)
-                                        )
-                                      )
-                                      (get_local $8)
                                     )
                                     (if
                                       (i32.eqz
@@ -6585,7 +6572,7 @@
                                             (block i32
                                               (drop
                                                 (call $___fwritex
-                                                  (get_local $35)
+                                                  (get_local $34)
                                                   (get_local $7)
                                                   (get_local $0)
                                                 )
@@ -6630,11 +6617,11 @@
                             )
                             (br $label$continue$L1)
                           )
-                          (set_local $7
+                          (set_local $6
                             (get_local $9)
                           )
                           (set_local $11
-                            (get_local $6)
+                            (get_local $7)
                           )
                           (set_local $8
                             (i32.const 0)
@@ -6649,7 +6636,7 @@
                         )
                         (set_local $10
                           (i32.and
-                            (get_local $17)
+                            (get_local $13)
                             (i32.const 32)
                           )
                         )
@@ -6658,7 +6645,7 @@
                             (i32.eqz
                               (tee_local $8
                                 (i32.load
-                                  (tee_local $7
+                                  (tee_local $6
                                     (get_local $18)
                                   )
                                 )
@@ -6667,13 +6654,13 @@
                             (i32.eqz
                               (tee_local $12
                                 (i32.load offset=4
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (get_local $23)
                             )
                             (set_local $8
@@ -6685,7 +6672,7 @@
                             (br $jumpthreading$inner$7)
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (get_local $8)
                             )
                             (set_local $8
@@ -6703,7 +6690,7 @@
                                   (i32.load8_u
                                     (i32.add
                                       (i32.and
-                                        (get_local $7)
+                                        (get_local $6)
                                         (i32.const 15)
                                       )
                                       (i32.const 4075)
@@ -6716,9 +6703,9 @@
                                 (i32.eqz
                                   (i32.and
                                     (i32.eqz
-                                      (tee_local $7
+                                      (tee_local $6
                                         (call $_bitshift64Lshr
-                                          (get_local $7)
+                                          (get_local $6)
                                           (get_local $12)
                                           (i32.const 4)
                                         )
@@ -6732,7 +6719,7 @@
                                   )
                                 )
                               )
-                              (set_local $7
+                              (set_local $6
                                 (get_local $8)
                               )
                             )
@@ -6775,7 +6762,7 @@
                                 (set_local $10
                                   (i32.add
                                     (i32.shr_s
-                                      (get_local $17)
+                                      (get_local $13)
                                       (i32.const 4)
                                     )
                                     (i32.const 4091)
@@ -6788,10 +6775,10 @@
                         )
                         (br $jumpthreading$outer$7)
                       )
-                      (set_local $7
+                      (set_local $6
                         (call $_fmt_u
                           (get_local $9)
-                          (get_local $7)
+                          (get_local $6)
                           (get_local $23)
                         )
                       )
@@ -6800,7 +6787,7 @@
                       )
                       (br $jumpthreading$inner$7)
                     )
-                    (set_local $26
+                    (set_local $27
                       (i32.const 0)
                     )
                     (set_local $17
@@ -6809,12 +6796,12 @@
                           (call $_memchr
                             (get_local $9)
                             (i32.const 0)
-                            (get_local $6)
+                            (get_local $7)
                           )
                         )
                       )
                     )
-                    (set_local $7
+                    (set_local $6
                       (get_local $9)
                     )
                     (set_local $12
@@ -6822,7 +6809,7 @@
                     )
                     (set_local $11
                       (select
-                        (get_local $6)
+                        (get_local $7)
                         (i32.sub
                           (get_local $13)
                           (get_local $9)
@@ -6840,7 +6827,7 @@
                       (select
                         (i32.add
                           (get_local $9)
-                          (get_local $6)
+                          (get_local $7)
                         )
                         (get_local $13)
                         (get_local $17)
@@ -6851,10 +6838,10 @@
                   (set_local $9
                     (i32.const 0)
                   )
-                  (set_local $7
+                  (set_local $6
                     (i32.const 0)
                   )
-                  (set_local $6
+                  (set_local $7
                     (i32.load
                       (get_local $18)
                     )
@@ -6865,7 +6852,7 @@
                         (i32.eqz
                           (tee_local $10
                             (i32.load
-                              (get_local $6)
+                              (get_local $7)
                             )
                           )
                         )
@@ -6873,16 +6860,16 @@
                       (br_if $while-out124
                         (i32.or
                           (i32.lt_s
-                            (tee_local $7
+                            (tee_local $6
                               (call $_wctomb
-                                (get_local $41)
+                                (get_local $40)
                                 (get_local $10)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.gt_u
-                            (get_local $7)
+                            (get_local $6)
                             (i32.sub
                               (get_local $8)
                               (get_local $9)
@@ -6890,9 +6877,9 @@
                           )
                         )
                       )
-                      (set_local $6
+                      (set_local $7
                         (i32.add
-                          (get_local $6)
+                          (get_local $7)
                           (i32.const 4)
                         )
                       )
@@ -6901,7 +6888,7 @@
                           (get_local $8)
                           (tee_local $9
                             (i32.add
-                              (get_local $7)
+                              (get_local $6)
                               (get_local $9)
                             )
                           )
@@ -6911,7 +6898,7 @@
                   )
                   (if
                     (i32.lt_s
-                      (get_local $7)
+                      (get_local $6)
                       (i32.const 0)
                     )
                     (block
@@ -6931,10 +6918,10 @@
                   (if
                     (get_local $9)
                     (block
-                      (set_local $6
+                      (set_local $7
                         (i32.const 0)
                       )
-                      (set_local $7
+                      (set_local $6
                         (i32.load
                           (get_local $18)
                         )
@@ -6944,40 +6931,34 @@
                           (i32.eqz
                             (tee_local $8
                               (i32.load
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (get_local $9)
                             )
                             (br $jumpthreading$inner$6)
                           )
                         )
-                        (set_local $7
-                          (i32.add
-                            (get_local $7)
-                            (i32.const 4)
-                          )
-                        )
                         (if
                           (i32.gt_s
-                            (tee_local $6
+                            (tee_local $7
                               (i32.add
                                 (tee_local $8
                                   (call $_wctomb
-                                    (get_local $41)
+                                    (get_local $40)
                                     (get_local $8)
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $7)
                               )
                             )
                             (get_local $9)
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (get_local $9)
                             )
                             (br $jumpthreading$inner$6)
@@ -6994,20 +6975,26 @@
                           )
                           (drop
                             (call $___fwritex
-                              (get_local $41)
+                              (get_local $40)
                               (get_local $8)
                               (get_local $0)
                             )
                           )
                         )
+                        (set_local $6
+                          (i32.add
+                            (get_local $6)
+                            (i32.const 4)
+                          )
+                        )
                         (br_if $while-in127
                           (i32.lt_u
-                            (get_local $6)
+                            (get_local $7)
                             (get_local $9)
                           )
                         )
                         (block
-                          (set_local $7
+                          (set_local $6
                             (get_local $9)
                           )
                           (br $jumpthreading$inner$6)
@@ -7015,7 +7002,7 @@
                       )
                     )
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.const 0)
                       )
                       (br $jumpthreading$inner$6)
@@ -7023,14 +7010,14 @@
                   )
                   (br $jumpthreading$outer$7)
                 )
-                (set_local $26
+                (set_local $27
                   (i32.const 0)
                 )
                 (call $_pad
                   (get_local $0)
                   (i32.const 32)
                   (get_local $14)
-                  (get_local $7)
+                  (get_local $6)
                   (i32.xor
                     (get_local $12)
                     (i32.const 8192)
@@ -7042,16 +7029,16 @@
                 (set_local $5
                   (select
                     (get_local $14)
-                    (get_local $7)
+                    (get_local $6)
                     (i32.gt_s
                       (get_local $14)
-                      (get_local $7)
+                      (get_local $6)
                     )
                   )
                 )
                 (br $label$continue$L1)
               )
-              (set_local $26
+              (set_local $27
                 (i32.const 0)
               )
               (set_local $12
@@ -7062,16 +7049,16 @@
                   )
                   (get_local $9)
                   (i32.gt_s
-                    (get_local $6)
+                    (get_local $7)
                     (i32.const -1)
                   )
                 )
               )
-              (set_local $7
+              (set_local $6
                 (if i32
                   (i32.or
                     (i32.ne
-                      (get_local $6)
+                      (get_local $7)
                       (i32.const 0)
                     )
                     (tee_local $9
@@ -7096,7 +7083,7 @@
                   (block i32
                     (set_local $11
                       (select
-                        (get_local $6)
+                        (get_local $7)
                         (tee_local $9
                           (i32.add
                             (i32.xor
@@ -7107,13 +7094,13 @@
                               (i32.const 1)
                             )
                             (i32.sub
-                              (get_local $45)
-                              (get_local $7)
+                              (get_local $44)
+                              (get_local $6)
                             )
                           )
                         )
                         (i32.gt_s
-                          (get_local $6)
+                          (get_local $7)
                           (get_local $9)
                         )
                       )
@@ -7121,7 +7108,7 @@
                     (set_local $9
                       (get_local $23)
                     )
-                    (get_local $7)
+                    (get_local $6)
                   )
                   (block i32
                     (set_local $11
@@ -7138,7 +7125,7 @@
             (call $_pad
               (get_local $0)
               (i32.const 32)
-              (tee_local $6
+              (tee_local $7
                 (select
                   (tee_local $9
                     (i32.add
@@ -7148,7 +7135,7 @@
                           (tee_local $13
                             (i32.sub
                               (get_local $9)
-                              (get_local $7)
+                              (get_local $6)
                             )
                           )
                           (get_local $11)
@@ -7190,7 +7177,7 @@
             (call $_pad
               (get_local $0)
               (i32.const 48)
-              (get_local $6)
+              (get_local $7)
               (get_local $9)
               (i32.xor
                 (get_local $12)
@@ -7215,7 +7202,7 @@
               )
               (drop
                 (call $___fwritex
-                  (get_local $7)
+                  (get_local $6)
                   (get_local $13)
                   (get_local $0)
                 )
@@ -7224,7 +7211,7 @@
             (call $_pad
               (get_local $0)
               (i32.const 32)
-              (get_local $6)
+              (get_local $7)
               (get_local $9)
               (i32.xor
                 (get_local $12)
@@ -7235,7 +7222,7 @@
               (get_local $5)
             )
             (set_local $5
-              (get_local $6)
+              (get_local $7)
             )
             (br $label$continue$L1)
           )
@@ -7305,12 +7292,6 @@
                 (i32.const 10)
               )
               (loop $while-in132
-                (set_local $1
-                  (i32.add
-                    (get_local $0)
-                    (i32.const 1)
-                  )
-                )
                 (if
                   (i32.load
                     (i32.add
@@ -7328,20 +7309,19 @@
                     (br $label$break$L343)
                   )
                 )
-                (if
+                (br_if $while-in132
                   (i32.lt_s
-                    (get_local $1)
+                    (tee_local $0
+                      (i32.add
+                        (get_local $0)
+                        (i32.const 1)
+                      )
+                    )
                     (i32.const 10)
                   )
-                  (block
-                    (set_local $0
-                      (get_local $1)
-                    )
-                    (br $while-in132)
-                  )
-                  (set_local $16
-                    (i32.const 1)
-                  )
+                )
+                (set_local $16
+                  (i32.const 1)
                 )
               )
               (set_local $16
@@ -7356,7 +7336,7 @@
       )
     )
     (set_global $STACKTOP
-      (get_local $25)
+      (get_local $26)
     )
     (get_local $16)
   )
@@ -7893,7 +7873,6 @@
     (local $5 i32)
     (local $6 i32)
     (local $7 i32)
-    (local $8 i32)
     (set_local $6
       (get_global $STACKTOP)
     )
@@ -7947,10 +7926,10 @@
               )
             )
           )
-          (set_local $7
+          (set_local $1
             (i32.eqz
               (i32.and
-                (tee_local $1
+                (tee_local $7
                   (i32.load
                     (get_local $0)
                   )
@@ -7965,25 +7944,13 @@
               (i32.const 255)
             )
             (block
-              (set_local $8
-                (i32.sub
-                  (get_local $2)
-                  (get_local $3)
-                )
-              )
-              (set_local $2
-                (get_local $4)
-              )
-              (set_local $3
-                (get_local $7)
-              )
               (loop $while-in
-                (set_local $3
+                (set_local $1
                   (i32.eqz
                     (i32.and
-                      (tee_local $1
+                      (tee_local $7
                         (if i32
-                          (get_local $3)
+                          (get_local $1)
                           (block i32
                             (drop
                               (call $___fwritex
@@ -7996,7 +7963,7 @@
                               (get_local $0)
                             )
                           )
-                          (get_local $1)
+                          (get_local $7)
                         )
                       )
                       (i32.const 32)
@@ -8005,9 +7972,9 @@
                 )
                 (br_if $while-in
                   (i32.gt_u
-                    (tee_local $2
+                    (tee_local $4
                       (i32.add
-                        (get_local $2)
+                        (get_local $4)
                         (i32.const -256)
                       )
                     )
@@ -8015,21 +7982,24 @@
                   )
                 )
               )
-              (set_local $4
-                (i32.and
-                  (get_local $8)
-                  (i32.const 255)
-                )
-              )
               (br_if $do-once
                 (i32.eqz
-                  (get_local $3)
+                  (get_local $1)
+                )
+              )
+              (set_local $4
+                (i32.and
+                  (i32.sub
+                    (get_local $2)
+                    (get_local $3)
+                  )
+                  (i32.const 255)
                 )
               )
             )
             (br_if $do-once
               (i32.eqz
-                (get_local $7)
+                (get_local $1)
               )
             )
           )
@@ -10947,24 +10917,18 @@
         )
       )
     )
-    (set_local $10
-      (i32.add
-        (get_local $0)
-        (i32.const 48)
-      )
-    )
     (if
       (i32.le_u
         (tee_local $7
           (i32.and
-            (tee_local $6
+            (tee_local $5
               (i32.add
                 (tee_local $1
                   (i32.load
                     (i32.const 656)
                   )
                 )
-                (tee_local $5
+                (tee_local $10
                   (i32.add
                     (get_local $0)
                     (i32.const 47)
@@ -11015,6 +10979,12 @@
         (return
           (i32.const 0)
         )
+      )
+    )
+    (set_local $6
+      (i32.add
+        (get_local $0)
+        (i32.const 48)
       )
     )
     (block $jumpthreading$outer$12
@@ -11093,7 +11063,7 @@
                       (tee_local $1
                         (i32.and
                           (i32.sub
-                            (get_local $6)
+                            (get_local $5)
                             (i32.load
                               (i32.const 188)
                             )
@@ -11247,7 +11217,7 @@
               (if
                 (i32.and
                   (i32.gt_u
-                    (get_local $10)
+                    (get_local $6)
                     (get_local $1)
                   )
                   (i32.and
@@ -11267,7 +11237,7 @@
                       (i32.and
                         (i32.add
                           (i32.sub
-                            (get_local $5)
+                            (get_local $10)
                             (get_local $1)
                           )
                           (tee_local $3
@@ -13659,7 +13629,7 @@
       (i32.eq
         (tee_local $5
           (i32.and
-            (tee_local $7
+            (tee_local $8
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -13674,12 +13644,12 @@
       )
       (call $_abort)
     )
-    (set_local $8
+    (set_local $7
       (i32.add
         (get_local $1)
         (tee_local $0
           (i32.and
-            (get_local $7)
+            (get_local $8)
             (i32.const -8)
           )
         )
@@ -13688,7 +13658,7 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $7)
+          (get_local $8)
           (i32.const 1)
         )
         (block
@@ -13700,22 +13670,11 @@
           )
         )
         (block
-          (set_local $7
-            (i32.load
-              (get_local $1)
-            )
-          )
           (if
             (i32.eqz
               (get_local $5)
             )
             (return)
-          )
-          (set_local $0
-            (i32.add
-              (get_local $7)
-              (get_local $0)
-            )
           )
           (if
             (i32.lt_u
@@ -13724,13 +13683,23 @@
                   (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $7)
+                    (tee_local $8
+                      (i32.load
+                        (get_local $1)
+                      )
+                    )
                   )
                 )
               )
               (get_local $11)
             )
             (call $_abort)
+          )
+          (set_local $0
+            (i32.add
+              (get_local $8)
+              (get_local $0)
+            )
           )
           (if
             (i32.eq
@@ -13747,7 +13716,7 @@
                       (i32.load
                         (tee_local $2
                           (i32.add
-                            (get_local $8)
+                            (get_local $7)
                             (i32.const 4)
                           )
                         )
@@ -13797,13 +13766,13 @@
           )
           (set_local $5
             (i32.shr_u
-              (get_local $7)
+              (get_local $8)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $7)
+              (get_local $8)
               (i32.const 256)
             )
             (block
@@ -13958,7 +13927,7 @@
                       (i32.load
                         (tee_local $4
                           (i32.add
-                            (tee_local $7
+                            (tee_local $8
                               (i32.add
                                 (get_local $1)
                                 (i32.const 16)
@@ -13973,11 +13942,11 @@
                   (if
                     (tee_local $5
                       (i32.load
-                        (get_local $7)
+                        (get_local $8)
                       )
                     )
                     (set_local $4
-                      (get_local $7)
+                      (get_local $8)
                     )
                     (block
                       (set_local $6
@@ -13989,7 +13958,7 @@
                 )
                 (loop $while-in
                   (if
-                    (tee_local $7
+                    (tee_local $8
                       (i32.load
                         (tee_local $10
                           (i32.add
@@ -14001,7 +13970,7 @@
                     )
                     (block
                       (set_local $5
-                        (get_local $7)
+                        (get_local $8)
                       )
                       (set_local $4
                         (get_local $10)
@@ -14010,7 +13979,7 @@
                     )
                   )
                   (if
-                    (tee_local $7
+                    (tee_local $8
                       (i32.load
                         (tee_local $10
                           (i32.add
@@ -14022,7 +13991,7 @@
                     )
                     (block
                       (set_local $5
-                        (get_local $7)
+                        (get_local $8)
                       )
                       (set_local $4
                         (get_local $10)
@@ -14063,7 +14032,7 @@
                 (if
                   (i32.ne
                     (i32.load
-                      (tee_local $7
+                      (tee_local $8
                         (i32.add
                           (get_local $10)
                           (i32.const 12)
@@ -14088,7 +14057,7 @@
                   )
                   (block
                     (i32.store
-                      (get_local $7)
+                      (get_local $8)
                       (get_local $4)
                     )
                     (i32.store
@@ -14224,7 +14193,7 @@
                 (get_local $12)
               )
               (if
-                (tee_local $7
+                (tee_local $8
                   (i32.load
                     (tee_local $4
                       (i32.add
@@ -14236,17 +14205,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $7)
+                    (get_local $8)
                     (get_local $5)
                   )
                   (call $_abort)
                   (block
                     (i32.store offset=16
                       (get_local $6)
-                      (get_local $7)
+                      (get_local $8)
                     )
                     (i32.store offset=24
-                      (get_local $7)
+                      (get_local $8)
                       (get_local $6)
                     )
                   )
@@ -14308,7 +14277,7 @@
     (if
       (i32.ge_u
         (get_local $2)
-        (get_local $8)
+        (get_local $7)
       )
       (call $_abort)
     )
@@ -14319,7 +14288,7 @@
             (i32.load
               (tee_local $0
                 (i32.add
-                  (get_local $8)
+                  (get_local $7)
                   (i32.const 4)
                 )
               )
@@ -14361,7 +14330,7 @@
       (block
         (if
           (i32.eq
-            (get_local $8)
+            (get_local $7)
             (i32.load
               (i32.const 200)
             )
@@ -14411,7 +14380,7 @@
         )
         (if
           (i32.eq
-            (get_local $8)
+            (get_local $7)
             (i32.load
               (i32.const 196)
             )
@@ -14473,14 +14442,14 @@
             (block
               (set_local $4
                 (i32.load offset=12
-                  (get_local $8)
+                  (get_local $7)
                 )
               )
               (if
                 (i32.ne
                   (tee_local $1
                     (i32.load offset=8
-                      (get_local $8)
+                      (get_local $7)
                     )
                   )
                   (tee_local $0
@@ -14511,7 +14480,7 @@
                       (i32.load offset=12
                         (get_local $1)
                       )
-                      (get_local $8)
+                      (get_local $7)
                     )
                     (call $_abort)
                   )
@@ -14572,7 +14541,7 @@
                           )
                         )
                       )
-                      (get_local $8)
+                      (get_local $7)
                     )
                     (set_local $14
                       (get_local $0)
@@ -14593,7 +14562,7 @@
             (block
               (set_local $6
                 (i32.load offset=24
-                  (get_local $8)
+                  (get_local $7)
                 )
               )
               (block $do-once6
@@ -14601,10 +14570,10 @@
                   (i32.eq
                     (tee_local $0
                       (i32.load offset=12
-                        (get_local $8)
+                        (get_local $7)
                       )
                     )
-                    (get_local $8)
+                    (get_local $7)
                   )
                   (block
                     (if
@@ -14615,7 +14584,7 @@
                               (i32.add
                                 (tee_local $1
                                   (i32.add
-                                    (get_local $8)
+                                    (get_local $7)
                                     (i32.const 16)
                                   )
                                 )
@@ -14710,7 +14679,7 @@
                       (i32.lt_u
                         (tee_local $4
                           (i32.load offset=8
-                            (get_local $8)
+                            (get_local $7)
                           )
                         )
                         (i32.load
@@ -14729,7 +14698,7 @@
                             )
                           )
                         )
-                        (get_local $8)
+                        (get_local $7)
                       )
                       (call $_abort)
                     )
@@ -14743,7 +14712,7 @@
                             )
                           )
                         )
-                        (get_local $8)
+                        (get_local $7)
                       )
                       (block
                         (i32.store
@@ -14768,14 +14737,14 @@
                 (block
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.load
                         (tee_local $0
                           (i32.add
                             (i32.shl
                               (tee_local $3
                                 (i32.load offset=28
-                                  (get_local $8)
+                                  (get_local $7)
                                 )
                               )
                               (i32.const 2)
@@ -14834,7 +14803,7 @@
                               )
                             )
                           )
-                          (get_local $8)
+                          (get_local $7)
                         )
                         (i32.store
                           (get_local $0)
@@ -14872,7 +14841,7 @@
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $8)
+                            (get_local $7)
                             (i32.const 16)
                           )
                         )
@@ -15466,7 +15435,6 @@
     (local $3 i32)
     (local $4 i32)
     (local $5 i32)
-    (local $6 i32)
     (set_local $4
       (i32.add
         (get_local $0)
@@ -15479,36 +15447,10 @@
         (i32.const 20)
       )
       (block
-        (set_local $5
-          (i32.or
-            (i32.or
-              (i32.or
-                (tee_local $1
-                  (i32.and
-                    (get_local $1)
-                    (i32.const 255)
-                  )
-                )
-                (i32.shl
-                  (get_local $1)
-                  (i32.const 8)
-                )
-              )
-              (i32.shl
-                (get_local $1)
-                (i32.const 16)
-              )
-            )
-            (i32.shl
-              (get_local $1)
-              (i32.const 24)
-            )
-          )
-        )
-        (set_local $6
+        (set_local $1
           (i32.and
-            (get_local $4)
-            (i32.const -4)
+            (get_local $1)
+            (i32.const 255)
           )
         )
         (if
@@ -15551,16 +15493,43 @@
             )
           )
         )
+        (set_local $3
+          (i32.or
+            (i32.or
+              (i32.or
+                (get_local $1)
+                (i32.shl
+                  (get_local $1)
+                  (i32.const 8)
+                )
+              )
+              (i32.shl
+                (get_local $1)
+                (i32.const 16)
+              )
+            )
+            (i32.shl
+              (get_local $1)
+              (i32.const 24)
+            )
+          )
+        )
+        (set_local $5
+          (i32.and
+            (get_local $4)
+            (i32.const -4)
+          )
+        )
         (loop $while-in1
           (if
             (i32.lt_s
               (get_local $0)
-              (get_local $6)
+              (get_local $5)
             )
             (block
               (i32.store
                 (get_local $0)
-                (get_local $5)
+                (get_local $3)
               )
               (set_local $0
                 (i32.add

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -791,7 +791,8 @@
     (local $12 i32)
     (local $13 i32)
     (local $14 i32)
-    (set_local $7
+    (local $15 i32)
+    (set_local $8
       (get_global $STACKTOP)
     )
     (set_global $STACKTOP
@@ -807,25 +808,25 @@
       )
       (call $abort)
     )
-    (set_local $8
+    (set_local $9
       (i32.add
-        (get_local $7)
+        (get_local $8)
         (i32.const 16)
       )
     )
-    (set_local $9
-      (get_local $7)
+    (set_local $10
+      (get_local $8)
     )
     (i32.store
       (tee_local $3
         (i32.add
-          (get_local $7)
+          (get_local $8)
           (i32.const 32)
         )
       )
-      (tee_local $5
+      (tee_local $4
         (i32.load
-          (tee_local $6
+          (tee_local $7
             (i32.add
               (get_local $0)
               (i32.const 28)
@@ -836,17 +837,17 @@
     )
     (i32.store offset=4
       (get_local $3)
-      (tee_local $4
+      (tee_local $6
         (i32.sub
           (i32.load
-            (tee_local $10
+            (tee_local $11
               (i32.add
                 (get_local $0)
                 (i32.const 20)
               )
             )
           )
-          (get_local $5)
+          (get_local $4)
         )
       )
     )
@@ -858,13 +859,13 @@
       (get_local $3)
       (get_local $2)
     )
-    (set_local $13
+    (set_local $14
       (i32.add
         (get_local $0)
         (i32.const 60)
       )
     )
-    (set_local $14
+    (set_local $15
       (i32.add
         (get_local $0)
         (i32.const 44)
@@ -873,12 +874,12 @@
     (set_local $1
       (get_local $3)
     )
-    (set_local $5
+    (set_local $4
       (i32.const 2)
     )
-    (set_local $11
+    (set_local $12
       (i32.add
-        (get_local $4)
+        (get_local $6)
         (get_local $2)
       )
     )
@@ -889,8 +890,8 @@
             (loop $while-in
               (br_if $jumpthreading$inner$0
                 (i32.eq
-                  (get_local $11)
-                  (tee_local $4
+                  (get_local $12)
+                  (tee_local $5
                     (if i32
                       (i32.load
                         (i32.const 16)
@@ -901,24 +902,24 @@
                           (get_local $0)
                         )
                         (i32.store
-                          (get_local $9)
+                          (get_local $10)
                           (i32.load
-                            (get_local $13)
+                            (get_local $14)
                           )
                         )
                         (i32.store offset=4
-                          (get_local $9)
+                          (get_local $10)
                           (get_local $1)
                         )
                         (i32.store offset=8
-                          (get_local $9)
-                          (get_local $5)
+                          (get_local $10)
+                          (get_local $4)
                         )
                         (set_local $3
                           (call $___syscall_ret
                             (call $___syscall146
                               (i32.const 146)
-                              (get_local $9)
+                              (get_local $10)
                             )
                           )
                         )
@@ -929,23 +930,23 @@
                       )
                       (block i32
                         (i32.store
-                          (get_local $8)
+                          (get_local $9)
                           (i32.load
-                            (get_local $13)
+                            (get_local $14)
                           )
                         )
                         (i32.store offset=4
-                          (get_local $8)
+                          (get_local $9)
                           (get_local $1)
                         )
                         (i32.store offset=8
-                          (get_local $8)
-                          (get_local $5)
+                          (get_local $9)
+                          (get_local $4)
                         )
                         (call $___syscall_ret
                           (call $___syscall146
                             (i32.const 146)
-                            (get_local $8)
+                            (get_local $9)
                           )
                         )
                       )
@@ -955,22 +956,16 @@
               )
               (br_if $jumpthreading$inner$1
                 (i32.lt_s
-                  (get_local $4)
+                  (get_local $5)
                   (i32.const 0)
                 )
               )
               (block
-                (set_local $11
-                  (i32.sub
-                    (get_local $11)
-                    (get_local $4)
-                  )
-                )
                 (set_local $1
                   (if i32
                     (i32.gt_u
-                      (get_local $4)
-                      (tee_local $12
+                      (get_local $5)
+                      (tee_local $13
                         (i32.load offset=4
                           (get_local $1)
                         )
@@ -978,21 +973,21 @@
                     )
                     (block i32
                       (i32.store
-                        (get_local $6)
+                        (get_local $7)
                         (tee_local $3
                           (i32.load
-                            (get_local $14)
+                            (get_local $15)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $10)
+                        (get_local $11)
                         (get_local $3)
                       )
-                      (set_local $4
+                      (set_local $6
                         (i32.sub
-                          (get_local $4)
-                          (get_local $12)
+                          (get_local $5)
+                          (get_local $13)
                         )
                       )
                       (set_local $3
@@ -1001,9 +996,9 @@
                           (i32.const 8)
                         )
                       )
-                      (set_local $5
+                      (set_local $4
                         (i32.add
-                          (get_local $5)
+                          (get_local $4)
                           (i32.const -1)
                         )
                       )
@@ -1013,32 +1008,38 @@
                     )
                     (if i32
                       (i32.eq
-                        (get_local $5)
+                        (get_local $4)
                         (i32.const 2)
                       )
                       (block i32
                         (i32.store
-                          (get_local $6)
+                          (get_local $7)
                           (i32.add
                             (i32.load
-                              (get_local $6)
+                              (get_local $7)
                             )
-                            (get_local $4)
+                            (get_local $5)
                           )
                         )
+                        (set_local $6
+                          (get_local $5)
+                        )
                         (set_local $3
                           (get_local $1)
                         )
-                        (set_local $5
+                        (set_local $4
                           (i32.const 2)
                         )
-                        (get_local $12)
+                        (get_local $13)
                       )
                       (block i32
+                        (set_local $6
+                          (get_local $5)
+                        )
                         (set_local $3
                           (get_local $1)
                         )
-                        (get_local $12)
+                        (get_local $13)
                       )
                     )
                   )
@@ -1049,18 +1050,24 @@
                     (i32.load
                       (get_local $3)
                     )
-                    (get_local $4)
+                    (get_local $6)
                   )
                 )
                 (i32.store offset=4
                   (get_local $3)
                   (i32.sub
                     (get_local $1)
-                    (get_local $4)
+                    (get_local $6)
                   )
                 )
                 (set_local $1
                   (get_local $3)
+                )
+                (set_local $12
+                  (i32.sub
+                    (get_local $12)
+                    (get_local $5)
+                  )
                 )
                 (br $while-in)
               )
@@ -1071,7 +1078,7 @@
             (i32.add
               (tee_local $1
                 (i32.load
-                  (get_local $14)
+                  (get_local $15)
                 )
               )
               (i32.load offset=48
@@ -1080,13 +1087,13 @@
             )
           )
           (i32.store
-            (get_local $6)
+            (get_local $7)
             (tee_local $0
               (get_local $1)
             )
           )
           (i32.store
-            (get_local $10)
+            (get_local $11)
             (get_local $0)
           )
           (br $jumpthreading$outer$1
@@ -1098,11 +1105,11 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $6)
+          (get_local $7)
           (i32.const 0)
         )
         (i32.store
-          (get_local $10)
+          (get_local $11)
           (i32.const 0)
         )
         (i32.store
@@ -1123,14 +1130,14 @@
             )
           )
           (i32.eq
-            (get_local $5)
+            (get_local $4)
             (i32.const 2)
           )
         )
       )
     )
     (set_global $STACKTOP
-      (get_local $7)
+      (get_local $8)
     )
     (get_local $0)
   )
@@ -1228,7 +1235,7 @@
         )
         (i32.const -1)
         (block i32
-          (set_local $14
+          (set_local $4
             (if i32
               (i32.gt_s
                 (i32.load offset=76
@@ -1242,14 +1249,9 @@
               (i32.const 0)
             )
           )
-          (set_local $4
-            (i32.and
-              (tee_local $2
-                (i32.load
-                  (get_local $0)
-                )
-              )
-              (i32.const 32)
+          (set_local $10
+            (i32.load
+              (get_local $0)
             )
           )
           (if
@@ -1262,166 +1264,169 @@
             (i32.store
               (get_local $0)
               (i32.and
-                (get_local $2)
+                (get_local $10)
                 (i32.const -33)
               )
             )
           )
-          (set_local $1
-            (select
-              (i32.const -1)
-              (if i32
-                (i32.load
-                  (tee_local $10
-                    (i32.add
-                      (get_local $0)
-                      (i32.const 48)
-                    )
-                  )
-                )
-                (call $_printf_core
-                  (get_local $0)
-                  (get_local $1)
-                  (get_local $5)
-                  (get_local $7)
-                  (get_local $8)
-                )
-                (block i32
-                  (set_local $12
-                    (i32.load
-                      (tee_local $11
-                        (i32.add
-                          (get_local $0)
-                          (i32.const 44)
-                        )
-                      )
-                    )
-                  )
-                  (i32.store
-                    (get_local $11)
-                    (get_local $6)
-                  )
-                  (i32.store
-                    (tee_local $9
-                      (i32.add
-                        (get_local $0)
-                        (i32.const 28)
-                      )
-                    )
-                    (get_local $6)
-                  )
-                  (i32.store
-                    (tee_local $13
-                      (i32.add
-                        (get_local $0)
-                        (i32.const 20)
-                      )
-                    )
-                    (get_local $6)
-                  )
-                  (i32.store
-                    (get_local $10)
-                    (i32.const 80)
-                  )
-                  (i32.store
-                    (tee_local $2
-                      (i32.add
-                        (get_local $0)
-                        (i32.const 16)
-                      )
-                    )
-                    (i32.add
-                      (get_local $6)
-                      (i32.const 80)
-                    )
-                  )
-                  (set_local $1
-                    (call $_printf_core
-                      (get_local $0)
-                      (get_local $1)
-                      (get_local $5)
-                      (get_local $7)
-                      (get_local $8)
-                    )
-                  )
-                  (if i32
-                    (get_local $12)
-                    (block i32
-                      (drop
-                        (call_indirect $FUNCSIG$iiii
-                          (get_local $0)
-                          (i32.const 0)
-                          (i32.const 0)
-                          (i32.add
-                            (i32.and
-                              (i32.load offset=36
-                                (get_local $0)
-                              )
-                              (i32.const 7)
-                            )
-                            (i32.const 2)
-                          )
-                        )
-                      )
-                      (set_local $1
-                        (select
-                          (get_local $1)
-                          (i32.const -1)
-                          (i32.load
-                            (get_local $13)
-                          )
-                        )
-                      )
-                      (i32.store
-                        (get_local $11)
-                        (get_local $12)
-                      )
-                      (i32.store
-                        (get_local $10)
-                        (i32.const 0)
-                      )
-                      (i32.store
-                        (get_local $2)
-                        (i32.const 0)
-                      )
-                      (i32.store
-                        (get_local $9)
-                        (i32.const 0)
-                      )
-                      (i32.store
-                        (get_local $13)
-                        (i32.const 0)
-                      )
-                      (get_local $1)
-                    )
-                    (get_local $1)
+          (set_local $2
+            (if i32
+              (i32.load
+                (tee_local $11
+                  (i32.add
+                    (get_local $0)
+                    (i32.const 48)
                   )
                 )
               )
-              (i32.and
-                (tee_local $2
+              (call $_printf_core
+                (get_local $0)
+                (get_local $1)
+                (get_local $5)
+                (get_local $7)
+                (get_local $8)
+              )
+              (block i32
+                (set_local $13
                   (i32.load
-                    (get_local $0)
+                    (tee_local $12
+                      (i32.add
+                        (get_local $0)
+                        (i32.const 44)
+                      )
+                    )
                   )
                 )
-                (i32.const 32)
+                (i32.store
+                  (get_local $12)
+                  (get_local $6)
+                )
+                (i32.store
+                  (tee_local $9
+                    (i32.add
+                      (get_local $0)
+                      (i32.const 28)
+                    )
+                  )
+                  (get_local $6)
+                )
+                (i32.store
+                  (tee_local $14
+                    (i32.add
+                      (get_local $0)
+                      (i32.const 20)
+                    )
+                  )
+                  (get_local $6)
+                )
+                (i32.store
+                  (get_local $11)
+                  (i32.const 80)
+                )
+                (i32.store
+                  (tee_local $2
+                    (i32.add
+                      (get_local $0)
+                      (i32.const 16)
+                    )
+                  )
+                  (i32.add
+                    (get_local $6)
+                    (i32.const 80)
+                  )
+                )
+                (set_local $1
+                  (call $_printf_core
+                    (get_local $0)
+                    (get_local $1)
+                    (get_local $5)
+                    (get_local $7)
+                    (get_local $8)
+                  )
+                )
+                (if i32
+                  (get_local $13)
+                  (block i32
+                    (drop
+                      (call_indirect $FUNCSIG$iiii
+                        (get_local $0)
+                        (i32.const 0)
+                        (i32.const 0)
+                        (i32.add
+                          (i32.and
+                            (i32.load offset=36
+                              (get_local $0)
+                            )
+                            (i32.const 7)
+                          )
+                          (i32.const 2)
+                        )
+                      )
+                    )
+                    (set_local $1
+                      (select
+                        (get_local $1)
+                        (i32.const -1)
+                        (i32.load
+                          (get_local $14)
+                        )
+                      )
+                    )
+                    (i32.store
+                      (get_local $12)
+                      (get_local $13)
+                    )
+                    (i32.store
+                      (get_local $11)
+                      (i32.const 0)
+                    )
+                    (i32.store
+                      (get_local $2)
+                      (i32.const 0)
+                    )
+                    (i32.store
+                      (get_local $9)
+                      (i32.const 0)
+                    )
+                    (i32.store
+                      (get_local $14)
+                      (i32.const 0)
+                    )
+                    (get_local $1)
+                  )
+                  (get_local $1)
+                )
               )
             )
           )
           (i32.store
             (get_local $0)
             (i32.or
-              (get_local $2)
-              (get_local $4)
+              (tee_local $1
+                (i32.load
+                  (get_local $0)
+                )
+              )
+              (i32.and
+                (get_local $10)
+                (i32.const 32)
+              )
             )
           )
           (if
-            (get_local $14)
+            (get_local $4)
             (call $___unlockfile
               (get_local $0)
             )
           )
-          (get_local $1)
+          (select
+            (i32.const -1)
+            (get_local $2)
+            (i32.and
+              (get_local $1)
+              (i32.const 32)
+            )
+          )
         )
       )
     )
@@ -1467,23 +1472,20 @@
         )
         (br $label$break$L5)
       )
-      (set_local $6
-        (tee_local $4
-          (i32.load
-            (tee_local $5
-              (i32.add
-                (get_local $2)
-                (i32.const 20)
-              )
-            )
-          )
-        )
-      )
       (if
         (i32.lt_u
           (i32.sub
             (get_local $3)
-            (get_local $4)
+            (tee_local $6
+              (i32.load
+                (tee_local $5
+                  (i32.add
+                    (get_local $2)
+                    (i32.const 20)
+                  )
+                )
+              )
+            )
           )
           (get_local $1)
         )
@@ -2346,7 +2348,7 @@
     (local $53 i32)
     (local $54 i32)
     (local $55 i32)
-    (set_local $25
+    (set_local $26
       (get_global $STACKTOP)
     )
     (set_global $STACKTOP
@@ -2364,31 +2366,31 @@
     )
     (set_local $20
       (i32.add
-        (get_local $25)
+        (get_local $26)
         (i32.const 16)
       )
     )
     (set_local $18
-      (get_local $25)
+      (get_local $26)
     )
-    (set_local $41
+    (set_local $40
       (i32.add
-        (get_local $25)
+        (get_local $26)
         (i32.const 528)
       )
     )
-    (set_local $32
+    (set_local $31
       (i32.ne
         (get_local $0)
         (i32.const 0)
       )
     )
-    (set_local $45
+    (set_local $44
       (tee_local $23
         (i32.add
           (tee_local $9
             (i32.add
-              (get_local $25)
+              (get_local $26)
               (i32.const 536)
             )
           )
@@ -2396,87 +2398,87 @@
         )
       )
     )
-    (set_local $46
+    (set_local $45
       (i32.add
         (get_local $9)
         (i32.const 39)
       )
     )
-    (set_local $50
+    (set_local $49
       (i32.add
-        (tee_local $47
+        (tee_local $46
           (i32.add
-            (get_local $25)
+            (get_local $26)
             (i32.const 8)
           )
         )
         (i32.const 4)
       )
     )
-    (set_local $38
+    (set_local $37
       (i32.add
         (tee_local $9
           (i32.add
-            (get_local $25)
+            (get_local $26)
             (i32.const 576)
           )
         )
         (i32.const 12)
       )
     )
-    (set_local $48
+    (set_local $47
       (i32.add
         (get_local $9)
         (i32.const 11)
       )
     )
-    (set_local $51
+    (set_local $50
       (i32.sub
         (tee_local $30
-          (get_local $38)
+          (get_local $37)
         )
-        (tee_local $42
+        (tee_local $41
           (tee_local $24
             (i32.add
-              (get_local $25)
+              (get_local $26)
               (i32.const 588)
             )
           )
         )
       )
     )
-    (set_local $52
+    (set_local $51
       (i32.sub
         (i32.const -2)
-        (get_local $42)
+        (get_local $41)
       )
     )
-    (set_local $53
+    (set_local $52
       (i32.add
         (get_local $30)
         (i32.const 2)
       )
     )
-    (set_local $55
+    (set_local $54
       (i32.add
-        (tee_local $54
+        (tee_local $53
           (i32.add
-            (get_local $25)
+            (get_local $26)
             (i32.const 24)
           )
         )
         (i32.const 288)
       )
     )
-    (set_local $49
-      (tee_local $33
+    (set_local $48
+      (tee_local $32
         (i32.add
           (get_local $24)
           (i32.const 9)
         )
       )
     )
-    (set_local $39
+    (set_local $38
       (i32.add
         (get_local $24)
         (i32.const 8)
@@ -2531,7 +2533,7 @@
               (i32.eqz
                 (i32.shr_s
                   (i32.shl
-                    (tee_local $7
+                    (tee_local $6
                       (i32.load8_s
                         (get_local $9)
                       )
@@ -2554,7 +2556,7 @@
                         (i32.sub
                           (i32.shr_s
                             (i32.shl
-                              (get_local $7)
+                              (get_local $6)
                               (i32.const 24)
                             )
                             (i32.const 24)
@@ -2563,26 +2565,26 @@
                         )
                       )
                     )
-                    (set_local $40
+                    (set_local $39
                       (get_local $5)
                     )
-                    (set_local $43
+                    (set_local $42
                       (get_local $5)
                     )
-                    (set_local $26
+                    (set_local $27
                       (i32.const 9)
                     )
                     (br $label$break$L9)
                   )
-                  (set_local $27
+                  (set_local $28
                     (get_local $5)
                   )
-                  (set_local $34
+                  (set_local $33
                     (get_local $5)
                   )
                   (br $label$break$L9)
                 )
-                (set_local $7
+                (set_local $6
                   (i32.load8_s
                     (tee_local $5
                       (i32.add
@@ -2598,42 +2600,42 @@
             (block $label$break$L12
               (if
                 (i32.eq
-                  (get_local $26)
+                  (get_local $27)
                   (i32.const 9)
                 )
                 (loop $while-in
-                  (set_local $26
+                  (set_local $27
                     (i32.const 0)
                   )
                   (if
                     (i32.ne
                       (i32.load8_s offset=1
-                        (get_local $40)
+                        (get_local $39)
                       )
                       (i32.const 37)
                     )
                     (block
-                      (set_local $27
-                        (get_local $40)
+                      (set_local $28
+                        (get_local $39)
                       )
-                      (set_local $34
-                        (get_local $43)
+                      (set_local $33
+                        (get_local $42)
                       )
                       (br $label$break$L12)
                     )
                   )
-                  (set_local $34
+                  (set_local $33
                     (i32.add
-                      (get_local $43)
+                      (get_local $42)
                       (i32.const 1)
                     )
                   )
                   (if
                     (i32.eq
                       (i32.load8_s
-                        (tee_local $27
+                        (tee_local $28
                           (i32.add
-                            (get_local $40)
+                            (get_local $39)
                             (i32.const 2)
                           )
                         )
@@ -2641,11 +2643,11 @@
                       (i32.const 37)
                     )
                     (block
-                      (set_local $40
-                        (get_local $27)
+                      (set_local $39
+                        (get_local $28)
                       )
-                      (set_local $43
-                        (get_local $34)
+                      (set_local $42
+                        (get_local $33)
                       )
                       (br $while-in)
                     )
@@ -2653,14 +2655,14 @@
                 )
               )
             )
-            (set_local $7
+            (set_local $6
               (i32.sub
-                (get_local $34)
+                (get_local $33)
                 (get_local $9)
               )
             )
             (if
-              (get_local $32)
+              (get_local $31)
               (if
                 (i32.eqz
                   (i32.and
@@ -2673,7 +2675,7 @@
                 (drop
                   (call $___fwritex
                     (get_local $9)
-                    (get_local $7)
+                    (get_local $6)
                     (get_local $0)
                   )
                 )
@@ -2681,15 +2683,15 @@
             )
             (if
               (i32.ne
-                (get_local $34)
+                (get_local $33)
                 (get_local $9)
               )
               (block
                 (set_local $9
-                  (get_local $27)
+                  (get_local $28)
                 )
                 (set_local $5
-                  (get_local $7)
+                  (get_local $6)
                 )
                 (br $label$continue$L1)
               )
@@ -2701,11 +2703,11 @@
                     (i32.add
                       (i32.shr_s
                         (i32.shl
-                          (tee_local $6
+                          (tee_local $7
                             (i32.load8_s
                               (tee_local $5
                                 (i32.add
-                                  (get_local $27)
+                                  (get_local $28)
                                   (i32.const 1)
                                 )
                               )
@@ -2721,19 +2723,19 @@
                   (i32.const 10)
                 )
                 (block i32
-                  (set_local $6
+                  (set_local $7
                     (i32.load8_s
                       (tee_local $5
                         (select
                           (i32.add
-                            (get_local $27)
+                            (get_local $28)
                             (i32.const 3)
                           )
                           (get_local $5)
                           (tee_local $12
                             (i32.eq
                               (i32.load8_s offset=2
-                                (get_local $27)
+                                (get_local $28)
                               )
                               (i32.const 36)
                             )
@@ -2770,7 +2772,7 @@
                     (tee_local $12
                       (i32.shr_s
                         (i32.shl
-                          (get_local $6)
+                          (get_local $7)
                           (i32.const 24)
                         )
                         (i32.const 24)
@@ -2782,9 +2784,9 @@
                 )
                 (block
                   (set_local $1
-                    (get_local $6)
+                    (get_local $7)
                   )
-                  (set_local $6
+                  (set_local $7
                     (i32.const 0)
                   )
                   (loop $while-in4
@@ -2802,7 +2804,7 @@
                         )
                       )
                     )
-                    (set_local $6
+                    (set_local $7
                       (i32.or
                         (i32.shl
                           (i32.const 1)
@@ -2817,7 +2819,7 @@
                             (i32.const -32)
                           )
                         )
-                        (get_local $6)
+                        (get_local $7)
                       )
                     )
                     (br_if $while-in4
@@ -2850,9 +2852,9 @@
                 )
                 (block
                   (set_local $1
-                    (get_local $6)
+                    (get_local $7)
                   )
-                  (set_local $6
+                  (set_local $7
                     (i32.const 0)
                   )
                 )
@@ -2939,7 +2941,7 @@
                           (i32.const 1)
                         )
                       )
-                      (set_local $26
+                      (set_local $27
                         (i32.const 0)
                       )
                       (if
@@ -2953,11 +2955,11 @@
                       )
                       (if
                         (i32.eqz
-                          (get_local $32)
+                          (get_local $31)
                         )
                         (block
                           (set_local $12
-                            (get_local $6)
+                            (get_local $7)
                           )
                           (set_local $5
                             (get_local $1)
@@ -3013,11 +3015,11 @@
                           )
                         )
                         (i32.or
-                          (get_local $6)
+                          (get_local $7)
                           (i32.const 8192)
                         )
                       )
-                      (get_local $6)
+                      (get_local $7)
                     )
                   )
                 )
@@ -3095,7 +3097,7 @@
                       )
                       (block
                         (set_local $12
-                          (get_local $6)
+                          (get_local $7)
                         )
                         (set_local $1
                           (get_local $8)
@@ -3105,7 +3107,7 @@
                   )
                   (block
                     (set_local $12
-                      (get_local $6)
+                      (get_local $7)
                     )
                     (set_local $1
                       (get_local $8)
@@ -3131,7 +3133,7 @@
                       (i32.ne
                         (i32.shr_s
                           (i32.shl
-                            (tee_local $6
+                            (tee_local $7
                               (i32.load8_s
                                 (tee_local $8
                                   (i32.add
@@ -3150,11 +3152,11 @@
                       (block
                         (if
                           (i32.lt_u
-                            (tee_local $6
+                            (tee_local $7
                               (i32.add
                                 (i32.shr_s
                                   (i32.shl
-                                    (get_local $6)
+                                    (get_local $7)
                                     (i32.const 24)
                                   )
                                   (i32.const 24)
@@ -3173,7 +3175,7 @@
                             )
                           )
                           (block
-                            (set_local $6
+                            (set_local $7
                               (i32.const 0)
                             )
                             (br $label$break$L46
@@ -3182,13 +3184,13 @@
                           )
                         )
                         (loop $while-in11
-                          (set_local $6
+                          (set_local $7
                             (i32.add
                               (i32.mul
                                 (get_local $8)
                                 (i32.const 10)
                               )
-                              (get_local $6)
+                              (get_local $7)
                             )
                           )
                           (if
@@ -3210,9 +3212,9 @@
                             )
                             (block
                               (set_local $8
-                                (get_local $6)
+                                (get_local $7)
                               )
-                              (set_local $6
+                              (set_local $7
                                 (get_local $10)
                               )
                               (br $while-in11)
@@ -3226,7 +3228,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (tee_local $6
+                        (tee_local $7
                           (i32.add
                             (i32.load8_s
                               (tee_local $8
@@ -3253,13 +3255,13 @@
                             (i32.add
                               (get_local $4)
                               (i32.shl
-                                (get_local $6)
+                                (get_local $7)
                                 (i32.const 2)
                               )
                             )
                             (i32.const 10)
                           )
-                          (set_local $6
+                          (set_local $7
                             (i32.add
                               (get_local $3)
                               (i32.shl
@@ -3273,9 +3275,9 @@
                               )
                             )
                           )
-                          (set_local $6
+                          (set_local $7
                             (i32.load
-                              (get_local $6)
+                              (get_local $7)
                             )
                           )
                           (br $label$break$L46
@@ -3297,9 +3299,9 @@
                       )
                     )
                     (if i32
-                      (get_local $32)
+                      (get_local $31)
                       (block i32
-                        (set_local $6
+                        (set_local $7
                           (i32.load
                             (tee_local $5
                               (i32.and
@@ -3324,7 +3326,7 @@
                         (get_local $8)
                       )
                       (block i32
-                        (set_local $6
+                        (set_local $7
                           (i32.const 0)
                         )
                         (get_local $8)
@@ -3332,7 +3334,7 @@
                     )
                   )
                   (block i32
-                    (set_local $6
+                    (set_local $7
                       (i32.const -1)
                     )
                     (get_local $5)
@@ -3499,7 +3501,7 @@
                     )
                     (if
                       (i32.eqz
-                        (get_local $32)
+                        (get_local $31)
                       )
                       (block
                         (set_local $16
@@ -3517,19 +3519,19 @@
                 )
                 (br $jumpthreading$outer$1)
               )
-              (set_local $26
+              (set_local $27
                 (i32.const 0)
               )
               (if
                 (i32.eqz
-                  (get_local $32)
+                  (get_local $31)
                 )
                 (block
                   (set_local $9
                     (get_local $5)
                   )
                   (set_local $5
-                    (get_local $7)
+                    (get_local $6)
                   )
                   (br $label$continue$L1)
                 )
@@ -3572,7 +3574,7 @@
                                                   (block $switch-case27
                                                     (br_table $switch-case42 $switch-default120 $switch-case40 $switch-default120 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case41 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case29 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-default120 $switch-case42 $switch-default120 $switch-case37 $switch-case34 $switch-case42 $switch-case42 $switch-case42 $switch-default120 $switch-case34 $switch-default120 $switch-default120 $switch-default120 $switch-case38 $switch-case27 $switch-case33 $switch-case28 $switch-default120 $switch-default120 $switch-case39 $switch-default120 $switch-case36 $switch-default120 $switch-default120 $switch-case29 $switch-default120
                                                       (i32.sub
-                                                        (tee_local $17
+                                                        (tee_local $13
                                                           (select
                                                             (i32.and
                                                               (tee_local $11
@@ -3627,7 +3629,7 @@
                                                                   (get_local $5)
                                                                 )
                                                                 (set_local $5
-                                                                  (get_local $7)
+                                                                  (get_local $6)
                                                                 )
                                                                 (br $label$continue$L1)
                                                               )
@@ -3641,7 +3643,7 @@
                                                                 (get_local $5)
                                                               )
                                                               (set_local $5
-                                                                (get_local $7)
+                                                                (get_local $6)
                                                               )
                                                               (br $label$continue$L1)
                                                             )
@@ -3670,7 +3672,7 @@
                                                               (get_local $5)
                                                             )
                                                             (set_local $5
-                                                              (get_local $7)
+                                                              (get_local $6)
                                                             )
                                                             (br $label$continue$L1)
                                                           )
@@ -3684,7 +3686,7 @@
                                                             (get_local $5)
                                                           )
                                                           (set_local $5
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                           )
                                                           (br $label$continue$L1)
                                                         )
@@ -3698,7 +3700,7 @@
                                                           (get_local $5)
                                                         )
                                                         (set_local $5
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                         )
                                                         (br $label$continue$L1)
                                                       )
@@ -3712,7 +3714,7 @@
                                                         (get_local $5)
                                                       )
                                                       (set_local $5
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                       )
                                                       (br $label$continue$L1)
                                                     )
@@ -3741,7 +3743,7 @@
                                                       (get_local $5)
                                                     )
                                                     (set_local $5
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                     )
                                                     (br $label$continue$L1)
                                                   )
@@ -3749,7 +3751,7 @@
                                                     (get_local $5)
                                                   )
                                                   (set_local $5
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (br $label$continue$L1)
                                                 )
@@ -3759,17 +3761,17 @@
                                                     (i32.const 8)
                                                   )
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (select
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const 8)
                                                     (i32.gt_u
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.const 8)
                                                     )
                                                   )
                                                 )
-                                                (set_local $17
+                                                (set_local $13
                                                   (i32.const 120)
                                                 )
                                                 (br $jumpthreading$inner$2)
@@ -3782,7 +3784,7 @@
                                             (if
                                               (i32.and
                                                 (i32.eqz
-                                                  (tee_local $7
+                                                  (tee_local $6
                                                     (i32.load
                                                       (tee_local $9
                                                         (get_local $18)
@@ -3803,9 +3805,9 @@
                                               )
                                               (block
                                                 (set_local $9
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
-                                                (set_local $7
+                                                (set_local $6
                                                   (get_local $8)
                                                 )
                                                 (set_local $8
@@ -3834,13 +3836,13 @@
                                                           (tee_local $9
                                                             (call $_bitshift64Lshr
                                                               (get_local $9)
-                                                              (get_local $7)
+                                                              (get_local $6)
                                                               (i32.const 3)
                                                             )
                                                           )
                                                         )
                                                         (i32.eqz
-                                                          (tee_local $7
+                                                          (tee_local $6
                                                             (get_global $tempRet0)
                                                           )
                                                         )
@@ -3856,26 +3858,26 @@
                                                 (i32.const 8)
                                               )
                                               (block
-                                                (set_local $7
+                                                (set_local $6
                                                   (get_local $8)
                                                 )
                                                 (set_local $9
                                                   (get_local $12)
                                                 )
-                                                (set_local $6
+                                                (set_local $7
                                                   (select
                                                     (tee_local $12
                                                       (i32.add
                                                         (i32.sub
-                                                          (get_local $45)
+                                                          (get_local $44)
                                                           (get_local $8)
                                                         )
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.lt_s
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (get_local $12)
                                                     )
                                                   )
@@ -3889,7 +3891,7 @@
                                                 (br $jumpthreading$inner$7)
                                               )
                                               (block
-                                                (set_local $7
+                                                (set_local $6
                                                   (get_local $8)
                                                 )
                                                 (set_local $9
@@ -3907,16 +3909,16 @@
                                           )
                                           (set_local $9
                                             (i32.load
-                                              (tee_local $7
+                                              (tee_local $6
                                                 (get_local $18)
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_s
-                                              (tee_local $7
+                                              (tee_local $6
                                                 (i32.load offset=4
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                               (i32.const 0)
@@ -3931,13 +3933,13 @@
                                                     (i32.const 0)
                                                     (i32.const 0)
                                                     (get_local $9)
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                 )
                                               )
                                               (i32.store offset=4
                                                 (get_local $8)
-                                                (tee_local $7
+                                                (tee_local $6
                                                   (get_global $tempRet0)
                                                 )
                                               )
@@ -3986,14 +3988,14 @@
                                         )
                                         (set_local $9
                                           (i32.load
-                                            (tee_local $7
+                                            (tee_local $6
                                               (get_local $18)
                                             )
                                           )
                                         )
-                                        (set_local $7
+                                        (set_local $6
                                           (i32.load offset=4
-                                            (get_local $7)
+                                            (get_local $6)
                                           )
                                         )
                                         (set_local $8
@@ -4008,13 +4010,13 @@
                                         (get_local $18)
                                       )
                                       (i32.store8
-                                        (get_local $46)
+                                        (get_local $45)
                                         (i32.load
                                           (get_local $9)
                                         )
                                       )
-                                      (set_local $7
-                                        (get_local $46)
+                                      (set_local $6
+                                        (get_local $45)
                                       )
                                       (set_local $12
                                         (get_local $8)
@@ -4062,18 +4064,18 @@
                                   (get_local $18)
                                 )
                                 (i32.store
-                                  (get_local $47)
+                                  (get_local $46)
                                   (i32.load
                                     (get_local $9)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $50)
+                                  (get_local $49)
                                   (i32.const 0)
                                 )
                                 (i32.store
                                   (get_local $18)
-                                  (get_local $47)
+                                  (get_local $46)
                                 )
                                 (set_local $8
                                   (i32.const -1)
@@ -4081,10 +4083,10 @@
                                 (br $jumpthreading$inner$5)
                               )
                               (if
-                                (get_local $6)
+                                (get_local $7)
                                 (block
                                   (set_local $8
-                                    (get_local $6)
+                                    (get_local $7)
                                   )
                                   (br $jumpthreading$inner$5)
                                 )
@@ -4096,7 +4098,7 @@
                                     (i32.const 0)
                                     (get_local $12)
                                   )
-                                  (set_local $7
+                                  (set_local $6
                                     (i32.const 0)
                                   )
                                   (br $jumpthreading$inner$6)
@@ -4116,7 +4118,7 @@
                               (get_global $tempDoublePtr)
                               (get_local $15)
                             )
-                            (set_local $35
+                            (set_local $34
                               (if i32
                                 (i32.lt_s
                                   (i32.load offset=4
@@ -4125,7 +4127,7 @@
                                   (i32.const 0)
                                 )
                                 (block i32
-                                  (set_local $28
+                                  (set_local $29
                                     (i32.const 1)
                                   )
                                   (set_local $15
@@ -4141,13 +4143,13 @@
                                     (i32.const 2048)
                                   )
                                   (block i32
-                                    (set_local $28
+                                    (set_local $29
                                       (i32.const 1)
                                     )
                                     (i32.const 4111)
                                   )
                                   (block i32
-                                    (set_local $28
+                                    (set_local $29
                                       (tee_local $9
                                         (i32.and
                                           (get_local $12)
@@ -4222,9 +4224,9 @@
                                     )
                                     (if
                                       (i32.eq
-                                        (tee_local $13
+                                        (tee_local $17
                                           (i32.or
-                                            (get_local $17)
+                                            (get_local $13)
                                             (i32.const 32)
                                           )
                                         )
@@ -4234,36 +4236,30 @@
                                         (set_local $10
                                           (select
                                             (i32.add
-                                              (get_local $35)
+                                              (get_local $34)
                                               (i32.const 9)
                                             )
-                                            (get_local $35)
-                                            (tee_local $13
+                                            (get_local $34)
+                                            (tee_local $17
                                               (i32.and
-                                                (get_local $17)
+                                                (get_local $13)
                                                 (i32.const 32)
                                               )
                                             )
-                                          )
-                                        )
-                                        (set_local $11
-                                          (i32.or
-                                            (get_local $28)
-                                            (i32.const 2)
                                           )
                                         )
                                         (set_local $15
                                           (if f64
                                             (i32.or
                                               (i32.gt_u
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (i32.const 11)
                                               )
                                               (i32.eqz
                                                 (tee_local $5
                                                   (i32.sub
                                                     (i32.const 12)
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                 )
                                               )
@@ -4318,14 +4314,20 @@
                                             )
                                           )
                                         )
+                                        (set_local $11
+                                          (i32.or
+                                            (get_local $29)
+                                            (i32.const 2)
+                                          )
+                                        )
                                         (i32.store8
                                           (i32.add
-                                            (tee_local $7
+                                            (tee_local $6
                                               (if i32
                                                 (i32.eq
-                                                  (tee_local $7
+                                                  (tee_local $6
                                                     (call $_fmt_u
-                                                      (tee_local $7
+                                                      (tee_local $6
                                                         (select
                                                           (i32.sub
                                                             (i32.const 0)
@@ -4345,26 +4347,26 @@
                                                       (i32.shr_s
                                                         (i32.shl
                                                           (i32.lt_s
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                             (i32.const 0)
                                                           )
                                                           (i32.const 31)
                                                         )
                                                         (i32.const 31)
                                                       )
-                                                      (get_local $38)
+                                                      (get_local $37)
                                                     )
                                                   )
-                                                  (get_local $38)
+                                                  (get_local $37)
                                                 )
                                                 (block i32
                                                   (i32.store8
-                                                    (get_local $48)
+                                                    (get_local $47)
                                                     (i32.const 48)
                                                   )
-                                                  (get_local $48)
+                                                  (get_local $47)
                                                 )
-                                                (get_local $7)
+                                                (get_local $6)
                                               )
                                             )
                                             (i32.const -1)
@@ -4381,20 +4383,20 @@
                                           )
                                         )
                                         (i32.store8
-                                          (tee_local $7
+                                          (tee_local $6
                                             (i32.add
-                                              (get_local $7)
+                                              (get_local $6)
                                               (i32.const -2)
                                             )
                                           )
                                           (i32.add
-                                            (get_local $17)
+                                            (get_local $13)
                                             (i32.const 15)
                                           )
                                         )
-                                        (set_local $17
+                                        (set_local $13
                                           (i32.lt_s
-                                            (get_local $6)
+                                            (get_local $7)
                                             (i32.const 1)
                                           )
                                         )
@@ -4423,7 +4425,7 @@
                                                   (i32.const 4075)
                                                 )
                                               )
-                                              (get_local $13)
+                                              (get_local $17)
                                             )
                                           )
                                           (set_local $15
@@ -4448,7 +4450,7 @@
                                                         (i32.const 1)
                                                       )
                                                     )
-                                                    (get_local $42)
+                                                    (get_local $41)
                                                   )
                                                   (i32.const 1)
                                                 )
@@ -4459,7 +4461,7 @@
                                                       (i32.and
                                                         (get_local $19)
                                                         (i32.and
-                                                          (get_local $17)
+                                                          (get_local $13)
                                                           (f64.eq
                                                             (get_local $15)
                                                             (f64.const 0)
@@ -4492,35 +4494,35 @@
                                           (get_local $0)
                                           (i32.const 32)
                                           (get_local $14)
-                                          (tee_local $6
+                                          (tee_local $7
                                             (i32.add
                                               (tee_local $8
                                                 (select
                                                   (i32.sub
                                                     (i32.add
-                                                      (get_local $53)
-                                                      (get_local $6)
+                                                      (get_local $52)
+                                                      (get_local $7)
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (i32.add
                                                     (i32.sub
-                                                      (get_local $51)
-                                                      (get_local $7)
+                                                      (get_local $50)
+                                                      (get_local $6)
                                                     )
                                                     (get_local $5)
                                                   )
                                                   (i32.and
                                                     (i32.ne
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.const 0)
                                                     )
                                                     (i32.lt_s
                                                       (i32.add
-                                                        (get_local $52)
+                                                        (get_local $51)
                                                         (get_local $5)
                                                       )
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                     )
                                                   )
                                                 )
@@ -4551,7 +4553,7 @@
                                           (get_local $0)
                                           (i32.const 48)
                                           (get_local $14)
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.xor
                                             (get_local $12)
                                             (i32.const 65536)
@@ -4560,7 +4562,7 @@
                                         (set_local $5
                                           (i32.sub
                                             (get_local $5)
-                                            (get_local $42)
+                                            (get_local $41)
                                           )
                                         )
                                         (if
@@ -4590,7 +4592,7 @@
                                               (tee_local $5
                                                 (i32.sub
                                                   (get_local $30)
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -4609,7 +4611,7 @@
                                           )
                                           (drop
                                             (call $___fwritex
-                                              (get_local $7)
+                                              (get_local $6)
                                               (get_local $5)
                                               (get_local $0)
                                             )
@@ -4619,7 +4621,7 @@
                                           (get_local $0)
                                           (i32.const 32)
                                           (get_local $14)
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.xor
                                             (get_local $12)
                                             (i32.const 8192)
@@ -4628,64 +4630,52 @@
                                         (br $do-once49
                                           (select
                                             (get_local $14)
-                                            (get_local $6)
+                                            (get_local $7)
                                             (i32.lt_s
-                                              (get_local $6)
+                                              (get_local $7)
                                               (get_local $14)
                                             )
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $19
+                                    (set_local $8
                                       (select
-                                        (i32.const 6)
-                                        (get_local $6)
+                                        (get_local $53)
+                                        (get_local $54)
                                         (i32.lt_s
-                                          (get_local $6)
-                                          (i32.const 0)
-                                        )
-                                      )
-                                    )
-                                    (set_local $31
-                                      (tee_local $8
-                                        (select
-                                          (get_local $54)
-                                          (get_local $55)
-                                          (i32.lt_s
-                                            (if i32
-                                              (get_local $5)
-                                              (block i32
-                                                (i32.store
-                                                  (get_local $20)
-                                                  (tee_local $5
-                                                    (i32.add
-                                                      (i32.load
-                                                        (get_local $20)
-                                                      )
-                                                      (i32.const -28)
+                                          (if i32
+                                            (get_local $5)
+                                            (block i32
+                                              (i32.store
+                                                (get_local $20)
+                                                (tee_local $5
+                                                  (i32.add
+                                                    (i32.load
+                                                      (get_local $20)
                                                     )
+                                                    (i32.const -28)
                                                   )
                                                 )
-                                                (set_local $15
-                                                  (f64.mul
-                                                    (get_local $21)
-                                                    (f64.const 268435456)
-                                                  )
-                                                )
-                                                (get_local $5)
                                               )
-                                              (block i32
-                                                (set_local $15
+                                              (set_local $15
+                                                (f64.mul
                                                   (get_local $21)
+                                                  (f64.const 268435456)
                                                 )
-                                                (i32.load
-                                                  (get_local $20)
-                                                )
+                                              )
+                                              (get_local $5)
+                                            )
+                                            (block i32
+                                              (set_local $15
+                                                (get_local $21)
+                                              )
+                                              (i32.load
+                                                (get_local $20)
                                               )
                                             )
-                                            (i32.const 0)
                                           )
+                                          (i32.const 0)
                                         )
                                       )
                                     )
@@ -4695,7 +4685,7 @@
                                     (loop $while-in60
                                       (i32.store
                                         (get_local $5)
-                                        (tee_local $7
+                                        (tee_local $6
                                           (i32.trunc_s/f64
                                             (get_local $15)
                                           )
@@ -4714,7 +4704,7 @@
                                               (f64.sub
                                                 (get_local $15)
                                                 (f64.convert_u/i32
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                               (f64.const 1e9)
@@ -4726,7 +4716,7 @@
                                     )
                                     (if
                                       (i32.gt_s
-                                        (tee_local $6
+                                        (tee_local $10
                                           (i32.load
                                             (get_local $20)
                                           )
@@ -4734,51 +4724,51 @@
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $7
+                                        (set_local $6
                                           (get_local $8)
                                         )
                                         (loop $while-in62
-                                          (set_local $11
+                                          (set_local $19
                                             (select
                                               (i32.const 29)
-                                              (get_local $6)
+                                              (get_local $10)
                                               (i32.gt_s
-                                                (get_local $6)
+                                                (get_local $10)
                                                 (i32.const 29)
                                               )
                                             )
                                           )
-                                          (set_local $7
+                                          (set_local $6
                                             (block $do-once63 i32
                                               (if i32
                                                 (i32.lt_u
-                                                  (tee_local $6
+                                                  (tee_local $10
                                                     (i32.add
                                                       (get_local $5)
                                                       (i32.const -4)
                                                     )
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (block i32
-                                                  (set_local $10
+                                                  (set_local $11
                                                     (i32.const 0)
                                                   )
                                                   (loop $while-in66
-                                                    (set_local $29
+                                                    (set_local $25
                                                       (call $___uremdi3
-                                                        (tee_local $10
+                                                        (tee_local $11
                                                           (call $_i64Add
                                                             (call $_bitshift64Shl
                                                               (i32.load
-                                                                (get_local $6)
+                                                                (get_local $10)
                                                               )
                                                               (i32.const 0)
-                                                              (get_local $11)
+                                                              (get_local $19)
                                                             )
                                                             (get_global $tempRet0)
-                                                            (get_local $10)
+                                                            (get_local $11)
                                                             (i32.const 0)
                                                           )
                                                         )
@@ -4790,12 +4780,12 @@
                                                       )
                                                     )
                                                     (i32.store
-                                                      (get_local $6)
-                                                      (get_local $29)
+                                                      (get_local $10)
+                                                      (get_local $25)
                                                     )
-                                                    (set_local $10
+                                                    (set_local $11
                                                       (call $___udivdi3
-                                                        (get_local $10)
+                                                        (get_local $11)
                                                         (get_local $22)
                                                         (i32.const 1000000000)
                                                         (i32.const 0)
@@ -4803,34 +4793,34 @@
                                                     )
                                                     (br_if $while-in66
                                                       (i32.ge_u
-                                                        (tee_local $6
+                                                        (tee_local $10
                                                           (i32.add
-                                                            (get_local $6)
+                                                            (get_local $10)
                                                             (i32.const -4)
                                                           )
                                                         )
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                       )
                                                     )
                                                   )
                                                   (drop
                                                     (br_if $do-once63
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.eqz
-                                                        (get_local $10)
+                                                        (get_local $11)
                                                       )
                                                     )
                                                   )
                                                   (i32.store
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const -4)
                                                       )
                                                     )
-                                                    (get_local $10)
+                                                    (get_local $11)
                                                   )
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -4840,13 +4830,13 @@
                                               (br_if $while-out67
                                                 (i32.le_u
                                                   (get_local $5)
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                               (if
                                                 (i32.eqz
                                                   (i32.load
-                                                    (tee_local $6
+                                                    (tee_local $10
                                                       (i32.add
                                                         (get_local $5)
                                                         (i32.const -4)
@@ -4856,7 +4846,7 @@
                                                 )
                                                 (block
                                                   (set_local $5
-                                                    (get_local $6)
+                                                    (get_local $10)
                                                   )
                                                   (br $while-in68)
                                                 )
@@ -4865,46 +4855,56 @@
                                           )
                                           (i32.store
                                             (get_local $20)
-                                            (tee_local $6
+                                            (tee_local $10
                                               (i32.sub
                                                 (i32.load
                                                   (get_local $20)
                                                 )
-                                                (get_local $11)
+                                                (get_local $19)
                                               )
                                             )
                                           )
                                           (br_if $while-in62
                                             (i32.gt_s
-                                              (get_local $6)
+                                              (get_local $10)
                                               (i32.const 0)
                                             )
                                           )
                                           (block
-                                            (set_local $10
-                                              (get_local $6)
+                                            (set_local $11
+                                              (get_local $10)
                                             )
-                                            (set_local $6
+                                            (set_local $10
                                               (get_local $5)
                                             )
                                           )
                                         )
                                       )
                                       (block
-                                        (set_local $10
-                                          (get_local $6)
-                                        )
-                                        (set_local $7
-                                          (get_local $8)
+                                        (set_local $11
+                                          (get_local $10)
                                         )
                                         (set_local $6
+                                          (get_local $8)
+                                        )
+                                        (set_local $10
                                           (get_local $5)
+                                        )
+                                      )
+                                    )
+                                    (set_local $19
+                                      (select
+                                        (i32.const 6)
+                                        (get_local $7)
+                                        (i32.lt_s
+                                          (get_local $7)
+                                          (i32.const 0)
                                         )
                                       )
                                     )
                                     (if
                                       (i32.lt_s
-                                        (get_local $10)
+                                        (get_local $11)
                                         (i32.const 0)
                                       )
                                       (block
@@ -4920,46 +4920,46 @@
                                             (i32.const 1)
                                           )
                                         )
-                                        (set_local $29
+                                        (set_local $25
                                           (i32.eq
-                                            (get_local $13)
+                                            (get_local $17)
                                             (i32.const 102)
                                           )
                                         )
                                         (set_local $5
-                                          (get_local $6)
+                                          (get_local $10)
                                         )
                                         (loop $while-in70
                                           (set_local $11
                                             (select
                                               (i32.const 9)
-                                              (tee_local $6
+                                              (tee_local $7
                                                 (i32.sub
                                                   (i32.const 0)
-                                                  (get_local $10)
+                                                  (get_local $11)
                                                 )
                                               )
                                               (i32.gt_s
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (i32.const 9)
                                               )
                                             )
                                           )
-                                          (set_local $6
+                                          (set_local $10
                                             (select
                                               (i32.add
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (select
                                                     (get_local $8)
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (block $do-once71 i32
                                                         (if i32
                                                           (i32.lt_u
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                             (get_local $5)
                                                           )
                                                           (block i32
-                                                            (set_local $36
+                                                            (set_local $35
                                                               (i32.add
                                                                 (i32.shl
                                                                   (i32.const 1)
@@ -4968,7 +4968,7 @@
                                                                 (i32.const -1)
                                                               )
                                                             )
-                                                            (set_local $37
+                                                            (set_local $43
                                                               (i32.shr_u
                                                                 (i32.const 1000000000)
                                                                 (get_local $11)
@@ -4977,17 +4977,17 @@
                                                             (set_local $10
                                                               (i32.const 0)
                                                             )
-                                                            (set_local $6
-                                                              (get_local $7)
+                                                            (set_local $7
+                                                              (get_local $6)
                                                             )
                                                             (loop $while-in74
                                                               (i32.store
-                                                                (get_local $6)
+                                                                (get_local $7)
                                                                 (i32.add
                                                                   (i32.shr_u
-                                                                    (tee_local $44
+                                                                    (tee_local $36
                                                                       (i32.load
-                                                                        (get_local $6)
+                                                                        (get_local $7)
                                                                       )
                                                                     )
                                                                     (get_local $11)
@@ -4998,17 +4998,17 @@
                                                               (set_local $10
                                                                 (i32.mul
                                                                   (i32.and
-                                                                    (get_local $44)
                                                                     (get_local $36)
+                                                                    (get_local $35)
                                                                   )
-                                                                  (get_local $37)
+                                                                  (get_local $43)
                                                                 )
                                                               )
                                                               (br_if $while-in74
                                                                 (i32.lt_u
-                                                                  (tee_local $6
+                                                                  (tee_local $7
                                                                     (i32.add
-                                                                      (get_local $6)
+                                                                      (get_local $7)
                                                                       (i32.const 4)
                                                                     )
                                                                   )
@@ -5016,21 +5016,21 @@
                                                                 )
                                                               )
                                                             )
-                                                            (set_local $7
+                                                            (set_local $6
                                                               (select
-                                                                (get_local $7)
+                                                                (get_local $6)
                                                                 (i32.add
-                                                                  (get_local $7)
+                                                                  (get_local $6)
                                                                   (i32.const 4)
                                                                 )
                                                                 (i32.load
-                                                                  (get_local $7)
+                                                                  (get_local $6)
                                                                 )
                                                               )
                                                             )
                                                             (drop
                                                               (br_if $do-once71
-                                                                (get_local $7)
+                                                                (get_local $6)
                                                                 (i32.eqz
                                                                   (get_local $10)
                                                                 )
@@ -5046,22 +5046,22 @@
                                                                 (i32.const 4)
                                                               )
                                                             )
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                           )
                                                           (select
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                             (i32.add
-                                                              (get_local $7)
+                                                              (get_local $6)
                                                               (i32.const 4)
                                                             )
                                                             (i32.load
-                                                              (get_local $7)
+                                                              (get_local $6)
                                                             )
                                                           )
                                                         )
                                                       )
                                                     )
-                                                    (get_local $29)
+                                                    (get_local $25)
                                                   )
                                                 )
                                                 (i32.shl
@@ -5074,7 +5074,7 @@
                                                 (i32.shr_s
                                                   (i32.sub
                                                     (get_local $5)
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (i32.const 2)
                                                 )
@@ -5084,7 +5084,7 @@
                                           )
                                           (i32.store
                                             (get_local $20)
-                                            (tee_local $10
+                                            (tee_local $11
                                               (i32.add
                                                 (i32.load
                                                   (get_local $20)
@@ -5095,34 +5095,27 @@
                                           )
                                           (if
                                             (i32.lt_s
-                                              (get_local $10)
+                                              (get_local $11)
                                               (i32.const 0)
                                             )
                                             (block
                                               (set_local $5
-                                                (get_local $6)
+                                                (get_local $10)
                                               )
                                               (br $while-in70)
                                             )
-                                            (block
-                                              (set_local $5
-                                                (get_local $7)
-                                              )
-                                              (set_local $10
-                                                (get_local $6)
-                                              )
+                                            (set_local $5
+                                              (get_local $6)
                                             )
                                           )
                                         )
                                       )
-                                      (block
-                                        (set_local $5
-                                          (get_local $7)
-                                        )
-                                        (set_local $10
-                                          (get_local $6)
-                                        )
+                                      (set_local $5
+                                        (get_local $6)
                                       )
+                                    )
+                                    (set_local $22
+                                      (get_local $8)
                                     )
                                     (block $do-once75
                                       (if
@@ -5131,11 +5124,11 @@
                                           (get_local $10)
                                         )
                                         (block
-                                          (set_local $7
+                                          (set_local $6
                                             (i32.mul
                                               (i32.shr_s
                                                 (i32.sub
-                                                  (get_local $31)
+                                                  (get_local $22)
                                                   (get_local $5)
                                                 )
                                                 (i32.const 2)
@@ -5153,22 +5146,22 @@
                                               (i32.const 10)
                                             )
                                           )
-                                          (set_local $6
+                                          (set_local $7
                                             (i32.const 10)
                                           )
                                           (loop $while-in78
-                                            (set_local $7
+                                            (set_local $6
                                               (i32.add
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (i32.const 1)
                                               )
                                             )
                                             (br_if $while-in78
                                               (i32.ge_u
                                                 (get_local $11)
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (i32.mul
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const 10)
                                                   )
                                                 )
@@ -5176,23 +5169,23 @@
                                             )
                                           )
                                         )
-                                        (set_local $7
+                                        (set_local $6
                                           (i32.const 0)
                                         )
                                       )
                                     )
-                                    (set_local $13
+                                    (set_local $17
                                       (if i32
                                         (i32.lt_s
-                                          (tee_local $6
+                                          (tee_local $7
                                             (i32.add
                                               (i32.sub
                                                 (get_local $19)
                                                 (select
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (i32.const 0)
                                                   (i32.ne
-                                                    (get_local $13)
+                                                    (get_local $17)
                                                     (i32.const 102)
                                                   )
                                                 )
@@ -5200,15 +5193,15 @@
                                               (i32.shr_s
                                                 (i32.shl
                                                   (i32.and
-                                                    (tee_local $29
+                                                    (tee_local $35
                                                       (i32.ne
                                                         (get_local $19)
                                                         (i32.const 0)
                                                       )
                                                     )
-                                                    (tee_local $36
+                                                    (tee_local $43
                                                       (i32.eq
-                                                        (get_local $13)
+                                                        (get_local $17)
                                                         (i32.const 103)
                                                       )
                                                     )
@@ -5224,7 +5217,7 @@
                                               (i32.shr_s
                                                 (i32.sub
                                                   (get_local $10)
-                                                  (get_local $31)
+                                                  (get_local $22)
                                                 )
                                                 (i32.const 2)
                                               )
@@ -5234,35 +5227,17 @@
                                           )
                                         )
                                         (block i32
-                                          (set_local $6
-                                            (i32.add
-                                              (i32.add
-                                                (get_local $8)
-                                                (i32.const 4)
-                                              )
-                                              (i32.shl
+                                          (if
+                                            (i32.lt_s
+                                              (tee_local $7
                                                 (i32.add
-                                                  (i32.div_s
-                                                    (tee_local $11
+                                                  (i32.rem_s
+                                                    (tee_local $17
                                                       (i32.add
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const 9216)
                                                       )
                                                     )
-                                                    (i32.const 9)
-                                                  )
-                                                  (i32.const -1024)
-                                                )
-                                                (i32.const 2)
-                                              )
-                                            )
-                                          )
-                                          (if
-                                            (i32.lt_s
-                                              (tee_local $11
-                                                (i32.add
-                                                  (i32.rem_s
-                                                    (get_local $11)
                                                     (i32.const 9)
                                                   )
                                                   (i32.const 1)
@@ -5271,21 +5246,21 @@
                                               (i32.const 9)
                                             )
                                             (block
-                                              (set_local $13
+                                              (set_local $11
                                                 (i32.const 10)
                                               )
                                               (loop $while-in80
-                                                (set_local $13
+                                                (set_local $11
                                                   (i32.mul
-                                                    (get_local $13)
+                                                    (get_local $11)
                                                     (i32.const 10)
                                                   )
                                                 )
                                                 (br_if $while-in80
                                                   (i32.ne
-                                                    (tee_local $11
+                                                    (tee_local $7
                                                       (i32.add
-                                                        (get_local $11)
+                                                        (get_local $7)
                                                         (i32.const 1)
                                                       )
                                                     )
@@ -5294,58 +5269,63 @@
                                                 )
                                               )
                                             )
-                                            (set_local $13
+                                            (set_local $11
                                               (i32.const 10)
+                                            )
+                                          )
+                                          (set_local $17
+                                            (i32.rem_u
+                                              (tee_local $25
+                                                (i32.load
+                                                  (tee_local $7
+                                                    (i32.add
+                                                      (i32.add
+                                                        (get_local $8)
+                                                        (i32.const 4)
+                                                      )
+                                                      (i32.shl
+                                                        (i32.add
+                                                          (i32.div_s
+                                                            (get_local $17)
+                                                            (i32.const 9)
+                                                          )
+                                                          (i32.const -1024)
+                                                        )
+                                                        (i32.const 2)
+                                                      )
+                                                    )
+                                                  )
+                                                )
+                                              )
+                                              (get_local $11)
                                             )
                                           )
                                           (block $do-once81
                                             (if
                                               (i32.eqz
                                                 (i32.and
-                                                  (tee_local $37
+                                                  (tee_local $36
                                                     (i32.eq
                                                       (i32.add
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const 4)
                                                       )
                                                       (get_local $10)
                                                     )
                                                   )
                                                   (i32.eqz
-                                                    (tee_local $11
-                                                      (i32.rem_u
-                                                        (tee_local $22
-                                                          (i32.load
-                                                            (get_local $6)
-                                                          )
-                                                        )
-                                                        (get_local $13)
-                                                      )
-                                                    )
+                                                    (get_local $17)
                                                   )
                                                 )
                                               )
                                               (block
-                                                (set_local $21
-                                                  (select
-                                                    (f64.const 9007199254740994)
-                                                    (f64.const 9007199254740992)
-                                                    (i32.and
-                                                      (i32.div_u
-                                                        (get_local $22)
-                                                        (get_local $13)
-                                                      )
-                                                      (i32.const 1)
-                                                    )
-                                                  )
-                                                )
                                                 (set_local $15
                                                   (if f64
                                                     (i32.lt_u
-                                                      (get_local $11)
-                                                      (tee_local $44
+                                                      (get_local $17)
+                                                      (tee_local $55
                                                         (i32.div_s
-                                                          (get_local $13)
+                                                          (get_local $11)
                                                           (i32.const 2)
                                                         )
                                                       )
@@ -5355,26 +5335,39 @@
                                                       (f64.const 1)
                                                       (f64.const 1.5)
                                                       (i32.and
-                                                        (get_local $37)
+                                                        (get_local $36)
                                                         (i32.eq
-                                                          (get_local $11)
-                                                          (get_local $44)
+                                                          (get_local $17)
+                                                          (get_local $55)
                                                         )
                                                       )
                                                     )
                                                   )
                                                 )
                                                 (set_local $21
+                                                  (select
+                                                    (f64.const 9007199254740994)
+                                                    (f64.const 9007199254740992)
+                                                    (i32.and
+                                                      (i32.div_u
+                                                        (get_local $25)
+                                                        (get_local $11)
+                                                      )
+                                                      (i32.const 1)
+                                                    )
+                                                  )
+                                                )
+                                                (set_local $21
                                                   (block $do-once83 f64
                                                     (if f64
-                                                      (get_local $28)
+                                                      (get_local $29)
                                                       (block f64
                                                         (drop
                                                           (br_if $do-once83
                                                             (get_local $21)
                                                             (i32.ne
                                                               (i32.load8_s
-                                                                (get_local $35)
+                                                                (get_local $34)
                                                               )
                                                               (i32.const 45)
                                                             )
@@ -5394,11 +5387,11 @@
                                                   )
                                                 )
                                                 (i32.store
-                                                  (get_local $6)
-                                                  (tee_local $11
+                                                  (get_local $7)
+                                                  (tee_local $17
                                                     (i32.sub
-                                                      (get_local $22)
-                                                      (get_local $11)
+                                                      (get_local $25)
+                                                      (get_local $17)
                                                     )
                                                   )
                                                 )
@@ -5412,30 +5405,30 @@
                                                   )
                                                 )
                                                 (i32.store
-                                                  (get_local $6)
-                                                  (tee_local $7
+                                                  (get_local $7)
+                                                  (tee_local $6
                                                     (i32.add
+                                                      (get_local $17)
                                                       (get_local $11)
-                                                      (get_local $13)
                                                     )
                                                   )
                                                 )
                                                 (if
                                                   (i32.gt_u
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 999999999)
                                                   )
                                                   (loop $while-in86
                                                     (i32.store
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (i32.const 0)
                                                     )
                                                     (set_local $5
                                                       (if i32
                                                         (i32.lt_u
-                                                          (tee_local $6
+                                                          (tee_local $7
                                                             (i32.add
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                               (i32.const -4)
                                                             )
                                                           )
@@ -5457,11 +5450,11 @@
                                                       )
                                                     )
                                                     (i32.store
-                                                      (get_local $6)
-                                                      (tee_local $7
+                                                      (get_local $7)
+                                                      (tee_local $6
                                                         (i32.add
                                                           (i32.load
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                           )
                                                           (i32.const 1)
                                                         )
@@ -5469,17 +5462,17 @@
                                                     )
                                                     (br_if $while-in86
                                                       (i32.gt_u
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const 999999999)
                                                       )
                                                     )
                                                   )
                                                 )
-                                                (set_local $7
+                                                (set_local $6
                                                   (i32.mul
                                                     (i32.shr_s
                                                       (i32.sub
-                                                        (get_local $31)
+                                                        (get_local $22)
                                                         (get_local $5)
                                                       )
                                                       (i32.const 2)
@@ -5489,7 +5482,7 @@
                                                 )
                                                 (br_if $do-once81
                                                   (i32.lt_u
-                                                    (tee_local $13
+                                                    (tee_local $17
                                                       (i32.load
                                                         (get_local $5)
                                                       )
@@ -5501,15 +5494,15 @@
                                                   (i32.const 10)
                                                 )
                                                 (loop $while-in88
-                                                  (set_local $7
+                                                  (set_local $6
                                                     (i32.add
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (i32.const 1)
                                                     )
                                                   )
                                                   (br_if $while-in88
                                                     (i32.ge_u
-                                                      (get_local $13)
+                                                      (get_local $17)
                                                       (tee_local $11
                                                         (i32.mul
                                                           (get_local $11)
@@ -5523,20 +5516,20 @@
                                             )
                                           )
                                           (set_local $11
-                                            (get_local $7)
+                                            (get_local $6)
                                           )
                                           (set_local $10
                                             (select
-                                              (tee_local $7
+                                              (tee_local $6
                                                 (i32.add
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (i32.const 4)
                                                 )
                                               )
                                               (get_local $10)
                                               (i32.gt_u
                                                 (get_local $10)
-                                                (get_local $7)
+                                                (get_local $6)
                                               )
                                             )
                                           )
@@ -5544,13 +5537,13 @@
                                         )
                                         (block i32
                                           (set_local $11
-                                            (get_local $7)
+                                            (get_local $6)
                                           )
                                           (get_local $5)
                                         )
                                       )
                                     )
-                                    (set_local $37
+                                    (set_local $36
                                       (i32.sub
                                         (i32.const 0)
                                         (get_local $11)
@@ -5564,10 +5557,10 @@
                                         (if
                                           (i32.le_u
                                             (get_local $5)
-                                            (get_local $13)
+                                            (get_local $17)
                                           )
                                           (block
-                                            (set_local $22
+                                            (set_local $25
                                               (i32.const 0)
                                             )
                                             (set_local $10
@@ -5578,7 +5571,7 @@
                                         )
                                         (if
                                           (i32.load
-                                            (tee_local $7
+                                            (tee_local $6
                                               (i32.add
                                                 (get_local $5)
                                                 (i32.const -4)
@@ -5586,7 +5579,7 @@
                                             )
                                           )
                                           (block
-                                            (set_local $22
+                                            (set_local $25
                                               (i32.const 1)
                                             )
                                             (set_local $10
@@ -5595,19 +5588,19 @@
                                           )
                                           (block
                                             (set_local $5
-                                              (get_local $7)
+                                              (get_local $6)
                                             )
                                             (br $while-in90)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $17
+                                    (set_local $13
                                       (block $do-once91 i32
                                         (if i32
-                                          (get_local $36)
+                                          (get_local $43)
                                           (block i32
-                                            (set_local $17
+                                            (set_local $13
                                               (if i32
                                                 (i32.and
                                                   (i32.gt_s
@@ -5615,7 +5608,7 @@
                                                       (i32.add
                                                         (i32.xor
                                                           (i32.and
-                                                            (get_local $29)
+                                                            (get_local $35)
                                                             (i32.const 1)
                                                           )
                                                           (i32.const 1)
@@ -5631,9 +5624,9 @@
                                                   )
                                                 )
                                                 (block i32
-                                                  (set_local $7
+                                                  (set_local $6
                                                     (i32.add
-                                                      (get_local $17)
+                                                      (get_local $13)
                                                       (i32.const -1)
                                                     )
                                                   )
@@ -5646,9 +5639,9 @@
                                                   )
                                                 )
                                                 (block i32
-                                                  (set_local $7
+                                                  (set_local $6
                                                     (i32.add
-                                                      (get_local $17)
+                                                      (get_local $13)
                                                       (i32.const -2)
                                                     )
                                                   )
@@ -5660,7 +5653,7 @@
                                               )
                                             )
                                             (if
-                                              (tee_local $6
+                                              (tee_local $7
                                                 (i32.and
                                                   (get_local $12)
                                                   (i32.const 8)
@@ -5668,16 +5661,16 @@
                                               )
                                               (block
                                                 (set_local $5
-                                                  (get_local $17)
+                                                  (get_local $13)
                                                 )
                                                 (br $do-once91
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                             )
                                             (block $do-once93
                                               (if
-                                                (get_local $22)
+                                                (get_local $25)
                                                 (block
                                                   (if
                                                     (i32.eqz
@@ -5709,7 +5702,7 @@
                                                       (br $do-once93)
                                                     )
                                                     (block
-                                                      (set_local $6
+                                                      (set_local $7
                                                         (i32.const 10)
                                                       )
                                                       (set_local $5
@@ -5728,9 +5721,9 @@
                                                       (i32.eqz
                                                         (i32.rem_u
                                                           (get_local $19)
-                                                          (tee_local $6
+                                                          (tee_local $7
                                                             (i32.mul
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                               (i32.const 10)
                                                             )
                                                           )
@@ -5744,13 +5737,13 @@
                                                 )
                                               )
                                             )
-                                            (set_local $6
+                                            (set_local $7
                                               (i32.add
                                                 (i32.mul
                                                   (i32.shr_s
                                                     (i32.sub
                                                       (get_local $10)
-                                                      (get_local $31)
+                                                      (get_local $22)
                                                     )
                                                     (i32.const 2)
                                                   )
@@ -5762,7 +5755,7 @@
                                             (if i32
                                               (i32.eq
                                                 (i32.or
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (i32.const 32)
                                                 )
                                                 (i32.const 102)
@@ -5770,13 +5763,13 @@
                                               (block i32
                                                 (set_local $5
                                                   (select
-                                                    (get_local $17)
+                                                    (get_local $13)
                                                     (tee_local $5
                                                       (select
                                                         (i32.const 0)
                                                         (tee_local $5
                                                           (i32.sub
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                             (get_local $5)
                                                           )
                                                         )
@@ -5787,7 +5780,7 @@
                                                       )
                                                     )
                                                     (i32.lt_s
-                                                      (get_local $17)
+                                                      (get_local $13)
                                                       (get_local $5)
                                                     )
                                                   )
@@ -5797,14 +5790,14 @@
                                               (block i32
                                                 (set_local $5
                                                   (select
-                                                    (get_local $17)
+                                                    (get_local $13)
                                                     (tee_local $5
                                                       (select
                                                         (i32.const 0)
                                                         (tee_local $5
                                                           (i32.sub
                                                             (i32.add
-                                                              (get_local $6)
+                                                              (get_local $7)
                                                               (get_local $11)
                                                             )
                                                             (get_local $5)
@@ -5817,7 +5810,7 @@
                                                       )
                                                     )
                                                     (i32.lt_s
-                                                      (get_local $17)
+                                                      (get_local $13)
                                                       (get_local $5)
                                                     )
                                                   )
@@ -5830,8 +5823,8 @@
                                             (set_local $5
                                               (get_local $19)
                                             )
-                                            (set_local $7
-                                              (get_local $17)
+                                            (set_local $6
+                                              (get_local $13)
                                             )
                                             (i32.and
                                               (get_local $12)
@@ -5841,30 +5834,19 @@
                                         )
                                       )
                                     )
-                                    (set_local $29
-                                      (i32.ne
-                                        (tee_local $31
-                                          (i32.or
-                                            (get_local $5)
-                                            (get_local $17)
-                                          )
-                                        )
-                                        (i32.const 0)
-                                      )
-                                    )
                                     (set_local $19
                                       (if i32
-                                        (tee_local $36
+                                        (tee_local $22
                                           (i32.eq
                                             (i32.or
-                                              (get_local $7)
+                                              (get_local $6)
                                               (i32.const 32)
                                             )
                                             (i32.const 102)
                                           )
                                         )
                                         (block i32
-                                          (set_local $7
+                                          (set_local $6
                                             (select
                                               (get_local $11)
                                               (i32.const 0)
@@ -5881,11 +5863,11 @@
                                             (i32.lt_s
                                               (i32.sub
                                                 (get_local $30)
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (call $_fmt_u
-                                                    (tee_local $6
+                                                    (tee_local $7
                                                       (select
-                                                        (get_local $37)
+                                                        (get_local $36)
                                                         (get_local $11)
                                                         (i32.lt_s
                                                           (get_local $11)
@@ -5896,14 +5878,14 @@
                                                     (i32.shr_s
                                                       (i32.shl
                                                         (i32.lt_s
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                           (i32.const 0)
                                                         )
                                                         (i32.const 31)
                                                       )
                                                       (i32.const 31)
                                                     )
-                                                    (get_local $38)
+                                                    (get_local $37)
                                                   )
                                                 )
                                               )
@@ -5911,9 +5893,9 @@
                                             )
                                             (loop $while-in98
                                               (i32.store8
-                                                (tee_local $6
+                                                (tee_local $7
                                                   (i32.add
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const -1)
                                                   )
                                                 )
@@ -5923,7 +5905,7 @@
                                                 (i32.lt_s
                                                   (i32.sub
                                                     (get_local $30)
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (i32.const 2)
                                                 )
@@ -5932,7 +5914,7 @@
                                           )
                                           (i32.store8
                                             (i32.add
-                                              (get_local $6)
+                                              (get_local $7)
                                               (i32.const -1)
                                             )
                                             (i32.add
@@ -5947,21 +5929,21 @@
                                             )
                                           )
                                           (i32.store8
-                                            (tee_local $6
+                                            (tee_local $7
                                               (i32.add
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (i32.const -2)
                                               )
                                             )
-                                            (get_local $7)
+                                            (get_local $6)
                                           )
-                                          (set_local $7
+                                          (set_local $6
                                             (i32.sub
                                               (get_local $30)
-                                              (get_local $6)
+                                              (get_local $7)
                                             )
                                           )
-                                          (get_local $6)
+                                          (get_local $7)
                                         )
                                       )
                                     )
@@ -5974,14 +5956,22 @@
                                           (i32.add
                                             (i32.add
                                               (i32.add
-                                                (get_local $28)
+                                                (get_local $29)
                                                 (i32.const 1)
                                               )
                                               (get_local $5)
                                             )
-                                            (get_local $29)
+                                            (i32.ne
+                                              (tee_local $35
+                                                (i32.or
+                                                  (get_local $5)
+                                                  (get_local $13)
+                                                )
+                                              )
+                                              (i32.const 0)
+                                            )
                                           )
-                                          (get_local $7)
+                                          (get_local $6)
                                         )
                                       )
                                       (get_local $12)
@@ -5997,8 +5987,8 @@
                                       )
                                       (drop
                                         (call $___fwritex
-                                          (get_local $35)
-                                          (get_local $28)
+                                          (get_local $34)
+                                          (get_local $29)
                                           (get_local $0)
                                         )
                                       )
@@ -6015,63 +6005,63 @@
                                     )
                                     (block $do-once99
                                       (if
-                                        (get_local $36)
+                                        (get_local $22)
                                         (block
-                                          (set_local $6
+                                          (set_local $7
                                             (tee_local $13
                                               (select
                                                 (get_local $8)
-                                                (get_local $13)
+                                                (get_local $17)
                                                 (i32.gt_u
-                                                  (get_local $13)
+                                                  (get_local $17)
                                                   (get_local $8)
                                                 )
                                               )
                                             )
                                           )
                                           (loop $while-in102
-                                            (set_local $7
+                                            (set_local $6
                                               (call $_fmt_u
                                                 (i32.load
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                                 (i32.const 0)
-                                                (get_local $33)
+                                                (get_local $32)
                                               )
                                             )
                                             (block $do-once103
                                               (if
                                                 (i32.eq
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (get_local $13)
                                                 )
                                                 (block
                                                   (br_if $do-once103
                                                     (i32.ne
-                                                      (get_local $7)
-                                                      (get_local $33)
+                                                      (get_local $6)
+                                                      (get_local $32)
                                                     )
                                                   )
                                                   (i32.store8
-                                                    (get_local $39)
+                                                    (get_local $38)
                                                     (i32.const 48)
                                                   )
-                                                  (set_local $7
-                                                    (get_local $39)
+                                                  (set_local $6
+                                                    (get_local $38)
                                                   )
                                                 )
                                                 (block
                                                   (br_if $do-once103
                                                     (i32.le_u
-                                                      (get_local $7)
+                                                      (get_local $6)
                                                       (get_local $24)
                                                     )
                                                   )
                                                   (loop $while-in106
                                                     (i32.store8
-                                                      (tee_local $7
+                                                      (tee_local $6
                                                         (i32.add
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                           (i32.const -1)
                                                         )
                                                       )
@@ -6079,7 +6069,7 @@
                                                     )
                                                     (br_if $while-in106
                                                       (i32.gt_u
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (get_local $24)
                                                       )
                                                     )
@@ -6098,10 +6088,10 @@
                                               )
                                               (drop
                                                 (call $___fwritex
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (i32.sub
-                                                    (get_local $49)
-                                                    (get_local $7)
+                                                    (get_local $48)
+                                                    (get_local $6)
                                                   )
                                                   (get_local $0)
                                                 )
@@ -6109,17 +6099,17 @@
                                             )
                                             (if
                                               (i32.le_u
-                                                (tee_local $7
+                                                (tee_local $6
                                                   (i32.add
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (i32.const 4)
                                                   )
                                                 )
                                                 (get_local $8)
                                               )
                                               (block
-                                                (set_local $6
-                                                  (get_local $7)
+                                                (set_local $7
+                                                  (get_local $6)
                                                 )
                                                 (br $while-in102)
                                               )
@@ -6127,7 +6117,7 @@
                                           )
                                           (block $do-once107
                                             (if
-                                              (get_local $31)
+                                              (get_local $35)
                                               (block
                                                 (br_if $do-once107
                                                   (i32.and
@@ -6154,29 +6144,29 @@
                                                 (i32.const 0)
                                               )
                                               (i32.lt_u
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (get_local $10)
                                               )
                                             )
                                             (loop $while-in110
                                               (if
                                                 (i32.gt_u
-                                                  (tee_local $6
+                                                  (tee_local $7
                                                     (call $_fmt_u
                                                       (i32.load
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                       )
                                                       (i32.const 0)
-                                                      (get_local $33)
+                                                      (get_local $32)
                                                     )
                                                   )
                                                   (get_local $24)
                                                 )
                                                 (loop $while-in112
                                                   (i32.store8
-                                                    (tee_local $6
+                                                    (tee_local $7
                                                       (i32.add
-                                                        (get_local $6)
+                                                        (get_local $7)
                                                         (i32.const -1)
                                                       )
                                                     )
@@ -6184,7 +6174,7 @@
                                                   )
                                                   (br_if $while-in112
                                                     (i32.gt_u
-                                                      (get_local $6)
+                                                      (get_local $7)
                                                       (get_local $24)
                                                     )
                                                   )
@@ -6201,7 +6191,7 @@
                                                 )
                                                 (drop
                                                   (call $___fwritex
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                     (select
                                                       (i32.const 9)
                                                       (get_local $5)
@@ -6214,7 +6204,7 @@
                                                   )
                                                 )
                                               )
-                                              (set_local $6
+                                              (set_local $7
                                                 (i32.add
                                                   (get_local $5)
                                                   (i32.const -9)
@@ -6227,9 +6217,9 @@
                                                     (i32.const 9)
                                                   )
                                                   (i32.lt_u
-                                                    (tee_local $7
+                                                    (tee_local $6
                                                       (i32.add
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.const 4)
                                                       )
                                                     )
@@ -6238,12 +6228,12 @@
                                                 )
                                                 (block
                                                   (set_local $5
-                                                    (get_local $6)
+                                                    (get_local $7)
                                                   )
                                                   (br $while-in110)
                                                 )
                                                 (set_local $5
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                 )
                                               )
                                             )
@@ -6264,10 +6254,10 @@
                                             (select
                                               (get_local $10)
                                               (i32.add
-                                                (get_local $13)
+                                                (get_local $17)
                                                 (i32.const 4)
                                               )
-                                              (get_local $22)
+                                              (get_local $25)
                                             )
                                           )
                                           (if
@@ -6276,38 +6266,38 @@
                                               (i32.const -1)
                                             )
                                             (block
-                                              (set_local $17
+                                              (set_local $13
                                                 (i32.eqz
-                                                  (get_local $17)
+                                                  (get_local $13)
                                                 )
                                               )
-                                              (set_local $6
-                                                (get_local $13)
-                                              )
                                               (set_local $7
+                                                (get_local $17)
+                                              )
+                                              (set_local $6
                                                 (get_local $5)
                                               )
                                               (loop $while-in114
-                                                (set_local $8
+                                                (set_local $5
                                                   (if i32
                                                     (i32.eq
                                                       (tee_local $5
                                                         (call $_fmt_u
                                                           (i32.load
-                                                            (get_local $6)
+                                                            (get_local $7)
                                                           )
                                                           (i32.const 0)
-                                                          (get_local $33)
+                                                          (get_local $32)
                                                         )
                                                       )
-                                                      (get_local $33)
+                                                      (get_local $32)
                                                     )
                                                     (block i32
                                                       (i32.store8
-                                                        (get_local $39)
+                                                        (get_local $38)
                                                         (i32.const 48)
                                                       )
-                                                      (get_local $39)
+                                                      (get_local $38)
                                                     )
                                                     (get_local $5)
                                                   )
@@ -6315,16 +6305,10 @@
                                                 (block $do-once115
                                                   (if
                                                     (i32.eq
-                                                      (get_local $6)
-                                                      (get_local $13)
+                                                      (get_local $7)
+                                                      (get_local $17)
                                                     )
                                                     (block
-                                                      (set_local $5
-                                                        (i32.add
-                                                          (get_local $8)
-                                                          (i32.const 1)
-                                                        )
-                                                      )
                                                       (if
                                                         (i32.eqz
                                                           (i32.and
@@ -6336,17 +6320,23 @@
                                                         )
                                                         (drop
                                                           (call $___fwritex
-                                                            (get_local $8)
+                                                            (get_local $5)
                                                             (i32.const 1)
                                                             (get_local $0)
                                                           )
                                                         )
                                                       )
+                                                      (set_local $5
+                                                        (i32.add
+                                                          (get_local $5)
+                                                          (i32.const 1)
+                                                        )
+                                                      )
                                                       (br_if $do-once115
                                                         (i32.and
-                                                          (get_local $17)
+                                                          (get_local $13)
                                                           (i32.lt_s
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                             (i32.const 1)
                                                           )
                                                         )
@@ -6368,19 +6358,10 @@
                                                       )
                                                     )
                                                     (block
-                                                      (if
-                                                        (i32.gt_u
-                                                          (get_local $8)
+                                                      (br_if $do-once115
+                                                        (i32.le_u
+                                                          (get_local $5)
                                                           (get_local $24)
-                                                        )
-                                                        (set_local $5
-                                                          (get_local $8)
-                                                        )
-                                                        (block
-                                                          (set_local $5
-                                                            (get_local $8)
-                                                          )
-                                                          (br $do-once115)
                                                         )
                                                       )
                                                       (loop $while-in118
@@ -6405,7 +6386,7 @@
                                                 )
                                                 (set_local $8
                                                   (i32.sub
-                                                    (get_local $49)
+                                                    (get_local $48)
                                                     (get_local $5)
                                                   )
                                                 )
@@ -6423,9 +6404,9 @@
                                                       (get_local $5)
                                                       (select
                                                         (get_local $8)
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                         (i32.gt_s
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                           (get_local $8)
                                                         )
                                                       )
@@ -6436,18 +6417,18 @@
                                                 (br_if $while-in114
                                                   (i32.and
                                                     (i32.lt_u
-                                                      (tee_local $6
+                                                      (tee_local $7
                                                         (i32.add
-                                                          (get_local $6)
+                                                          (get_local $7)
                                                           (i32.const 4)
                                                         )
                                                       )
                                                       (get_local $10)
                                                     )
                                                     (i32.gt_s
-                                                      (tee_local $7
+                                                      (tee_local $6
                                                         (i32.sub
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                           (get_local $8)
                                                         )
                                                       )
@@ -6456,7 +6437,7 @@
                                                   )
                                                 )
                                                 (set_local $5
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
@@ -6512,30 +6493,41 @@
                                     )
                                   )
                                   (block i32
-                                    (set_local $7
-                                      (select
-                                        (i32.const 0)
-                                        (get_local $28)
-                                        (tee_local $5
-                                          (i32.or
-                                            (f64.ne
-                                              (get_local $15)
-                                              (get_local $15)
+                                    (call $_pad
+                                      (get_local $0)
+                                      (i32.const 32)
+                                      (get_local $14)
+                                      (tee_local $5
+                                        (i32.add
+                                          (tee_local $7
+                                            (select
+                                              (i32.const 0)
+                                              (get_local $29)
+                                              (tee_local $6
+                                                (i32.or
+                                                  (f64.ne
+                                                    (get_local $15)
+                                                    (get_local $15)
+                                                  )
+                                                  (i32.const 0)
+                                                )
+                                              )
                                             )
-                                            (i32.const 0)
                                           )
+                                          (i32.const 3)
                                         )
                                       )
+                                      (get_local $8)
                                     )
                                     (set_local $6
                                       (select
                                         (select
                                           (i32.const 4135)
                                           (i32.const 4139)
-                                          (tee_local $6
+                                          (tee_local $8
                                             (i32.ne
                                               (i32.and
-                                                (get_local $17)
+                                                (get_local $13)
                                                 (i32.const 32)
                                               )
                                               (i32.const 0)
@@ -6545,22 +6537,10 @@
                                         (select
                                           (i32.const 4127)
                                           (i32.const 4131)
-                                          (get_local $6)
+                                          (get_local $8)
                                         )
-                                        (get_local $5)
+                                        (get_local $6)
                                       )
-                                    )
-                                    (call $_pad
-                                      (get_local $0)
-                                      (i32.const 32)
-                                      (get_local $14)
-                                      (tee_local $5
-                                        (i32.add
-                                          (get_local $7)
-                                          (i32.const 3)
-                                        )
-                                      )
-                                      (get_local $8)
                                     )
                                     (if
                                       (i32.eqz
@@ -6578,7 +6558,7 @@
                                             (block i32
                                               (drop
                                                 (call $___fwritex
-                                                  (get_local $35)
+                                                  (get_local $34)
                                                   (get_local $7)
                                                   (get_local $0)
                                                 )
@@ -6623,11 +6603,11 @@
                             )
                             (br $label$continue$L1)
                           )
-                          (set_local $7
+                          (set_local $6
                             (get_local $9)
                           )
                           (set_local $11
-                            (get_local $6)
+                            (get_local $7)
                           )
                           (set_local $8
                             (i32.const 0)
@@ -6642,7 +6622,7 @@
                         )
                         (set_local $10
                           (i32.and
-                            (get_local $17)
+                            (get_local $13)
                             (i32.const 32)
                           )
                         )
@@ -6651,7 +6631,7 @@
                             (i32.eqz
                               (tee_local $8
                                 (i32.load
-                                  (tee_local $7
+                                  (tee_local $6
                                     (get_local $18)
                                   )
                                 )
@@ -6660,13 +6640,13 @@
                             (i32.eqz
                               (tee_local $12
                                 (i32.load offset=4
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (get_local $23)
                             )
                             (set_local $8
@@ -6678,7 +6658,7 @@
                             (br $jumpthreading$inner$7)
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (get_local $8)
                             )
                             (set_local $8
@@ -6696,7 +6676,7 @@
                                   (i32.load8_u
                                     (i32.add
                                       (i32.and
-                                        (get_local $7)
+                                        (get_local $6)
                                         (i32.const 15)
                                       )
                                       (i32.const 4075)
@@ -6709,9 +6689,9 @@
                                 (i32.eqz
                                   (i32.and
                                     (i32.eqz
-                                      (tee_local $7
+                                      (tee_local $6
                                         (call $_bitshift64Lshr
-                                          (get_local $7)
+                                          (get_local $6)
                                           (get_local $12)
                                           (i32.const 4)
                                         )
@@ -6725,7 +6705,7 @@
                                   )
                                 )
                               )
-                              (set_local $7
+                              (set_local $6
                                 (get_local $8)
                               )
                             )
@@ -6768,7 +6748,7 @@
                                 (set_local $10
                                   (i32.add
                                     (i32.shr_s
-                                      (get_local $17)
+                                      (get_local $13)
                                       (i32.const 4)
                                     )
                                     (i32.const 4091)
@@ -6781,10 +6761,10 @@
                         )
                         (br $jumpthreading$outer$7)
                       )
-                      (set_local $7
+                      (set_local $6
                         (call $_fmt_u
                           (get_local $9)
-                          (get_local $7)
+                          (get_local $6)
                           (get_local $23)
                         )
                       )
@@ -6793,7 +6773,7 @@
                       )
                       (br $jumpthreading$inner$7)
                     )
-                    (set_local $26
+                    (set_local $27
                       (i32.const 0)
                     )
                     (set_local $17
@@ -6802,12 +6782,12 @@
                           (call $_memchr
                             (get_local $9)
                             (i32.const 0)
-                            (get_local $6)
+                            (get_local $7)
                           )
                         )
                       )
                     )
-                    (set_local $7
+                    (set_local $6
                       (get_local $9)
                     )
                     (set_local $12
@@ -6815,7 +6795,7 @@
                     )
                     (set_local $11
                       (select
-                        (get_local $6)
+                        (get_local $7)
                         (i32.sub
                           (get_local $13)
                           (get_local $9)
@@ -6833,7 +6813,7 @@
                       (select
                         (i32.add
                           (get_local $9)
-                          (get_local $6)
+                          (get_local $7)
                         )
                         (get_local $13)
                         (get_local $17)
@@ -6844,10 +6824,10 @@
                   (set_local $9
                     (i32.const 0)
                   )
-                  (set_local $7
+                  (set_local $6
                     (i32.const 0)
                   )
-                  (set_local $6
+                  (set_local $7
                     (i32.load
                       (get_local $18)
                     )
@@ -6858,7 +6838,7 @@
                         (i32.eqz
                           (tee_local $10
                             (i32.load
-                              (get_local $6)
+                              (get_local $7)
                             )
                           )
                         )
@@ -6866,16 +6846,16 @@
                       (br_if $while-out124
                         (i32.or
                           (i32.lt_s
-                            (tee_local $7
+                            (tee_local $6
                               (call $_wctomb
-                                (get_local $41)
+                                (get_local $40)
                                 (get_local $10)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.gt_u
-                            (get_local $7)
+                            (get_local $6)
                             (i32.sub
                               (get_local $8)
                               (get_local $9)
@@ -6883,9 +6863,9 @@
                           )
                         )
                       )
-                      (set_local $6
+                      (set_local $7
                         (i32.add
-                          (get_local $6)
+                          (get_local $7)
                           (i32.const 4)
                         )
                       )
@@ -6894,7 +6874,7 @@
                           (get_local $8)
                           (tee_local $9
                             (i32.add
-                              (get_local $7)
+                              (get_local $6)
                               (get_local $9)
                             )
                           )
@@ -6904,7 +6884,7 @@
                   )
                   (if
                     (i32.lt_s
-                      (get_local $7)
+                      (get_local $6)
                       (i32.const 0)
                     )
                     (block
@@ -6924,10 +6904,10 @@
                   (if
                     (get_local $9)
                     (block
-                      (set_local $6
+                      (set_local $7
                         (i32.const 0)
                       )
-                      (set_local $7
+                      (set_local $6
                         (i32.load
                           (get_local $18)
                         )
@@ -6937,40 +6917,34 @@
                           (i32.eqz
                             (tee_local $8
                               (i32.load
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (get_local $9)
                             )
                             (br $jumpthreading$inner$6)
                           )
                         )
-                        (set_local $7
-                          (i32.add
-                            (get_local $7)
-                            (i32.const 4)
-                          )
-                        )
                         (if
                           (i32.gt_s
-                            (tee_local $6
+                            (tee_local $7
                               (i32.add
                                 (tee_local $8
                                   (call $_wctomb
-                                    (get_local $41)
+                                    (get_local $40)
                                     (get_local $8)
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $7)
                               )
                             )
                             (get_local $9)
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (get_local $9)
                             )
                             (br $jumpthreading$inner$6)
@@ -6987,20 +6961,26 @@
                           )
                           (drop
                             (call $___fwritex
-                              (get_local $41)
+                              (get_local $40)
                               (get_local $8)
                               (get_local $0)
                             )
                           )
                         )
+                        (set_local $6
+                          (i32.add
+                            (get_local $6)
+                            (i32.const 4)
+                          )
+                        )
                         (br_if $while-in127
                           (i32.lt_u
-                            (get_local $6)
+                            (get_local $7)
                             (get_local $9)
                           )
                         )
                         (block
-                          (set_local $7
+                          (set_local $6
                             (get_local $9)
                           )
                           (br $jumpthreading$inner$6)
@@ -7008,7 +6988,7 @@
                       )
                     )
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.const 0)
                       )
                       (br $jumpthreading$inner$6)
@@ -7016,14 +6996,14 @@
                   )
                   (br $jumpthreading$outer$7)
                 )
-                (set_local $26
+                (set_local $27
                   (i32.const 0)
                 )
                 (call $_pad
                   (get_local $0)
                   (i32.const 32)
                   (get_local $14)
-                  (get_local $7)
+                  (get_local $6)
                   (i32.xor
                     (get_local $12)
                     (i32.const 8192)
@@ -7035,16 +7015,16 @@
                 (set_local $5
                   (select
                     (get_local $14)
-                    (get_local $7)
+                    (get_local $6)
                     (i32.gt_s
                       (get_local $14)
-                      (get_local $7)
+                      (get_local $6)
                     )
                   )
                 )
                 (br $label$continue$L1)
               )
-              (set_local $26
+              (set_local $27
                 (i32.const 0)
               )
               (set_local $12
@@ -7055,16 +7035,16 @@
                   )
                   (get_local $9)
                   (i32.gt_s
-                    (get_local $6)
+                    (get_local $7)
                     (i32.const -1)
                   )
                 )
               )
-              (set_local $7
+              (set_local $6
                 (if i32
                   (i32.or
                     (i32.ne
-                      (get_local $6)
+                      (get_local $7)
                       (i32.const 0)
                     )
                     (tee_local $9
@@ -7089,7 +7069,7 @@
                   (block i32
                     (set_local $11
                       (select
-                        (get_local $6)
+                        (get_local $7)
                         (tee_local $9
                           (i32.add
                             (i32.xor
@@ -7100,13 +7080,13 @@
                               (i32.const 1)
                             )
                             (i32.sub
-                              (get_local $45)
-                              (get_local $7)
+                              (get_local $44)
+                              (get_local $6)
                             )
                           )
                         )
                         (i32.gt_s
-                          (get_local $6)
+                          (get_local $7)
                           (get_local $9)
                         )
                       )
@@ -7114,7 +7094,7 @@
                     (set_local $9
                       (get_local $23)
                     )
-                    (get_local $7)
+                    (get_local $6)
                   )
                   (block i32
                     (set_local $11
@@ -7131,7 +7111,7 @@
             (call $_pad
               (get_local $0)
               (i32.const 32)
-              (tee_local $6
+              (tee_local $7
                 (select
                   (tee_local $9
                     (i32.add
@@ -7141,7 +7121,7 @@
                           (tee_local $13
                             (i32.sub
                               (get_local $9)
-                              (get_local $7)
+                              (get_local $6)
                             )
                           )
                           (get_local $11)
@@ -7183,7 +7163,7 @@
             (call $_pad
               (get_local $0)
               (i32.const 48)
-              (get_local $6)
+              (get_local $7)
               (get_local $9)
               (i32.xor
                 (get_local $12)
@@ -7208,7 +7188,7 @@
               )
               (drop
                 (call $___fwritex
-                  (get_local $7)
+                  (get_local $6)
                   (get_local $13)
                   (get_local $0)
                 )
@@ -7217,7 +7197,7 @@
             (call $_pad
               (get_local $0)
               (i32.const 32)
-              (get_local $6)
+              (get_local $7)
               (get_local $9)
               (i32.xor
                 (get_local $12)
@@ -7228,7 +7208,7 @@
               (get_local $5)
             )
             (set_local $5
-              (get_local $6)
+              (get_local $7)
             )
             (br $label$continue$L1)
           )
@@ -7298,12 +7278,6 @@
                 (i32.const 10)
               )
               (loop $while-in132
-                (set_local $1
-                  (i32.add
-                    (get_local $0)
-                    (i32.const 1)
-                  )
-                )
                 (if
                   (i32.load
                     (i32.add
@@ -7321,20 +7295,19 @@
                     (br $label$break$L343)
                   )
                 )
-                (if
+                (br_if $while-in132
                   (i32.lt_s
-                    (get_local $1)
+                    (tee_local $0
+                      (i32.add
+                        (get_local $0)
+                        (i32.const 1)
+                      )
+                    )
                     (i32.const 10)
                   )
-                  (block
-                    (set_local $0
-                      (get_local $1)
-                    )
-                    (br $while-in132)
-                  )
-                  (set_local $16
-                    (i32.const 1)
-                  )
+                )
+                (set_local $16
+                  (i32.const 1)
                 )
               )
               (set_local $16
@@ -7349,7 +7322,7 @@
       )
     )
     (set_global $STACKTOP
-      (get_local $25)
+      (get_local $26)
     )
     (get_local $16)
   )
@@ -7886,7 +7859,6 @@
     (local $5 i32)
     (local $6 i32)
     (local $7 i32)
-    (local $8 i32)
     (set_local $6
       (get_global $STACKTOP)
     )
@@ -7940,10 +7912,10 @@
               )
             )
           )
-          (set_local $7
+          (set_local $1
             (i32.eqz
               (i32.and
-                (tee_local $1
+                (tee_local $7
                   (i32.load
                     (get_local $0)
                   )
@@ -7958,25 +7930,13 @@
               (i32.const 255)
             )
             (block
-              (set_local $8
-                (i32.sub
-                  (get_local $2)
-                  (get_local $3)
-                )
-              )
-              (set_local $2
-                (get_local $4)
-              )
-              (set_local $3
-                (get_local $7)
-              )
               (loop $while-in
-                (set_local $3
+                (set_local $1
                   (i32.eqz
                     (i32.and
-                      (tee_local $1
+                      (tee_local $7
                         (if i32
-                          (get_local $3)
+                          (get_local $1)
                           (block i32
                             (drop
                               (call $___fwritex
@@ -7989,7 +7949,7 @@
                               (get_local $0)
                             )
                           )
-                          (get_local $1)
+                          (get_local $7)
                         )
                       )
                       (i32.const 32)
@@ -7998,9 +7958,9 @@
                 )
                 (br_if $while-in
                   (i32.gt_u
-                    (tee_local $2
+                    (tee_local $4
                       (i32.add
-                        (get_local $2)
+                        (get_local $4)
                         (i32.const -256)
                       )
                     )
@@ -8008,21 +7968,24 @@
                   )
                 )
               )
-              (set_local $4
-                (i32.and
-                  (get_local $8)
-                  (i32.const 255)
-                )
-              )
               (br_if $do-once
                 (i32.eqz
-                  (get_local $3)
+                  (get_local $1)
+                )
+              )
+              (set_local $4
+                (i32.and
+                  (i32.sub
+                    (get_local $2)
+                    (get_local $3)
+                  )
+                  (i32.const 255)
                 )
               )
             )
             (br_if $do-once
               (i32.eqz
-                (get_local $7)
+                (get_local $1)
               )
             )
           )
@@ -10940,24 +10903,18 @@
         )
       )
     )
-    (set_local $10
-      (i32.add
-        (get_local $0)
-        (i32.const 48)
-      )
-    )
     (if
       (i32.le_u
         (tee_local $7
           (i32.and
-            (tee_local $6
+            (tee_local $5
               (i32.add
                 (tee_local $1
                   (i32.load
                     (i32.const 656)
                   )
                 )
-                (tee_local $5
+                (tee_local $10
                   (i32.add
                     (get_local $0)
                     (i32.const 47)
@@ -11008,6 +10965,12 @@
         (return
           (i32.const 0)
         )
+      )
+    )
+    (set_local $6
+      (i32.add
+        (get_local $0)
+        (i32.const 48)
       )
     )
     (block $jumpthreading$outer$12
@@ -11086,7 +11049,7 @@
                       (tee_local $1
                         (i32.and
                           (i32.sub
-                            (get_local $6)
+                            (get_local $5)
                             (i32.load
                               (i32.const 188)
                             )
@@ -11240,7 +11203,7 @@
               (if
                 (i32.and
                   (i32.gt_u
-                    (get_local $10)
+                    (get_local $6)
                     (get_local $1)
                   )
                   (i32.and
@@ -11260,7 +11223,7 @@
                       (i32.and
                         (i32.add
                           (i32.sub
-                            (get_local $5)
+                            (get_local $10)
                             (get_local $1)
                           )
                           (tee_local $3
@@ -13652,7 +13615,7 @@
       (i32.eq
         (tee_local $5
           (i32.and
-            (tee_local $7
+            (tee_local $8
               (i32.load
                 (i32.add
                   (get_local $0)
@@ -13667,12 +13630,12 @@
       )
       (call $_abort)
     )
-    (set_local $8
+    (set_local $7
       (i32.add
         (get_local $1)
         (tee_local $0
           (i32.and
-            (get_local $7)
+            (get_local $8)
             (i32.const -8)
           )
         )
@@ -13681,7 +13644,7 @@
     (block $do-once
       (if
         (i32.and
-          (get_local $7)
+          (get_local $8)
           (i32.const 1)
         )
         (block
@@ -13693,22 +13656,11 @@
           )
         )
         (block
-          (set_local $7
-            (i32.load
-              (get_local $1)
-            )
-          )
           (if
             (i32.eqz
               (get_local $5)
             )
             (return)
-          )
-          (set_local $0
-            (i32.add
-              (get_local $7)
-              (get_local $0)
-            )
           )
           (if
             (i32.lt_u
@@ -13717,13 +13669,23 @@
                   (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $7)
+                    (tee_local $8
+                      (i32.load
+                        (get_local $1)
+                      )
+                    )
                   )
                 )
               )
               (get_local $11)
             )
             (call $_abort)
+          )
+          (set_local $0
+            (i32.add
+              (get_local $8)
+              (get_local $0)
+            )
           )
           (if
             (i32.eq
@@ -13740,7 +13702,7 @@
                       (i32.load
                         (tee_local $2
                           (i32.add
-                            (get_local $8)
+                            (get_local $7)
                             (i32.const 4)
                           )
                         )
@@ -13790,13 +13752,13 @@
           )
           (set_local $5
             (i32.shr_u
-              (get_local $7)
+              (get_local $8)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $7)
+              (get_local $8)
               (i32.const 256)
             )
             (block
@@ -13951,7 +13913,7 @@
                       (i32.load
                         (tee_local $4
                           (i32.add
-                            (tee_local $7
+                            (tee_local $8
                               (i32.add
                                 (get_local $1)
                                 (i32.const 16)
@@ -13966,11 +13928,11 @@
                   (if
                     (tee_local $5
                       (i32.load
-                        (get_local $7)
+                        (get_local $8)
                       )
                     )
                     (set_local $4
-                      (get_local $7)
+                      (get_local $8)
                     )
                     (block
                       (set_local $6
@@ -13982,7 +13944,7 @@
                 )
                 (loop $while-in
                   (if
-                    (tee_local $7
+                    (tee_local $8
                       (i32.load
                         (tee_local $10
                           (i32.add
@@ -13994,7 +13956,7 @@
                     )
                     (block
                       (set_local $5
-                        (get_local $7)
+                        (get_local $8)
                       )
                       (set_local $4
                         (get_local $10)
@@ -14003,7 +13965,7 @@
                     )
                   )
                   (if
-                    (tee_local $7
+                    (tee_local $8
                       (i32.load
                         (tee_local $10
                           (i32.add
@@ -14015,7 +13977,7 @@
                     )
                     (block
                       (set_local $5
-                        (get_local $7)
+                        (get_local $8)
                       )
                       (set_local $4
                         (get_local $10)
@@ -14056,7 +14018,7 @@
                 (if
                   (i32.ne
                     (i32.load
-                      (tee_local $7
+                      (tee_local $8
                         (i32.add
                           (get_local $10)
                           (i32.const 12)
@@ -14081,7 +14043,7 @@
                   )
                   (block
                     (i32.store
-                      (get_local $7)
+                      (get_local $8)
                       (get_local $4)
                     )
                     (i32.store
@@ -14217,7 +14179,7 @@
                 (get_local $12)
               )
               (if
-                (tee_local $7
+                (tee_local $8
                   (i32.load
                     (tee_local $4
                       (i32.add
@@ -14229,17 +14191,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $7)
+                    (get_local $8)
                     (get_local $5)
                   )
                   (call $_abort)
                   (block
                     (i32.store offset=16
                       (get_local $6)
-                      (get_local $7)
+                      (get_local $8)
                     )
                     (i32.store offset=24
-                      (get_local $7)
+                      (get_local $8)
                       (get_local $6)
                     )
                   )
@@ -14301,7 +14263,7 @@
     (if
       (i32.ge_u
         (get_local $2)
-        (get_local $8)
+        (get_local $7)
       )
       (call $_abort)
     )
@@ -14312,7 +14274,7 @@
             (i32.load
               (tee_local $0
                 (i32.add
-                  (get_local $8)
+                  (get_local $7)
                   (i32.const 4)
                 )
               )
@@ -14354,7 +14316,7 @@
       (block
         (if
           (i32.eq
-            (get_local $8)
+            (get_local $7)
             (i32.load
               (i32.const 200)
             )
@@ -14404,7 +14366,7 @@
         )
         (if
           (i32.eq
-            (get_local $8)
+            (get_local $7)
             (i32.load
               (i32.const 196)
             )
@@ -14466,14 +14428,14 @@
             (block
               (set_local $4
                 (i32.load offset=12
-                  (get_local $8)
+                  (get_local $7)
                 )
               )
               (if
                 (i32.ne
                   (tee_local $1
                     (i32.load offset=8
-                      (get_local $8)
+                      (get_local $7)
                     )
                   )
                   (tee_local $0
@@ -14504,7 +14466,7 @@
                       (i32.load offset=12
                         (get_local $1)
                       )
-                      (get_local $8)
+                      (get_local $7)
                     )
                     (call $_abort)
                   )
@@ -14565,7 +14527,7 @@
                           )
                         )
                       )
-                      (get_local $8)
+                      (get_local $7)
                     )
                     (set_local $14
                       (get_local $0)
@@ -14586,7 +14548,7 @@
             (block
               (set_local $6
                 (i32.load offset=24
-                  (get_local $8)
+                  (get_local $7)
                 )
               )
               (block $do-once6
@@ -14594,10 +14556,10 @@
                   (i32.eq
                     (tee_local $0
                       (i32.load offset=12
-                        (get_local $8)
+                        (get_local $7)
                       )
                     )
-                    (get_local $8)
+                    (get_local $7)
                   )
                   (block
                     (if
@@ -14608,7 +14570,7 @@
                               (i32.add
                                 (tee_local $1
                                   (i32.add
-                                    (get_local $8)
+                                    (get_local $7)
                                     (i32.const 16)
                                   )
                                 )
@@ -14703,7 +14665,7 @@
                       (i32.lt_u
                         (tee_local $4
                           (i32.load offset=8
-                            (get_local $8)
+                            (get_local $7)
                           )
                         )
                         (i32.load
@@ -14722,7 +14684,7 @@
                             )
                           )
                         )
-                        (get_local $8)
+                        (get_local $7)
                       )
                       (call $_abort)
                     )
@@ -14736,7 +14698,7 @@
                             )
                           )
                         )
-                        (get_local $8)
+                        (get_local $7)
                       )
                       (block
                         (i32.store
@@ -14761,14 +14723,14 @@
                 (block
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.load
                         (tee_local $0
                           (i32.add
                             (i32.shl
                               (tee_local $3
                                 (i32.load offset=28
-                                  (get_local $8)
+                                  (get_local $7)
                                 )
                               )
                               (i32.const 2)
@@ -14827,7 +14789,7 @@
                               )
                             )
                           )
-                          (get_local $8)
+                          (get_local $7)
                         )
                         (i32.store
                           (get_local $0)
@@ -14865,7 +14827,7 @@
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $8)
+                            (get_local $7)
                             (i32.const 16)
                           )
                         )
@@ -15459,7 +15421,6 @@
     (local $3 i32)
     (local $4 i32)
     (local $5 i32)
-    (local $6 i32)
     (set_local $4
       (i32.add
         (get_local $0)
@@ -15472,36 +15433,10 @@
         (i32.const 20)
       )
       (block
-        (set_local $5
-          (i32.or
-            (i32.or
-              (i32.or
-                (tee_local $1
-                  (i32.and
-                    (get_local $1)
-                    (i32.const 255)
-                  )
-                )
-                (i32.shl
-                  (get_local $1)
-                  (i32.const 8)
-                )
-              )
-              (i32.shl
-                (get_local $1)
-                (i32.const 16)
-              )
-            )
-            (i32.shl
-              (get_local $1)
-              (i32.const 24)
-            )
-          )
-        )
-        (set_local $6
+        (set_local $1
           (i32.and
-            (get_local $4)
-            (i32.const -4)
+            (get_local $1)
+            (i32.const 255)
           )
         )
         (if
@@ -15544,16 +15479,43 @@
             )
           )
         )
+        (set_local $3
+          (i32.or
+            (i32.or
+              (i32.or
+                (get_local $1)
+                (i32.shl
+                  (get_local $1)
+                  (i32.const 8)
+                )
+              )
+              (i32.shl
+                (get_local $1)
+                (i32.const 16)
+              )
+            )
+            (i32.shl
+              (get_local $1)
+              (i32.const 24)
+            )
+          )
+        )
+        (set_local $5
+          (i32.and
+            (get_local $4)
+            (i32.const -4)
+          )
+        )
         (loop $while-in1
           (if
             (i32.lt_s
               (get_local $0)
-              (get_local $6)
+              (get_local $5)
             )
             (block
               (i32.store
                 (get_local $0)
-                (get_local $5)
+                (get_local $3)
               )
               (set_local $0
                 (i32.add

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -8284,23 +8284,20 @@
           (i32.const 5)
         )
         (block
-          (set_local $4
-            (tee_local $3
-              (i32.load
-                (tee_local $5
-                  (i32.add
-                    (get_local $2)
-                    (i32.const 20)
-                  )
-                )
-              )
-            )
-          )
           (if
             (i32.lt_u
               (i32.sub
                 (get_local $6)
-                (get_local $3)
+                (tee_local $3
+                  (i32.load
+                    (tee_local $5
+                      (i32.add
+                        (get_local $2)
+                        (i32.const 20)
+                      )
+                    )
+                  )
+                )
               )
               (get_local $1)
             )
@@ -8323,6 +8320,9 @@
               )
               (br $label$break$a)
             )
+          )
+          (set_local $4
+            (get_local $3)
           )
           (set_local $1
             (block $label$break$b i32
@@ -9180,7 +9180,6 @@
     (local $3 i32)
     (local $4 i32)
     (local $5 i32)
-    (local $6 i32)
     (set_local $4
       (i32.add
         (get_local $0)
@@ -9193,36 +9192,10 @@
         (i32.const 20)
       )
       (block
-        (set_local $5
-          (i32.or
-            (i32.or
-              (i32.or
-                (tee_local $1
-                  (i32.and
-                    (get_local $1)
-                    (i32.const 255)
-                  )
-                )
-                (i32.shl
-                  (get_local $1)
-                  (i32.const 8)
-                )
-              )
-              (i32.shl
-                (get_local $1)
-                (i32.const 16)
-              )
-            )
-            (i32.shl
-              (get_local $1)
-              (i32.const 24)
-            )
-          )
-        )
-        (set_local $6
+        (set_local $1
           (i32.and
-            (get_local $4)
-            (i32.const -4)
+            (get_local $1)
+            (i32.const 255)
           )
         )
         (if
@@ -9265,16 +9238,43 @@
             )
           )
         )
+        (set_local $3
+          (i32.or
+            (i32.or
+              (i32.or
+                (get_local $1)
+                (i32.shl
+                  (get_local $1)
+                  (i32.const 8)
+                )
+              )
+              (i32.shl
+                (get_local $1)
+                (i32.const 16)
+              )
+            )
+            (i32.shl
+              (get_local $1)
+              (i32.const 24)
+            )
+          )
+        )
+        (set_local $5
+          (i32.and
+            (get_local $4)
+            (i32.const -4)
+          )
+        )
         (loop $while-in1
           (if
             (i32.lt_s
               (get_local $0)
-              (get_local $6)
+              (get_local $5)
             )
             (block
               (i32.store
                 (get_local $0)
-                (get_local $5)
+                (get_local $3)
               )
               (set_local $0
                 (i32.add

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -8282,23 +8282,20 @@
           (i32.const 5)
         )
         (block
-          (set_local $4
-            (tee_local $3
-              (i32.load
-                (tee_local $5
-                  (i32.add
-                    (get_local $2)
-                    (i32.const 20)
-                  )
-                )
-              )
-            )
-          )
           (if
             (i32.lt_u
               (i32.sub
                 (get_local $6)
-                (get_local $3)
+                (tee_local $3
+                  (i32.load
+                    (tee_local $5
+                      (i32.add
+                        (get_local $2)
+                        (i32.const 20)
+                      )
+                    )
+                  )
+                )
               )
               (get_local $1)
             )
@@ -8321,6 +8318,9 @@
               )
               (br $label$break$a)
             )
+          )
+          (set_local $4
+            (get_local $3)
           )
           (set_local $1
             (block $label$break$b i32
@@ -9178,7 +9178,6 @@
     (local $3 i32)
     (local $4 i32)
     (local $5 i32)
-    (local $6 i32)
     (set_local $4
       (i32.add
         (get_local $0)
@@ -9191,36 +9190,10 @@
         (i32.const 20)
       )
       (block
-        (set_local $5
-          (i32.or
-            (i32.or
-              (i32.or
-                (tee_local $1
-                  (i32.and
-                    (get_local $1)
-                    (i32.const 255)
-                  )
-                )
-                (i32.shl
-                  (get_local $1)
-                  (i32.const 8)
-                )
-              )
-              (i32.shl
-                (get_local $1)
-                (i32.const 16)
-              )
-            )
-            (i32.shl
-              (get_local $1)
-              (i32.const 24)
-            )
-          )
-        )
-        (set_local $6
+        (set_local $1
           (i32.and
-            (get_local $4)
-            (i32.const -4)
+            (get_local $1)
+            (i32.const 255)
           )
         )
         (if
@@ -9263,16 +9236,43 @@
             )
           )
         )
+        (set_local $3
+          (i32.or
+            (i32.or
+              (i32.or
+                (get_local $1)
+                (i32.shl
+                  (get_local $1)
+                  (i32.const 8)
+                )
+              )
+              (i32.shl
+                (get_local $1)
+                (i32.const 16)
+              )
+            )
+            (i32.shl
+              (get_local $1)
+              (i32.const 24)
+            )
+          )
+        )
+        (set_local $5
+          (i32.and
+            (get_local $4)
+            (i32.const -4)
+          )
+        )
         (loop $while-in1
           (if
             (i32.lt_s
               (get_local $0)
-              (get_local $6)
+              (get_local $5)
             )
             (block
               (i32.store
                 (get_local $0)
-                (get_local $5)
+                (get_local $3)
               )
               (set_local $0
                 (i32.add

--- a/test/passes/code-pushing.txt
+++ b/test/passes/code-pushing.txt
@@ -1,0 +1,244 @@
+(module
+  (type $0 (func))
+  (type $1 (func (result i32)))
+  (memory $0 0)
+  (func $push1 (type $0)
+    (local $x i32)
+    (block $out
+      (br_if $out
+        (i32.const 2)
+      )
+      (set_local $x
+        (i32.const 1)
+      )
+      (drop
+        (get_local $x)
+      )
+    )
+  )
+  (func $push2 (type $0)
+    (local $x i32)
+    (local $y i32)
+    (block $out
+      (br_if $out
+        (i32.const 2)
+      )
+      (set_local $x
+        (i32.const 1)
+      )
+      (set_local $y
+        (i32.const 3)
+      )
+      (drop
+        (get_local $x)
+      )
+      (drop
+        (get_local $y)
+      )
+    )
+  )
+  (func $push1-twice (type $0)
+    (local $x i32)
+    (block $out
+      (br_if $out
+        (i32.const 2)
+      )
+      (br_if $out
+        (i32.const 3)
+      )
+      (set_local $x
+        (i32.const 1)
+      )
+      (drop
+        (get_local $x)
+      )
+    )
+  )
+  (func $push1-twiceb (type $0)
+    (local $x i32)
+    (block $out
+      (br_if $out
+        (i32.const 2)
+      )
+      (nop)
+      (br_if $out
+        (i32.const 3)
+      )
+      (set_local $x
+        (i32.const 1)
+      )
+      (drop
+        (get_local $x)
+      )
+    )
+  )
+  (func $push2-twice (type $0)
+    (local $x i32)
+    (local $y i32)
+    (block $out
+      (br_if $out
+        (i32.const 2)
+      )
+      (br_if $out
+        (i32.const 2)
+      )
+      (set_local $x
+        (i32.const 1)
+      )
+      (set_local $y
+        (i32.const 3)
+      )
+      (drop
+        (get_local $x)
+      )
+      (drop
+        (get_local $y)
+      )
+    )
+  )
+  (func $ignore-last (type $0)
+    (local $x i32)
+    (block $out
+      (set_local $x
+        (i32.const 1)
+      )
+      (br_if $out
+        (i32.const 2)
+      )
+    )
+  )
+  (func $push-if (type $0)
+    (local $x i32)
+    (block $out
+      (if
+        (i32.const 2)
+        (nop)
+      )
+      (set_local $x
+        (i32.const 1)
+      )
+      (drop
+        (get_local $x)
+      )
+    )
+  )
+  (func $push-dropped (type $1) (result i32)
+    (local $x i32)
+    (block $out i32
+      (drop
+        (br_if $out
+          (i32.const 2)
+          (i32.const 3)
+        )
+      )
+      (set_local $x
+        (i32.const 1)
+      )
+      (drop
+        (get_local $x)
+      )
+      (i32.const 4)
+    )
+  )
+  (func $used (type $0)
+    (local $x i32)
+    (block $out
+      (set_local $x
+        (i32.const 1)
+      )
+      (br_if $out
+        (get_local $x)
+      )
+      (drop
+        (get_local $x)
+      )
+    )
+  )
+  (func $not-sfa (type $0)
+    (local $x i32)
+    (set_local $x
+      (i32.const 1)
+    )
+    (block $out
+      (set_local $x
+        (i32.const 1)
+      )
+      (br_if $out
+        (i32.const 2)
+      )
+      (drop
+        (get_local $x)
+      )
+    )
+  )
+  (func $not-sfa2 (type $0)
+    (local $x i32)
+    (drop
+      (get_local $x)
+    )
+    (block $out
+      (set_local $x
+        (i32.const 1)
+      )
+      (br_if $out
+        (i32.const 2)
+      )
+      (drop
+        (get_local $x)
+      )
+    )
+  )
+  (func $used-out (type $0)
+    (local $x i32)
+    (block $out
+      (set_local $x
+        (i32.const 1)
+      )
+      (br_if $out
+        (i32.const 2)
+      )
+      (drop
+        (get_local $x)
+      )
+    )
+    (drop
+      (get_local $x)
+    )
+  )
+  (func $value-might-interfere (type $0)
+    (local $x i32)
+    (block $out
+      (br_if $out
+        (i32.const 2)
+      )
+      (set_local $x
+        (i32.load
+          (i32.const 0)
+        )
+      )
+      (drop
+        (get_local $x)
+      )
+    )
+  )
+  (func $value-interferes (type $0)
+    (local $x i32)
+    (block $out
+      (set_local $x
+        (i32.load
+          (i32.const 0)
+        )
+      )
+      (i32.store
+        (i32.const 1)
+        (i32.const 3)
+      )
+      (br_if $out
+        (i32.const 2)
+      )
+      (drop
+        (get_local $x)
+      )
+    )
+  )
+)

--- a/test/passes/code-pushing.txt
+++ b/test/passes/code-pushing.txt
@@ -107,6 +107,19 @@
       )
     )
   )
+  (func $ignore-last2 (type $0)
+    (local $x i32)
+    (block $out
+      (set_local $x
+        (i32.const 1)
+      )
+      (nop)
+      (nop)
+      (br_if $out
+        (i32.const 2)
+      )
+    )
+  )
   (func $push-if (type $0)
     (local $x i32)
     (block $out
@@ -138,6 +151,51 @@
         (get_local $x)
       )
       (i32.const 4)
+    )
+  )
+  (func $push-past-stuff (type $0)
+    (local $x i32)
+    (block $out
+      (call $push-past-stuff)
+      (drop
+        (i32.const 1)
+      )
+      (br_if $out
+        (i32.const 2)
+      )
+      (set_local $x
+        (i32.const 1)
+      )
+      (drop
+        (get_local $x)
+      )
+    )
+  )
+  (func $fail-then-push (type $0)
+    (local $x i32)
+    (local $y i32)
+    (block $out
+      (set_local $x
+        (i32.const 1)
+      )
+      (drop
+        (get_local $x)
+      )
+      (br_if $out
+        (i32.const 2)
+      )
+      (br_if $out
+        (i32.const 3)
+      )
+      (set_local $y
+        (i32.const 1)
+      )
+      (drop
+        (get_local $x)
+      )
+      (drop
+        (get_local $y)
+      )
     )
   )
   (func $used (type $0)
@@ -239,6 +297,114 @@
       (drop
         (get_local $x)
       )
+    )
+  )
+  (func $value-interferes-accumulation (type $0)
+    (local $x i32)
+    (block $out
+      (set_local $x
+        (i32.load
+          (i32.const 0)
+        )
+      )
+      (nop)
+      (i32.store
+        (i32.const 1)
+        (i32.const 3)
+      )
+      (nop)
+      (br_if $out
+        (i32.const 2)
+      )
+      (drop
+        (get_local $x)
+      )
+    )
+  )
+  (func $value-interferes-in-pushpoint (type $0)
+    (local $x i32)
+    (block $out
+      (set_local $x
+        (i32.load
+          (i32.const 0)
+        )
+      )
+      (if
+        (i32.const 1)
+        (call $value-interferes)
+      )
+      (drop
+        (get_local $x)
+      )
+    )
+  )
+  (func $values-might-interfere (type $0)
+    (local $x i32)
+    (local $y i32)
+    (block $out
+      (br_if $out
+        (i32.const 2)
+      )
+      (set_local $x
+        (call $push-dropped)
+      )
+      (set_local $y
+        (call $push-dropped)
+      )
+      (drop
+        (get_local $x)
+      )
+      (drop
+        (get_local $y)
+      )
+    )
+  )
+  (func $unpushed-interferes (type $0)
+    (local $x i32)
+    (local $y i32)
+    (block $out
+      (set_local $x
+        (call $push-dropped)
+      )
+      (set_local $y
+        (call $push-dropped)
+      )
+      (br_if $out
+        (i32.const 2)
+      )
+      (drop
+        (get_local $x)
+      )
+      (drop
+        (get_local $y)
+      )
+    )
+    (drop
+      (get_local $y)
+    )
+  )
+  (func $unpushed-ignorable (type $0)
+    (local $x i32)
+    (local $y i32)
+    (block $out
+      (set_local $x
+        (call $push-dropped)
+      )
+      (br_if $out
+        (i32.const 2)
+      )
+      (set_local $y
+        (call $push-dropped)
+      )
+      (drop
+        (get_local $x)
+      )
+      (drop
+        (get_local $y)
+      )
+    )
+    (drop
+      (get_local $x)
     )
   )
 )

--- a/test/passes/code-pushing.wast
+++ b/test/passes/code-pushing.wast
@@ -1,0 +1,130 @@
+(module
+  (func $push1
+    (local $x i32)
+    (block $out
+      (set_local $x (i32.const 1))
+      (br_if $out (i32.const 2))
+      (drop (get_local $x))
+    )
+  )
+  (func $push2
+    (local $x i32)
+    (local $y i32)
+    (block $out
+      (set_local $x (i32.const 1))
+      (set_local $y (i32.const 3))
+      (br_if $out (i32.const 2))
+      (drop (get_local $x))
+      (drop (get_local $y))
+    )
+  )
+  (func $push1-twice
+    (local $x i32)
+    (block $out
+      (set_local $x (i32.const 1))
+      (br_if $out (i32.const 2))
+      (br_if $out (i32.const 3))
+      (drop (get_local $x))
+    )
+  )
+  (func $push1-twiceb
+    (local $x i32)
+    (block $out
+      (set_local $x (i32.const 1))
+      (br_if $out (i32.const 2))
+      (nop)
+      (br_if $out (i32.const 3))
+      (drop (get_local $x))
+    )
+  )
+  (func $push2-twice
+    (local $x i32)
+    (local $y i32)
+    (block $out
+      (set_local $x (i32.const 1))
+      (set_local $y (i32.const 3))
+      (br_if $out (i32.const 2))
+      (br_if $out (i32.const 2))
+      (drop (get_local $x))
+      (drop (get_local $y))
+    )
+  )
+  (func $ignore-last
+    (local $x i32)
+    (block $out
+      (set_local $x (i32.const 1))
+      (br_if $out (i32.const 2))
+    )
+  )
+  (func $push-if
+    (local $x i32)
+    (block $out
+      (set_local $x (i32.const 1))
+      (if (i32.const 2) (nop))
+      (drop (get_local $x))
+    )
+  )
+  (func $push-dropped (result i32)
+    (local $x i32)
+    (block $out i32
+      (set_local $x (i32.const 1))
+      (drop (br_if $out (i32.const 2) (i32.const 3)))
+      (drop (get_local $x))
+      (i32.const 4)
+    )
+  )
+  ;; and now for stuff that should *not* be pushed
+  (func $used
+    (local $x i32)
+    (block $out
+      (set_local $x (i32.const 1))
+      (br_if $out (get_local $x))
+      (drop (get_local $x))
+    )
+  )
+  (func $not-sfa
+    (local $x i32)
+    (set_local $x (i32.const 1))
+    (block $out
+      (set_local $x (i32.const 1))
+      (br_if $out (i32.const 2))
+      (drop (get_local $x))
+    )
+  )
+  (func $not-sfa2
+    (local $x i32)
+    (drop (get_local $x))
+    (block $out
+      (set_local $x (i32.const 1))
+      (br_if $out (i32.const 2))
+      (drop (get_local $x))
+    )
+  )
+  (func $used-out
+    (local $x i32)
+    (block $out
+      (set_local $x (i32.const 1))
+      (br_if $out (i32.const 2))
+      (drop (get_local $x))
+    )
+    (drop (get_local $x))
+  )
+  (func $value-might-interfere ;; but doesn't
+    (local $x i32)
+    (block $out
+      (set_local $x (i32.load (i32.const 0)))
+      (br_if $out (i32.const 2))
+      (drop (get_local $x))
+    )
+  )
+  (func $value-interferes
+    (local $x i32)
+    (block $out
+      (set_local $x (i32.load (i32.const 0)))
+      (i32.store (i32.const 1) (i32.const 3))
+      (br_if $out (i32.const 2))
+      (drop (get_local $x))
+    )
+  )
+)
+

--- a/test/passes/code-pushing.wast
+++ b/test/passes/code-pushing.wast
@@ -56,6 +56,15 @@
       (br_if $out (i32.const 2))
     )
   )
+  (func $ignore-last2
+    (local $x i32)
+    (block $out
+      (set_local $x (i32.const 1))
+      (nop)
+      (nop)
+      (br_if $out (i32.const 2))
+    )
+  )
   (func $push-if
     (local $x i32)
     (block $out
@@ -71,6 +80,29 @@
       (drop (br_if $out (i32.const 2) (i32.const 3)))
       (drop (get_local $x))
       (i32.const 4)
+    )
+  )
+  (func $push-past-stuff
+    (local $x i32)
+    (block $out
+      (set_local $x (i32.const 1))
+      (call $push-past-stuff)
+      (drop (i32.const 1))
+      (br_if $out (i32.const 2))
+      (drop (get_local $x))
+    )
+  )
+  (func $fail-then-push
+    (local $x i32)
+    (local $y i32)
+    (block $out
+      (set_local $x (i32.const 1))
+      (drop (get_local $x))
+      (br_if $out (i32.const 2))
+      (set_local $y (i32.const 1))
+      (br_if $out (i32.const 3))
+      (drop (get_local $x))
+      (drop (get_local $y))
     )
   )
   ;; and now for stuff that should *not* be pushed
@@ -125,6 +157,62 @@
       (br_if $out (i32.const 2))
       (drop (get_local $x))
     )
+  )
+  (func $value-interferes-accumulation
+    (local $x i32)
+    (block $out
+      (set_local $x (i32.load (i32.const 0)))
+      (nop)
+      (i32.store (i32.const 1) (i32.const 3))
+      (nop)
+      (br_if $out (i32.const 2))
+      (drop (get_local $x))
+    )
+  )
+  (func $value-interferes-in-pushpoint
+    (local $x i32)
+    (block $out
+      (set_local $x (i32.load (i32.const 0)))
+      (if (i32.const 1)
+        (call $value-interferes)
+      )
+      (drop (get_local $x))
+    )
+  )
+  (func $values-might-interfere ;; but don't, as we keep the order
+    (local $x i32)
+    (local $y i32)
+    (block $out
+      (set_local $x (call $push-dropped))
+      (set_local $y (call $push-dropped))
+      (br_if $out (i32.const 2))
+      (drop (get_local $x))
+      (drop (get_local $y))
+    )
+  )
+  (func $unpushed-interferes
+    (local $x i32)
+    (local $y i32)
+    (block $out
+      (set_local $x (call $push-dropped))
+      (set_local $y (call $push-dropped))
+      (br_if $out (i32.const 2))
+      (drop (get_local $x))
+      (drop (get_local $y))
+    )
+    (drop (get_local $y)) ;; $y can't be pushed, so x can't be
+  )
+  (func $unpushed-ignorable
+    (local $x i32)
+    (local $y i32)
+    (block $out
+      (set_local $x (call $push-dropped))
+      (set_local $y (call $push-dropped))
+      (br_if $out (i32.const 2))
+      (drop (get_local $x))
+      (drop (get_local $y))
+    )
+    (drop (get_local $x)) ;; $x can't be pushed, but y doesn't care
   )
 )
 


### PR DESCRIPTION
This "pushes" code forward in blocks, past conditional control flow when possible. That brings definitions closer to their uses, allowing better optimizations elsewhere, and can also move code to a location where it executes only some of the time.

This doesn't do a full CFG analysis, instead it does a simple and cheap computation on our AST, using the structure in our control flow. That isn't enough for everything, but it should be for most things and for inner loops in particular.

This makes the `primes` benchmark as fast as asm.js (or slightly faster). Also has some (very minor, but consistent) code size benefits.