### PR TITLE
Set the type of the implicit blocks we use for a loop body in s2wasm

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -1129,6 +1129,7 @@ class S2WasmBuilder {
         curr->name = getNextLabel();
         auto implicitBlock = allocator->alloc<Block>();
         curr->body = implicitBlock;
+        implicitBlock->type = loopType;
         bstack.push_back(curr);
       } else if (match("end_loop")) {
         auto* loop = bstack.back()->cast<Loop>();

--- a/test/dot_s/return.s
+++ b/test/dot_s/return.s
@@ -15,3 +15,15 @@ return_void:
 .Lfunc_end0:
 	.size	return_void, .Lfunc_end0-return_void
 
+  .type fallthrough_return_nested_loop_i32,@function
+fallthrough_return_nested_loop_i32:
+  .result   i32
+  loop      i32
+  loop      i32
+  i32.const $push0=, 1
+  return    $pop0
+  end_loop
+  end_loop
+  .endfunc
+.Lfunc_end0:
+  .size fallthrough_return_nested_loop_i32, .Lfunc_end0-fallthrough_return_nested_loop_i32

--- a/test/dot_s/return.wast
+++ b/test/dot_s/return.wast
@@ -8,5 +8,14 @@
   )
   (func $return_void
   )
+  (func $fallthrough_return_nested_loop_i32 (result i32)
+    (loop $label$0 i32
+      (loop $label$1 i32
+        (return
+          (i32.const 1)
+        )
+      )
+    )
+  )
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }


### PR DESCRIPTION
Loops are modeled in Binaryen IR as having a Block as a body. The block
is added to module walkers and validated like a normal block.
In s2wasm when we add the blocks, we need to make sure that the type of
the loop body matches the type of the loop itself, or we run into
issues.