### PR TITLE
Fix mergeblocks drop br if

### DIFF
--- a/test/passes/merge-blocks.txt
+++ b/test/passes/merge-blocks.txt
@@ -14,12 +14,10 @@
   (func $drop-block-br (type $0)
     (block $block
       (block $x
-        (block
-          (drop
-            (i32.const 1)
-          )
-          (br $x)
+        (drop
+          (i32.const 1)
         )
+        (br $x)
         (drop
           (i32.const 0)
         )
@@ -29,13 +27,11 @@
   (func $drop-block-br-if (type $0)
     (block $block
       (block $x
-        (block
-          (drop
-            (i32.const 1)
-          )
-          (br_if $x
-            (i32.const 2)
-          )
+        (drop
+          (i32.const 1)
+        )
+        (br_if $x
+          (i32.const 2)
         )
         (drop
           (i32.const 0)
@@ -53,6 +49,27 @@
               (i32.const 2)
             )
           )
+          (i32.const 0)
+        )
+      )
+    )
+  )
+  (func $drop-block-nested-br-if (type $0)
+    (block $block
+      (block $x
+        (if
+          (i32.const 100)
+          (block $block0
+            (drop
+              (i32.const 1)
+            )
+            (br_if $x
+              (i32.const 2)
+            )
+            (nop)
+          )
+        )
+        (drop
           (i32.const 0)
         )
       )

--- a/test/passes/merge-blocks.txt
+++ b/test/passes/merge-blocks.txt
@@ -29,14 +29,12 @@
   (func $drop-block-br-if (type $0)
     (block $block
       (block $x
-        (drop
-          (block i32
-            (drop
-              (i32.const 1)
-            )
-            (br_if $x
-              (i32.const 2)
-            )
+        (block
+          (drop
+            (i32.const 1)
+          )
+          (br_if $x
+            (i32.const 2)
           )
         )
         (drop

--- a/test/passes/merge-blocks.txt
+++ b/test/passes/merge-blocks.txt
@@ -1,0 +1,63 @@
+(module
+  (type $0 (func))
+  (type $1 (func (param i32)))
+  (memory $0 0)
+  (func $drop-block (type $0)
+    (block $block
+      (block $x
+        (drop
+          (i32.const 0)
+        )
+      )
+    )
+  )
+  (func $drop-block-br (type $0)
+    (block $block
+      (block $x
+        (block
+          (drop
+            (i32.const 1)
+          )
+          (br $x)
+        )
+        (drop
+          (i32.const 0)
+        )
+      )
+    )
+  )
+  (func $drop-block-br-if (type $0)
+    (block $block
+      (block $x
+        (drop
+          (block i32
+            (drop
+              (i32.const 1)
+            )
+            (br_if $x
+              (i32.const 2)
+            )
+          )
+        )
+        (drop
+          (i32.const 0)
+        )
+      )
+    )
+  )
+  (func $undroppable-block-br-if (type $1) (param $0 i32)
+    (block $block
+      (drop
+        (block $x i32
+          (call $undroppable-block-br-if
+            (br_if $x
+              (i32.const 1)
+              (i32.const 2)
+            )
+          )
+          (i32.const 0)
+        )
+      )
+    )
+  )
+)

--- a/test/passes/merge-blocks.wast
+++ b/test/passes/merge-blocks.wast
@@ -38,5 +38,20 @@
       )
     )
   )
+  (func $drop-block-nested-br-if
+    (block
+      (drop
+        (block $x i32
+          (if (i32.const 100)
+            (block
+              (drop (br_if $x (i32.const 1) (i32.const 2)))
+              (nop)
+            )
+          )
+          (i32.const 0)
+        )
+      )
+    )
+  )
 )
 

--- a/test/passes/merge-blocks.wast
+++ b/test/passes/merge-blocks.wast
@@ -1,0 +1,42 @@
+(module
+  (func $drop-block
+    (block
+      (drop
+        (block $x i32
+          (i32.const 0)
+        )
+      )
+    )
+  )
+  (func $drop-block-br
+    (block
+      (drop
+        (block $x i32
+          (br $x (i32.const 1))
+          (i32.const 0)
+        )
+      )
+    )
+  )
+  (func $drop-block-br-if
+    (block
+      (drop
+        (block $x i32
+          (drop (br_if $x (i32.const 1) (i32.const 2)))
+          (i32.const 0)
+        )
+      )
+    )
+  )
+  (func $undroppable-block-br-if (param i32)
+    (block
+      (drop
+        (block $x i32
+          (call $undroppable-block-br-if (br_if $x (i32.const 1) (i32.const 2)))
+          (i32.const 0)
+        )
+      )
+    )
+  )
+)
+


### PR DESCRIPTION
A dropped `br_if` changes its type. We still dropped it, which was wrong. Also noticed some other minor non-optimal code here and fixed that. Also we didn't handle the case of a `br_if` which is *not* dropped (which we don't ever emit, but maybe someone will), fixed too.