### PR TITLE
If copies

### DIFF
--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -30,6 +30,7 @@
 #include "pass.h"
 #include "ast_utils.h"
 #include "cfg/cfg-traversal.h"
+#include "wasm-builder.h"
 #include "support/learning.h"
 #ifdef CFG_PROFILE
 #include "support/timing.h"
@@ -177,12 +178,26 @@ struct CoalesceLocals : public WalkerPass<CFGWalker<CoalesceLocals, Visitor<Coal
     }
     self->currBasicBlock->contents.actions.emplace_back(Action::Set, curr->index, currp);
     // if this is a copy, note it
-    auto* get = curr->value->dynCast<GetLocal>();
-    if (get) {
+    if (auto* get = self->getCopy(curr)) {
       // add 2 units, so that backedge prioritization can decide ties, but not much more
       self->addCopy(curr->index, get->index);
       self->addCopy(curr->index, get->index);
     }
+  }
+
+  // A simple copy is a set of a get. A more interesting copy
+  // is a set of an if with a value, where one side a get.
+  // That can happen when we create an if value in simplify-locals. TODO: recurse into
+  // nested ifs, and block return values? Those cases are trickier, need to
+  // count to see if worth it.
+  // TODO: an if can have two copies
+  GetLocal* getCopy(SetLocal* set) {
+    if (auto* get = set->value->dynCast<GetLocal>()) return get;
+    if (auto* iff = set->value->dynCast<If>()) {
+      if (auto* get = iff->ifTrue->dynCast<GetLocal>()) return get;
+      if (auto* get = iff->ifFalse->dynCast<GetLocal>()) return get;
+    }
+    return false;
   }
 
   // main entry point
@@ -293,7 +308,7 @@ void CoalesceLocals::increaseBackEdgePriorities() {
       for (auto& action : arrivingBlock->contents.actions) {
         if (action.what == Action::Set) {
           auto* set = (*action.origin)->cast<SetLocal>();
-          if (auto* get = set->value->dynCast<GetLocal>()) {
+          if (auto* get = getCopy(set)) {
             // this is indeed a copy, add to the cost (default cost is 2, so this adds 50%, and can mostly break ties)
             addCopy(set->index, get->index);
           }
@@ -605,6 +620,21 @@ void CoalesceLocals::pickIndices(std::vector<Index>& indices) {
   }
 }
 
+// Remove a copy from a set of an if, where one if arm is a get of the same set
+static void removeIfCopy(Expression** origin, SetLocal* set, If* iff, Expression*& copy, Expression*& other, Module* module) {
+  // replace the origin with the if, and sink the set into the other non-copying arm
+  *origin = iff;
+  set->value = other;
+  other = set;
+  if (!set->isTee()) {
+    // we don't need the copy at all
+    copy = nullptr;
+    if (!iff->ifTrue) {
+      Builder(*module).flip(iff);
+    }
+  }
+}
+
 void CoalesceLocals::applyIndices(std::vector<Index>& indices, Expression* root) {
   assert(indices.size() == numLocals);
   for (auto& curr : basicBlocks) {
@@ -624,7 +654,9 @@ void CoalesceLocals::applyIndices(std::vector<Index>& indices, Expression* root)
           } else {
             ExpressionManipulator::nop(set);
           }
-        } else if (!action.effective) {
+          continue;
+        }
+        if (!action.effective) {
           *action.origin = set->value; // value may have no side effects, further optimizations can eliminate it
           if (!set->isTee()) {
             // we need to drop it
@@ -632,6 +664,20 @@ void CoalesceLocals::applyIndices(std::vector<Index>& indices, Expression* root)
             drop->value = *action.origin;
             *action.origin = drop;
           }
+          continue;
+        }
+        if (auto* iff = set->value->dynCast<If>()) {
+          if (auto* get = iff->ifTrue->dynCast<GetLocal>()) {
+            if (get->index == set->index) {
+              removeIfCopy(action.origin, set, iff, iff->ifTrue, iff->ifFalse, getModule());
+            }
+          }
+          if (auto* get = iff->ifFalse->dynCast<GetLocal>()) {
+            if (get->index == set->index) {
+              removeIfCopy(action.origin, set, iff, iff->ifFalse, iff->ifTrue, getModule());
+            }
+          }
+          continue;
         }
       }
     }

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -632,6 +632,7 @@ static void removeIfCopy(Expression** origin, SetLocal* set, If* iff, Expression
     if (!iff->ifTrue) {
       Builder(*module).flip(iff);
     }
+    iff->finalize();
   }
 }
 
@@ -670,14 +671,15 @@ void CoalesceLocals::applyIndices(std::vector<Index>& indices, Expression* root)
           if (auto* get = iff->ifTrue->dynCast<GetLocal>()) {
             if (get->index == set->index) {
               removeIfCopy(action.origin, set, iff, iff->ifTrue, iff->ifFalse, getModule());
+              continue;
             }
           }
           if (auto* get = iff->ifFalse->dynCast<GetLocal>()) {
             if (get->index == set->index) {
               removeIfCopy(action.origin, set, iff, iff->ifFalse, iff->ifTrue, getModule());
+              continue;
             }
           }
-          continue;
         }
       }
     }

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -197,7 +197,7 @@ struct CoalesceLocals : public WalkerPass<CFGWalker<CoalesceLocals, Visitor<Coal
       if (auto* get = iff->ifTrue->dynCast<GetLocal>()) return get;
       if (auto* get = iff->ifFalse->dynCast<GetLocal>()) return get;
     }
-    return false;
+    return nullptr;
   }
 
   // main entry point

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -245,6 +245,7 @@ public:
   }
 
   // Additional utility functions for building on top of nodes
+  // Convenient to have these on Builder, as it has allocation built in
 
   static Index addParam(Function* func, Name name, WasmType type) {
     // only ok to add a param if no vars, otherwise indices are invalidated
@@ -367,6 +368,11 @@ public:
   Expression* dropIfConcretelyTyped(Expression* curr) {
     if (!isConcreteWasmType(curr->type)) return curr;
     return makeDrop(curr);
+  }
+
+  void flip(If* iff) {
+    std::swap(iff->ifTrue, iff->ifFalse);
+    iff->condition = makeUnary(EqZInt32, iff->condition);
   }
 };
 

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -151,7 +151,7 @@
                       (i32.const 176)
                     )
                   )
-                  (tee_local $8
+                  (tee_local $7
                     (i32.shr_u
                       (tee_local $9
                         (select
@@ -198,7 +198,7 @@
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $8)
+                                          (get_local $7)
                                         )
                                       )
                                       (i32.const 1)
@@ -236,7 +236,7 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $7
+                        (tee_local $8
                           (i32.add
                             (get_local $2)
                             (i32.const 12)
@@ -247,7 +247,7 @@
                     )
                     (block
                       (i32.store
-                        (get_local $7)
+                        (get_local $8)
                         (get_local $1)
                       )
                       (i32.store
@@ -329,13 +329,13 @@
                                 (i32.and
                                   (i32.shl
                                     (get_local $2)
-                                    (get_local $8)
+                                    (get_local $7)
                                   )
                                   (i32.or
                                     (tee_local $2
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $8)
+                                        (get_local $7)
                                       )
                                     )
                                     (i32.sub
@@ -360,7 +360,7 @@
                   )
                   (set_local $1
                     (i32.load
-                      (tee_local $7
+                      (tee_local $8
                         (i32.add
                           (tee_local $0
                             (i32.load
@@ -379,7 +379,7 @@
                                                       (tee_local $2
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $7
+                                                            (tee_local $8
                                                               (i32.shr_u
                                                                 (get_local $2)
                                                                 (get_local $1)
@@ -392,12 +392,12 @@
                                                       )
                                                       (get_local $1)
                                                     )
-                                                    (tee_local $7
+                                                    (tee_local $8
                                                       (i32.and
                                                         (i32.shr_u
                                                           (tee_local $0
                                                             (i32.shr_u
-                                                              (get_local $7)
+                                                              (get_local $8)
                                                               (get_local $2)
                                                             )
                                                           )
@@ -413,7 +413,7 @@
                                                         (tee_local $11
                                                           (i32.shr_u
                                                             (get_local $0)
-                                                            (get_local $7)
+                                                            (get_local $8)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -585,7 +585,7 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $8
+                          (tee_local $7
                             (i32.load
                               (i32.const 176)
                             )
@@ -627,7 +627,7 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $8)
+                              (get_local $7)
                               (get_local $2)
                             )
                           )
@@ -669,7 +669,7 @@
                     (get_local $15)
                   )
                   (return
-                    (get_local $7)
+                    (get_local $8)
                   )
                 )
               )
@@ -761,7 +761,7 @@
                                     (tee_local $2
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $8
+                                          (tee_local $7
                                             (i32.shr_u
                                               (get_local $2)
                                               (get_local $1)
@@ -774,7 +774,7 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $8)
+                                    (get_local $7)
                                     (get_local $2)
                                   )
                                 )
@@ -788,7 +788,7 @@
                       (get_local $9)
                     )
                   )
-                  (set_local $8
+                  (set_local $7
                     (get_local $17)
                   )
                   (set_local $1
@@ -799,7 +799,7 @@
                       (if
                         (tee_local $17
                           (i32.load offset=16
-                            (get_local $8)
+                            (get_local $7)
                           )
                         )
                         (set_local $0
@@ -808,7 +808,7 @@
                         (if
                           (tee_local $11
                             (i32.load offset=20
-                              (get_local $8)
+                              (get_local $7)
                             )
                           )
                           (set_local $0
@@ -848,7 +848,7 @@
                           (get_local $11)
                         )
                       )
-                      (set_local $8
+                      (set_local $7
                         (get_local $0)
                       )
                       (set_local $1
@@ -875,7 +875,7 @@
                   (if
                     (i32.ge_u
                       (get_local $5)
-                      (tee_local $8
+                      (tee_local $7
                         (i32.add
                           (get_local $5)
                           (get_local $9)
@@ -892,7 +892,7 @@
                   (block $do-once4
                     (if
                       (i32.eq
-                        (tee_local $7
+                        (tee_local $8
                           (i32.load offset=12
                             (get_local $5)
                           )
@@ -1033,7 +1033,7 @@
                             (i32.load
                               (tee_local $11
                                 (i32.add
-                                  (get_local $7)
+                                  (get_local $8)
                                   (i32.const 8)
                                 )
                               )
@@ -1043,14 +1043,14 @@
                           (block
                             (i32.store
                               (get_local $10)
-                              (get_local $7)
+                              (get_local $8)
                             )
                             (i32.store
                               (get_local $11)
                               (get_local $0)
                             )
                             (set_local $19
-                              (get_local $7)
+                              (get_local $8)
                             )
                           )
                           (call $_abort)
@@ -1069,7 +1069,7 @@
                               (tee_local $1
                                 (i32.add
                                   (i32.shl
-                                    (tee_local $7
+                                    (tee_local $8
                                       (i32.load offset=28
                                         (get_local $5)
                                       )
@@ -1100,7 +1100,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $7)
+                                        (get_local $8)
                                       )
                                       (i32.const -1)
                                     )
@@ -1123,7 +1123,7 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $7
+                                  (tee_local $8
                                     (i32.add
                                       (get_local $2)
                                       (i32.const 16)
@@ -1133,7 +1133,7 @@
                                 (get_local $5)
                               )
                               (i32.store
-                                (get_local $7)
+                                (get_local $8)
                                 (get_local $19)
                               )
                               (i32.store offset=20
@@ -1151,7 +1151,7 @@
                         (if
                           (i32.lt_u
                             (get_local $19)
-                            (tee_local $7
+                            (tee_local $8
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1172,7 +1172,7 @@
                           (if
                             (i32.lt_u
                               (get_local $1)
-                              (get_local $7)
+                              (get_local $8)
                             )
                             (call $_abort)
                             (block
@@ -1261,7 +1261,7 @@
                         )
                       )
                       (i32.store offset=4
-                        (get_local $8)
+                        (get_local $7)
                         (i32.or
                           (get_local $3)
                           (i32.const 1)
@@ -1269,7 +1269,7 @@
                       )
                       (i32.store
                         (i32.add
-                          (get_local $8)
+                          (get_local $7)
                           (get_local $3)
                         )
                         (get_local $3)
@@ -1290,7 +1290,7 @@
                             (i32.add
                               (i32.shl
                                 (i32.shl
-                                  (tee_local $7
+                                  (tee_local $8
                                     (i32.shr_u
                                       (get_local $1)
                                       (i32.const 3)
@@ -1313,7 +1313,7 @@
                               (tee_local $11
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $7)
+                                  (get_local $8)
                                 )
                               )
                             )
@@ -1321,7 +1321,7 @@
                               (i32.lt_u
                                 (tee_local $10
                                   (i32.load
-                                    (tee_local $7
+                                    (tee_local $8
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 8)
@@ -1336,7 +1336,7 @@
                               (call $_abort)
                               (block
                                 (set_local $39
-                                  (get_local $7)
+                                  (get_local $8)
                                 )
                                 (set_local $32
                                   (get_local $10)
@@ -1386,7 +1386,7 @@
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $8)
+                        (get_local $7)
                       )
                     )
                   )
@@ -1465,7 +1465,7 @@
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $7
+                                                          (tee_local $8
                                                             (i32.shl
                                                               (get_local $10)
                                                               (tee_local $1
@@ -1491,13 +1491,13 @@
                                                   )
                                                   (get_local $1)
                                                 )
-                                                (tee_local $7
+                                                (tee_local $8
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
                                                         (tee_local $17
                                                           (i32.shl
-                                                            (get_local $7)
+                                                            (get_local $8)
                                                             (get_local $10)
                                                           )
                                                         )
@@ -1513,7 +1513,7 @@
                                             (i32.shr_u
                                               (i32.shl
                                                 (get_local $17)
-                                                (get_local $7)
+                                                (get_local $8)
                                               )
                                               (i32.const 15)
                                             )
@@ -1538,7 +1538,7 @@
                       )
                     )
                     (block
-                      (set_local $7
+                      (set_local $8
                         (get_local $0)
                       )
                       (set_local $17
@@ -1585,7 +1585,7 @@
                                 (get_local $2)
                               )
                             )
-                            (get_local $7)
+                            (get_local $8)
                           )
                           (if
                             (i32.eq
@@ -1602,13 +1602,13 @@
                               (set_local $29
                                 (get_local $10)
                               )
-                              (set_local $7
+                              (set_local $8
                                 (i32.const 90)
                               )
                               (br $label$break$L123)
                             )
                             (block
-                              (set_local $7
+                              (set_local $8
                                 (get_local $0)
                               )
                               (set_local $6
@@ -1660,15 +1660,15 @@
                           )
                           (block
                             (set_local $33
-                              (get_local $7)
+                              (get_local $8)
                             )
-                            (set_local $8
+                            (set_local $7
                               (get_local $19)
                             )
                             (set_local $30
                               (get_local $6)
                             )
-                            (set_local $7
+                            (set_local $8
                               (i32.const 86)
                             )
                           )
@@ -1697,13 +1697,13 @@
                       (set_local $33
                         (get_local $0)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 0)
                       )
                       (set_local $30
                         (i32.const 0)
                       )
-                      (set_local $7
+                      (set_local $8
                         (i32.const 86)
                       )
                     )
@@ -1711,68 +1711,68 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $7)
+                    (get_local $8)
                     (i32.const 86)
                   )
                   (if
-                    (tee_local $0
-                      (if i32
-                        (i32.and
+                    (if i32
+                      (i32.and
+                        (i32.eqz
+                          (get_local $7)
+                        )
+                        (i32.eqz
+                          (get_local $30)
+                        )
+                      )
+                      (block i32
+                        (if
                           (i32.eqz
-                            (get_local $8)
+                            (tee_local $0
+                              (i32.and
+                                (get_local $11)
+                                (i32.or
+                                  (tee_local $15
+                                    (i32.shl
+                                      (i32.const 2)
+                                      (get_local $9)
+                                    )
+                                  )
+                                  (i32.sub
+                                    (i32.const 0)
+                                    (get_local $15)
+                                  )
+                                )
+                              )
+                            )
                           )
-                          (i32.eqz
-                            (get_local $30)
+                          (block
+                            (set_local $9
+                              (get_local $2)
+                            )
+                            (br $do-once)
                           )
                         )
-                        (block i32
-                          (if
-                            (i32.eqz
-                              (tee_local $0
-                                (i32.and
-                                  (get_local $11)
-                                  (i32.or
-                                    (tee_local $15
-                                      (i32.shl
-                                        (i32.const 2)
-                                        (get_local $9)
-                                      )
-                                    )
+                        (set_local $0
+                          (i32.and
+                            (i32.shr_u
+                              (tee_local $15
+                                (i32.add
+                                  (i32.and
+                                    (get_local $0)
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $15)
-                                    )
-                                  )
-                                )
-                              )
-                            )
-                            (block
-                              (set_local $9
-                                (get_local $2)
-                              )
-                              (br $do-once)
-                            )
-                          )
-                          (set_local $0
-                            (i32.and
-                              (i32.shr_u
-                                (tee_local $15
-                                  (i32.add
-                                    (i32.and
                                       (get_local $0)
-                                      (i32.sub
-                                        (i32.const 0)
-                                        (get_local $0)
-                                      )
                                     )
-                                    (i32.const -1)
                                   )
+                                  (i32.const -1)
                                 )
-                                (i32.const 12)
                               )
-                              (i32.const 16)
+                              (i32.const 12)
                             )
+                            (i32.const 16)
                           )
+                        )
+                        (tee_local $7
                           (i32.load offset=480
                             (i32.shl
                               (i32.add
@@ -1799,7 +1799,7 @@
                                       (tee_local $9
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $8
+                                            (tee_local $7
                                               (i32.shr_u
                                                 (get_local $9)
                                                 (get_local $15)
@@ -1811,12 +1811,12 @@
                                         )
                                       )
                                     )
-                                    (tee_local $8
+                                    (tee_local $7
                                       (i32.and
                                         (i32.shr_u
                                           (tee_local $6
                                             (i32.shr_u
-                                              (get_local $8)
+                                              (get_local $7)
                                               (get_local $9)
                                             )
                                           )
@@ -1832,7 +1832,7 @@
                                         (tee_local $1
                                           (i32.shr_u
                                             (get_local $6)
-                                            (get_local $8)
+                                            (get_local $7)
                                           )
                                         )
                                         (i32.const 1)
@@ -1850,20 +1850,20 @@
                             )
                           )
                         )
-                        (get_local $8)
                       )
+                      (get_local $7)
                     )
                     (block
                       (set_local $27
                         (get_local $33)
                       )
                       (set_local $25
-                        (get_local $0)
+                        (get_local $7)
                       )
                       (set_local $29
                         (get_local $30)
                       )
-                      (set_local $7
+                      (set_local $8
                         (i32.const 90)
                       )
                     )
@@ -1879,11 +1879,11 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $7)
+                    (get_local $8)
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $7
+                    (set_local $8
                       (i32.const 0)
                     )
                     (set_local $1
@@ -1902,7 +1902,7 @@
                         (get_local $27)
                       )
                     )
-                    (set_local $8
+                    (set_local $7
                       (select
                         (get_local $6)
                         (get_local $27)
@@ -1924,7 +1924,7 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $8)
+                          (get_local $7)
                         )
                         (set_local $25
                           (get_local $1)
@@ -1943,7 +1943,7 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $8)
+                          (get_local $7)
                         )
                         (set_local $29
                           (get_local $6)
@@ -1952,7 +1952,7 @@
                       )
                       (block
                         (set_local $4
-                          (get_local $8)
+                          (get_local $7)
                         )
                         (set_local $12
                           (get_local $6)
@@ -1999,7 +1999,7 @@
                       )
                       (call $_abort)
                     )
-                    (set_local $8
+                    (set_local $7
                       (i32.load offset=24
                         (get_local $12)
                       )
@@ -2175,7 +2175,7 @@
                     )
                     (block $do-once21
                       (if
-                        (get_local $8)
+                        (get_local $7)
                         (block
                           (if
                             (i32.eq
@@ -2228,7 +2228,7 @@
                             (block
                               (if
                                 (i32.lt_u
-                                  (get_local $8)
+                                  (get_local $7)
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -2240,7 +2240,7 @@
                                   (i32.load
                                     (tee_local $1
                                       (i32.add
-                                        (get_local $8)
+                                        (get_local $7)
                                         (i32.const 16)
                                       )
                                     )
@@ -2252,7 +2252,7 @@
                                   (get_local $5)
                                 )
                                 (i32.store offset=20
-                                  (get_local $8)
+                                  (get_local $7)
                                   (get_local $5)
                                 )
                               )
@@ -2276,7 +2276,7 @@
                           )
                           (i32.store offset=24
                             (get_local $5)
-                            (get_local $8)
+                            (get_local $7)
                           )
                           (if
                             (tee_local $11
@@ -2359,7 +2359,7 @@
                             )
                             (get_local $4)
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.shr_u
                               (get_local $4)
                               (i32.const 3)
@@ -2375,7 +2375,7 @@
                                 (i32.add
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $8)
+                                      (get_local $7)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -2393,7 +2393,7 @@
                                   (tee_local $9
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $8)
+                                      (get_local $7)
                                     )
                                   )
                                 )
@@ -2401,7 +2401,7 @@
                                   (i32.lt_u
                                     (tee_local $15
                                       (i32.load
-                                        (tee_local $8
+                                        (tee_local $7
                                           (i32.add
                                             (get_local $11)
                                             (i32.const 8)
@@ -2416,7 +2416,7 @@
                                   (call $_abort)
                                   (block
                                     (set_local $16
-                                      (get_local $8)
+                                      (get_local $7)
                                     )
                                     (set_local $26
                                       (get_local $15)
@@ -2461,7 +2461,7 @@
                               (br $do-once25)
                             )
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.add
                               (i32.shl
                                 (tee_local $10
@@ -2483,7 +2483,7 @@
                                           (i32.shr_u
                                             (get_local $4)
                                             (i32.add
-                                              (tee_local $8
+                                              (tee_local $7
                                                 (i32.add
                                                   (i32.sub
                                                     (i32.const 14)
@@ -2553,7 +2553,7 @@
                                           (i32.const 1)
                                         )
                                         (i32.shl
-                                          (get_local $8)
+                                          (get_local $7)
                                           (i32.const 1)
                                         )
                                       )
@@ -2608,12 +2608,12 @@
                                 )
                               )
                               (i32.store
-                                (get_local $8)
+                                (get_local $7)
                                 (get_local $6)
                               )
                               (i32.store offset=24
                                 (get_local $6)
-                                (get_local $8)
+                                (get_local $7)
                               )
                               (i32.store offset=12
                                 (get_local $6)
@@ -2647,7 +2647,7 @@
                           )
                           (set_local $1
                             (i32.load
-                              (get_local $8)
+                              (get_local $7)
                             )
                           )
                           (loop $while-in28
@@ -2666,7 +2666,7 @@
                                   (set_local $14
                                     (get_local $1)
                                   )
-                                  (set_local $7
+                                  (set_local $8
                                     (i32.const 148)
                                   )
                                   (br $while-out27)
@@ -2675,7 +2675,7 @@
                               (if
                                 (tee_local $9
                                   (i32.load
-                                    (tee_local $8
+                                    (tee_local $7
                                       (i32.add
                                         (i32.add
                                           (get_local $1)
@@ -2706,12 +2706,12 @@
                                 )
                                 (block
                                   (set_local $23
-                                    (get_local $8)
+                                    (get_local $7)
                                   )
                                   (set_local $21
                                     (get_local $1)
                                   )
-                                  (set_local $7
+                                  (set_local $8
                                     (i32.const 145)
                                   )
                                 )
@@ -2720,7 +2720,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $7)
+                              (get_local $8)
                               (i32.const 145)
                             )
                             (if
@@ -2752,7 +2752,7 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $7)
+                                (get_local $8)
                                 (i32.const 148)
                               )
                               (if
@@ -3160,7 +3160,7 @@
             )
             (i32.const 0)
             (i32.eq
-              (tee_local $7
+              (tee_local $8
                 (block $label$break$L257 i32
                   (if i32
                     (i32.and
@@ -3211,7 +3211,7 @@
                                     (i32.const 0)
                                   )
                                   (block
-                                    (set_local $8
+                                    (set_local $7
                                       (get_local $16)
                                     )
                                     (set_local $1
@@ -3227,7 +3227,7 @@
                                     )
                                   )
                                 )
-                                (set_local $7
+                                (set_local $8
                                   (i32.const 173)
                                 )
                                 (br $label$break$L259)
@@ -3257,7 +3257,7 @@
                                   )
                                   (i32.add
                                     (i32.load
-                                      (get_local $8)
+                                      (get_local $7)
                                     )
                                     (i32.load
                                       (get_local $1)
@@ -3288,14 +3288,14 @@
                                   (set_local $18
                                     (get_local $16)
                                   )
-                                  (set_local $7
+                                  (set_local $8
                                     (i32.const 183)
                                   )
                                 )
                               )
                             )
                           )
-                          (set_local $7
+                          (set_local $8
                             (i32.const 173)
                           )
                         )
@@ -3304,7 +3304,7 @@
                         (if
                           (if i32
                             (i32.eq
-                              (get_local $7)
+                              (get_local $8)
                               (i32.const 173)
                             )
                             (i32.ne
@@ -3423,7 +3423,7 @@
                                     (set_local $18
                                       (get_local $0)
                                     )
-                                    (set_local $7
+                                    (set_local $8
                                       (i32.const 183)
                                     )
                                   )
@@ -3436,7 +3436,7 @@
                       (block $label$break$L279
                         (if
                           (i32.eq
-                            (get_local $7)
+                            (get_local $8)
                             (i32.const 183)
                           )
                           (block
@@ -3598,14 +3598,14 @@
         (set_local $22
           (get_local $13)
         )
-        (set_local $7
+        (set_local $8
           (i32.const 193)
         )
       )
     )
     (if
       (i32.eq
-        (get_local $7)
+        (get_local $8)
         (i32.const 193)
       )
       (block
@@ -3679,7 +3679,7 @@
                       (set_local $49
                         (get_local $3)
                       )
-                      (set_local $7
+                      (set_local $8
                         (i32.const 203)
                       )
                       (br $do-out)
@@ -3718,7 +3718,7 @@
                     )
                     (i32.const 0)
                     (i32.eq
-                      (get_local $7)
+                      (get_local $8)
                       (i32.const 203)
                     )
                   )
@@ -3844,7 +3844,7 @@
                       (set_local $40
                         (get_local $3)
                       )
-                      (set_local $7
+                      (set_local $8
                         (i32.const 211)
                       )
                       (br $while-out42)
@@ -3864,7 +3864,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $7)
+                  (get_local $8)
                   (i32.const 211)
                 )
                 (if
@@ -4014,7 +4014,7 @@
                             )
                           )
                           (i32.store
-                            (tee_local $8
+                            (tee_local $7
                               (i32.add
                                 (if i32
                                   (i32.eq
@@ -4035,7 +4035,7 @@
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $8
+                                    (set_local $7
                                       (i32.shr_u
                                         (get_local $0)
                                         (i32.const 3)
@@ -4402,7 +4402,7 @@
                                                   (i32.add
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $8)
+                                                        (get_local $7)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4446,7 +4446,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $8)
+                                                      (get_local $7)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4527,7 +4527,7 @@
                             )
                             (i32.and
                               (i32.load
-                                (get_local $8)
+                                (get_local $7)
                               )
                               (i32.const -2)
                             )
@@ -4546,7 +4546,7 @@
                             )
                             (get_local $14)
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.shr_u
                               (get_local $14)
                               (i32.const 3)
@@ -4562,7 +4562,7 @@
                                 (i32.add
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $8)
+                                      (get_local $7)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4581,7 +4581,7 @@
                                     (tee_local $2
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $8)
+                                        (get_local $7)
                                       )
                                     )
                                   )
@@ -4590,7 +4590,7 @@
                                       (i32.ge_u
                                         (tee_local $10
                                           (i32.load
-                                            (tee_local $8
+                                            (tee_local $7
                                               (i32.add
                                                 (get_local $0)
                                                 (i32.const 8)
@@ -4604,7 +4604,7 @@
                                       )
                                       (block
                                         (set_local $42
-                                          (get_local $8)
+                                          (get_local $7)
                                         )
                                         (set_local $34
                                           (get_local $10)
@@ -4720,7 +4720,7 @@
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $8
+                                                                (tee_local $7
                                                                   (i32.shl
                                                                     (get_local $1)
                                                                     (get_local $10)
@@ -4737,7 +4737,7 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $8)
+                                                        (get_local $7)
                                                         (get_local $1)
                                                       )
                                                       (i32.const 15)
@@ -4864,7 +4864,7 @@
                                   (set_local $35
                                     (get_local $0)
                                   )
-                                  (set_local $7
+                                  (set_local $8
                                     (i32.const 281)
                                   )
                                   (br $while-out63)
@@ -4909,7 +4909,7 @@
                                   (set_local $51
                                     (get_local $0)
                                   )
-                                  (set_local $7
+                                  (set_local $8
                                     (i32.const 278)
                                   )
                                 )
@@ -4918,7 +4918,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $7)
+                              (get_local $8)
                               (i32.const 278)
                             )
                             (if
@@ -4950,7 +4950,7 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $7)
+                                (get_local $8)
                                 (i32.const 281)
                               )
                               (if
@@ -5594,7 +5594,7 @@
                           (set_local $37
                             (get_local $0)
                           )
-                          (set_local $7
+                          (set_local $8
                             (i32.const 307)
                           )
                           (br $while-out69)
@@ -5639,7 +5639,7 @@
                           (set_local $52
                             (get_local $0)
                           )
-                          (set_local $7
+                          (set_local $8
                             (i32.const 304)
                           )
                         )
@@ -5648,7 +5648,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $7)
+                      (get_local $8)
                       (i32.const 304)
                     )
                     (if
@@ -5680,7 +5680,7 @@
                     )
                     (if
                       (i32.eq
-                        (get_local $7)
+                        (get_local $8)
                         (i32.const 307)
                       )
                       (if
@@ -8483,23 +8483,22 @@
                     (i32.const 0)
                   )
                 )
-                (set_local $2
-                  (if i32
-                    (i32.gt_u
-                      (i32.load offset=20
-                        (get_local $1)
-                      )
-                      (i32.load offset=28
-                        (get_local $1)
-                      )
+                (if
+                  (i32.gt_u
+                    (i32.load offset=20
+                      (get_local $1)
                     )
+                    (i32.load offset=28
+                      (get_local $1)
+                    )
+                  )
+                  (set_local $2
                     (i32.or
                       (call $___fflush_unlocked
                         (get_local $1)
                       )
                       (get_local $2)
                     )
-                    (get_local $2)
                   )
                 )
                 (if

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -149,7 +149,7 @@
                       (i32.const 176)
                     )
                   )
-                  (tee_local $8
+                  (tee_local $7
                     (i32.shr_u
                       (tee_local $9
                         (select
@@ -196,7 +196,7 @@
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $8)
+                                          (get_local $7)
                                         )
                                       )
                                       (i32.const 1)
@@ -234,7 +234,7 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (tee_local $7
+                        (tee_local $8
                           (i32.add
                             (get_local $2)
                             (i32.const 12)
@@ -245,7 +245,7 @@
                     )
                     (block
                       (i32.store
-                        (get_local $7)
+                        (get_local $8)
                         (get_local $1)
                       )
                       (i32.store
@@ -327,13 +327,13 @@
                                 (i32.and
                                   (i32.shl
                                     (get_local $2)
-                                    (get_local $8)
+                                    (get_local $7)
                                   )
                                   (i32.or
                                     (tee_local $2
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $8)
+                                        (get_local $7)
                                       )
                                     )
                                     (i32.sub
@@ -358,7 +358,7 @@
                   )
                   (set_local $1
                     (i32.load
-                      (tee_local $7
+                      (tee_local $8
                         (i32.add
                           (tee_local $0
                             (i32.load
@@ -377,7 +377,7 @@
                                                       (tee_local $2
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (tee_local $7
+                                                            (tee_local $8
                                                               (i32.shr_u
                                                                 (get_local $2)
                                                                 (get_local $1)
@@ -390,12 +390,12 @@
                                                       )
                                                       (get_local $1)
                                                     )
-                                                    (tee_local $7
+                                                    (tee_local $8
                                                       (i32.and
                                                         (i32.shr_u
                                                           (tee_local $0
                                                             (i32.shr_u
-                                                              (get_local $7)
+                                                              (get_local $8)
                                                               (get_local $2)
                                                             )
                                                           )
@@ -411,7 +411,7 @@
                                                         (tee_local $11
                                                           (i32.shr_u
                                                             (get_local $0)
-                                                            (get_local $7)
+                                                            (get_local $8)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -583,7 +583,7 @@
                       )
                       (if
                         (i32.and
-                          (tee_local $8
+                          (tee_local $7
                             (i32.load
                               (i32.const 176)
                             )
@@ -625,7 +625,7 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $8)
+                              (get_local $7)
                               (get_local $2)
                             )
                           )
@@ -667,7 +667,7 @@
                     (get_local $15)
                   )
                   (return
-                    (get_local $7)
+                    (get_local $8)
                   )
                 )
               )
@@ -759,7 +759,7 @@
                                     (tee_local $2
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $8
+                                          (tee_local $7
                                             (i32.shr_u
                                               (get_local $2)
                                               (get_local $1)
@@ -772,7 +772,7 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $8)
+                                    (get_local $7)
                                     (get_local $2)
                                   )
                                 )
@@ -786,7 +786,7 @@
                       (get_local $9)
                     )
                   )
-                  (set_local $8
+                  (set_local $7
                     (get_local $17)
                   )
                   (set_local $1
@@ -797,7 +797,7 @@
                       (if
                         (tee_local $17
                           (i32.load offset=16
-                            (get_local $8)
+                            (get_local $7)
                           )
                         )
                         (set_local $0
@@ -806,7 +806,7 @@
                         (if
                           (tee_local $11
                             (i32.load offset=20
-                              (get_local $8)
+                              (get_local $7)
                             )
                           )
                           (set_local $0
@@ -846,7 +846,7 @@
                           (get_local $11)
                         )
                       )
-                      (set_local $8
+                      (set_local $7
                         (get_local $0)
                       )
                       (set_local $1
@@ -873,7 +873,7 @@
                   (if
                     (i32.ge_u
                       (get_local $5)
-                      (tee_local $8
+                      (tee_local $7
                         (i32.add
                           (get_local $5)
                           (get_local $9)
@@ -890,7 +890,7 @@
                   (block $do-once4
                     (if
                       (i32.eq
-                        (tee_local $7
+                        (tee_local $8
                           (i32.load offset=12
                             (get_local $5)
                           )
@@ -1031,7 +1031,7 @@
                             (i32.load
                               (tee_local $11
                                 (i32.add
-                                  (get_local $7)
+                                  (get_local $8)
                                   (i32.const 8)
                                 )
                               )
@@ -1041,14 +1041,14 @@
                           (block
                             (i32.store
                               (get_local $10)
-                              (get_local $7)
+                              (get_local $8)
                             )
                             (i32.store
                               (get_local $11)
                               (get_local $0)
                             )
                             (set_local $19
-                              (get_local $7)
+                              (get_local $8)
                             )
                           )
                           (call $_abort)
@@ -1067,7 +1067,7 @@
                               (tee_local $1
                                 (i32.add
                                   (i32.shl
-                                    (tee_local $7
+                                    (tee_local $8
                                       (i32.load offset=28
                                         (get_local $5)
                                       )
@@ -1098,7 +1098,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $7)
+                                        (get_local $8)
                                       )
                                       (i32.const -1)
                                     )
@@ -1121,7 +1121,7 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $7
+                                  (tee_local $8
                                     (i32.add
                                       (get_local $2)
                                       (i32.const 16)
@@ -1131,7 +1131,7 @@
                                 (get_local $5)
                               )
                               (i32.store
-                                (get_local $7)
+                                (get_local $8)
                                 (get_local $19)
                               )
                               (i32.store offset=20
@@ -1149,7 +1149,7 @@
                         (if
                           (i32.lt_u
                             (get_local $19)
-                            (tee_local $7
+                            (tee_local $8
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1170,7 +1170,7 @@
                           (if
                             (i32.lt_u
                               (get_local $1)
-                              (get_local $7)
+                              (get_local $8)
                             )
                             (call $_abort)
                             (block
@@ -1259,7 +1259,7 @@
                         )
                       )
                       (i32.store offset=4
-                        (get_local $8)
+                        (get_local $7)
                         (i32.or
                           (get_local $3)
                           (i32.const 1)
@@ -1267,7 +1267,7 @@
                       )
                       (i32.store
                         (i32.add
-                          (get_local $8)
+                          (get_local $7)
                           (get_local $3)
                         )
                         (get_local $3)
@@ -1288,7 +1288,7 @@
                             (i32.add
                               (i32.shl
                                 (i32.shl
-                                  (tee_local $7
+                                  (tee_local $8
                                     (i32.shr_u
                                       (get_local $1)
                                       (i32.const 3)
@@ -1311,7 +1311,7 @@
                               (tee_local $11
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $7)
+                                  (get_local $8)
                                 )
                               )
                             )
@@ -1319,7 +1319,7 @@
                               (i32.lt_u
                                 (tee_local $10
                                   (i32.load
-                                    (tee_local $7
+                                    (tee_local $8
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 8)
@@ -1334,7 +1334,7 @@
                               (call $_abort)
                               (block
                                 (set_local $39
-                                  (get_local $7)
+                                  (get_local $8)
                                 )
                                 (set_local $32
                                   (get_local $10)
@@ -1384,7 +1384,7 @@
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $8)
+                        (get_local $7)
                       )
                     )
                   )
@@ -1463,7 +1463,7 @@
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $7
+                                                          (tee_local $8
                                                             (i32.shl
                                                               (get_local $10)
                                                               (tee_local $1
@@ -1489,13 +1489,13 @@
                                                   )
                                                   (get_local $1)
                                                 )
-                                                (tee_local $7
+                                                (tee_local $8
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
                                                         (tee_local $17
                                                           (i32.shl
-                                                            (get_local $7)
+                                                            (get_local $8)
                                                             (get_local $10)
                                                           )
                                                         )
@@ -1511,7 +1511,7 @@
                                             (i32.shr_u
                                               (i32.shl
                                                 (get_local $17)
-                                                (get_local $7)
+                                                (get_local $8)
                                               )
                                               (i32.const 15)
                                             )
@@ -1536,7 +1536,7 @@
                       )
                     )
                     (block
-                      (set_local $7
+                      (set_local $8
                         (get_local $0)
                       )
                       (set_local $17
@@ -1583,7 +1583,7 @@
                                 (get_local $2)
                               )
                             )
-                            (get_local $7)
+                            (get_local $8)
                           )
                           (if
                             (i32.eq
@@ -1600,13 +1600,13 @@
                               (set_local $29
                                 (get_local $10)
                               )
-                              (set_local $7
+                              (set_local $8
                                 (i32.const 90)
                               )
                               (br $label$break$L123)
                             )
                             (block
-                              (set_local $7
+                              (set_local $8
                                 (get_local $0)
                               )
                               (set_local $6
@@ -1658,15 +1658,15 @@
                           )
                           (block
                             (set_local $33
-                              (get_local $7)
+                              (get_local $8)
                             )
-                            (set_local $8
+                            (set_local $7
                               (get_local $19)
                             )
                             (set_local $30
                               (get_local $6)
                             )
-                            (set_local $7
+                            (set_local $8
                               (i32.const 86)
                             )
                           )
@@ -1695,13 +1695,13 @@
                       (set_local $33
                         (get_local $0)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 0)
                       )
                       (set_local $30
                         (i32.const 0)
                       )
-                      (set_local $7
+                      (set_local $8
                         (i32.const 86)
                       )
                     )
@@ -1709,68 +1709,68 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $7)
+                    (get_local $8)
                     (i32.const 86)
                   )
                   (if
-                    (tee_local $0
-                      (if i32
-                        (i32.and
+                    (if i32
+                      (i32.and
+                        (i32.eqz
+                          (get_local $7)
+                        )
+                        (i32.eqz
+                          (get_local $30)
+                        )
+                      )
+                      (block i32
+                        (if
                           (i32.eqz
-                            (get_local $8)
+                            (tee_local $0
+                              (i32.and
+                                (get_local $11)
+                                (i32.or
+                                  (tee_local $15
+                                    (i32.shl
+                                      (i32.const 2)
+                                      (get_local $9)
+                                    )
+                                  )
+                                  (i32.sub
+                                    (i32.const 0)
+                                    (get_local $15)
+                                  )
+                                )
+                              )
+                            )
                           )
-                          (i32.eqz
-                            (get_local $30)
+                          (block
+                            (set_local $9
+                              (get_local $2)
+                            )
+                            (br $do-once)
                           )
                         )
-                        (block i32
-                          (if
-                            (i32.eqz
-                              (tee_local $0
-                                (i32.and
-                                  (get_local $11)
-                                  (i32.or
-                                    (tee_local $15
-                                      (i32.shl
-                                        (i32.const 2)
-                                        (get_local $9)
-                                      )
-                                    )
+                        (set_local $0
+                          (i32.and
+                            (i32.shr_u
+                              (tee_local $15
+                                (i32.add
+                                  (i32.and
+                                    (get_local $0)
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $15)
-                                    )
-                                  )
-                                )
-                              )
-                            )
-                            (block
-                              (set_local $9
-                                (get_local $2)
-                              )
-                              (br $do-once)
-                            )
-                          )
-                          (set_local $0
-                            (i32.and
-                              (i32.shr_u
-                                (tee_local $15
-                                  (i32.add
-                                    (i32.and
                                       (get_local $0)
-                                      (i32.sub
-                                        (i32.const 0)
-                                        (get_local $0)
-                                      )
                                     )
-                                    (i32.const -1)
                                   )
+                                  (i32.const -1)
                                 )
-                                (i32.const 12)
                               )
-                              (i32.const 16)
+                              (i32.const 12)
                             )
+                            (i32.const 16)
                           )
+                        )
+                        (tee_local $7
                           (i32.load offset=480
                             (i32.shl
                               (i32.add
@@ -1797,7 +1797,7 @@
                                       (tee_local $9
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $8
+                                            (tee_local $7
                                               (i32.shr_u
                                                 (get_local $9)
                                                 (get_local $15)
@@ -1809,12 +1809,12 @@
                                         )
                                       )
                                     )
-                                    (tee_local $8
+                                    (tee_local $7
                                       (i32.and
                                         (i32.shr_u
                                           (tee_local $6
                                             (i32.shr_u
-                                              (get_local $8)
+                                              (get_local $7)
                                               (get_local $9)
                                             )
                                           )
@@ -1830,7 +1830,7 @@
                                         (tee_local $1
                                           (i32.shr_u
                                             (get_local $6)
-                                            (get_local $8)
+                                            (get_local $7)
                                           )
                                         )
                                         (i32.const 1)
@@ -1848,20 +1848,20 @@
                             )
                           )
                         )
-                        (get_local $8)
                       )
+                      (get_local $7)
                     )
                     (block
                       (set_local $27
                         (get_local $33)
                       )
                       (set_local $25
-                        (get_local $0)
+                        (get_local $7)
                       )
                       (set_local $29
                         (get_local $30)
                       )
-                      (set_local $7
+                      (set_local $8
                         (i32.const 90)
                       )
                     )
@@ -1877,11 +1877,11 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $7)
+                    (get_local $8)
                     (i32.const 90)
                   )
                   (loop $while-in16
-                    (set_local $7
+                    (set_local $8
                       (i32.const 0)
                     )
                     (set_local $1
@@ -1900,7 +1900,7 @@
                         (get_local $27)
                       )
                     )
-                    (set_local $8
+                    (set_local $7
                       (select
                         (get_local $6)
                         (get_local $27)
@@ -1922,7 +1922,7 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $8)
+                          (get_local $7)
                         )
                         (set_local $25
                           (get_local $1)
@@ -1941,7 +1941,7 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $8)
+                          (get_local $7)
                         )
                         (set_local $29
                           (get_local $6)
@@ -1950,7 +1950,7 @@
                       )
                       (block
                         (set_local $4
-                          (get_local $8)
+                          (get_local $7)
                         )
                         (set_local $12
                           (get_local $6)
@@ -1997,7 +1997,7 @@
                       )
                       (call $_abort)
                     )
-                    (set_local $8
+                    (set_local $7
                       (i32.load offset=24
                         (get_local $12)
                       )
@@ -2173,7 +2173,7 @@
                     )
                     (block $do-once21
                       (if
-                        (get_local $8)
+                        (get_local $7)
                         (block
                           (if
                             (i32.eq
@@ -2226,7 +2226,7 @@
                             (block
                               (if
                                 (i32.lt_u
-                                  (get_local $8)
+                                  (get_local $7)
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -2238,7 +2238,7 @@
                                   (i32.load
                                     (tee_local $1
                                       (i32.add
-                                        (get_local $8)
+                                        (get_local $7)
                                         (i32.const 16)
                                       )
                                     )
@@ -2250,7 +2250,7 @@
                                   (get_local $5)
                                 )
                                 (i32.store offset=20
-                                  (get_local $8)
+                                  (get_local $7)
                                   (get_local $5)
                                 )
                               )
@@ -2274,7 +2274,7 @@
                           )
                           (i32.store offset=24
                             (get_local $5)
-                            (get_local $8)
+                            (get_local $7)
                           )
                           (if
                             (tee_local $11
@@ -2357,7 +2357,7 @@
                             )
                             (get_local $4)
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.shr_u
                               (get_local $4)
                               (i32.const 3)
@@ -2373,7 +2373,7 @@
                                 (i32.add
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $8)
+                                      (get_local $7)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -2391,7 +2391,7 @@
                                   (tee_local $9
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $8)
+                                      (get_local $7)
                                     )
                                   )
                                 )
@@ -2399,7 +2399,7 @@
                                   (i32.lt_u
                                     (tee_local $15
                                       (i32.load
-                                        (tee_local $8
+                                        (tee_local $7
                                           (i32.add
                                             (get_local $11)
                                             (i32.const 8)
@@ -2414,7 +2414,7 @@
                                   (call $_abort)
                                   (block
                                     (set_local $16
-                                      (get_local $8)
+                                      (get_local $7)
                                     )
                                     (set_local $26
                                       (get_local $15)
@@ -2459,7 +2459,7 @@
                               (br $do-once25)
                             )
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.add
                               (i32.shl
                                 (tee_local $10
@@ -2481,7 +2481,7 @@
                                           (i32.shr_u
                                             (get_local $4)
                                             (i32.add
-                                              (tee_local $8
+                                              (tee_local $7
                                                 (i32.add
                                                   (i32.sub
                                                     (i32.const 14)
@@ -2551,7 +2551,7 @@
                                           (i32.const 1)
                                         )
                                         (i32.shl
-                                          (get_local $8)
+                                          (get_local $7)
                                           (i32.const 1)
                                         )
                                       )
@@ -2606,12 +2606,12 @@
                                 )
                               )
                               (i32.store
-                                (get_local $8)
+                                (get_local $7)
                                 (get_local $6)
                               )
                               (i32.store offset=24
                                 (get_local $6)
-                                (get_local $8)
+                                (get_local $7)
                               )
                               (i32.store offset=12
                                 (get_local $6)
@@ -2645,7 +2645,7 @@
                           )
                           (set_local $1
                             (i32.load
-                              (get_local $8)
+                              (get_local $7)
                             )
                           )
                           (loop $while-in28
@@ -2664,7 +2664,7 @@
                                   (set_local $14
                                     (get_local $1)
                                   )
-                                  (set_local $7
+                                  (set_local $8
                                     (i32.const 148)
                                   )
                                   (br $while-out27)
@@ -2673,7 +2673,7 @@
                               (if
                                 (tee_local $9
                                   (i32.load
-                                    (tee_local $8
+                                    (tee_local $7
                                       (i32.add
                                         (i32.add
                                           (get_local $1)
@@ -2704,12 +2704,12 @@
                                 )
                                 (block
                                   (set_local $23
-                                    (get_local $8)
+                                    (get_local $7)
                                   )
                                   (set_local $21
                                     (get_local $1)
                                   )
-                                  (set_local $7
+                                  (set_local $8
                                     (i32.const 145)
                                   )
                                 )
@@ -2718,7 +2718,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $7)
+                              (get_local $8)
                               (i32.const 145)
                             )
                             (if
@@ -2750,7 +2750,7 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $7)
+                                (get_local $8)
                                 (i32.const 148)
                               )
                               (if
@@ -3158,7 +3158,7 @@
             )
             (i32.const 0)
             (i32.eq
-              (tee_local $7
+              (tee_local $8
                 (block $label$break$L257 i32
                   (if i32
                     (i32.and
@@ -3209,7 +3209,7 @@
                                     (i32.const 0)
                                   )
                                   (block
-                                    (set_local $8
+                                    (set_local $7
                                       (get_local $16)
                                     )
                                     (set_local $1
@@ -3225,7 +3225,7 @@
                                     )
                                   )
                                 )
-                                (set_local $7
+                                (set_local $8
                                   (i32.const 173)
                                 )
                                 (br $label$break$L259)
@@ -3255,7 +3255,7 @@
                                   )
                                   (i32.add
                                     (i32.load
-                                      (get_local $8)
+                                      (get_local $7)
                                     )
                                     (i32.load
                                       (get_local $1)
@@ -3286,14 +3286,14 @@
                                   (set_local $18
                                     (get_local $16)
                                   )
-                                  (set_local $7
+                                  (set_local $8
                                     (i32.const 183)
                                   )
                                 )
                               )
                             )
                           )
-                          (set_local $7
+                          (set_local $8
                             (i32.const 173)
                           )
                         )
@@ -3302,7 +3302,7 @@
                         (if
                           (if i32
                             (i32.eq
-                              (get_local $7)
+                              (get_local $8)
                               (i32.const 173)
                             )
                             (i32.ne
@@ -3421,7 +3421,7 @@
                                     (set_local $18
                                       (get_local $0)
                                     )
-                                    (set_local $7
+                                    (set_local $8
                                       (i32.const 183)
                                     )
                                   )
@@ -3434,7 +3434,7 @@
                       (block $label$break$L279
                         (if
                           (i32.eq
-                            (get_local $7)
+                            (get_local $8)
                             (i32.const 183)
                           )
                           (block
@@ -3596,14 +3596,14 @@
         (set_local $22
           (get_local $13)
         )
-        (set_local $7
+        (set_local $8
           (i32.const 193)
         )
       )
     )
     (if
       (i32.eq
-        (get_local $7)
+        (get_local $8)
         (i32.const 193)
       )
       (block
@@ -3677,7 +3677,7 @@
                       (set_local $49
                         (get_local $3)
                       )
-                      (set_local $7
+                      (set_local $8
                         (i32.const 203)
                       )
                       (br $do-out)
@@ -3716,7 +3716,7 @@
                     )
                     (i32.const 0)
                     (i32.eq
-                      (get_local $7)
+                      (get_local $8)
                       (i32.const 203)
                     )
                   )
@@ -3842,7 +3842,7 @@
                       (set_local $40
                         (get_local $3)
                       )
-                      (set_local $7
+                      (set_local $8
                         (i32.const 211)
                       )
                       (br $while-out42)
@@ -3862,7 +3862,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $7)
+                  (get_local $8)
                   (i32.const 211)
                 )
                 (if
@@ -4012,7 +4012,7 @@
                             )
                           )
                           (i32.store
-                            (tee_local $8
+                            (tee_local $7
                               (i32.add
                                 (if i32
                                   (i32.eq
@@ -4033,7 +4033,7 @@
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $8
+                                    (set_local $7
                                       (i32.shr_u
                                         (get_local $0)
                                         (i32.const 3)
@@ -4400,7 +4400,7 @@
                                                   (i32.add
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $8)
+                                                        (get_local $7)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4444,7 +4444,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $8)
+                                                      (get_local $7)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4525,7 +4525,7 @@
                             )
                             (i32.and
                               (i32.load
-                                (get_local $8)
+                                (get_local $7)
                               )
                               (i32.const -2)
                             )
@@ -4544,7 +4544,7 @@
                             )
                             (get_local $14)
                           )
-                          (set_local $8
+                          (set_local $7
                             (i32.shr_u
                               (get_local $14)
                               (i32.const 3)
@@ -4560,7 +4560,7 @@
                                 (i32.add
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $8)
+                                      (get_local $7)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4579,7 +4579,7 @@
                                     (tee_local $2
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $8)
+                                        (get_local $7)
                                       )
                                     )
                                   )
@@ -4588,7 +4588,7 @@
                                       (i32.ge_u
                                         (tee_local $10
                                           (i32.load
-                                            (tee_local $8
+                                            (tee_local $7
                                               (i32.add
                                                 (get_local $0)
                                                 (i32.const 8)
@@ -4602,7 +4602,7 @@
                                       )
                                       (block
                                         (set_local $42
-                                          (get_local $8)
+                                          (get_local $7)
                                         )
                                         (set_local $34
                                           (get_local $10)
@@ -4718,7 +4718,7 @@
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (tee_local $8
+                                                                (tee_local $7
                                                                   (i32.shl
                                                                     (get_local $1)
                                                                     (get_local $10)
@@ -4735,7 +4735,7 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $8)
+                                                        (get_local $7)
                                                         (get_local $1)
                                                       )
                                                       (i32.const 15)
@@ -4862,7 +4862,7 @@
                                   (set_local $35
                                     (get_local $0)
                                   )
-                                  (set_local $7
+                                  (set_local $8
                                     (i32.const 281)
                                   )
                                   (br $while-out63)
@@ -4907,7 +4907,7 @@
                                   (set_local $51
                                     (get_local $0)
                                   )
-                                  (set_local $7
+                                  (set_local $8
                                     (i32.const 278)
                                   )
                                 )
@@ -4916,7 +4916,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $7)
+                              (get_local $8)
                               (i32.const 278)
                             )
                             (if
@@ -4948,7 +4948,7 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $7)
+                                (get_local $8)
                                 (i32.const 281)
                               )
                               (if
@@ -5592,7 +5592,7 @@
                           (set_local $37
                             (get_local $0)
                           )
-                          (set_local $7
+                          (set_local $8
                             (i32.const 307)
                           )
                           (br $while-out69)
@@ -5637,7 +5637,7 @@
                           (set_local $52
                             (get_local $0)
                           )
-                          (set_local $7
+                          (set_local $8
                             (i32.const 304)
                           )
                         )
@@ -5646,7 +5646,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $7)
+                      (get_local $8)
                       (i32.const 304)
                     )
                     (if
@@ -5678,7 +5678,7 @@
                     )
                     (if
                       (i32.eq
-                        (get_local $7)
+                        (get_local $8)
                         (i32.const 307)
                       )
                       (if
@@ -8481,23 +8481,22 @@
                     (i32.const 0)
                   )
                 )
-                (set_local $2
-                  (if i32
-                    (i32.gt_u
-                      (i32.load offset=20
-                        (get_local $1)
-                      )
-                      (i32.load offset=28
-                        (get_local $1)
-                      )
+                (if
+                  (i32.gt_u
+                    (i32.load offset=20
+                      (get_local $1)
                     )
+                    (i32.load offset=28
+                      (get_local $1)
+                    )
+                  )
+                  (set_local $2
                     (i32.or
                       (call $___fflush_unlocked
                         (get_local $1)
                       )
                       (get_local $2)
                     )
-                    (get_local $2)
                   )
                 )
                 (if

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -661,7 +661,7 @@
           )
         )
         (block i32
-          (set_local $1
+          (set_local $0
             (if i32
               (i32.load
                 (i32.const 12)
@@ -678,7 +678,7 @@
             (i32.const 44)
           )
           (if
-            (tee_local $0
+            (tee_local $1
               (i32.load
                 (i32.const 40)
               )
@@ -688,45 +688,44 @@
                 (if i32
                   (i32.gt_s
                     (i32.load offset=76
-                      (get_local $0)
+                      (get_local $1)
                     )
                     (i32.const -1)
                   )
                   (call $___lockfile
-                    (get_local $0)
+                    (get_local $1)
                   )
                   (i32.const 0)
                 )
               )
-              (set_local $1
-                (if i32
-                  (i32.gt_u
-                    (i32.load offset=20
-                      (get_local $0)
-                    )
-                    (i32.load offset=28
-                      (get_local $0)
-                    )
-                  )
-                  (i32.or
-                    (call $___fflush_unlocked
-                      (get_local $0)
-                    )
+              (if
+                (i32.gt_u
+                  (i32.load offset=20
                     (get_local $1)
                   )
-                  (get_local $1)
+                  (i32.load offset=28
+                    (get_local $1)
+                  )
+                )
+                (set_local $0
+                  (i32.or
+                    (call $___fflush_unlocked
+                      (get_local $1)
+                    )
+                    (get_local $0)
+                  )
                 )
               )
               (if
                 (get_local $2)
                 (call $___unlockfile
-                  (get_local $0)
+                  (get_local $1)
                 )
               )
               (br_if $while-in
-                (tee_local $0
+                (tee_local $1
                   (i32.load offset=56
-                    (get_local $0)
+                    (get_local $1)
                   )
                 )
               )
@@ -735,7 +734,7 @@
           (call $___unlock
             (i32.const 44)
           )
-          (get_local $1)
+          (get_local $0)
         )
       )
     )
@@ -2492,7 +2491,7 @@
         (i32.const 8)
       )
     )
-    (set_local $16
+    (set_local $17
       (i32.const 0)
     )
     (set_local $9
@@ -2508,18 +2507,18 @@
       (block $jumpthreading$inner$8
         (loop $label$continue$L1
           (block $label$break$L1
-            (set_local $16
-              (if i32
-                (i32.gt_s
-                  (get_local $16)
-                  (i32.const -1)
-                )
+            (if
+              (i32.gt_s
+                (get_local $17)
+                (i32.const -1)
+              )
+              (set_local $17
                 (if i32
                   (i32.gt_s
                     (get_local $5)
                     (i32.sub
                       (i32.const 2147483647)
-                      (get_local $16)
+                      (get_local $17)
                     )
                   )
                   (block i32
@@ -2531,10 +2530,9 @@
                   )
                   (i32.add
                     (get_local $5)
-                    (get_local $16)
+                    (get_local $17)
                   )
                 )
-                (get_local $16)
               )
             )
             (br_if $jumpthreading$inner$8
@@ -2955,7 +2953,7 @@
                       (if
                         (get_local $8)
                         (block
-                          (set_local $16
+                          (set_local $17
                             (i32.const -1)
                           )
                           (br $label$break$L1)
@@ -3098,7 +3096,7 @@
                         (i32.const 0)
                       )
                       (block
-                        (set_local $16
+                        (set_local $17
                           (i32.const -1)
                         )
                         (br $label$break$L1)
@@ -3300,7 +3298,7 @@
                     (if
                       (get_local $1)
                       (block
-                        (set_local $16
+                        (set_local $17
                           (i32.const -1)
                         )
                         (br $label$break$L1)
@@ -3367,7 +3365,7 @@
                   (i32.const 57)
                 )
                 (block
-                  (set_local $16
+                  (set_local $17
                     (i32.const -1)
                   )
                   (br $label$break$L1)
@@ -3414,7 +3412,7 @@
                   )
                   (br $while-in13)
                 )
-                (set_local $17
+                (set_local $16
                   (get_local $8)
                 )
               )
@@ -3430,7 +3428,7 @@
                 )
               )
               (block
-                (set_local $16
+                (set_local $17
                   (i32.const -1)
                 )
                 (br $label$break$L1)
@@ -3458,7 +3456,7 @@
                   (if
                     (get_local $8)
                     (block
-                      (set_local $16
+                      (set_local $17
                         (i32.const -1)
                       )
                       (br $label$break$L1)
@@ -3512,7 +3510,7 @@
                         (get_local $31)
                       )
                       (block
-                        (set_local $16
+                        (set_local $17
                           (i32.const 0)
                         )
                         (br $label$break$L1)
@@ -3587,7 +3585,7 @@
                                                             (i32.and
                                                               (tee_local $11
                                                                 (i32.load8_s
-                                                                  (get_local $17)
+                                                                  (get_local $16)
                                                                 )
                                                               )
                                                               (i32.const -33)
@@ -3631,7 +3629,7 @@
                                                                   (i32.load
                                                                     (get_local $18)
                                                                   )
-                                                                  (get_local $16)
+                                                                  (get_local $17)
                                                                 )
                                                                 (set_local $9
                                                                   (get_local $5)
@@ -3645,7 +3643,7 @@
                                                                 (i32.load
                                                                   (get_local $18)
                                                                 )
-                                                                (get_local $16)
+                                                                (get_local $17)
                                                               )
                                                               (set_local $9
                                                                 (get_local $5)
@@ -3661,14 +3659,14 @@
                                                                   (get_local $18)
                                                                 )
                                                               )
-                                                              (get_local $16)
+                                                              (get_local $17)
                                                             )
                                                             (i32.store offset=4
                                                               (get_local $9)
                                                               (i32.shr_s
                                                                 (i32.shl
                                                                   (i32.lt_s
-                                                                    (get_local $16)
+                                                                    (get_local $17)
                                                                     (i32.const 0)
                                                                   )
                                                                   (i32.const 31)
@@ -3688,7 +3686,7 @@
                                                             (i32.load
                                                               (get_local $18)
                                                             )
-                                                            (get_local $16)
+                                                            (get_local $17)
                                                           )
                                                           (set_local $9
                                                             (get_local $5)
@@ -3702,7 +3700,7 @@
                                                           (i32.load
                                                             (get_local $18)
                                                           )
-                                                          (get_local $16)
+                                                          (get_local $17)
                                                         )
                                                         (set_local $9
                                                           (get_local $5)
@@ -3716,7 +3714,7 @@
                                                         (i32.load
                                                           (get_local $18)
                                                         )
-                                                        (get_local $16)
+                                                        (get_local $17)
                                                       )
                                                       (set_local $9
                                                         (get_local $5)
@@ -3732,14 +3730,14 @@
                                                           (get_local $18)
                                                         )
                                                       )
-                                                      (get_local $16)
+                                                      (get_local $17)
                                                     )
                                                     (i32.store offset=4
                                                       (get_local $9)
                                                       (i32.shr_s
                                                         (i32.shl
                                                           (i32.lt_s
-                                                            (get_local $16)
+                                                            (get_local $17)
                                                             (i32.const 0)
                                                           )
                                                           (i32.const 31)
@@ -4229,7 +4227,7 @@
                                     )
                                     (if
                                       (i32.eq
-                                        (tee_local $17
+                                        (tee_local $16
                                           (i32.or
                                             (get_local $13)
                                             (i32.const 32)
@@ -4245,7 +4243,7 @@
                                               (i32.const 9)
                                             )
                                             (get_local $34)
-                                            (tee_local $17
+                                            (tee_local $16
                                               (i32.and
                                                 (get_local $13)
                                                 (i32.const 32)
@@ -4327,59 +4325,59 @@
                                         )
                                         (i32.store8
                                           (i32.add
-                                            (tee_local $6
-                                              (if i32
-                                                (i32.eq
-                                                  (tee_local $6
-                                                    (call $_fmt_u
-                                                      (tee_local $6
-                                                        (select
-                                                          (i32.sub
-                                                            (i32.const 0)
-                                                            (tee_local $5
-                                                              (i32.load
-                                                                (get_local $20)
-                                                              )
+                                            (if i32
+                                              (i32.eq
+                                                (tee_local $5
+                                                  (call $_fmt_u
+                                                    (tee_local $5
+                                                      (select
+                                                        (i32.sub
+                                                          (i32.const 0)
+                                                          (tee_local $6
+                                                            (i32.load
+                                                              (get_local $20)
                                                             )
                                                           )
-                                                          (get_local $5)
-                                                          (i32.lt_s
-                                                            (get_local $5)
-                                                            (i32.const 0)
-                                                          )
+                                                        )
+                                                        (get_local $6)
+                                                        (i32.lt_s
+                                                          (get_local $6)
+                                                          (i32.const 0)
                                                         )
                                                       )
-                                                      (i32.shr_s
-                                                        (i32.shl
-                                                          (i32.lt_s
-                                                            (get_local $6)
-                                                            (i32.const 0)
-                                                          )
-                                                          (i32.const 31)
+                                                    )
+                                                    (i32.shr_s
+                                                      (i32.shl
+                                                        (i32.lt_s
+                                                          (get_local $5)
+                                                          (i32.const 0)
                                                         )
                                                         (i32.const 31)
                                                       )
-                                                      (get_local $37)
+                                                      (i32.const 31)
                                                     )
+                                                    (get_local $37)
                                                   )
-                                                  (get_local $37)
                                                 )
-                                                (block i32
-                                                  (i32.store8
-                                                    (get_local $47)
-                                                    (i32.const 48)
-                                                  )
+                                                (get_local $37)
+                                              )
+                                              (block i32
+                                                (i32.store8
+                                                  (get_local $47)
+                                                  (i32.const 48)
+                                                )
+                                                (tee_local $5
                                                   (get_local $47)
                                                 )
-                                                (get_local $6)
                                               )
+                                              (get_local $5)
                                             )
                                             (i32.const -1)
                                           )
                                           (i32.add
                                             (i32.and
                                               (i32.shr_s
-                                                (get_local $5)
+                                                (get_local $6)
                                                 (i32.const 31)
                                               )
                                               (i32.const 2)
@@ -4390,7 +4388,7 @@
                                         (i32.store8
                                           (tee_local $6
                                             (i32.add
-                                              (get_local $6)
+                                              (get_local $5)
                                               (i32.const -2)
                                             )
                                           )
@@ -4430,7 +4428,7 @@
                                                   (i32.const 4075)
                                                 )
                                               )
-                                              (get_local $17)
+                                              (get_local $16)
                                             )
                                           )
                                           (set_local $15
@@ -4928,7 +4926,7 @@
                                         )
                                         (set_local $25
                                           (i32.eq
-                                            (get_local $17)
+                                            (get_local $16)
                                             (i32.const 102)
                                           )
                                         )
@@ -5180,7 +5178,7 @@
                                         )
                                       )
                                     )
-                                    (set_local $17
+                                    (set_local $16
                                       (if i32
                                         (i32.lt_s
                                           (tee_local $7
@@ -5191,7 +5189,7 @@
                                                   (get_local $6)
                                                   (i32.const 0)
                                                   (i32.ne
-                                                    (get_local $17)
+                                                    (get_local $16)
                                                     (i32.const 102)
                                                   )
                                                 )
@@ -5207,7 +5205,7 @@
                                                     )
                                                     (tee_local $43
                                                       (i32.eq
-                                                        (get_local $17)
+                                                        (get_local $16)
                                                         (i32.const 103)
                                                       )
                                                     )
@@ -5233,7 +5231,7 @@
                                           )
                                         )
                                         (block i32
-                                          (set_local $17
+                                          (set_local $16
                                             (call $i32s-div
                                               (tee_local $7
                                                 (i32.add
@@ -5285,7 +5283,7 @@
                                               (i32.const 10)
                                             )
                                           )
-                                          (set_local $17
+                                          (set_local $16
                                             (call $i32u-rem
                                               (tee_local $25
                                                 (i32.load
@@ -5297,7 +5295,7 @@
                                                       )
                                                       (i32.shl
                                                         (i32.add
-                                                          (get_local $17)
+                                                          (get_local $16)
                                                           (i32.const -1024)
                                                         )
                                                         (i32.const 2)
@@ -5323,7 +5321,7 @@
                                                     )
                                                   )
                                                   (i32.eqz
-                                                    (get_local $17)
+                                                    (get_local $16)
                                                   )
                                                 )
                                               )
@@ -5337,7 +5335,7 @@
                                                 (set_local $15
                                                   (if f64
                                                     (i32.lt_u
-                                                      (get_local $17)
+                                                      (get_local $16)
                                                       (tee_local $56
                                                         (call $i32s-div
                                                           (get_local $11)
@@ -5352,7 +5350,7 @@
                                                       (i32.and
                                                         (get_local $36)
                                                         (i32.eq
-                                                          (get_local $17)
+                                                          (get_local $16)
                                                           (get_local $56)
                                                         )
                                                       )
@@ -5400,10 +5398,10 @@
                                                 )
                                                 (i32.store
                                                   (get_local $7)
-                                                  (tee_local $17
+                                                  (tee_local $16
                                                     (i32.sub
                                                       (get_local $25)
-                                                      (get_local $17)
+                                                      (get_local $16)
                                                     )
                                                   )
                                                 )
@@ -5420,7 +5418,7 @@
                                                   (get_local $7)
                                                   (tee_local $6
                                                     (i32.add
-                                                      (get_local $17)
+                                                      (get_local $16)
                                                       (get_local $11)
                                                     )
                                                   )
@@ -5435,30 +5433,29 @@
                                                       (get_local $7)
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $5
-                                                      (if i32
-                                                        (i32.lt_u
-                                                          (tee_local $7
+                                                    (if
+                                                      (i32.lt_u
+                                                        (tee_local $7
+                                                          (i32.add
+                                                            (get_local $7)
+                                                            (i32.const -4)
+                                                          )
+                                                        )
+                                                        (get_local $5)
+                                                      )
+                                                      (block
+                                                        (i32.store
+                                                          (tee_local $5
                                                             (i32.add
-                                                              (get_local $7)
+                                                              (get_local $5)
                                                               (i32.const -4)
                                                             )
                                                           )
+                                                          (i32.const 0)
+                                                        )
+                                                        (set_local $5
                                                           (get_local $5)
                                                         )
-                                                        (block i32
-                                                          (i32.store
-                                                            (tee_local $5
-                                                              (i32.add
-                                                                (get_local $5)
-                                                                (i32.const -4)
-                                                              )
-                                                            )
-                                                            (i32.const 0)
-                                                          )
-                                                          (get_local $5)
-                                                        )
-                                                        (get_local $5)
                                                       )
                                                     )
                                                     (i32.store
@@ -5494,7 +5491,7 @@
                                                 )
                                                 (br_if $do-once81
                                                   (i32.lt_u
-                                                    (tee_local $17
+                                                    (tee_local $16
                                                       (i32.load
                                                         (get_local $5)
                                                       )
@@ -5514,7 +5511,7 @@
                                                   )
                                                   (br_if $while-in88
                                                     (i32.ge_u
-                                                      (get_local $17)
+                                                      (get_local $16)
                                                       (tee_local $11
                                                         (i32.mul
                                                           (get_local $11)
@@ -5569,7 +5566,7 @@
                                         (if
                                           (i32.le_u
                                             (get_local $5)
-                                            (get_local $17)
+                                            (get_local $16)
                                           )
                                           (block
                                             (set_local $25
@@ -6023,9 +6020,9 @@
                                             (tee_local $13
                                               (select
                                                 (get_local $8)
-                                                (get_local $17)
+                                                (get_local $16)
                                                 (i32.gt_u
-                                                  (get_local $17)
+                                                  (get_local $16)
                                                   (get_local $8)
                                                 )
                                               )
@@ -6266,7 +6263,7 @@
                                             (select
                                               (get_local $10)
                                               (i32.add
-                                                (get_local $17)
+                                                (get_local $16)
                                                 (i32.const 4)
                                               )
                                               (get_local $25)
@@ -6284,41 +6281,40 @@
                                                 )
                                               )
                                               (set_local $7
-                                                (get_local $17)
+                                                (get_local $16)
                                               )
                                               (set_local $6
                                                 (get_local $5)
                                               )
                                               (loop $while-in114
-                                                (set_local $5
-                                                  (if i32
-                                                    (i32.eq
-                                                      (tee_local $5
-                                                        (call $_fmt_u
-                                                          (i32.load
-                                                            (get_local $7)
-                                                          )
-                                                          (i32.const 0)
-                                                          (get_local $32)
+                                                (if
+                                                  (i32.eq
+                                                    (tee_local $5
+                                                      (call $_fmt_u
+                                                        (i32.load
+                                                          (get_local $7)
                                                         )
+                                                        (i32.const 0)
+                                                        (get_local $32)
                                                       )
-                                                      (get_local $32)
                                                     )
-                                                    (block i32
-                                                      (i32.store8
-                                                        (get_local $38)
-                                                        (i32.const 48)
-                                                      )
+                                                    (get_local $32)
+                                                  )
+                                                  (block
+                                                    (i32.store8
+                                                      (get_local $38)
+                                                      (i32.const 48)
+                                                    )
+                                                    (set_local $5
                                                       (get_local $38)
                                                     )
-                                                    (get_local $5)
                                                   )
                                                 )
                                                 (block $do-once115
                                                   (if
                                                     (i32.eq
                                                       (get_local $7)
-                                                      (get_local $17)
+                                                      (get_local $16)
                                                     )
                                                     (block
                                                       (if
@@ -6788,7 +6784,7 @@
                     (set_local $27
                       (i32.const 0)
                     )
-                    (set_local $17
+                    (set_local $16
                       (i32.eqz
                         (tee_local $13
                           (call $_memchr
@@ -6812,7 +6808,7 @@
                           (get_local $13)
                           (get_local $9)
                         )
-                        (get_local $17)
+                        (get_local $16)
                       )
                     )
                     (set_local $8
@@ -6828,7 +6824,7 @@
                           (get_local $7)
                         )
                         (get_local $13)
-                        (get_local $17)
+                        (get_local $16)
                       )
                     )
                     (br $jumpthreading$outer$7)
@@ -6900,7 +6896,7 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $16
+                      (set_local $17
                         (i32.const -1)
                       )
                       (br $label$break$L1)
@@ -7275,7 +7271,7 @@
                     )
                   )
                   (block
-                    (set_local $16
+                    (set_local $17
                       (i32.const 1)
                     )
                     (br $label$break$L343)
@@ -7300,7 +7296,7 @@
                     )
                   )
                   (block
-                    (set_local $16
+                    (set_local $17
                       (i32.const -1)
                     )
                     (br $label$break$L343)
@@ -7317,16 +7313,16 @@
                     (i32.const 10)
                   )
                 )
-                (set_local $16
+                (set_local $17
                   (i32.const 1)
                 )
               )
-              (set_local $16
+              (set_local $17
                 (i32.const 1)
               )
             )
           )
-          (set_local $16
+          (set_local $17
             (i32.const 0)
           )
         )
@@ -7335,7 +7331,7 @@
     (set_global $STACKTOP
       (get_local $26)
     )
-    (get_local $16)
+    (get_local $17)
   )
   (func $_pop_arg_336 (param $0 i32) (param $1 i32) (param $2 i32)
     (local $3 i32)
@@ -7870,7 +7866,7 @@
     (local $5 i32)
     (local $6 i32)
     (local $7 i32)
-    (set_local $6
+    (set_local $7
       (get_global $STACKTOP)
     )
     (set_global $STACKTOP
@@ -7886,8 +7882,8 @@
       )
       (call $abort)
     )
-    (set_local $5
-      (get_local $6)
+    (set_local $6
+      (get_local $7)
     )
     (block $do-once
       (if
@@ -7906,27 +7902,27 @@
         (block
           (drop
             (call $_memset
-              (get_local $5)
+              (get_local $6)
               (get_local $1)
               (select
                 (i32.const 256)
-                (tee_local $4
+                (tee_local $5
                   (i32.sub
                     (get_local $2)
                     (get_local $3)
                   )
                 )
                 (i32.gt_u
-                  (get_local $4)
+                  (get_local $5)
                   (i32.const 256)
                 )
               )
             )
           )
-          (set_local $1
+          (set_local $4
             (i32.eqz
               (i32.and
-                (tee_local $7
+                (tee_local $1
                   (i32.load
                     (get_local $0)
                   )
@@ -7937,31 +7933,31 @@
           )
           (if
             (i32.gt_u
-              (get_local $4)
+              (get_local $5)
               (i32.const 255)
             )
             (block
               (loop $while-in
-                (set_local $1
+                (set_local $4
                   (i32.eqz
                     (i32.and
-                      (tee_local $7
-                        (if i32
-                          (get_local $1)
-                          (block i32
-                            (drop
-                              (call $___fwritex
-                                (get_local $5)
-                                (i32.const 256)
-                                (get_local $0)
-                              )
+                      (if i32
+                        (get_local $4)
+                        (block i32
+                          (drop
+                            (call $___fwritex
+                              (get_local $6)
+                              (i32.const 256)
+                              (get_local $0)
                             )
+                          )
+                          (tee_local $1
                             (i32.load
                               (get_local $0)
                             )
                           )
-                          (get_local $7)
                         )
+                        (get_local $1)
                       )
                       (i32.const 32)
                     )
@@ -7969,9 +7965,9 @@
                 )
                 (br_if $while-in
                   (i32.gt_u
-                    (tee_local $4
+                    (tee_local $5
                       (i32.add
-                        (get_local $4)
+                        (get_local $5)
                         (i32.const -256)
                       )
                     )
@@ -7981,10 +7977,10 @@
               )
               (br_if $do-once
                 (i32.eqz
-                  (get_local $1)
+                  (get_local $4)
                 )
               )
-              (set_local $4
+              (set_local $5
                 (i32.and
                   (i32.sub
                     (get_local $2)
@@ -7996,14 +7992,14 @@
             )
             (br_if $do-once
               (i32.eqz
-                (get_local $1)
+                (get_local $4)
               )
             )
           )
           (drop
             (call $___fwritex
+              (get_local $6)
               (get_local $5)
-              (get_local $4)
               (get_local $0)
             )
           )
@@ -8011,7 +8007,7 @@
       )
     )
     (set_global $STACKTOP
-      (get_local $6)
+      (get_local $7)
     )
   )
   (func $_malloc (param $0 i32) (result i32)
@@ -8081,7 +8077,7 @@
               (i32.const 3)
             )
             (block
-              (set_local $6
+              (set_local $5
                 (i32.load
                   (tee_local $1
                     (i32.add
@@ -8125,7 +8121,7 @@
               (if
                 (i32.eq
                   (get_local $3)
-                  (get_local $6)
+                  (get_local $5)
                 )
                 (i32.store
                   (i32.const 176)
@@ -8143,7 +8139,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $6)
+                      (get_local $5)
                       (i32.load
                         (i32.const 192)
                       )
@@ -8155,7 +8151,7 @@
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $6)
+                            (get_local $5)
                             (i32.const 12)
                           )
                         )
@@ -8169,7 +8165,7 @@
                       )
                       (i32.store
                         (get_local $2)
-                        (get_local $6)
+                        (get_local $5)
                       )
                     )
                     (call $_abort)
@@ -8266,7 +8262,7 @@
                     (i32.load
                       (tee_local $4
                         (i32.add
-                          (tee_local $6
+                          (tee_local $5
                             (i32.load
                               (tee_local $1
                                 (i32.add
@@ -8274,7 +8270,7 @@
                                     (i32.add
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $5
+                                          (tee_local $6
                                             (i32.add
                                               (i32.or
                                                 (i32.or
@@ -8377,7 +8373,7 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $5)
+                              (get_local $6)
                             )
                             (i32.const -1)
                           )
@@ -8407,7 +8403,7 @@
                               )
                             )
                           )
-                          (get_local $6)
+                          (get_local $5)
                         )
                         (block
                           (i32.store
@@ -8429,16 +8425,16 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $6)
+                    (get_local $5)
                     (i32.or
                       (get_local $3)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $6
+                    (tee_local $5
                       (i32.add
-                        (get_local $6)
+                        (get_local $5)
                         (get_local $3)
                       )
                     )
@@ -8446,7 +8442,7 @@
                       (tee_local $3
                         (i32.sub
                           (i32.shl
-                            (get_local $5)
+                            (get_local $6)
                             (i32.const 3)
                           )
                           (get_local $3)
@@ -8457,7 +8453,7 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $6)
+                      (get_local $5)
                       (get_local $3)
                     )
                     (get_local $3)
@@ -8465,7 +8461,7 @@
                   (if
                     (get_local $16)
                     (block
-                      (set_local $5
+                      (set_local $6
                         (i32.load
                           (i32.const 196)
                         )
@@ -8548,18 +8544,18 @@
                       )
                       (i32.store
                         (get_local $15)
-                        (get_local $5)
+                        (get_local $6)
                       )
                       (i32.store offset=12
                         (get_local $9)
-                        (get_local $5)
+                        (get_local $6)
                       )
                       (i32.store offset=8
-                        (get_local $5)
+                        (get_local $6)
                         (get_local $9)
                       )
                       (i32.store offset=12
-                        (get_local $5)
+                        (get_local $6)
                         (get_local $2)
                       )
                     )
@@ -8570,7 +8566,7 @@
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $6)
+                    (get_local $5)
                   )
                   (return
                     (get_local $4)
@@ -8829,7 +8825,7 @@
                               )
                             )
                             (block
-                              (set_local $6
+                              (set_local $5
                                 (i32.const 0)
                               )
                               (br $do-once4)
@@ -8891,7 +8887,7 @@
                               (get_local $0)
                               (i32.const 0)
                             )
-                            (set_local $6
+                            (set_local $5
                               (get_local $1)
                             )
                           )
@@ -8944,7 +8940,7 @@
                               (get_local $1)
                               (get_local $9)
                             )
-                            (set_local $6
+                            (set_local $5
                               (get_local $0)
                             )
                           )
@@ -8979,11 +8975,11 @@
                           (block
                             (i32.store
                               (get_local $0)
-                              (get_local $6)
+                              (get_local $5)
                             )
                             (if
                               (i32.eqz
-                                (get_local $6)
+                                (get_local $5)
                               )
                               (block
                                 (i32.store
@@ -9029,23 +9025,23 @@
                               )
                               (i32.store
                                 (get_local $0)
-                                (get_local $6)
+                                (get_local $5)
                               )
                               (i32.store offset=20
                                 (get_local $7)
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                             (br_if $do-once8
                               (i32.eqz
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $6)
+                            (get_local $5)
                             (tee_local $0
                               (i32.load
                                 (i32.const 192)
@@ -9055,7 +9051,7 @@
                           (call $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $6)
+                          (get_local $5)
                           (get_local $7)
                         )
                         (if
@@ -9072,12 +9068,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $6)
+                                (get_local $5)
                                 (get_local $1)
                               )
                               (i32.store offset=24
                                 (get_local $1)
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                           )
@@ -9098,12 +9094,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $6)
+                                (get_local $5)
                                 (get_local $0)
                               )
                               (i32.store offset=24
                                 (get_local $0)
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                           )
@@ -9230,7 +9226,7 @@
                               )
                               (call $_abort)
                               (block
-                                (set_local $5
+                                (set_local $6
                                   (get_local $1)
                                 )
                                 (set_local $4
@@ -9246,7 +9242,7 @@
                                   (get_local $0)
                                 )
                               )
-                              (set_local $5
+                              (set_local $6
                                 (i32.add
                                   (get_local $2)
                                   (i32.const 8)
@@ -9258,7 +9254,7 @@
                             )
                           )
                           (i32.store
-                            (get_local $5)
+                            (get_local $6)
                             (get_local $3)
                           )
                           (i32.store offset=12
@@ -9311,7 +9307,7 @@
             (i32.const -1)
           )
           (block
-            (set_local $6
+            (set_local $5
               (i32.and
                 (tee_local $0
                   (i32.add
@@ -9332,7 +9328,7 @@
                 (set_local $9
                   (i32.sub
                     (i32.const 0)
-                    (get_local $6)
+                    (get_local $5)
                   )
                 )
                 (block $jumpthreading$outer$2
@@ -9351,14 +9347,14 @@
                                 )
                                 (if i32
                                   (i32.gt_u
-                                    (get_local $6)
+                                    (get_local $5)
                                     (i32.const 16777215)
                                   )
                                   (i32.const 31)
                                   (i32.or
                                     (i32.and
                                       (i32.shr_u
-                                        (get_local $6)
+                                        (get_local $5)
                                         (i32.add
                                           (tee_local $0
                                             (i32.add
@@ -9373,7 +9369,7 @@
                                                             (tee_local $4
                                                               (i32.shl
                                                                 (get_local $0)
-                                                                (tee_local $5
+                                                                (tee_local $6
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
@@ -9394,7 +9390,7 @@
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $5)
+                                                    (get_local $6)
                                                   )
                                                   (tee_local $0
                                                     (i32.and
@@ -9448,7 +9444,7 @@
                         )
                         (set_local $18
                           (i32.shl
-                            (get_local $6)
+                            (get_local $5)
                             (select
                               (i32.const 0)
                               (i32.sub
@@ -9471,7 +9467,7 @@
                         (loop $while-in14
                           (if
                             (i32.lt_u
-                              (tee_local $5
+                              (tee_local $6
                                 (i32.sub
                                   (tee_local $15
                                     (i32.and
@@ -9481,7 +9477,7 @@
                                       (i32.const -8)
                                     )
                                   )
-                                  (get_local $6)
+                                  (get_local $5)
                                 )
                               )
                               (get_local $9)
@@ -9489,11 +9485,11 @@
                             (if
                               (i32.eq
                                 (get_local $15)
-                                (get_local $6)
+                                (get_local $5)
                               )
                               (block
                                 (set_local $2
-                                  (get_local $5)
+                                  (get_local $6)
                                 )
                                 (set_local $3
                                   (get_local $0)
@@ -9508,7 +9504,7 @@
                               )
                               (block
                                 (set_local $9
-                                  (get_local $5)
+                                  (get_local $6)
                                 )
                                 (set_local $4
                                   (get_local $0)
@@ -9519,17 +9515,17 @@
                           (set_local $0
                             (select
                               (get_local $16)
-                              (tee_local $5
+                              (tee_local $6
                                 (i32.load offset=20
                                   (get_local $0)
                                 )
                               )
                               (i32.or
                                 (i32.eqz
-                                  (get_local $5)
+                                  (get_local $6)
                                 )
                                 (i32.eq
-                                  (get_local $5)
+                                  (get_local $6)
                                   (tee_local $15
                                     (i32.load
                                       (i32.add
@@ -9551,7 +9547,7 @@
                               )
                             )
                           )
-                          (set_local $5
+                          (set_local $6
                             (i32.shl
                               (get_local $18)
                               (i32.xor
@@ -9575,7 +9571,7 @@
                               (get_local $0)
                             )
                             (set_local $18
-                              (get_local $5)
+                              (get_local $6)
                             )
                             (set_local $0
                               (get_local $15)
@@ -9597,64 +9593,64 @@
                     (br $jumpthreading$outer$2)
                   )
                   (if
-                    (tee_local $0
-                      (if i32
-                        (i32.and
+                    (if i32
+                      (i32.and
+                        (i32.eqz
+                          (get_local $0)
+                        )
+                        (i32.eqz
+                          (get_local $4)
+                        )
+                      )
+                      (block i32
+                        (if
                           (i32.eqz
-                            (get_local $0)
+                            (tee_local $0
+                              (i32.and
+                                (get_local $24)
+                                (i32.or
+                                  (tee_local $0
+                                    (i32.shl
+                                      (i32.const 2)
+                                      (get_local $17)
+                                    )
+                                  )
+                                  (i32.sub
+                                    (i32.const 0)
+                                    (get_local $0)
+                                  )
+                                )
+                              )
+                            )
                           )
-                          (i32.eqz
-                            (get_local $4)
+                          (block
+                            (set_local $0
+                              (get_local $5)
+                            )
+                            (br $do-once)
                           )
                         )
-                        (block i32
-                          (if
-                            (i32.eqz
+                        (set_local $15
+                          (i32.and
+                            (i32.shr_u
                               (tee_local $0
-                                (i32.and
-                                  (get_local $24)
-                                  (i32.or
-                                    (tee_local $0
-                                      (i32.shl
-                                        (i32.const 2)
-                                        (get_local $17)
-                                      )
-                                    )
+                                (i32.add
+                                  (i32.and
+                                    (get_local $0)
                                     (i32.sub
                                       (i32.const 0)
                                       (get_local $0)
                                     )
                                   )
+                                  (i32.const -1)
                                 )
                               )
+                              (i32.const 12)
                             )
-                            (block
-                              (set_local $0
-                                (get_local $6)
-                              )
-                              (br $do-once)
-                            )
+                            (i32.const 16)
                           )
-                          (set_local $15
-                            (i32.and
-                              (i32.shr_u
-                                (tee_local $0
-                                  (i32.add
-                                    (i32.and
-                                      (get_local $0)
-                                      (i32.sub
-                                        (i32.const 0)
-                                        (get_local $0)
-                                      )
-                                    )
-                                    (i32.const -1)
-                                  )
-                                )
-                                (i32.const 12)
-                              )
-                              (i32.const 16)
-                            )
-                          )
+                        )
+                        (tee_local $0
                           (i32.load offset=480
                             (i32.shl
                               (i32.add
@@ -9665,7 +9661,7 @@
                                         (tee_local $0
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $5
+                                              (tee_local $6
                                                 (i32.shr_u
                                                   (get_local $0)
                                                   (get_local $15)
@@ -9681,9 +9677,9 @@
                                       (tee_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $5
+                                            (tee_local $6
                                               (i32.shr_u
-                                                (get_local $5)
+                                                (get_local $6)
                                                 (get_local $0)
                                               )
                                             )
@@ -9696,9 +9692,9 @@
                                     (tee_local $0
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $5
+                                          (tee_local $6
                                             (i32.shr_u
-                                              (get_local $5)
+                                              (get_local $6)
                                               (get_local $0)
                                             )
                                           )
@@ -9711,9 +9707,9 @@
                                   (tee_local $0
                                     (i32.and
                                       (i32.shr_u
-                                        (tee_local $5
+                                        (tee_local $6
                                           (i32.shr_u
-                                            (get_local $5)
+                                            (get_local $6)
                                             (get_local $0)
                                           )
                                         )
@@ -9724,7 +9720,7 @@
                                   )
                                 )
                                 (i32.shr_u
-                                  (get_local $5)
+                                  (get_local $6)
                                   (get_local $0)
                                 )
                               )
@@ -9732,8 +9728,8 @@
                             )
                           )
                         )
-                        (get_local $0)
                       )
+                      (get_local $0)
                     )
                     (block
                       (set_local $2
@@ -9775,7 +9771,7 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $6)
+                            (get_local $5)
                           )
                         )
                         (get_local $2)
@@ -9834,7 +9830,7 @@
                         (i32.load
                           (i32.const 184)
                         )
-                        (get_local $6)
+                        (get_local $5)
                       )
                     )
                     (block
@@ -9852,10 +9848,10 @@
                       (if
                         (i32.ge_u
                           (get_local $13)
-                          (tee_local $5
+                          (tee_local $6
                             (i32.add
                               (get_local $13)
-                              (get_local $6)
+                              (get_local $5)
                             )
                           )
                         )
@@ -10199,7 +10195,7 @@
                                 (tee_local $0
                                   (i32.add
                                     (get_local $8)
-                                    (get_local $6)
+                                    (get_local $5)
                                   )
                                 )
                                 (i32.const 3)
@@ -10227,12 +10223,12 @@
                             (i32.store offset=4
                               (get_local $13)
                               (i32.or
-                                (get_local $6)
+                                (get_local $5)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
-                              (get_local $5)
+                              (get_local $6)
                               (i32.or
                                 (get_local $8)
                                 (i32.const 1)
@@ -10240,7 +10236,7 @@
                             )
                             (i32.store
                               (i32.add
-                                (get_local $5)
+                                (get_local $6)
                                 (get_local $8)
                               )
                               (get_local $8)
@@ -10330,18 +10326,18 @@
                                 )
                                 (i32.store
                                   (get_local $20)
-                                  (get_local $5)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=12
                                   (get_local $10)
-                                  (get_local $5)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=8
-                                  (get_local $5)
+                                  (get_local $6)
                                   (get_local $10)
                                 )
                                 (i32.store offset=12
-                                  (get_local $5)
+                                  (get_local $6)
                                   (get_local $2)
                                 )
                                 (br $do-once25)
@@ -10453,13 +10449,13 @@
                               )
                             )
                             (i32.store offset=28
-                              (get_local $5)
+                              (get_local $6)
                               (get_local $3)
                             )
                             (i32.store offset=4
                               (tee_local $0
                                 (i32.add
-                                  (get_local $5)
+                                  (get_local $6)
                                   (i32.const 16)
                                 )
                               )
@@ -10495,19 +10491,19 @@
                                 )
                                 (i32.store
                                   (get_local $2)
-                                  (get_local $5)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=24
-                                  (get_local $5)
+                                  (get_local $6)
                                   (get_local $2)
                                 )
                                 (i32.store offset=12
-                                  (get_local $5)
-                                  (get_local $5)
+                                  (get_local $6)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=8
-                                  (get_local $5)
-                                  (get_local $5)
+                                  (get_local $6)
+                                  (get_local $6)
                                 )
                                 (br $do-once25)
                               )
@@ -10602,19 +10598,19 @@
                                   (block
                                     (i32.store
                                       (get_local $3)
-                                      (get_local $5)
+                                      (get_local $6)
                                     )
                                     (i32.store offset=24
-                                      (get_local $5)
+                                      (get_local $6)
                                       (get_local $0)
                                     )
                                     (i32.store offset=12
-                                      (get_local $5)
-                                      (get_local $5)
+                                      (get_local $6)
+                                      (get_local $6)
                                     )
                                     (i32.store offset=8
-                                      (get_local $5)
-                                      (get_local $5)
+                                      (get_local $6)
+                                      (get_local $6)
                                     )
                                     (br $do-once25)
                                   )
@@ -10648,22 +10644,22 @@
                                 (block
                                   (i32.store offset=12
                                     (get_local $3)
-                                    (get_local $5)
+                                    (get_local $6)
                                   )
                                   (i32.store
                                     (get_local $2)
-                                    (get_local $5)
+                                    (get_local $6)
                                   )
                                   (i32.store offset=8
-                                    (get_local $5)
+                                    (get_local $6)
                                     (get_local $3)
                                   )
                                   (i32.store offset=12
-                                    (get_local $5)
+                                    (get_local $6)
                                     (get_local $0)
                                   )
                                   (i32.store offset=24
-                                    (get_local $5)
+                                    (get_local $6)
                                     (i32.const 0)
                                   )
                                 )
@@ -10681,16 +10677,16 @@
                       )
                     )
                     (set_local $0
-                      (get_local $6)
+                      (get_local $5)
                     )
                   )
                   (set_local $0
-                    (get_local $6)
+                    (get_local $5)
                   )
                 )
               )
               (set_local $0
-                (get_local $6)
+                (get_local $5)
               )
             )
           )
@@ -10916,16 +10912,16 @@
     )
     (if
       (i32.le_u
-        (tee_local $7
+        (tee_local $9
           (i32.and
-            (tee_local $5
+            (tee_local $10
               (i32.add
                 (tee_local $1
                   (i32.load
                     (i32.const 656)
                   )
                 )
-                (tee_local $10
+                (tee_local $7
                   (i32.add
                     (get_local $0)
                     (i32.const 47)
@@ -10933,7 +10929,7 @@
                 )
               )
             )
-            (tee_local $9
+            (tee_local $5
               (i32.sub
                 (i32.const 0)
                 (get_local $1)
@@ -10963,7 +10959,7 @@
                     (i32.const 608)
                   )
                 )
-                (get_local $7)
+                (get_local $9)
               )
             )
             (get_local $2)
@@ -11060,12 +11056,12 @@
                       (tee_local $1
                         (i32.and
                           (i32.sub
-                            (get_local $5)
+                            (get_local $10)
                             (i32.load
                               (i32.const 188)
                             )
                           )
-                          (get_local $9)
+                          (get_local $5)
                         )
                       )
                       (i32.const 2147483647)
@@ -11109,7 +11105,7 @@
                   (block
                     (set_local $4
                       (i32.add
-                        (tee_local $9
+                        (tee_local $5
                           (i32.load
                             (i32.const 608)
                           )
@@ -11133,7 +11129,7 @@
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $7)
+                                (get_local $9)
                                 (get_local $1)
                               )
                               (i32.and
@@ -11147,7 +11143,7 @@
                                 )
                               )
                             )
-                            (get_local $7)
+                            (get_local $9)
                           )
                         )
                       )
@@ -11174,7 +11170,7 @@
                             (i32.or
                               (i32.le_u
                                 (get_local $4)
-                                (get_local $9)
+                                (get_local $5)
                               )
                               (i32.gt_u
                                 (get_local $4)
@@ -11234,7 +11230,7 @@
                       (i32.and
                         (i32.add
                           (i32.sub
-                            (get_local $10)
+                            (get_local $7)
                             (get_local $1)
                           )
                           (tee_local $3
@@ -11295,7 +11291,7 @@
         )
         (if
           (i32.lt_u
-            (get_local $7)
+            (get_local $9)
             (i32.const 2147483647)
           )
           (if
@@ -11303,7 +11299,7 @@
               (i32.lt_u
                 (tee_local $2
                   (call $_sbrk
-                    (get_local $7)
+                    (get_local $9)
                   )
                 )
                 (tee_local $1
@@ -11382,7 +11378,7 @@
                     (i32.eq
                       (get_local $2)
                       (i32.add
-                        (tee_local $6
+                        (tee_local $5
                           (i32.load
                             (get_local $3)
                           )
@@ -11427,7 +11423,7 @@
                     )
                     (i32.ge_u
                       (get_local $8)
-                      (get_local $6)
+                      (get_local $5)
                     )
                   )
                   (block
@@ -11508,7 +11504,7 @@
                 )
               )
             )
-            (set_local $5
+            (set_local $9
               (if i32
                 (i32.lt_u
                   (get_local $2)
@@ -11528,7 +11524,7 @@
                 (get_local $3)
               )
             )
-            (set_local $9
+            (set_local $5
               (i32.add
                 (get_local $2)
                 (get_local $1)
@@ -11545,7 +11541,7 @@
                       (i32.load
                         (get_local $3)
                       )
-                      (get_local $9)
+                      (get_local $5)
                     )
                     (block
                       (set_local $4
@@ -11630,14 +11626,14 @@
                       (i32.sub
                         (tee_local $10
                           (i32.add
-                            (get_local $9)
+                            (get_local $5)
                             (select
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
                                   (tee_local $1
                                     (i32.add
-                                      (get_local $9)
+                                      (get_local $5)
                                       (i32.const 8)
                                     )
                                   )
@@ -11751,7 +11747,7 @@
                                   (i32.const 1)
                                 )
                                 (block i32
-                                  (set_local $9
+                                  (set_local $5
                                     (i32.and
                                       (get_local $0)
                                       (i32.const -8)
@@ -11800,7 +11796,7 @@
                                               (if
                                                 (i32.lt_u
                                                   (get_local $2)
-                                                  (get_local $5)
+                                                  (get_local $9)
                                                 )
                                                 (call $_abort)
                                               )
@@ -11856,7 +11852,7 @@
                                               (if
                                                 (i32.lt_u
                                                   (get_local $3)
-                                                  (get_local $5)
+                                                  (get_local $9)
                                                 )
                                                 (call $_abort)
                                               )
@@ -11991,7 +11987,7 @@
                                               (if
                                                 (i32.lt_u
                                                   (get_local $0)
-                                                  (get_local $5)
+                                                  (get_local $9)
                                                 )
                                                 (call $_abort)
                                                 (block
@@ -12013,7 +12009,7 @@
                                                       (get_local $10)
                                                     )
                                                   )
-                                                  (get_local $5)
+                                                  (get_local $9)
                                                 )
                                                 (call $_abort)
                                               )
@@ -12227,13 +12223,13 @@
                                   )
                                   (set_local $4
                                     (i32.add
-                                      (get_local $9)
+                                      (get_local $5)
                                       (get_local $4)
                                     )
                                   )
                                   (i32.add
                                     (get_local $10)
-                                    (get_local $9)
+                                    (get_local $5)
                                   )
                                 )
                                 (get_local $10)
@@ -12754,7 +12750,7 @@
                 (i32.const 8)
               )
             )
-            (set_local $5
+            (set_local $6
               (i32.add
                 (tee_local $11
                   (select
@@ -12794,7 +12790,7 @@
             )
             (i32.store
               (i32.const 200)
-              (tee_local $6
+              (tee_local $5
                 (i32.add
                   (get_local $2)
                   (tee_local $4
@@ -12834,7 +12830,7 @@
               )
             )
             (i32.store offset=4
-              (get_local $6)
+              (get_local $5)
               (i32.or
                 (get_local $4)
                 (i32.const 1)
@@ -12842,7 +12838,7 @@
             )
             (i32.store offset=4
               (i32.add
-                (get_local $6)
+                (get_local $5)
                 (get_local $4)
               )
               (i32.const 40)
@@ -12863,25 +12859,25 @@
               (i32.const 27)
             )
             (i32.store
-              (get_local $5)
+              (get_local $6)
               (i32.load
                 (i32.const 624)
               )
             )
             (i32.store offset=4
-              (get_local $5)
+              (get_local $6)
               (i32.load
                 (i32.const 628)
               )
             )
             (i32.store offset=8
-              (get_local $5)
+              (get_local $6)
               (i32.load
                 (i32.const 632)
               )
             )
             (i32.store offset=12
-              (get_local $5)
+              (get_local $6)
               (i32.load
                 (i32.const 636)
               )
@@ -12900,7 +12896,7 @@
             )
             (i32.store
               (i32.const 632)
-              (get_local $5)
+              (get_local $6)
             )
             (set_local $1
               (i32.add
@@ -12946,7 +12942,7 @@
                 (i32.store offset=4
                   (get_local $8)
                   (i32.or
-                    (tee_local $6
+                    (tee_local $5
                       (i32.sub
                         (get_local $11)
                         (get_local $8)
@@ -12957,17 +12953,17 @@
                 )
                 (i32.store
                   (get_local $11)
-                  (get_local $6)
+                  (get_local $5)
                 )
                 (set_local $1
                   (i32.shr_u
-                    (get_local $6)
+                    (get_local $5)
                     (i32.const 3)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $6)
+                    (get_local $5)
                     (i32.const 256)
                   )
                   (block
@@ -13068,20 +13064,20 @@
                         (if i32
                           (tee_local $1
                             (i32.shr_u
-                              (get_local $6)
+                              (get_local $5)
                               (i32.const 8)
                             )
                           )
                           (if i32
                             (i32.gt_u
-                              (get_local $6)
+                              (get_local $5)
                               (i32.const 16777215)
                             )
                             (i32.const 31)
                             (i32.or
                               (i32.and
                                 (i32.shr_u
-                                  (get_local $6)
+                                  (get_local $5)
                                   (i32.add
                                     (tee_local $1
                                       (i32.add
@@ -13223,7 +13219,7 @@
                 )
                 (set_local $4
                   (i32.shl
-                    (get_local $6)
+                    (get_local $5)
                     (select
                       (i32.const 0)
                       (i32.sub
@@ -13257,7 +13253,7 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $6)
+                            (get_local $5)
                           )
                         )
                         (set_local $3

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -654,7 +654,7 @@
           )
         )
         (block i32
-          (set_local $1
+          (set_local $0
             (if i32
               (i32.load
                 (i32.const 12)
@@ -671,7 +671,7 @@
             (i32.const 44)
           )
           (if
-            (tee_local $0
+            (tee_local $1
               (i32.load
                 (i32.const 40)
               )
@@ -681,45 +681,44 @@
                 (if i32
                   (i32.gt_s
                     (i32.load offset=76
-                      (get_local $0)
+                      (get_local $1)
                     )
                     (i32.const -1)
                   )
                   (call $___lockfile
-                    (get_local $0)
+                    (get_local $1)
                   )
                   (i32.const 0)
                 )
               )
-              (set_local $1
-                (if i32
-                  (i32.gt_u
-                    (i32.load offset=20
-                      (get_local $0)
-                    )
-                    (i32.load offset=28
-                      (get_local $0)
-                    )
-                  )
-                  (i32.or
-                    (call $___fflush_unlocked
-                      (get_local $0)
-                    )
+              (if
+                (i32.gt_u
+                  (i32.load offset=20
                     (get_local $1)
                   )
-                  (get_local $1)
+                  (i32.load offset=28
+                    (get_local $1)
+                  )
+                )
+                (set_local $0
+                  (i32.or
+                    (call $___fflush_unlocked
+                      (get_local $1)
+                    )
+                    (get_local $0)
+                  )
                 )
               )
               (if
                 (get_local $2)
                 (call $___unlockfile
-                  (get_local $0)
+                  (get_local $1)
                 )
               )
               (br_if $while-in
-                (tee_local $0
+                (tee_local $1
                   (i32.load offset=56
-                    (get_local $0)
+                    (get_local $1)
                   )
                 )
               )
@@ -728,7 +727,7 @@
           (call $___unlock
             (i32.const 44)
           )
-          (get_local $1)
+          (get_local $0)
         )
       )
     )
@@ -2484,7 +2483,7 @@
         (i32.const 8)
       )
     )
-    (set_local $16
+    (set_local $17
       (i32.const 0)
     )
     (set_local $9
@@ -2500,18 +2499,18 @@
       (block $jumpthreading$inner$8
         (loop $label$continue$L1
           (block $label$break$L1
-            (set_local $16
-              (if i32
-                (i32.gt_s
-                  (get_local $16)
-                  (i32.const -1)
-                )
+            (if
+              (i32.gt_s
+                (get_local $17)
+                (i32.const -1)
+              )
+              (set_local $17
                 (if i32
                   (i32.gt_s
                     (get_local $5)
                     (i32.sub
                       (i32.const 2147483647)
-                      (get_local $16)
+                      (get_local $17)
                     )
                   )
                   (block i32
@@ -2523,10 +2522,9 @@
                   )
                   (i32.add
                     (get_local $5)
-                    (get_local $16)
+                    (get_local $17)
                   )
                 )
-                (get_local $16)
               )
             )
             (br_if $jumpthreading$inner$8
@@ -2947,7 +2945,7 @@
                       (if
                         (get_local $8)
                         (block
-                          (set_local $16
+                          (set_local $17
                             (i32.const -1)
                           )
                           (br $label$break$L1)
@@ -3090,7 +3088,7 @@
                         (i32.const 0)
                       )
                       (block
-                        (set_local $16
+                        (set_local $17
                           (i32.const -1)
                         )
                         (br $label$break$L1)
@@ -3292,7 +3290,7 @@
                     (if
                       (get_local $1)
                       (block
-                        (set_local $16
+                        (set_local $17
                           (i32.const -1)
                         )
                         (br $label$break$L1)
@@ -3359,7 +3357,7 @@
                   (i32.const 57)
                 )
                 (block
-                  (set_local $16
+                  (set_local $17
                     (i32.const -1)
                   )
                   (br $label$break$L1)
@@ -3406,7 +3404,7 @@
                   )
                   (br $while-in13)
                 )
-                (set_local $17
+                (set_local $16
                   (get_local $8)
                 )
               )
@@ -3422,7 +3420,7 @@
                 )
               )
               (block
-                (set_local $16
+                (set_local $17
                   (i32.const -1)
                 )
                 (br $label$break$L1)
@@ -3450,7 +3448,7 @@
                   (if
                     (get_local $8)
                     (block
-                      (set_local $16
+                      (set_local $17
                         (i32.const -1)
                       )
                       (br $label$break$L1)
@@ -3504,7 +3502,7 @@
                         (get_local $31)
                       )
                       (block
-                        (set_local $16
+                        (set_local $17
                           (i32.const 0)
                         )
                         (br $label$break$L1)
@@ -3579,7 +3577,7 @@
                                                             (i32.and
                                                               (tee_local $11
                                                                 (i32.load8_s
-                                                                  (get_local $17)
+                                                                  (get_local $16)
                                                                 )
                                                               )
                                                               (i32.const -33)
@@ -3623,7 +3621,7 @@
                                                                   (i32.load
                                                                     (get_local $18)
                                                                   )
-                                                                  (get_local $16)
+                                                                  (get_local $17)
                                                                 )
                                                                 (set_local $9
                                                                   (get_local $5)
@@ -3637,7 +3635,7 @@
                                                                 (i32.load
                                                                   (get_local $18)
                                                                 )
-                                                                (get_local $16)
+                                                                (get_local $17)
                                                               )
                                                               (set_local $9
                                                                 (get_local $5)
@@ -3653,14 +3651,14 @@
                                                                   (get_local $18)
                                                                 )
                                                               )
-                                                              (get_local $16)
+                                                              (get_local $17)
                                                             )
                                                             (i32.store offset=4
                                                               (get_local $9)
                                                               (i32.shr_s
                                                                 (i32.shl
                                                                   (i32.lt_s
-                                                                    (get_local $16)
+                                                                    (get_local $17)
                                                                     (i32.const 0)
                                                                   )
                                                                   (i32.const 31)
@@ -3680,7 +3678,7 @@
                                                             (i32.load
                                                               (get_local $18)
                                                             )
-                                                            (get_local $16)
+                                                            (get_local $17)
                                                           )
                                                           (set_local $9
                                                             (get_local $5)
@@ -3694,7 +3692,7 @@
                                                           (i32.load
                                                             (get_local $18)
                                                           )
-                                                          (get_local $16)
+                                                          (get_local $17)
                                                         )
                                                         (set_local $9
                                                           (get_local $5)
@@ -3708,7 +3706,7 @@
                                                         (i32.load
                                                           (get_local $18)
                                                         )
-                                                        (get_local $16)
+                                                        (get_local $17)
                                                       )
                                                       (set_local $9
                                                         (get_local $5)
@@ -3724,14 +3722,14 @@
                                                           (get_local $18)
                                                         )
                                                       )
-                                                      (get_local $16)
+                                                      (get_local $17)
                                                     )
                                                     (i32.store offset=4
                                                       (get_local $9)
                                                       (i32.shr_s
                                                         (i32.shl
                                                           (i32.lt_s
-                                                            (get_local $16)
+                                                            (get_local $17)
                                                             (i32.const 0)
                                                           )
                                                           (i32.const 31)
@@ -4221,7 +4219,7 @@
                                     )
                                     (if
                                       (i32.eq
-                                        (tee_local $17
+                                        (tee_local $16
                                           (i32.or
                                             (get_local $13)
                                             (i32.const 32)
@@ -4237,7 +4235,7 @@
                                               (i32.const 9)
                                             )
                                             (get_local $34)
-                                            (tee_local $17
+                                            (tee_local $16
                                               (i32.and
                                                 (get_local $13)
                                                 (i32.const 32)
@@ -4319,59 +4317,59 @@
                                         )
                                         (i32.store8
                                           (i32.add
-                                            (tee_local $6
-                                              (if i32
-                                                (i32.eq
-                                                  (tee_local $6
-                                                    (call $_fmt_u
-                                                      (tee_local $6
-                                                        (select
-                                                          (i32.sub
-                                                            (i32.const 0)
-                                                            (tee_local $5
-                                                              (i32.load
-                                                                (get_local $20)
-                                                              )
+                                            (if i32
+                                              (i32.eq
+                                                (tee_local $5
+                                                  (call $_fmt_u
+                                                    (tee_local $5
+                                                      (select
+                                                        (i32.sub
+                                                          (i32.const 0)
+                                                          (tee_local $6
+                                                            (i32.load
+                                                              (get_local $20)
                                                             )
                                                           )
-                                                          (get_local $5)
-                                                          (i32.lt_s
-                                                            (get_local $5)
-                                                            (i32.const 0)
-                                                          )
+                                                        )
+                                                        (get_local $6)
+                                                        (i32.lt_s
+                                                          (get_local $6)
+                                                          (i32.const 0)
                                                         )
                                                       )
-                                                      (i32.shr_s
-                                                        (i32.shl
-                                                          (i32.lt_s
-                                                            (get_local $6)
-                                                            (i32.const 0)
-                                                          )
-                                                          (i32.const 31)
+                                                    )
+                                                    (i32.shr_s
+                                                      (i32.shl
+                                                        (i32.lt_s
+                                                          (get_local $5)
+                                                          (i32.const 0)
                                                         )
                                                         (i32.const 31)
                                                       )
-                                                      (get_local $37)
+                                                      (i32.const 31)
                                                     )
+                                                    (get_local $37)
                                                   )
-                                                  (get_local $37)
                                                 )
-                                                (block i32
-                                                  (i32.store8
-                                                    (get_local $47)
-                                                    (i32.const 48)
-                                                  )
+                                                (get_local $37)
+                                              )
+                                              (block i32
+                                                (i32.store8
+                                                  (get_local $47)
+                                                  (i32.const 48)
+                                                )
+                                                (tee_local $5
                                                   (get_local $47)
                                                 )
-                                                (get_local $6)
                                               )
+                                              (get_local $5)
                                             )
                                             (i32.const -1)
                                           )
                                           (i32.add
                                             (i32.and
                                               (i32.shr_s
-                                                (get_local $5)
+                                                (get_local $6)
                                                 (i32.const 31)
                                               )
                                               (i32.const 2)
@@ -4382,7 +4380,7 @@
                                         (i32.store8
                                           (tee_local $6
                                             (i32.add
-                                              (get_local $6)
+                                              (get_local $5)
                                               (i32.const -2)
                                             )
                                           )
@@ -4422,7 +4420,7 @@
                                                   (i32.const 4075)
                                                 )
                                               )
-                                              (get_local $17)
+                                              (get_local $16)
                                             )
                                           )
                                           (set_local $15
@@ -4920,7 +4918,7 @@
                                         )
                                         (set_local $25
                                           (i32.eq
-                                            (get_local $17)
+                                            (get_local $16)
                                             (i32.const 102)
                                           )
                                         )
@@ -5172,7 +5170,7 @@
                                         )
                                       )
                                     )
-                                    (set_local $17
+                                    (set_local $16
                                       (if i32
                                         (i32.lt_s
                                           (tee_local $7
@@ -5183,7 +5181,7 @@
                                                   (get_local $6)
                                                   (i32.const 0)
                                                   (i32.ne
-                                                    (get_local $17)
+                                                    (get_local $16)
                                                     (i32.const 102)
                                                   )
                                                 )
@@ -5199,7 +5197,7 @@
                                                     )
                                                     (tee_local $43
                                                       (i32.eq
-                                                        (get_local $17)
+                                                        (get_local $16)
                                                         (i32.const 103)
                                                       )
                                                     )
@@ -5230,7 +5228,7 @@
                                               (tee_local $7
                                                 (i32.add
                                                   (i32.rem_s
-                                                    (tee_local $17
+                                                    (tee_local $16
                                                       (i32.add
                                                         (get_local $7)
                                                         (i32.const 9216)
@@ -5271,7 +5269,7 @@
                                               (i32.const 10)
                                             )
                                           )
-                                          (set_local $17
+                                          (set_local $16
                                             (i32.rem_u
                                               (tee_local $25
                                                 (i32.load
@@ -5284,7 +5282,7 @@
                                                       (i32.shl
                                                         (i32.add
                                                           (i32.div_s
-                                                            (get_local $17)
+                                                            (get_local $16)
                                                             (i32.const 9)
                                                           )
                                                           (i32.const -1024)
@@ -5312,7 +5310,7 @@
                                                     )
                                                   )
                                                   (i32.eqz
-                                                    (get_local $17)
+                                                    (get_local $16)
                                                   )
                                                 )
                                               )
@@ -5320,7 +5318,7 @@
                                                 (set_local $15
                                                   (if f64
                                                     (i32.lt_u
-                                                      (get_local $17)
+                                                      (get_local $16)
                                                       (tee_local $55
                                                         (i32.div_s
                                                           (get_local $11)
@@ -5335,7 +5333,7 @@
                                                       (i32.and
                                                         (get_local $36)
                                                         (i32.eq
-                                                          (get_local $17)
+                                                          (get_local $16)
                                                           (get_local $55)
                                                         )
                                                       )
@@ -5386,10 +5384,10 @@
                                                 )
                                                 (i32.store
                                                   (get_local $7)
-                                                  (tee_local $17
+                                                  (tee_local $16
                                                     (i32.sub
                                                       (get_local $25)
-                                                      (get_local $17)
+                                                      (get_local $16)
                                                     )
                                                   )
                                                 )
@@ -5406,7 +5404,7 @@
                                                   (get_local $7)
                                                   (tee_local $6
                                                     (i32.add
-                                                      (get_local $17)
+                                                      (get_local $16)
                                                       (get_local $11)
                                                     )
                                                   )
@@ -5421,30 +5419,29 @@
                                                       (get_local $7)
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $5
-                                                      (if i32
-                                                        (i32.lt_u
-                                                          (tee_local $7
+                                                    (if
+                                                      (i32.lt_u
+                                                        (tee_local $7
+                                                          (i32.add
+                                                            (get_local $7)
+                                                            (i32.const -4)
+                                                          )
+                                                        )
+                                                        (get_local $5)
+                                                      )
+                                                      (block
+                                                        (i32.store
+                                                          (tee_local $5
                                                             (i32.add
-                                                              (get_local $7)
+                                                              (get_local $5)
                                                               (i32.const -4)
                                                             )
                                                           )
+                                                          (i32.const 0)
+                                                        )
+                                                        (set_local $5
                                                           (get_local $5)
                                                         )
-                                                        (block i32
-                                                          (i32.store
-                                                            (tee_local $5
-                                                              (i32.add
-                                                                (get_local $5)
-                                                                (i32.const -4)
-                                                              )
-                                                            )
-                                                            (i32.const 0)
-                                                          )
-                                                          (get_local $5)
-                                                        )
-                                                        (get_local $5)
                                                       )
                                                     )
                                                     (i32.store
@@ -5480,7 +5477,7 @@
                                                 )
                                                 (br_if $do-once81
                                                   (i32.lt_u
-                                                    (tee_local $17
+                                                    (tee_local $16
                                                       (i32.load
                                                         (get_local $5)
                                                       )
@@ -5500,7 +5497,7 @@
                                                   )
                                                   (br_if $while-in88
                                                     (i32.ge_u
-                                                      (get_local $17)
+                                                      (get_local $16)
                                                       (tee_local $11
                                                         (i32.mul
                                                           (get_local $11)
@@ -5555,7 +5552,7 @@
                                         (if
                                           (i32.le_u
                                             (get_local $5)
-                                            (get_local $17)
+                                            (get_local $16)
                                           )
                                           (block
                                             (set_local $25
@@ -6009,9 +6006,9 @@
                                             (tee_local $13
                                               (select
                                                 (get_local $8)
-                                                (get_local $17)
+                                                (get_local $16)
                                                 (i32.gt_u
-                                                  (get_local $17)
+                                                  (get_local $16)
                                                   (get_local $8)
                                                 )
                                               )
@@ -6252,7 +6249,7 @@
                                             (select
                                               (get_local $10)
                                               (i32.add
-                                                (get_local $17)
+                                                (get_local $16)
                                                 (i32.const 4)
                                               )
                                               (get_local $25)
@@ -6270,41 +6267,40 @@
                                                 )
                                               )
                                               (set_local $7
-                                                (get_local $17)
+                                                (get_local $16)
                                               )
                                               (set_local $6
                                                 (get_local $5)
                                               )
                                               (loop $while-in114
-                                                (set_local $5
-                                                  (if i32
-                                                    (i32.eq
-                                                      (tee_local $5
-                                                        (call $_fmt_u
-                                                          (i32.load
-                                                            (get_local $7)
-                                                          )
-                                                          (i32.const 0)
-                                                          (get_local $32)
+                                                (if
+                                                  (i32.eq
+                                                    (tee_local $5
+                                                      (call $_fmt_u
+                                                        (i32.load
+                                                          (get_local $7)
                                                         )
+                                                        (i32.const 0)
+                                                        (get_local $32)
                                                       )
-                                                      (get_local $32)
                                                     )
-                                                    (block i32
-                                                      (i32.store8
-                                                        (get_local $38)
-                                                        (i32.const 48)
-                                                      )
+                                                    (get_local $32)
+                                                  )
+                                                  (block
+                                                    (i32.store8
+                                                      (get_local $38)
+                                                      (i32.const 48)
+                                                    )
+                                                    (set_local $5
                                                       (get_local $38)
                                                     )
-                                                    (get_local $5)
                                                   )
                                                 )
                                                 (block $do-once115
                                                   (if
                                                     (i32.eq
                                                       (get_local $7)
-                                                      (get_local $17)
+                                                      (get_local $16)
                                                     )
                                                     (block
                                                       (if
@@ -6774,7 +6770,7 @@
                     (set_local $27
                       (i32.const 0)
                     )
-                    (set_local $17
+                    (set_local $16
                       (i32.eqz
                         (tee_local $13
                           (call $_memchr
@@ -6798,7 +6794,7 @@
                           (get_local $13)
                           (get_local $9)
                         )
-                        (get_local $17)
+                        (get_local $16)
                       )
                     )
                     (set_local $8
@@ -6814,7 +6810,7 @@
                           (get_local $7)
                         )
                         (get_local $13)
-                        (get_local $17)
+                        (get_local $16)
                       )
                     )
                     (br $jumpthreading$outer$7)
@@ -6886,7 +6882,7 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $16
+                      (set_local $17
                         (i32.const -1)
                       )
                       (br $label$break$L1)
@@ -7261,7 +7257,7 @@
                     )
                   )
                   (block
-                    (set_local $16
+                    (set_local $17
                       (i32.const 1)
                     )
                     (br $label$break$L343)
@@ -7286,7 +7282,7 @@
                     )
                   )
                   (block
-                    (set_local $16
+                    (set_local $17
                       (i32.const -1)
                     )
                     (br $label$break$L343)
@@ -7303,16 +7299,16 @@
                     (i32.const 10)
                   )
                 )
-                (set_local $16
+                (set_local $17
                   (i32.const 1)
                 )
               )
-              (set_local $16
+              (set_local $17
                 (i32.const 1)
               )
             )
           )
-          (set_local $16
+          (set_local $17
             (i32.const 0)
           )
         )
@@ -7321,7 +7317,7 @@
     (set_global $STACKTOP
       (get_local $26)
     )
-    (get_local $16)
+    (get_local $17)
   )
   (func $_pop_arg_336 (param $0 i32) (param $1 i32) (param $2 i32)
     (local $3 i32)
@@ -7856,7 +7852,7 @@
     (local $5 i32)
     (local $6 i32)
     (local $7 i32)
-    (set_local $6
+    (set_local $7
       (get_global $STACKTOP)
     )
     (set_global $STACKTOP
@@ -7872,8 +7868,8 @@
       )
       (call $abort)
     )
-    (set_local $5
-      (get_local $6)
+    (set_local $6
+      (get_local $7)
     )
     (block $do-once
       (if
@@ -7892,27 +7888,27 @@
         (block
           (drop
             (call $_memset
-              (get_local $5)
+              (get_local $6)
               (get_local $1)
               (select
                 (i32.const 256)
-                (tee_local $4
+                (tee_local $5
                   (i32.sub
                     (get_local $2)
                     (get_local $3)
                   )
                 )
                 (i32.gt_u
-                  (get_local $4)
+                  (get_local $5)
                   (i32.const 256)
                 )
               )
             )
           )
-          (set_local $1
+          (set_local $4
             (i32.eqz
               (i32.and
-                (tee_local $7
+                (tee_local $1
                   (i32.load
                     (get_local $0)
                   )
@@ -7923,31 +7919,31 @@
           )
           (if
             (i32.gt_u
-              (get_local $4)
+              (get_local $5)
               (i32.const 255)
             )
             (block
               (loop $while-in
-                (set_local $1
+                (set_local $4
                   (i32.eqz
                     (i32.and
-                      (tee_local $7
-                        (if i32
-                          (get_local $1)
-                          (block i32
-                            (drop
-                              (call $___fwritex
-                                (get_local $5)
-                                (i32.const 256)
-                                (get_local $0)
-                              )
+                      (if i32
+                        (get_local $4)
+                        (block i32
+                          (drop
+                            (call $___fwritex
+                              (get_local $6)
+                              (i32.const 256)
+                              (get_local $0)
                             )
+                          )
+                          (tee_local $1
                             (i32.load
                               (get_local $0)
                             )
                           )
-                          (get_local $7)
                         )
+                        (get_local $1)
                       )
                       (i32.const 32)
                     )
@@ -7955,9 +7951,9 @@
                 )
                 (br_if $while-in
                   (i32.gt_u
-                    (tee_local $4
+                    (tee_local $5
                       (i32.add
-                        (get_local $4)
+                        (get_local $5)
                         (i32.const -256)
                       )
                     )
@@ -7967,10 +7963,10 @@
               )
               (br_if $do-once
                 (i32.eqz
-                  (get_local $1)
+                  (get_local $4)
                 )
               )
-              (set_local $4
+              (set_local $5
                 (i32.and
                   (i32.sub
                     (get_local $2)
@@ -7982,14 +7978,14 @@
             )
             (br_if $do-once
               (i32.eqz
-                (get_local $1)
+                (get_local $4)
               )
             )
           )
           (drop
             (call $___fwritex
+              (get_local $6)
               (get_local $5)
-              (get_local $4)
               (get_local $0)
             )
           )
@@ -7997,7 +7993,7 @@
       )
     )
     (set_global $STACKTOP
-      (get_local $6)
+      (get_local $7)
     )
   )
   (func $_malloc (param $0 i32) (result i32)
@@ -8067,7 +8063,7 @@
               (i32.const 3)
             )
             (block
-              (set_local $6
+              (set_local $5
                 (i32.load
                   (tee_local $1
                     (i32.add
@@ -8111,7 +8107,7 @@
               (if
                 (i32.eq
                   (get_local $3)
-                  (get_local $6)
+                  (get_local $5)
                 )
                 (i32.store
                   (i32.const 176)
@@ -8129,7 +8125,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $6)
+                      (get_local $5)
                       (i32.load
                         (i32.const 192)
                       )
@@ -8141,7 +8137,7 @@
                       (i32.load
                         (tee_local $0
                           (i32.add
-                            (get_local $6)
+                            (get_local $5)
                             (i32.const 12)
                           )
                         )
@@ -8155,7 +8151,7 @@
                       )
                       (i32.store
                         (get_local $2)
-                        (get_local $6)
+                        (get_local $5)
                       )
                     )
                     (call $_abort)
@@ -8252,7 +8248,7 @@
                     (i32.load
                       (tee_local $4
                         (i32.add
-                          (tee_local $6
+                          (tee_local $5
                             (i32.load
                               (tee_local $1
                                 (i32.add
@@ -8260,7 +8256,7 @@
                                     (i32.add
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $5
+                                          (tee_local $6
                                             (i32.add
                                               (i32.or
                                                 (i32.or
@@ -8363,7 +8359,7 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $5)
+                              (get_local $6)
                             )
                             (i32.const -1)
                           )
@@ -8393,7 +8389,7 @@
                               )
                             )
                           )
-                          (get_local $6)
+                          (get_local $5)
                         )
                         (block
                           (i32.store
@@ -8415,16 +8411,16 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $6)
+                    (get_local $5)
                     (i32.or
                       (get_local $3)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $6
+                    (tee_local $5
                       (i32.add
-                        (get_local $6)
+                        (get_local $5)
                         (get_local $3)
                       )
                     )
@@ -8432,7 +8428,7 @@
                       (tee_local $3
                         (i32.sub
                           (i32.shl
-                            (get_local $5)
+                            (get_local $6)
                             (i32.const 3)
                           )
                           (get_local $3)
@@ -8443,7 +8439,7 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $6)
+                      (get_local $5)
                       (get_local $3)
                     )
                     (get_local $3)
@@ -8451,7 +8447,7 @@
                   (if
                     (get_local $16)
                     (block
-                      (set_local $5
+                      (set_local $6
                         (i32.load
                           (i32.const 196)
                         )
@@ -8534,18 +8530,18 @@
                       )
                       (i32.store
                         (get_local $15)
-                        (get_local $5)
+                        (get_local $6)
                       )
                       (i32.store offset=12
                         (get_local $9)
-                        (get_local $5)
+                        (get_local $6)
                       )
                       (i32.store offset=8
-                        (get_local $5)
+                        (get_local $6)
                         (get_local $9)
                       )
                       (i32.store offset=12
-                        (get_local $5)
+                        (get_local $6)
                         (get_local $2)
                       )
                     )
@@ -8556,7 +8552,7 @@
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $6)
+                    (get_local $5)
                   )
                   (return
                     (get_local $4)
@@ -8815,7 +8811,7 @@
                               )
                             )
                             (block
-                              (set_local $6
+                              (set_local $5
                                 (i32.const 0)
                               )
                               (br $do-once4)
@@ -8877,7 +8873,7 @@
                               (get_local $0)
                               (i32.const 0)
                             )
-                            (set_local $6
+                            (set_local $5
                               (get_local $1)
                             )
                           )
@@ -8930,7 +8926,7 @@
                               (get_local $1)
                               (get_local $9)
                             )
-                            (set_local $6
+                            (set_local $5
                               (get_local $0)
                             )
                           )
@@ -8965,11 +8961,11 @@
                           (block
                             (i32.store
                               (get_local $0)
-                              (get_local $6)
+                              (get_local $5)
                             )
                             (if
                               (i32.eqz
-                                (get_local $6)
+                                (get_local $5)
                               )
                               (block
                                 (i32.store
@@ -9015,23 +9011,23 @@
                               )
                               (i32.store
                                 (get_local $0)
-                                (get_local $6)
+                                (get_local $5)
                               )
                               (i32.store offset=20
                                 (get_local $7)
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                             (br_if $do-once8
                               (i32.eqz
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $6)
+                            (get_local $5)
                             (tee_local $0
                               (i32.load
                                 (i32.const 192)
@@ -9041,7 +9037,7 @@
                           (call $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $6)
+                          (get_local $5)
                           (get_local $7)
                         )
                         (if
@@ -9058,12 +9054,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $6)
+                                (get_local $5)
                                 (get_local $1)
                               )
                               (i32.store offset=24
                                 (get_local $1)
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                           )
@@ -9084,12 +9080,12 @@
                             (call $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $6)
+                                (get_local $5)
                                 (get_local $0)
                               )
                               (i32.store offset=24
                                 (get_local $0)
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                           )
@@ -9216,7 +9212,7 @@
                               )
                               (call $_abort)
                               (block
-                                (set_local $5
+                                (set_local $6
                                   (get_local $1)
                                 )
                                 (set_local $4
@@ -9232,7 +9228,7 @@
                                   (get_local $0)
                                 )
                               )
-                              (set_local $5
+                              (set_local $6
                                 (i32.add
                                   (get_local $2)
                                   (i32.const 8)
@@ -9244,7 +9240,7 @@
                             )
                           )
                           (i32.store
-                            (get_local $5)
+                            (get_local $6)
                             (get_local $3)
                           )
                           (i32.store offset=12
@@ -9297,7 +9293,7 @@
             (i32.const -1)
           )
           (block
-            (set_local $6
+            (set_local $5
               (i32.and
                 (tee_local $0
                   (i32.add
@@ -9318,7 +9314,7 @@
                 (set_local $9
                   (i32.sub
                     (i32.const 0)
-                    (get_local $6)
+                    (get_local $5)
                   )
                 )
                 (block $jumpthreading$outer$2
@@ -9337,14 +9333,14 @@
                                 )
                                 (if i32
                                   (i32.gt_u
-                                    (get_local $6)
+                                    (get_local $5)
                                     (i32.const 16777215)
                                   )
                                   (i32.const 31)
                                   (i32.or
                                     (i32.and
                                       (i32.shr_u
-                                        (get_local $6)
+                                        (get_local $5)
                                         (i32.add
                                           (tee_local $0
                                             (i32.add
@@ -9359,7 +9355,7 @@
                                                             (tee_local $4
                                                               (i32.shl
                                                                 (get_local $0)
-                                                                (tee_local $5
+                                                                (tee_local $6
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
@@ -9380,7 +9376,7 @@
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $5)
+                                                    (get_local $6)
                                                   )
                                                   (tee_local $0
                                                     (i32.and
@@ -9434,7 +9430,7 @@
                         )
                         (set_local $18
                           (i32.shl
-                            (get_local $6)
+                            (get_local $5)
                             (select
                               (i32.const 0)
                               (i32.sub
@@ -9457,7 +9453,7 @@
                         (loop $while-in14
                           (if
                             (i32.lt_u
-                              (tee_local $5
+                              (tee_local $6
                                 (i32.sub
                                   (tee_local $15
                                     (i32.and
@@ -9467,7 +9463,7 @@
                                       (i32.const -8)
                                     )
                                   )
-                                  (get_local $6)
+                                  (get_local $5)
                                 )
                               )
                               (get_local $9)
@@ -9475,11 +9471,11 @@
                             (if
                               (i32.eq
                                 (get_local $15)
-                                (get_local $6)
+                                (get_local $5)
                               )
                               (block
                                 (set_local $2
-                                  (get_local $5)
+                                  (get_local $6)
                                 )
                                 (set_local $3
                                   (get_local $0)
@@ -9494,7 +9490,7 @@
                               )
                               (block
                                 (set_local $9
-                                  (get_local $5)
+                                  (get_local $6)
                                 )
                                 (set_local $4
                                   (get_local $0)
@@ -9505,17 +9501,17 @@
                           (set_local $0
                             (select
                               (get_local $16)
-                              (tee_local $5
+                              (tee_local $6
                                 (i32.load offset=20
                                   (get_local $0)
                                 )
                               )
                               (i32.or
                                 (i32.eqz
-                                  (get_local $5)
+                                  (get_local $6)
                                 )
                                 (i32.eq
-                                  (get_local $5)
+                                  (get_local $6)
                                   (tee_local $15
                                     (i32.load
                                       (i32.add
@@ -9537,7 +9533,7 @@
                               )
                             )
                           )
-                          (set_local $5
+                          (set_local $6
                             (i32.shl
                               (get_local $18)
                               (i32.xor
@@ -9561,7 +9557,7 @@
                               (get_local $0)
                             )
                             (set_local $18
-                              (get_local $5)
+                              (get_local $6)
                             )
                             (set_local $0
                               (get_local $15)
@@ -9583,64 +9579,64 @@
                     (br $jumpthreading$outer$2)
                   )
                   (if
-                    (tee_local $0
-                      (if i32
-                        (i32.and
+                    (if i32
+                      (i32.and
+                        (i32.eqz
+                          (get_local $0)
+                        )
+                        (i32.eqz
+                          (get_local $4)
+                        )
+                      )
+                      (block i32
+                        (if
                           (i32.eqz
-                            (get_local $0)
+                            (tee_local $0
+                              (i32.and
+                                (get_local $24)
+                                (i32.or
+                                  (tee_local $0
+                                    (i32.shl
+                                      (i32.const 2)
+                                      (get_local $17)
+                                    )
+                                  )
+                                  (i32.sub
+                                    (i32.const 0)
+                                    (get_local $0)
+                                  )
+                                )
+                              )
+                            )
                           )
-                          (i32.eqz
-                            (get_local $4)
+                          (block
+                            (set_local $0
+                              (get_local $5)
+                            )
+                            (br $do-once)
                           )
                         )
-                        (block i32
-                          (if
-                            (i32.eqz
+                        (set_local $15
+                          (i32.and
+                            (i32.shr_u
                               (tee_local $0
-                                (i32.and
-                                  (get_local $24)
-                                  (i32.or
-                                    (tee_local $0
-                                      (i32.shl
-                                        (i32.const 2)
-                                        (get_local $17)
-                                      )
-                                    )
+                                (i32.add
+                                  (i32.and
+                                    (get_local $0)
                                     (i32.sub
                                       (i32.const 0)
                                       (get_local $0)
                                     )
                                   )
+                                  (i32.const -1)
                                 )
                               )
+                              (i32.const 12)
                             )
-                            (block
-                              (set_local $0
-                                (get_local $6)
-                              )
-                              (br $do-once)
-                            )
+                            (i32.const 16)
                           )
-                          (set_local $15
-                            (i32.and
-                              (i32.shr_u
-                                (tee_local $0
-                                  (i32.add
-                                    (i32.and
-                                      (get_local $0)
-                                      (i32.sub
-                                        (i32.const 0)
-                                        (get_local $0)
-                                      )
-                                    )
-                                    (i32.const -1)
-                                  )
-                                )
-                                (i32.const 12)
-                              )
-                              (i32.const 16)
-                            )
-                          )
+                        )
+                        (tee_local $0
                           (i32.load offset=480
                             (i32.shl
                               (i32.add
@@ -9651,7 +9647,7 @@
                                         (tee_local $0
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $5
+                                              (tee_local $6
                                                 (i32.shr_u
                                                   (get_local $0)
                                                   (get_local $15)
@@ -9667,9 +9663,9 @@
                                       (tee_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $5
+                                            (tee_local $6
                                               (i32.shr_u
-                                                (get_local $5)
+                                                (get_local $6)
                                                 (get_local $0)
                                               )
                                             )
@@ -9682,9 +9678,9 @@
                                     (tee_local $0
                                       (i32.and
                                         (i32.shr_u
-                                          (tee_local $5
+                                          (tee_local $6
                                             (i32.shr_u
-                                              (get_local $5)
+                                              (get_local $6)
                                               (get_local $0)
                                             )
                                           )
@@ -9697,9 +9693,9 @@
                                   (tee_local $0
                                     (i32.and
                                       (i32.shr_u
-                                        (tee_local $5
+                                        (tee_local $6
                                           (i32.shr_u
-                                            (get_local $5)
+                                            (get_local $6)
                                             (get_local $0)
                                           )
                                         )
@@ -9710,7 +9706,7 @@
                                   )
                                 )
                                 (i32.shr_u
-                                  (get_local $5)
+                                  (get_local $6)
                                   (get_local $0)
                                 )
                               )
@@ -9718,8 +9714,8 @@
                             )
                           )
                         )
-                        (get_local $0)
                       )
+                      (get_local $0)
                     )
                     (block
                       (set_local $2
@@ -9761,7 +9757,7 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $6)
+                            (get_local $5)
                           )
                         )
                         (get_local $2)
@@ -9820,7 +9816,7 @@
                         (i32.load
                           (i32.const 184)
                         )
-                        (get_local $6)
+                        (get_local $5)
                       )
                     )
                     (block
@@ -9838,10 +9834,10 @@
                       (if
                         (i32.ge_u
                           (get_local $13)
-                          (tee_local $5
+                          (tee_local $6
                             (i32.add
                               (get_local $13)
-                              (get_local $6)
+                              (get_local $5)
                             )
                           )
                         )
@@ -10185,7 +10181,7 @@
                                 (tee_local $0
                                   (i32.add
                                     (get_local $8)
-                                    (get_local $6)
+                                    (get_local $5)
                                   )
                                 )
                                 (i32.const 3)
@@ -10213,12 +10209,12 @@
                             (i32.store offset=4
                               (get_local $13)
                               (i32.or
-                                (get_local $6)
+                                (get_local $5)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
-                              (get_local $5)
+                              (get_local $6)
                               (i32.or
                                 (get_local $8)
                                 (i32.const 1)
@@ -10226,7 +10222,7 @@
                             )
                             (i32.store
                               (i32.add
-                                (get_local $5)
+                                (get_local $6)
                                 (get_local $8)
                               )
                               (get_local $8)
@@ -10316,18 +10312,18 @@
                                 )
                                 (i32.store
                                   (get_local $20)
-                                  (get_local $5)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=12
                                   (get_local $10)
-                                  (get_local $5)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=8
-                                  (get_local $5)
+                                  (get_local $6)
                                   (get_local $10)
                                 )
                                 (i32.store offset=12
-                                  (get_local $5)
+                                  (get_local $6)
                                   (get_local $2)
                                 )
                                 (br $do-once25)
@@ -10439,13 +10435,13 @@
                               )
                             )
                             (i32.store offset=28
-                              (get_local $5)
+                              (get_local $6)
                               (get_local $3)
                             )
                             (i32.store offset=4
                               (tee_local $0
                                 (i32.add
-                                  (get_local $5)
+                                  (get_local $6)
                                   (i32.const 16)
                                 )
                               )
@@ -10481,19 +10477,19 @@
                                 )
                                 (i32.store
                                   (get_local $2)
-                                  (get_local $5)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=24
-                                  (get_local $5)
+                                  (get_local $6)
                                   (get_local $2)
                                 )
                                 (i32.store offset=12
-                                  (get_local $5)
-                                  (get_local $5)
+                                  (get_local $6)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=8
-                                  (get_local $5)
-                                  (get_local $5)
+                                  (get_local $6)
+                                  (get_local $6)
                                 )
                                 (br $do-once25)
                               )
@@ -10588,19 +10584,19 @@
                                   (block
                                     (i32.store
                                       (get_local $3)
-                                      (get_local $5)
+                                      (get_local $6)
                                     )
                                     (i32.store offset=24
-                                      (get_local $5)
+                                      (get_local $6)
                                       (get_local $0)
                                     )
                                     (i32.store offset=12
-                                      (get_local $5)
-                                      (get_local $5)
+                                      (get_local $6)
+                                      (get_local $6)
                                     )
                                     (i32.store offset=8
-                                      (get_local $5)
-                                      (get_local $5)
+                                      (get_local $6)
+                                      (get_local $6)
                                     )
                                     (br $do-once25)
                                   )
@@ -10634,22 +10630,22 @@
                                 (block
                                   (i32.store offset=12
                                     (get_local $3)
-                                    (get_local $5)
+                                    (get_local $6)
                                   )
                                   (i32.store
                                     (get_local $2)
-                                    (get_local $5)
+                                    (get_local $6)
                                   )
                                   (i32.store offset=8
-                                    (get_local $5)
+                                    (get_local $6)
                                     (get_local $3)
                                   )
                                   (i32.store offset=12
-                                    (get_local $5)
+                                    (get_local $6)
                                     (get_local $0)
                                   )
                                   (i32.store offset=24
-                                    (get_local $5)
+                                    (get_local $6)
                                     (i32.const 0)
                                   )
                                 )
@@ -10667,16 +10663,16 @@
                       )
                     )
                     (set_local $0
-                      (get_local $6)
+                      (get_local $5)
                     )
                   )
                   (set_local $0
-                    (get_local $6)
+                    (get_local $5)
                   )
                 )
               )
               (set_local $0
-                (get_local $6)
+                (get_local $5)
               )
             )
           )
@@ -10902,16 +10898,16 @@
     )
     (if
       (i32.le_u
-        (tee_local $7
+        (tee_local $9
           (i32.and
-            (tee_local $5
+            (tee_local $10
               (i32.add
                 (tee_local $1
                   (i32.load
                     (i32.const 656)
                   )
                 )
-                (tee_local $10
+                (tee_local $7
                   (i32.add
                     (get_local $0)
                     (i32.const 47)
@@ -10919,7 +10915,7 @@
                 )
               )
             )
-            (tee_local $9
+            (tee_local $5
               (i32.sub
                 (i32.const 0)
                 (get_local $1)
@@ -10949,7 +10945,7 @@
                     (i32.const 608)
                   )
                 )
-                (get_local $7)
+                (get_local $9)
               )
             )
             (get_local $2)
@@ -11046,12 +11042,12 @@
                       (tee_local $1
                         (i32.and
                           (i32.sub
-                            (get_local $5)
+                            (get_local $10)
                             (i32.load
                               (i32.const 188)
                             )
                           )
-                          (get_local $9)
+                          (get_local $5)
                         )
                       )
                       (i32.const 2147483647)
@@ -11095,7 +11091,7 @@
                   (block
                     (set_local $4
                       (i32.add
-                        (tee_local $9
+                        (tee_local $5
                           (i32.load
                             (i32.const 608)
                           )
@@ -11119,7 +11115,7 @@
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $7)
+                                (get_local $9)
                                 (get_local $1)
                               )
                               (i32.and
@@ -11133,7 +11129,7 @@
                                 )
                               )
                             )
-                            (get_local $7)
+                            (get_local $9)
                           )
                         )
                       )
@@ -11160,7 +11156,7 @@
                             (i32.or
                               (i32.le_u
                                 (get_local $4)
-                                (get_local $9)
+                                (get_local $5)
                               )
                               (i32.gt_u
                                 (get_local $4)
@@ -11220,7 +11216,7 @@
                       (i32.and
                         (i32.add
                           (i32.sub
-                            (get_local $10)
+                            (get_local $7)
                             (get_local $1)
                           )
                           (tee_local $3
@@ -11281,7 +11277,7 @@
         )
         (if
           (i32.lt_u
-            (get_local $7)
+            (get_local $9)
             (i32.const 2147483647)
           )
           (if
@@ -11289,7 +11285,7 @@
               (i32.lt_u
                 (tee_local $2
                   (call $_sbrk
-                    (get_local $7)
+                    (get_local $9)
                   )
                 )
                 (tee_local $1
@@ -11368,7 +11364,7 @@
                     (i32.eq
                       (get_local $2)
                       (i32.add
-                        (tee_local $6
+                        (tee_local $5
                           (i32.load
                             (get_local $3)
                           )
@@ -11413,7 +11409,7 @@
                     )
                     (i32.ge_u
                       (get_local $8)
-                      (get_local $6)
+                      (get_local $5)
                     )
                   )
                   (block
@@ -11494,7 +11490,7 @@
                 )
               )
             )
-            (set_local $5
+            (set_local $9
               (if i32
                 (i32.lt_u
                   (get_local $2)
@@ -11514,7 +11510,7 @@
                 (get_local $3)
               )
             )
-            (set_local $9
+            (set_local $5
               (i32.add
                 (get_local $2)
                 (get_local $1)
@@ -11531,7 +11527,7 @@
                       (i32.load
                         (get_local $3)
                       )
-                      (get_local $9)
+                      (get_local $5)
                     )
                     (block
                       (set_local $4
@@ -11616,14 +11612,14 @@
                       (i32.sub
                         (tee_local $10
                           (i32.add
-                            (get_local $9)
+                            (get_local $5)
                             (select
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
                                   (tee_local $1
                                     (i32.add
-                                      (get_local $9)
+                                      (get_local $5)
                                       (i32.const 8)
                                     )
                                   )
@@ -11737,7 +11733,7 @@
                                   (i32.const 1)
                                 )
                                 (block i32
-                                  (set_local $9
+                                  (set_local $5
                                     (i32.and
                                       (get_local $0)
                                       (i32.const -8)
@@ -11786,7 +11782,7 @@
                                               (if
                                                 (i32.lt_u
                                                   (get_local $2)
-                                                  (get_local $5)
+                                                  (get_local $9)
                                                 )
                                                 (call $_abort)
                                               )
@@ -11842,7 +11838,7 @@
                                               (if
                                                 (i32.lt_u
                                                   (get_local $3)
-                                                  (get_local $5)
+                                                  (get_local $9)
                                                 )
                                                 (call $_abort)
                                               )
@@ -11977,7 +11973,7 @@
                                               (if
                                                 (i32.lt_u
                                                   (get_local $0)
-                                                  (get_local $5)
+                                                  (get_local $9)
                                                 )
                                                 (call $_abort)
                                                 (block
@@ -11999,7 +11995,7 @@
                                                       (get_local $10)
                                                     )
                                                   )
-                                                  (get_local $5)
+                                                  (get_local $9)
                                                 )
                                                 (call $_abort)
                                               )
@@ -12213,13 +12209,13 @@
                                   )
                                   (set_local $4
                                     (i32.add
-                                      (get_local $9)
+                                      (get_local $5)
                                       (get_local $4)
                                     )
                                   )
                                   (i32.add
                                     (get_local $10)
-                                    (get_local $9)
+                                    (get_local $5)
                                   )
                                 )
                                 (get_local $10)
@@ -12740,7 +12736,7 @@
                 (i32.const 8)
               )
             )
-            (set_local $5
+            (set_local $6
               (i32.add
                 (tee_local $11
                   (select
@@ -12780,7 +12776,7 @@
             )
             (i32.store
               (i32.const 200)
-              (tee_local $6
+              (tee_local $5
                 (i32.add
                   (get_local $2)
                   (tee_local $4
@@ -12820,7 +12816,7 @@
               )
             )
             (i32.store offset=4
-              (get_local $6)
+              (get_local $5)
               (i32.or
                 (get_local $4)
                 (i32.const 1)
@@ -12828,7 +12824,7 @@
             )
             (i32.store offset=4
               (i32.add
-                (get_local $6)
+                (get_local $5)
                 (get_local $4)
               )
               (i32.const 40)
@@ -12849,25 +12845,25 @@
               (i32.const 27)
             )
             (i32.store
-              (get_local $5)
+              (get_local $6)
               (i32.load
                 (i32.const 624)
               )
             )
             (i32.store offset=4
-              (get_local $5)
+              (get_local $6)
               (i32.load
                 (i32.const 628)
               )
             )
             (i32.store offset=8
-              (get_local $5)
+              (get_local $6)
               (i32.load
                 (i32.const 632)
               )
             )
             (i32.store offset=12
-              (get_local $5)
+              (get_local $6)
               (i32.load
                 (i32.const 636)
               )
@@ -12886,7 +12882,7 @@
             )
             (i32.store
               (i32.const 632)
-              (get_local $5)
+              (get_local $6)
             )
             (set_local $1
               (i32.add
@@ -12932,7 +12928,7 @@
                 (i32.store offset=4
                   (get_local $8)
                   (i32.or
-                    (tee_local $6
+                    (tee_local $5
                       (i32.sub
                         (get_local $11)
                         (get_local $8)
@@ -12943,17 +12939,17 @@
                 )
                 (i32.store
                   (get_local $11)
-                  (get_local $6)
+                  (get_local $5)
                 )
                 (set_local $1
                   (i32.shr_u
-                    (get_local $6)
+                    (get_local $5)
                     (i32.const 3)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $6)
+                    (get_local $5)
                     (i32.const 256)
                   )
                   (block
@@ -13054,20 +13050,20 @@
                         (if i32
                           (tee_local $1
                             (i32.shr_u
-                              (get_local $6)
+                              (get_local $5)
                               (i32.const 8)
                             )
                           )
                           (if i32
                             (i32.gt_u
-                              (get_local $6)
+                              (get_local $5)
                               (i32.const 16777215)
                             )
                             (i32.const 31)
                             (i32.or
                               (i32.and
                                 (i32.shr_u
-                                  (get_local $6)
+                                  (get_local $5)
                                   (i32.add
                                     (tee_local $1
                                       (i32.add
@@ -13209,7 +13205,7 @@
                 )
                 (set_local $4
                   (i32.shl
-                    (get_local $6)
+                    (get_local $5)
                     (select
                       (i32.const 0)
                       (i32.sub
@@ -13243,7 +13239,7 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $6)
+                            (get_local $5)
                           )
                         )
                         (set_local $3

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -135,7 +135,6 @@
     (local $52 i32)
     (local $53 i32)
     (local $54 i32)
-    (local $55 i32)
     (set_local $25
       (get_global $r)
     )
@@ -145,7 +144,7 @@
         (i32.const 16)
       )
     )
-    (set_local $12
+    (set_local $13
       (get_local $25)
     )
     (block $do-once
@@ -157,9 +156,9 @@
         (block
           (if
             (i32.and
-              (tee_local $4
+              (tee_local $5
                 (i32.shr_u
-                  (tee_local $5
+                  (tee_local $4
                     (i32.load
                       (i32.const 1208)
                     )
@@ -194,9 +193,9 @@
                 (i32.load
                   (tee_local $3
                     (i32.add
-                      (tee_local $4
+                      (tee_local $12
                         (i32.load
-                          (tee_local $13
+                          (tee_local $14
                             (i32.add
                               (tee_local $8
                                 (i32.add
@@ -206,7 +205,7 @@
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $4)
+                                              (get_local $5)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
@@ -239,7 +238,7 @@
                 (i32.store
                   (i32.const 1208)
                   (i32.and
-                    (get_local $5)
+                    (get_local $4)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
@@ -269,7 +268,7 @@
                           )
                         )
                       )
-                      (get_local $4)
+                      (get_local $12)
                     )
                     (block
                       (i32.store
@@ -277,7 +276,7 @@
                         (get_local $8)
                       )
                       (i32.store
-                        (get_local $13)
+                        (get_local $14)
                         (get_local $6)
                       )
                     )
@@ -286,7 +285,7 @@
                 )
               )
               (i32.store offset=4
-                (get_local $4)
+                (get_local $12)
                 (i32.or
                   (tee_local $6
                     (i32.shl
@@ -298,10 +297,10 @@
                 )
               )
               (i32.store
-                (tee_local $13
+                (tee_local $14
                   (i32.add
                     (i32.add
-                      (get_local $4)
+                      (get_local $12)
                       (get_local $6)
                     )
                     (i32.const 4)
@@ -309,7 +308,7 @@
                 )
                 (i32.or
                   (i32.load
-                    (get_local $13)
+                    (get_local $14)
                   )
                   (i32.const 1)
                 )
@@ -325,7 +324,7 @@
           (if
             (i32.gt_u
               (get_local $3)
-              (tee_local $13
+              (tee_local $14
                 (i32.load
                   (i32.const 1216)
                 )
@@ -333,7 +332,7 @@
             )
             (block
               (if
-                (get_local $4)
+                (get_local $5)
                 (block
                   (set_local $8
                     (i32.and
@@ -344,7 +343,7 @@
                               (tee_local $8
                                 (i32.and
                                   (i32.shl
-                                    (get_local $4)
+                                    (get_local $5)
                                     (get_local $0)
                                   )
                                   (i32.or
@@ -380,13 +379,13 @@
                         (i32.add
                           (tee_local $9
                             (i32.load
-                              (tee_local $16
+                              (tee_local $12
                                 (i32.add
                                   (tee_local $1
                                     (i32.add
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $15
+                                          (tee_local $16
                                             (i32.add
                                               (i32.or
                                                 (i32.or
@@ -441,7 +440,7 @@
                                                 (tee_local $1
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (tee_local $16
+                                                      (tee_local $12
                                                         (i32.shr_u
                                                           (get_local $1)
                                                           (get_local $9)
@@ -454,7 +453,7 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $16)
+                                                (get_local $12)
                                                 (get_local $1)
                                               )
                                             )
@@ -485,18 +484,18 @@
                       (i32.store
                         (i32.const 1208)
                         (i32.and
-                          (get_local $5)
+                          (get_local $4)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $15)
+                              (get_local $16)
                             )
                             (i32.const -1)
                           )
                         )
                       )
                       (set_local $34
-                        (get_local $13)
+                        (get_local $14)
                       )
                     )
                     (block
@@ -527,7 +526,7 @@
                             (get_local $1)
                           )
                           (i32.store
-                            (get_local $16)
+                            (get_local $12)
                             (get_local $8)
                           )
                           (set_local $34
@@ -548,7 +547,7 @@
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $16
+                    (tee_local $12
                       (i32.add
                         (get_local $9)
                         (get_local $3)
@@ -558,7 +557,7 @@
                       (tee_local $8
                         (i32.sub
                           (i32.shl
-                            (get_local $15)
+                            (get_local $16)
                             (i32.const 3)
                           )
                           (get_local $3)
@@ -569,7 +568,7 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $16)
+                      (get_local $12)
                       (get_local $8)
                     )
                     (get_local $8)
@@ -582,11 +581,11 @@
                           (i32.const 1228)
                         )
                       )
-                      (set_local $5
+                      (set_local $4
                         (i32.add
                           (i32.shl
                             (i32.shl
-                              (tee_local $13
+                              (tee_local $14
                                 (i32.shr_u
                                   (get_local $34)
                                   (i32.const 3)
@@ -606,10 +605,10 @@
                               (i32.const 1208)
                             )
                           )
-                          (tee_local $4
+                          (tee_local $5
                             (i32.shl
                               (i32.const 1)
-                              (get_local $13)
+                              (get_local $14)
                             )
                           )
                         )
@@ -617,9 +616,9 @@
                           (i32.lt_u
                             (tee_local $0
                               (i32.load
-                                (tee_local $4
+                                (tee_local $5
                                   (i32.add
-                                    (get_local $5)
+                                    (get_local $4)
                                     (i32.const 8)
                                   )
                                 )
@@ -631,8 +630,8 @@
                           )
                           (call $qa)
                           (block
-                            (set_local $41
-                              (get_local $4)
+                            (set_local $40
+                              (get_local $5)
                             )
                             (set_local $35
                               (get_local $0)
@@ -644,22 +643,22 @@
                             (i32.const 1208)
                             (i32.or
                               (get_local $0)
-                              (get_local $4)
+                              (get_local $5)
                             )
                           )
-                          (set_local $41
+                          (set_local $40
                             (i32.add
-                              (get_local $5)
+                              (get_local $4)
                               (i32.const 8)
                             )
                           )
                           (set_local $35
-                            (get_local $5)
+                            (get_local $4)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $41)
+                        (get_local $40)
                         (get_local $1)
                       )
                       (i32.store offset=12
@@ -672,7 +671,7 @@
                       )
                       (i32.store offset=12
                         (get_local $1)
-                        (get_local $5)
+                        (get_local $4)
                       )
                     )
                   )
@@ -682,7 +681,7 @@
                   )
                   (i32.store
                     (i32.const 1228)
-                    (get_local $16)
+                    (get_local $12)
                   )
                   (set_global $r
                     (get_local $25)
@@ -693,22 +692,22 @@
                 )
               )
               (if
-                (tee_local $16
+                (tee_local $12
                   (i32.load
                     (i32.const 1212)
                   )
                 )
                 (block
-                  (set_local $16
+                  (set_local $12
                     (i32.and
                       (i32.shr_u
                         (tee_local $8
                           (i32.add
                             (i32.and
-                              (get_local $16)
+                              (get_local $12)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $16)
+                                (get_local $12)
                               )
                             )
                             (i32.const -1)
@@ -723,7 +722,7 @@
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (tee_local $13
+                          (tee_local $14
                             (i32.load
                               (i32.add
                                 (i32.shl
@@ -735,10 +734,10 @@
                                             (tee_local $8
                                               (i32.and
                                                 (i32.shr_u
-                                                  (tee_local $5
+                                                  (tee_local $4
                                                     (i32.shr_u
                                                       (get_local $8)
-                                                      (get_local $16)
+                                                      (get_local $12)
                                                     )
                                                   )
                                                   (i32.const 5)
@@ -746,14 +745,14 @@
                                                 (i32.const 8)
                                               )
                                             )
-                                            (get_local $16)
+                                            (get_local $12)
                                           )
-                                          (tee_local $5
+                                          (tee_local $4
                                             (i32.and
                                               (i32.shr_u
                                                 (tee_local $1
                                                   (i32.shr_u
-                                                    (get_local $5)
+                                                    (get_local $4)
                                                     (get_local $8)
                                                   )
                                                 )
@@ -769,7 +768,7 @@
                                               (tee_local $0
                                                 (i32.shr_u
                                                   (get_local $1)
-                                                  (get_local $5)
+                                                  (get_local $4)
                                                 )
                                               )
                                               (i32.const 1)
@@ -781,7 +780,7 @@
                                       (tee_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $4
+                                            (tee_local $5
                                               (i32.shr_u
                                                 (get_local $0)
                                                 (get_local $1)
@@ -794,7 +793,7 @@
                                       )
                                     )
                                     (i32.shr_u
-                                      (get_local $4)
+                                      (get_local $5)
                                       (get_local $0)
                                     )
                                   )
@@ -810,31 +809,31 @@
                       (get_local $3)
                     )
                   )
-                  (set_local $4
-                    (get_local $13)
+                  (set_local $5
+                    (get_local $14)
                   )
                   (set_local $1
-                    (get_local $13)
+                    (get_local $14)
                   )
                   (loop $while-in
                     (block $while-out
                       (if
-                        (tee_local $13
+                        (tee_local $14
                           (i32.load offset=16
-                            (get_local $4)
+                            (get_local $5)
                           )
                         )
                         (set_local $6
-                          (get_local $13)
+                          (get_local $14)
                         )
                         (if
-                          (tee_local $5
+                          (tee_local $4
                             (i32.load offset=20
-                              (get_local $4)
+                              (get_local $5)
                             )
                           )
                           (set_local $6
-                            (get_local $5)
+                            (get_local $4)
                           )
                           (block
                             (set_local $6
@@ -847,9 +846,9 @@
                           )
                         )
                       )
-                      (set_local $5
+                      (set_local $4
                         (i32.lt_u
-                          (tee_local $13
+                          (tee_local $14
                             (i32.sub
                               (i32.and
                                 (i32.load offset=4
@@ -865,19 +864,19 @@
                       )
                       (set_local $0
                         (select
-                          (get_local $13)
+                          (get_local $14)
                           (get_local $0)
-                          (get_local $5)
+                          (get_local $4)
                         )
                       )
-                      (set_local $4
+                      (set_local $5
                         (get_local $6)
                       )
                       (set_local $1
                         (select
                           (get_local $6)
                           (get_local $1)
-                          (get_local $5)
+                          (get_local $4)
                         )
                       )
                       (br $while-in)
@@ -897,7 +896,7 @@
                   (if
                     (i32.ge_u
                       (get_local $2)
-                      (tee_local $4
+                      (tee_local $5
                         (i32.add
                           (get_local $2)
                           (get_local $3)
@@ -923,7 +922,7 @@
                       )
                       (block
                         (if
-                          (tee_local $15
+                          (tee_local $16
                             (i32.load
                               (tee_local $9
                                 (i32.add
@@ -934,18 +933,18 @@
                             )
                           )
                           (block
-                            (set_local $13
-                              (get_local $15)
+                            (set_local $14
+                              (get_local $16)
                             )
-                            (set_local $5
+                            (set_local $4
                               (get_local $9)
                             )
                           )
                           (if
                             (i32.eqz
-                              (tee_local $13
+                              (tee_local $14
                                 (i32.load
-                                  (tee_local $5
+                                  (tee_local $4
                                     (i32.add
                                       (get_local $2)
                                       (i32.const 16)
@@ -964,42 +963,42 @@
                         )
                         (loop $while-in7
                           (if
-                            (tee_local $15
+                            (tee_local $16
                               (i32.load
                                 (tee_local $9
                                   (i32.add
-                                    (get_local $13)
+                                    (get_local $14)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $13
-                                (get_local $15)
+                              (set_local $14
+                                (get_local $16)
                               )
-                              (set_local $5
+                              (set_local $4
                                 (get_local $9)
                               )
                               (br $while-in7)
                             )
                           )
                           (if
-                            (tee_local $15
+                            (tee_local $16
                               (i32.load
                                 (tee_local $9
                                   (i32.add
-                                    (get_local $13)
+                                    (get_local $14)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $13
-                                (get_local $15)
+                              (set_local $14
+                                (get_local $16)
                               )
-                              (set_local $5
+                              (set_local $4
                                 (get_local $9)
                               )
                               (br $while-in7)
@@ -1008,17 +1007,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $5)
+                            (get_local $4)
                             (get_local $1)
                           )
                           (call $qa)
                           (block
                             (i32.store
-                              (get_local $5)
+                              (get_local $4)
                               (i32.const 0)
                             )
                             (set_local $23
-                              (get_local $13)
+                              (get_local $14)
                             )
                           )
                         )
@@ -1038,7 +1037,7 @@
                         (if
                           (i32.ne
                             (i32.load
-                              (tee_local $15
+                              (tee_local $16
                                 (i32.add
                                   (get_local $9)
                                   (i32.const 12)
@@ -1052,7 +1051,7 @@
                         (if
                           (i32.eq
                             (i32.load
-                              (tee_local $5
+                              (tee_local $4
                                 (i32.add
                                   (get_local $7)
                                   (i32.const 8)
@@ -1063,11 +1062,11 @@
                           )
                           (block
                             (i32.store
-                              (get_local $15)
+                              (get_local $16)
                               (get_local $7)
                             )
                             (i32.store
-                              (get_local $5)
+                              (get_local $4)
                               (get_local $9)
                             )
                             (set_local $23
@@ -1282,7 +1281,7 @@
                         )
                       )
                       (i32.store offset=4
-                        (get_local $4)
+                        (get_local $5)
                         (i32.or
                           (get_local $6)
                           (i32.const 1)
@@ -1290,7 +1289,7 @@
                       )
                       (i32.store
                         (i32.add
-                          (get_local $4)
+                          (get_local $5)
                           (get_local $6)
                         )
                         (get_local $6)
@@ -1331,7 +1330,7 @@
                                   (i32.const 1208)
                                 )
                               )
-                              (tee_local $5
+                              (tee_local $4
                                 (i32.shl
                                   (i32.const 1)
                                   (get_local $7)
@@ -1342,7 +1341,7 @@
                               (i32.lt_u
                                 (tee_local $9
                                   (i32.load
-                                    (tee_local $5
+                                    (tee_local $4
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 8)
@@ -1356,8 +1355,8 @@
                               )
                               (call $qa)
                               (block
-                                (set_local $42
-                                  (get_local $5)
+                                (set_local $41
+                                  (get_local $4)
                                 )
                                 (set_local $27
                                   (get_local $9)
@@ -1369,10 +1368,10 @@
                                 (i32.const 1208)
                                 (i32.or
                                   (get_local $9)
-                                  (get_local $5)
+                                  (get_local $4)
                                 )
                               )
-                              (set_local $42
+                              (set_local $41
                                 (i32.add
                                   (get_local $1)
                                   (i32.const 8)
@@ -1384,7 +1383,7 @@
                             )
                           )
                           (i32.store
-                            (get_local $42)
+                            (get_local $41)
                             (get_local $0)
                           )
                           (i32.store offset=12
@@ -1407,7 +1406,7 @@
                       )
                       (i32.store
                         (i32.const 1228)
-                        (get_local $4)
+                        (get_local $5)
                       )
                     )
                   )
@@ -1421,12 +1420,12 @@
                     )
                   )
                 )
-                (set_local $4
+                (set_local $5
                   (get_local $3)
                 )
               )
             )
-            (set_local $4
+            (set_local $5
               (get_local $3)
             )
           )
@@ -1436,7 +1435,7 @@
             (get_local $0)
             (i32.const -65)
           )
-          (set_local $4
+          (set_local $5
             (i32.const -1)
           )
           (block
@@ -1458,7 +1457,7 @@
                 )
               )
               (block
-                (set_local $5
+                (set_local $4
                   (i32.sub
                     (i32.const 0)
                     (get_local $0)
@@ -1466,7 +1465,7 @@
                 )
                 (block $label$break$a
                   (if
-                    (tee_local $16
+                    (tee_local $12
                       (i32.load
                         (i32.add
                           (i32.shl
@@ -1489,7 +1488,7 @@
                                       (i32.shr_u
                                         (get_local $0)
                                         (i32.add
-                                          (tee_local $16
+                                          (tee_local $12
                                             (i32.add
                                               (i32.sub
                                                 (i32.const 14)
@@ -1499,7 +1498,7 @@
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (tee_local $15
+                                                            (tee_local $16
                                                               (i32.shl
                                                                 (get_local $7)
                                                                 (tee_local $1
@@ -1525,13 +1524,13 @@
                                                     )
                                                     (get_local $1)
                                                   )
-                                                  (tee_local $15
+                                                  (tee_local $16
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $13
+                                                          (tee_local $14
                                                             (i32.shl
-                                                              (get_local $15)
+                                                              (get_local $16)
                                                               (get_local $7)
                                                             )
                                                           )
@@ -1546,8 +1545,8 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $13)
-                                                  (get_local $15)
+                                                  (get_local $14)
+                                                  (get_local $16)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -1559,7 +1558,7 @@
                                       (i32.const 1)
                                     )
                                     (i32.shl
-                                      (get_local $16)
+                                      (get_local $12)
                                       (i32.const 1)
                                     )
                                   )
@@ -1574,10 +1573,10 @@
                       )
                     )
                     (block
-                      (set_local $15
-                        (get_local $5)
+                      (set_local $16
+                        (get_local $4)
                       )
-                      (set_local $13
+                      (set_local $14
                         (i32.const 0)
                       )
                       (set_local $1
@@ -1600,7 +1599,7 @@
                         )
                       )
                       (set_local $7
-                        (get_local $16)
+                        (get_local $12)
                       )
                       (set_local $8
                         (i32.const 0)
@@ -1608,7 +1607,7 @@
                       (loop $while-in14
                         (if
                           (i32.lt_u
-                            (tee_local $4
+                            (tee_local $12
                               (i32.sub
                                 (tee_local $3
                                   (i32.and
@@ -1621,7 +1620,7 @@
                                 (get_local $0)
                               )
                             )
-                            (get_local $15)
+                            (get_local $16)
                           )
                           (if
                             (i32.eq
@@ -1630,7 +1629,7 @@
                             )
                             (block
                               (set_local $29
-                                (get_local $4)
+                                (get_local $12)
                               )
                               (set_local $28
                                 (get_local $7)
@@ -1644,8 +1643,8 @@
                               (br $label$break$a)
                             )
                             (block
-                              (set_local $15
-                                (get_local $4)
+                              (set_local $16
+                                (get_local $12)
                               )
                               (set_local $8
                                 (get_local $7)
@@ -1655,18 +1654,18 @@
                         )
                         (set_local $3
                           (select
-                            (get_local $13)
-                            (tee_local $4
+                            (get_local $14)
+                            (tee_local $12
                               (i32.load offset=20
                                 (get_local $7)
                               )
                             )
                             (i32.or
                               (i32.eqz
-                                (get_local $4)
+                                (get_local $12)
                               )
                               (i32.eq
-                                (get_local $4)
+                                (get_local $12)
                                 (tee_local $7
                                   (i32.load
                                     (i32.add
@@ -1689,16 +1688,16 @@
                           )
                         )
                         (if
-                          (tee_local $4
+                          (tee_local $12
                             (i32.eqz
                               (get_local $7)
                             )
                           )
                           (block
                             (set_local $36
-                              (get_local $15)
+                              (get_local $16)
                             )
-                            (set_local $37
+                            (set_local $5
                               (get_local $3)
                             )
                             (set_local $33
@@ -1709,7 +1708,7 @@
                             )
                           )
                           (block
-                            (set_local $13
+                            (set_local $14
                               (get_local $3)
                             )
                             (set_local $1
@@ -1717,7 +1716,7 @@
                                 (get_local $1)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $4)
+                                    (get_local $12)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
@@ -1731,9 +1730,9 @@
                     )
                     (block
                       (set_local $36
-                        (get_local $5)
+                        (get_local $4)
                       )
-                      (set_local $37
+                      (set_local $5
                         (i32.const 0)
                       )
                       (set_local $33
@@ -1755,7 +1754,7 @@
                       (if i32
                         (i32.and
                           (i32.eqz
-                            (get_local $37)
+                            (get_local $5)
                           )
                           (i32.eqz
                             (get_local $33)
@@ -1764,11 +1763,11 @@
                         (block i32
                           (if
                             (i32.eqz
-                              (tee_local $5
+                              (tee_local $4
                                 (i32.and
                                   (get_local $9)
                                   (i32.or
-                                    (tee_local $16
+                                    (tee_local $12
                                       (i32.shl
                                         (i32.const 2)
                                         (get_local $27)
@@ -1776,29 +1775,29 @@
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $16)
+                                      (get_local $12)
                                     )
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $4
+                              (set_local $5
                                 (get_local $0)
                               )
                               (br $do-once)
                             )
                           )
-                          (set_local $5
+                          (set_local $4
                             (i32.and
                               (i32.shr_u
-                                (tee_local $16
+                                (tee_local $12
                                   (i32.add
                                     (i32.and
-                                      (get_local $5)
+                                      (get_local $4)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $5)
+                                        (get_local $4)
                                       )
                                     )
                                     (i32.const -1)
@@ -1817,13 +1816,13 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (tee_local $16
+                                          (tee_local $12
                                             (i32.and
                                               (i32.shr_u
                                                 (tee_local $3
                                                   (i32.shr_u
-                                                    (get_local $16)
-                                                    (get_local $5)
+                                                    (get_local $12)
+                                                    (get_local $4)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -1831,15 +1830,15 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $5)
+                                          (get_local $4)
                                         )
                                         (tee_local $3
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $4
+                                              (tee_local $5
                                                 (i32.shr_u
                                                   (get_local $3)
-                                                  (get_local $16)
+                                                  (get_local $12)
                                                 )
                                               )
                                               (i32.const 2)
@@ -1848,12 +1847,12 @@
                                           )
                                         )
                                       )
-                                      (tee_local $4
+                                      (tee_local $5
                                         (i32.and
                                           (i32.shr_u
                                             (tee_local $8
                                               (i32.shr_u
-                                                (get_local $4)
+                                                (get_local $5)
                                                 (get_local $3)
                                               )
                                             )
@@ -1869,7 +1868,7 @@
                                           (tee_local $1
                                             (i32.shr_u
                                               (get_local $8)
-                                              (get_local $4)
+                                              (get_local $5)
                                             )
                                           )
                                           (i32.const 1)
@@ -1889,7 +1888,7 @@
                             )
                           )
                         )
-                        (get_local $37)
+                        (get_local $5)
                       )
                     )
                     (block
@@ -1941,7 +1940,7 @@
                         (get_local $29)
                       )
                     )
-                    (set_local $4
+                    (set_local $5
                       (select
                         (get_local $8)
                         (get_local $29)
@@ -1963,7 +1962,7 @@
                       )
                       (block
                         (set_local $29
-                          (get_local $4)
+                          (get_local $5)
                         )
                         (set_local $28
                           (get_local $1)
@@ -1982,7 +1981,7 @@
                       )
                       (block
                         (set_local $29
-                          (get_local $4)
+                          (get_local $5)
                         )
                         (set_local $32
                           (get_local $8)
@@ -1991,7 +1990,7 @@
                       )
                       (block
                         (set_local $18
-                          (get_local $4)
+                          (get_local $5)
                         )
                         (set_local $10
                           (get_local $8)
@@ -2036,7 +2035,7 @@
                         )
                         (call $qa)
                       )
-                      (set_local $4
+                      (set_local $5
                         (i32.load offset=24
                           (get_local $10)
                         )
@@ -2053,7 +2052,7 @@
                           )
                           (block
                             (if
-                              (tee_local $5
+                              (tee_local $4
                                 (i32.load
                                   (tee_local $3
                                     (i32.add
@@ -2064,17 +2063,17 @@
                                 )
                               )
                               (block
-                                (set_local $13
-                                  (get_local $5)
+                                (set_local $14
+                                  (get_local $4)
                                 )
                                 (set_local $1
                                   (get_local $3)
                                 )
                               )
                               (if
-                                (tee_local $13
+                                (tee_local $14
                                   (i32.load
-                                    (tee_local $16
+                                    (tee_local $12
                                       (i32.add
                                         (get_local $10)
                                         (i32.const 16)
@@ -2083,7 +2082,7 @@
                                   )
                                 )
                                 (set_local $1
-                                  (get_local $16)
+                                  (get_local $12)
                                 )
                                 (block
                                   (set_local $22
@@ -2095,19 +2094,19 @@
                             )
                             (loop $while-in20
                               (if
-                                (tee_local $5
+                                (tee_local $4
                                   (i32.load
                                     (tee_local $3
                                       (i32.add
-                                        (get_local $13)
+                                        (get_local $14)
                                         (i32.const 20)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $13
-                                    (get_local $5)
+                                  (set_local $14
+                                    (get_local $4)
                                   )
                                   (set_local $1
                                     (get_local $3)
@@ -2116,19 +2115,19 @@
                                 )
                               )
                               (if
-                                (tee_local $5
+                                (tee_local $4
                                   (i32.load
                                     (tee_local $3
                                       (i32.add
-                                        (get_local $13)
+                                        (get_local $14)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $13
-                                    (get_local $5)
+                                  (set_local $14
+                                    (get_local $4)
                                   )
                                   (set_local $1
                                     (get_local $3)
@@ -2149,7 +2148,7 @@
                                   (i32.const 0)
                                 )
                                 (set_local $22
-                                  (get_local $13)
+                                  (get_local $14)
                                 )
                               )
                             )
@@ -2169,7 +2168,7 @@
                             (if
                               (i32.ne
                                 (i32.load
-                                  (tee_local $5
+                                  (tee_local $4
                                     (i32.add
                                       (get_local $3)
                                       (i32.const 12)
@@ -2183,7 +2182,7 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $16
+                                  (tee_local $12
                                     (i32.add
                                       (get_local $1)
                                       (i32.const 8)
@@ -2194,11 +2193,11 @@
                               )
                               (block
                                 (i32.store
-                                  (get_local $5)
+                                  (get_local $4)
                                   (get_local $1)
                                 )
                                 (i32.store
-                                  (get_local $16)
+                                  (get_local $12)
                                   (get_local $3)
                                 )
                                 (set_local $22
@@ -2212,7 +2211,7 @@
                       )
                       (block $do-once21
                         (if
-                          (get_local $4)
+                          (get_local $5)
                           (block
                             (if
                               (i32.eq
@@ -2265,7 +2264,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $4)
+                                    (get_local $5)
                                     (i32.load
                                       (i32.const 1224)
                                     )
@@ -2277,7 +2276,7 @@
                                     (i32.load
                                       (tee_local $1
                                         (i32.add
-                                          (get_local $4)
+                                          (get_local $5)
                                           (i32.const 16)
                                         )
                                       )
@@ -2289,7 +2288,7 @@
                                     (get_local $22)
                                   )
                                   (i32.store offset=20
-                                    (get_local $4)
+                                    (get_local $5)
                                     (get_local $22)
                                   )
                                 )
@@ -2313,7 +2312,7 @@
                             )
                             (i32.store offset=24
                               (get_local $22)
-                              (get_local $4)
+                              (get_local $5)
                             )
                             (if
                               (tee_local $9
@@ -2378,7 +2377,7 @@
                             (i32.store offset=4
                               (get_local $10)
                               (i32.or
-                                (tee_local $4
+                                (tee_local $5
                                   (i32.add
                                     (get_local $18)
                                     (get_local $0)
@@ -2392,7 +2391,7 @@
                                 (i32.add
                                   (i32.add
                                     (get_local $10)
-                                    (get_local $4)
+                                    (get_local $5)
                                   )
                                   (i32.const 4)
                                 )
@@ -2439,7 +2438,7 @@
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $4
+                                (set_local $5
                                   (i32.add
                                     (i32.shl
                                       (i32.shl
@@ -2471,7 +2470,7 @@
                                         (i32.load
                                           (tee_local $3
                                             (i32.add
-                                              (get_local $4)
+                                              (get_local $5)
                                               (i32.const 8)
                                             )
                                           )
@@ -2501,12 +2500,12 @@
                                     )
                                     (set_local $19
                                       (i32.add
-                                        (get_local $4)
+                                        (get_local $5)
                                         (i32.const 8)
                                       )
                                     )
                                     (set_local $6
-                                      (get_local $4)
+                                      (get_local $5)
                                     )
                                   )
                                 )
@@ -2524,17 +2523,17 @@
                                 )
                                 (i32.store offset=12
                                   (get_local $8)
-                                  (get_local $4)
+                                  (get_local $5)
                                 )
                                 (br $do-once25)
                               )
                             )
-                            (set_local $16
+                            (set_local $12
                               (i32.add
                                 (i32.shl
-                                  (tee_local $15
+                                  (tee_local $16
                                     (if i32
-                                      (tee_local $4
+                                      (tee_local $5
                                         (i32.shr_u
                                           (get_local $18)
                                           (i32.const 8)
@@ -2551,24 +2550,24 @@
                                             (i32.shr_u
                                               (get_local $18)
                                               (i32.add
-                                                (tee_local $16
+                                                (tee_local $12
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (tee_local $4
+                                                          (tee_local $5
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
                                                                   (tee_local $3
                                                                     (i32.shl
-                                                                      (get_local $4)
+                                                                      (get_local $5)
                                                                       (tee_local $1
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $4)
+                                                                              (get_local $5)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -2594,7 +2593,7 @@
                                                                 (tee_local $9
                                                                   (i32.shl
                                                                     (get_local $3)
-                                                                    (get_local $4)
+                                                                    (get_local $5)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -2621,7 +2620,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $16)
+                                            (get_local $12)
                                             (i32.const 1)
                                           )
                                         )
@@ -2636,7 +2635,7 @@
                             )
                             (i32.store offset=28
                               (get_local $8)
-                              (get_local $15)
+                              (get_local $16)
                             )
                             (i32.store offset=4
                               (tee_local $3
@@ -2662,7 +2661,7 @@
                                   (tee_local $9
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $15)
+                                      (get_local $16)
                                     )
                                   )
                                 )
@@ -2676,12 +2675,12 @@
                                   )
                                 )
                                 (i32.store
-                                  (get_local $16)
+                                  (get_local $12)
                                   (get_local $8)
                                 )
                                 (i32.store offset=24
                                   (get_local $8)
-                                  (get_local $16)
+                                  (get_local $12)
                                 )
                                 (i32.store offset=12
                                   (get_local $8)
@@ -2702,12 +2701,12 @@
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $15)
+                                      (get_local $16)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $15)
+                                    (get_local $16)
                                     (i32.const 31)
                                   )
                                 )
@@ -2715,7 +2714,7 @@
                             )
                             (set_local $3
                               (i32.load
-                                (get_local $16)
+                                (get_local $12)
                               )
                             )
                             (loop $while-in28
@@ -2743,7 +2742,7 @@
                                 (if
                                   (tee_local $1
                                     (i32.load
-                                      (tee_local $16
+                                      (tee_local $12
                                         (i32.add
                                           (i32.add
                                             (get_local $3)
@@ -2774,9 +2773,9 @@
                                   )
                                   (block
                                     (set_local $21
-                                      (get_local $16)
+                                      (get_local $12)
                                     )
-                                    (set_local $14
+                                    (set_local $15
                                       (get_local $3)
                                     )
                                     (set_local $7
@@ -2806,7 +2805,7 @@
                                   )
                                   (i32.store offset=24
                                     (get_local $8)
-                                    (get_local $14)
+                                    (get_local $15)
                                   )
                                   (i32.store offset=12
                                     (get_local $8)
@@ -2886,16 +2885,16 @@
                         )
                       )
                     )
-                    (set_local $4
+                    (set_local $5
                       (get_local $0)
                     )
                   )
-                  (set_local $4
+                  (set_local $5
                     (get_local $0)
                   )
                 )
               )
-              (set_local $4
+              (set_local $5
                 (get_local $0)
               )
             )
@@ -2910,10 +2909,10 @@
             (i32.const 1216)
           )
         )
-        (get_local $4)
+        (get_local $5)
       )
       (block
-        (set_local $14
+        (set_local $15
           (i32.load
             (i32.const 1228)
           )
@@ -2923,7 +2922,7 @@
             (tee_local $17
               (i32.sub
                 (get_local $10)
-                (get_local $4)
+                (get_local $5)
               )
             )
             (i32.const 15)
@@ -2933,8 +2932,8 @@
               (i32.const 1228)
               (tee_local $21
                 (i32.add
-                  (get_local $14)
-                  (get_local $4)
+                  (get_local $15)
+                  (get_local $5)
                 )
               )
             )
@@ -2957,9 +2956,9 @@
               (get_local $17)
             )
             (i32.store offset=4
-              (get_local $14)
+              (get_local $15)
               (i32.or
-                (get_local $4)
+                (get_local $5)
                 (i32.const 3)
               )
             )
@@ -2974,7 +2973,7 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $14)
+              (get_local $15)
               (i32.or
                 (get_local $10)
                 (i32.const 3)
@@ -2984,7 +2983,7 @@
               (tee_local $17
                 (i32.add
                   (i32.add
-                    (get_local $14)
+                    (get_local $15)
                     (get_local $10)
                   )
                   (i32.const 4)
@@ -3004,7 +3003,7 @@
         )
         (return
           (i32.add
-            (get_local $14)
+            (get_local $15)
             (i32.const 8)
           )
         )
@@ -3012,20 +3011,20 @@
     )
     (if
       (i32.gt_u
-        (tee_local $14
+        (tee_local $15
           (i32.load
             (i32.const 1220)
           )
         )
-        (get_local $4)
+        (get_local $5)
       )
       (block
         (i32.store
           (i32.const 1220)
           (tee_local $17
             (i32.sub
-              (get_local $14)
-              (get_local $4)
+              (get_local $15)
+              (get_local $5)
             )
           )
         )
@@ -3033,12 +3032,12 @@
           (i32.const 1232)
           (tee_local $10
             (i32.add
-              (tee_local $14
+              (tee_local $15
                 (i32.load
                   (i32.const 1232)
                 )
               )
-              (get_local $4)
+              (get_local $5)
             )
           )
         )
@@ -3050,9 +3049,9 @@
           )
         )
         (i32.store offset=4
-          (get_local $14)
+          (get_local $15)
           (i32.or
-            (get_local $4)
+            (get_local $5)
             (i32.const 3)
           )
         )
@@ -3061,7 +3060,7 @@
         )
         (return
           (i32.add
-            (get_local $14)
+            (get_local $15)
             (i32.const 8)
           )
         )
@@ -3099,11 +3098,11 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $12)
-          (tee_local $14
+          (get_local $13)
+          (tee_local $15
             (i32.xor
               (i32.and
-                (get_local $12)
+                (get_local $13)
                 (i32.const -16)
               )
               (i32.const 1431655768)
@@ -3112,30 +3111,30 @@
         )
         (i32.store
           (i32.const 1680)
-          (get_local $14)
+          (get_local $15)
         )
       )
     )
-    (set_local $14
+    (set_local $15
       (i32.add
-        (get_local $4)
+        (get_local $5)
         (i32.const 48)
       )
     )
     (if
       (i32.le_u
-        (tee_local $12
+        (tee_local $13
           (i32.and
             (tee_local $10
               (i32.add
-                (tee_local $12
+                (tee_local $13
                   (i32.load
                     (i32.const 1688)
                   )
                 )
                 (tee_local $17
                   (i32.add
-                    (get_local $4)
+                    (get_local $5)
                     (i32.const 47)
                   )
                 )
@@ -3144,12 +3143,12 @@
             (tee_local $21
               (i32.sub
                 (i32.const 0)
-                (get_local $12)
+                (get_local $13)
               )
             )
           )
         )
-        (get_local $4)
+        (get_local $5)
       )
       (block
         (set_global $r
@@ -3171,15 +3170,15 @@
           (i32.le_u
             (tee_local $6
               (i32.add
-                (tee_local $15
+                (tee_local $16
                   (i32.load
                     (i32.const 1640)
                   )
                 )
-                (get_local $12)
+                (get_local $13)
               )
             )
-            (get_local $15)
+            (get_local $16)
           )
           (i32.gt_u
             (get_local $6)
@@ -3224,7 +3223,7 @@
                         (block $while-out31
                           (if
                             (i32.le_u
-                              (tee_local $15
+                              (tee_local $16
                                 (i32.load
                                   (get_local $6)
                                 )
@@ -3234,7 +3233,7 @@
                             (if
                               (i32.gt_u
                                 (i32.add
-                                  (get_local $15)
+                                  (get_local $16)
                                   (i32.load
                                     (tee_local $19
                                       (i32.add
@@ -3250,7 +3249,7 @@
                                 (set_local $0
                                   (get_local $6)
                                 )
-                                (set_local $5
+                                (set_local $4
                                   (get_local $19)
                                 )
                                 (br $while-out31)
@@ -3297,7 +3296,7 @@
                                 (get_local $0)
                               )
                               (i32.load
-                                (get_local $5)
+                                (get_local $4)
                               )
                             )
                           )
@@ -3372,7 +3371,7 @@
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $12)
+                                (get_local $13)
                                 (get_local $0)
                               )
                               (i32.and
@@ -3386,7 +3385,7 @@
                                 )
                               )
                             )
-                            (get_local $12)
+                            (get_local $13)
                           )
                         )
                         (set_local $0
@@ -3403,7 +3402,7 @@
                           (i32.and
                             (i32.gt_u
                               (get_local $3)
-                              (get_local $4)
+                              (get_local $5)
                             )
                             (i32.lt_u
                               (get_local $3)
@@ -3484,7 +3483,7 @@
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $14)
+                            (get_local $15)
                             (get_local $2)
                           )
                           (i32.and
@@ -3589,7 +3588,7 @@
       )
       (if
         (i32.lt_u
-          (get_local $12)
+          (get_local $13)
           (i32.const 2147483647)
         )
         (if
@@ -3597,10 +3596,10 @@
             (i32.lt_u
               (tee_local $1
                 (call $ta
-                  (get_local $12)
+                  (get_local $13)
                 )
               )
-              (tee_local $12
+              (tee_local $13
                 (call $ta
                   (i32.const 0)
                 )
@@ -3612,7 +3611,7 @@
                 (i32.const -1)
               )
               (i32.ne
-                (get_local $12)
+                (get_local $13)
                 (i32.const -1)
               )
             )
@@ -3621,12 +3620,12 @@
             (i32.gt_u
               (tee_local $11
                 (i32.sub
-                  (get_local $12)
+                  (get_local $13)
                   (get_local $1)
                 )
               )
               (i32.add
-                (get_local $4)
+                (get_local $5)
                 (i32.const 40)
               )
             )
@@ -3698,7 +3697,7 @@
                         )
                         (tee_local $17
                           (i32.load
-                            (tee_local $12
+                            (tee_local $13
                               (i32.add
                                 (get_local $2)
                                 (i32.const 4)
@@ -3709,16 +3708,16 @@
                       )
                     )
                     (block
-                      (set_local $49
+                      (set_local $48
                         (get_local $1)
                       )
-                      (set_local $50
-                        (get_local $12)
+                      (set_local $49
+                        (get_local $13)
                       )
-                      (set_local $51
+                      (set_local $50
                         (get_local $17)
                       )
-                      (set_local $52
+                      (set_local $51
                         (get_local $2)
                       )
                       (set_local $7
@@ -3745,7 +3744,7 @@
                   (i32.eqz
                     (i32.and
                       (i32.load offset=12
-                        (get_local $52)
+                        (get_local $51)
                       )
                       (i32.const 8)
                     )
@@ -3758,14 +3757,14 @@
                       )
                       (i32.ge_u
                         (get_local $11)
-                        (get_local $49)
+                        (get_local $48)
                       )
                     )
                     (block
                       (i32.store
-                        (get_local $50)
+                        (get_local $49)
                         (i32.add
-                          (get_local $51)
+                          (get_local $50)
                           (get_local $26)
                         )
                       )
@@ -3795,7 +3794,7 @@
                           )
                         )
                       )
-                      (set_local $12
+                      (set_local $13
                         (i32.add
                           (i32.sub
                             (get_local $26)
@@ -3812,19 +3811,19 @@
                       )
                       (i32.store
                         (i32.const 1220)
-                        (get_local $12)
+                        (get_local $13)
                       )
                       (i32.store offset=4
                         (get_local $2)
                         (i32.or
-                          (get_local $12)
+                          (get_local $13)
                           (i32.const 1)
                         )
                       )
                       (i32.store offset=4
                         (i32.add
                           (get_local $2)
-                          (get_local $12)
+                          (get_local $13)
                         )
                         (i32.const 40)
                       )
@@ -3839,11 +3838,11 @@
                   )
                 )
               )
-              (set_local $13
+              (set_local $14
                 (if i32
                   (i32.lt_u
                     (get_local $20)
-                    (tee_local $12
+                    (tee_local $13
                       (i32.load
                         (i32.const 1224)
                       )
@@ -3856,10 +3855,10 @@
                     )
                     (get_local $20)
                   )
-                  (get_local $12)
+                  (get_local $13)
                 )
               )
-              (set_local $12
+              (set_local $13
                 (i32.add
                   (get_local $20)
                   (get_local $26)
@@ -3875,13 +3874,13 @@
                       (i32.load
                         (get_local $2)
                       )
-                      (get_local $12)
+                      (get_local $13)
                     )
                     (block
-                      (set_local $53
+                      (set_local $52
                         (get_local $2)
                       )
-                      (set_local $43
+                      (set_local $42
                         (get_local $2)
                       )
                       (set_local $7
@@ -3910,7 +3909,7 @@
                 (if
                   (i32.and
                     (i32.load offset=12
-                      (get_local $43)
+                      (get_local $42)
                     )
                     (i32.const 8)
                   )
@@ -3919,13 +3918,13 @@
                   )
                   (block
                     (i32.store
-                      (get_local $53)
+                      (get_local $52)
                       (get_local $20)
                     )
                     (i32.store
                       (tee_local $2
                         (i32.add
-                          (get_local $43)
+                          (get_local $42)
                           (i32.const 4)
                         )
                       )
@@ -3962,14 +3961,14 @@
                     )
                     (set_local $1
                       (i32.add
-                        (get_local $12)
+                        (get_local $13)
                         (select
                           (i32.and
                             (i32.sub
                               (i32.const 0)
                               (tee_local $2
                                 (i32.add
-                                  (get_local $12)
+                                  (get_local $13)
                                   (i32.const 8)
                                 )
                               )
@@ -3987,22 +3986,22 @@
                     (set_local $2
                       (i32.add
                         (get_local $17)
-                        (get_local $4)
+                        (get_local $5)
                       )
                     )
-                    (set_local $14
+                    (set_local $15
                       (i32.sub
                         (i32.sub
                           (get_local $1)
                           (get_local $17)
                         )
-                        (get_local $4)
+                        (get_local $5)
                       )
                     )
                     (i32.store offset=4
                       (get_local $17)
                       (i32.or
-                        (get_local $4)
+                        (get_local $5)
                         (i32.const 3)
                       )
                     )
@@ -4020,7 +4019,7 @@
                                 (i32.load
                                   (i32.const 1220)
                                 )
-                                (get_local $14)
+                                (get_local $15)
                               )
                             )
                           )
@@ -4052,7 +4051,7 @@
                                     (i32.load
                                       (i32.const 1216)
                                     )
-                                    (get_local $14)
+                                    (get_local $15)
                                   )
                                 )
                               )
@@ -4093,7 +4092,7 @@
                                     (i32.const 1)
                                   )
                                   (block i32
-                                    (set_local $5
+                                    (set_local $4
                                       (i32.and
                                         (get_local $3)
                                         (i32.const -8)
@@ -4142,7 +4141,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $21)
-                                                    (get_local $13)
+                                                    (get_local $14)
                                                   )
                                                   (call $qa)
                                                 )
@@ -4188,7 +4187,7 @@
                                                 (get_local $10)
                                                 (get_local $19)
                                               )
-                                              (set_local $44
+                                              (set_local $43
                                                 (i32.add
                                                   (get_local $10)
                                                   (i32.const 8)
@@ -4198,7 +4197,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $10)
-                                                    (get_local $13)
+                                                    (get_local $14)
                                                   )
                                                   (call $qa)
                                                 )
@@ -4215,7 +4214,7 @@
                                                     (get_local $1)
                                                   )
                                                   (block
-                                                    (set_local $44
+                                                    (set_local $43
                                                       (get_local $0)
                                                     )
                                                     (br $do-once49)
@@ -4230,7 +4229,7 @@
                                             (get_local $10)
                                           )
                                           (i32.store
-                                            (get_local $44)
+                                            (get_local $43)
                                             (get_local $21)
                                           )
                                         )
@@ -4252,7 +4251,7 @@
                                               )
                                               (block
                                                 (if
-                                                  (tee_local $15
+                                                  (tee_local $16
                                                     (i32.load
                                                       (tee_local $6
                                                         (i32.add
@@ -4269,7 +4268,7 @@
                                                   )
                                                   (block
                                                     (set_local $3
-                                                      (get_local $15)
+                                                      (get_local $16)
                                                     )
                                                     (set_local $0
                                                       (get_local $6)
@@ -4299,7 +4298,7 @@
                                                 )
                                                 (loop $while-in54
                                                   (if
-                                                    (tee_local $15
+                                                    (tee_local $16
                                                       (i32.load
                                                         (tee_local $6
                                                           (i32.add
@@ -4311,7 +4310,7 @@
                                                     )
                                                     (block
                                                       (set_local $3
-                                                        (get_local $15)
+                                                        (get_local $16)
                                                       )
                                                       (set_local $0
                                                         (get_local $6)
@@ -4320,7 +4319,7 @@
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $15
+                                                    (tee_local $16
                                                       (i32.load
                                                         (tee_local $6
                                                           (i32.add
@@ -4332,7 +4331,7 @@
                                                     )
                                                     (block
                                                       (set_local $3
-                                                        (get_local $15)
+                                                        (get_local $16)
                                                       )
                                                       (set_local $0
                                                         (get_local $6)
@@ -4344,7 +4343,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $0)
-                                                    (get_local $13)
+                                                    (get_local $14)
                                                   )
                                                   (call $qa)
                                                   (block
@@ -4366,14 +4365,14 @@
                                                         (get_local $1)
                                                       )
                                                     )
-                                                    (get_local $13)
+                                                    (get_local $14)
                                                   )
                                                   (call $qa)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (tee_local $15
+                                                      (tee_local $16
                                                         (i32.add
                                                           (get_local $6)
                                                           (i32.const 12)
@@ -4398,7 +4397,7 @@
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $15)
+                                                      (get_local $16)
                                                       (get_local $0)
                                                     )
                                                     (i32.store
@@ -4578,15 +4577,15 @@
                                         )
                                       )
                                     )
-                                    (set_local $14
+                                    (set_local $15
                                       (i32.add
-                                        (get_local $5)
-                                        (get_local $14)
+                                        (get_local $4)
+                                        (get_local $15)
                                       )
                                     )
                                     (i32.add
                                       (get_local $1)
-                                      (get_local $5)
+                                      (get_local $4)
                                     )
                                   )
                                   (get_local $1)
@@ -4604,26 +4603,26 @@
                           (i32.store offset=4
                             (get_local $2)
                             (i32.or
-                              (get_local $14)
+                              (get_local $15)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
                               (get_local $2)
-                              (get_local $14)
+                              (get_local $15)
                             )
-                            (get_local $14)
+                            (get_local $15)
                           )
                           (set_local $0
                             (i32.shr_u
-                              (get_local $14)
+                              (get_local $15)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $14)
+                              (get_local $15)
                               (i32.const 256)
                             )
                             (block
@@ -4672,10 +4671,10 @@
                                         )
                                       )
                                       (block
-                                        (set_local $45
+                                        (set_local $44
                                           (get_local $0)
                                         )
-                                        (set_local $38
+                                        (set_local $37
                                           (get_local $19)
                                         )
                                         (br $do-once59)
@@ -4691,29 +4690,29 @@
                                         (get_local $0)
                                       )
                                     )
-                                    (set_local $45
+                                    (set_local $44
                                       (i32.add
                                         (get_local $3)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $38
+                                    (set_local $37
                                       (get_local $3)
                                     )
                                   )
                                 )
                               )
                               (i32.store
-                                (get_local $45)
+                                (get_local $44)
                                 (get_local $2)
                               )
                               (i32.store offset=12
-                                (get_local $38)
+                                (get_local $37)
                                 (get_local $2)
                               )
                               (i32.store offset=8
                                 (get_local $2)
-                                (get_local $38)
+                                (get_local $37)
                               )
                               (i32.store offset=12
                                 (get_local $2)
@@ -4725,12 +4724,12 @@
                           (set_local $0
                             (i32.add
                               (i32.shl
-                                (tee_local $5
+                                (tee_local $4
                                   (block $do-once61 i32
                                     (if i32
                                       (tee_local $0
                                         (i32.shr_u
-                                          (get_local $14)
+                                          (get_local $15)
                                           (i32.const 8)
                                         )
                                       )
@@ -4739,7 +4738,7 @@
                                           (br_if $do-once61
                                             (i32.const 31)
                                             (i32.gt_u
-                                              (get_local $14)
+                                              (get_local $15)
                                               (i32.const 16777215)
                                             )
                                           )
@@ -4747,7 +4746,7 @@
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $14)
+                                              (get_local $15)
                                               (i32.add
                                                 (tee_local $6
                                                   (i32.add
@@ -4759,7 +4758,7 @@
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (tee_local $5
+                                                                  (tee_local $4
                                                                     (i32.shl
                                                                       (get_local $0)
                                                                       (tee_local $10
@@ -4785,13 +4784,13 @@
                                                           )
                                                           (get_local $10)
                                                         )
-                                                        (tee_local $5
+                                                        (tee_local $4
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
                                                                 (tee_local $0
                                                                   (i32.shl
-                                                                    (get_local $5)
+                                                                    (get_local $4)
                                                                     (get_local $19)
                                                                   )
                                                                 )
@@ -4807,7 +4806,7 @@
                                                     (i32.shr_u
                                                       (i32.shl
                                                         (get_local $0)
-                                                        (get_local $5)
+                                                        (get_local $4)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4835,7 +4834,7 @@
                           )
                           (i32.store offset=28
                             (get_local $2)
-                            (get_local $5)
+                            (get_local $4)
                           )
                           (i32.store offset=4
                             (tee_local $3
@@ -4861,7 +4860,7 @@
                                 (tee_local $6
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $5)
+                                    (get_local $4)
                                   )
                                 )
                               )
@@ -4895,18 +4894,18 @@
                           )
                           (set_local $6
                             (i32.shl
-                              (get_local $14)
+                              (get_local $15)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $5)
+                                    (get_local $4)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $5)
+                                  (get_local $4)
                                   (i32.const 31)
                                 )
                               )
@@ -4927,10 +4926,10 @@
                                     )
                                     (i32.const -8)
                                   )
-                                  (get_local $14)
+                                  (get_local $15)
                                 )
                                 (block
-                                  (set_local $39
+                                  (set_local $38
                                     (get_local $3)
                                   )
                                   (set_local $7
@@ -4940,7 +4939,7 @@
                                 )
                               )
                               (if
-                                (tee_local $5
+                                (tee_local $4
                                   (i32.load
                                     (tee_local $0
                                       (i32.add
@@ -4967,15 +4966,15 @@
                                     )
                                   )
                                   (set_local $3
-                                    (get_local $5)
+                                    (get_local $4)
                                   )
                                   (br $while-in64)
                                 )
                                 (block
-                                  (set_local $46
+                                  (set_local $45
                                     (get_local $0)
                                   )
-                                  (set_local $54
+                                  (set_local $53
                                     (get_local $3)
                                   )
                                   (set_local $7
@@ -4992,7 +4991,7 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $46)
+                                (get_local $45)
                                 (i32.load
                                   (i32.const 1224)
                                 )
@@ -5000,12 +4999,12 @@
                               (call $qa)
                               (block
                                 (i32.store
-                                  (get_local $46)
+                                  (get_local $45)
                                   (get_local $2)
                                 )
                                 (i32.store offset=24
                                   (get_local $2)
-                                  (get_local $54)
+                                  (get_local $53)
                                 )
                                 (i32.store offset=12
                                   (get_local $2)
@@ -5029,21 +5028,21 @@
                                       (i32.load
                                         (tee_local $3
                                           (i32.add
-                                            (get_local $39)
+                                            (get_local $38)
                                             (i32.const 8)
                                           )
                                         )
                                       )
                                     )
-                                    (tee_local $5
+                                    (tee_local $4
                                       (i32.load
                                         (i32.const 1224)
                                       )
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $39)
-                                    (get_local $5)
+                                    (get_local $38)
+                                    (get_local $4)
                                   )
                                 )
                                 (block
@@ -5061,7 +5060,7 @@
                                   )
                                   (i32.store offset=12
                                     (get_local $2)
-                                    (get_local $39)
+                                    (get_local $38)
                                   )
                                   (i32.store offset=24
                                     (get_local $2)
@@ -5100,7 +5099,7 @@
                     )
                     (if
                       (i32.gt_u
-                        (tee_local $14
+                        (tee_local $15
                           (i32.add
                             (get_local $2)
                             (i32.load offset=4
@@ -5112,7 +5111,7 @@
                       )
                       (block
                         (set_local $0
-                          (get_local $14)
+                          (get_local $15)
                         )
                         (br $while-out65)
                       )
@@ -5126,7 +5125,7 @@
                   (br $while-in66)
                 )
               )
-              (set_local $14
+              (set_local $15
                 (i32.add
                   (tee_local $17
                     (i32.add
@@ -5149,13 +5148,13 @@
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $14)
+                                (get_local $15)
                               )
                               (i32.const 7)
                             )
                             (i32.const 0)
                             (i32.and
-                              (get_local $14)
+                              (get_local $15)
                               (i32.const 7)
                             )
                           )
@@ -5163,7 +5162,7 @@
                       )
                       (i32.lt_u
                         (get_local $2)
-                        (tee_local $14
+                        (tee_local $15
                           (i32.add
                             (get_local $11)
                             (i32.const 16)
@@ -5180,7 +5179,7 @@
                 (tee_local $1
                   (i32.add
                     (get_local $20)
-                    (tee_local $12
+                    (tee_local $13
                       (select
                         (i32.and
                           (i32.sub
@@ -5212,7 +5211,7 @@
                       (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $12)
+                    (get_local $13)
                   )
                 )
               )
@@ -5354,7 +5353,7 @@
                       (i32.const 256)
                     )
                     (block
-                      (set_local $12
+                      (set_local $13
                         (i32.add
                           (i32.shl
                             (i32.shl
@@ -5373,7 +5372,7 @@
                               (i32.const 1208)
                             )
                           )
-                          (tee_local $5
+                          (tee_local $4
                             (i32.shl
                               (i32.const 1)
                               (get_local $1)
@@ -5384,9 +5383,9 @@
                           (i32.lt_u
                             (tee_local $3
                               (i32.load
-                                (tee_local $5
+                                (tee_local $4
                                   (i32.add
-                                    (get_local $12)
+                                    (get_local $13)
                                     (i32.const 8)
                                   )
                                 )
@@ -5398,10 +5397,10 @@
                           )
                           (call $qa)
                           (block
-                            (set_local $47
-                              (get_local $5)
+                            (set_local $46
+                              (get_local $4)
                             )
-                            (set_local $40
+                            (set_local $39
                               (get_local $3)
                             )
                           )
@@ -5411,35 +5410,35 @@
                             (i32.const 1208)
                             (i32.or
                               (get_local $3)
-                              (get_local $5)
+                              (get_local $4)
                             )
                           )
-                          (set_local $47
+                          (set_local $46
                             (i32.add
-                              (get_local $12)
+                              (get_local $13)
                               (i32.const 8)
                             )
                           )
-                          (set_local $40
-                            (get_local $12)
+                          (set_local $39
+                            (get_local $13)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $47)
+                        (get_local $46)
                         (get_local $11)
                       )
                       (i32.store offset=12
-                        (get_local $40)
+                        (get_local $39)
                         (get_local $11)
                       )
                       (i32.store offset=8
                         (get_local $11)
-                        (get_local $40)
+                        (get_local $39)
                       )
                       (i32.store offset=12
                         (get_local $11)
-                        (get_local $12)
+                        (get_local $13)
                       )
                       (br $do-once38)
                     )
@@ -5449,7 +5448,7 @@
                       (i32.shl
                         (tee_local $3
                           (if i32
-                            (tee_local $12
+                            (tee_local $13
                               (i32.shr_u
                                 (get_local $2)
                                 (i32.const 8)
@@ -5472,18 +5471,18 @@
                                             (i32.const 14)
                                             (i32.or
                                               (i32.or
-                                                (tee_local $12
+                                                (tee_local $13
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (tee_local $5
+                                                        (tee_local $4
                                                           (i32.shl
-                                                            (get_local $12)
+                                                            (get_local $13)
                                                             (tee_local $3
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
-                                                                    (get_local $12)
+                                                                    (get_local $13)
                                                                     (i32.const 1048320)
                                                                   )
                                                                   (i32.const 16)
@@ -5502,14 +5501,14 @@
                                                 )
                                                 (get_local $3)
                                               )
-                                              (tee_local $5
+                                              (tee_local $4
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
                                                       (tee_local $1
                                                         (i32.shl
-                                                          (get_local $5)
-                                                          (get_local $12)
+                                                          (get_local $4)
+                                                          (get_local $13)
                                                         )
                                                       )
                                                       (i32.const 245760)
@@ -5524,7 +5523,7 @@
                                           (i32.shr_u
                                             (i32.shl
                                               (get_local $1)
-                                              (get_local $5)
+                                              (get_local $4)
                                             )
                                             (i32.const 15)
                                           )
@@ -5558,13 +5557,13 @@
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $14)
+                    (get_local $15)
                     (i32.const 0)
                   )
                   (if
                     (i32.eqz
                       (i32.and
-                        (tee_local $5
+                        (tee_local $4
                           (i32.load
                             (i32.const 1212)
                           )
@@ -5581,7 +5580,7 @@
                       (i32.store
                         (i32.const 1212)
                         (i32.or
-                          (get_local $5)
+                          (get_local $4)
                           (get_local $1)
                         )
                       )
@@ -5623,7 +5622,7 @@
                       )
                     )
                   )
-                  (set_local $5
+                  (set_local $4
                     (i32.load
                       (get_local $0)
                     )
@@ -5634,7 +5633,7 @@
                         (i32.eq
                           (i32.and
                             (i32.load offset=4
-                              (get_local $5)
+                              (get_local $4)
                             )
                             (i32.const -8)
                           )
@@ -5642,7 +5641,7 @@
                         )
                         (block
                           (set_local $31
-                            (get_local $5)
+                            (get_local $4)
                           )
                           (set_local $7
                             (i32.const 305)
@@ -5656,7 +5655,7 @@
                             (tee_local $0
                               (i32.add
                                 (i32.add
-                                  (get_local $5)
+                                  (get_local $4)
                                   (i32.const 16)
                                 )
                                 (i32.shl
@@ -5677,17 +5676,17 @@
                               (i32.const 1)
                             )
                           )
-                          (set_local $5
+                          (set_local $4
                             (get_local $3)
                           )
                           (br $while-in70)
                         )
                         (block
-                          (set_local $48
+                          (set_local $47
                             (get_local $0)
                           )
-                          (set_local $55
-                            (get_local $5)
+                          (set_local $54
+                            (get_local $4)
                           )
                           (set_local $7
                             (i32.const 302)
@@ -5703,7 +5702,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $48)
+                        (get_local $47)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -5711,12 +5710,12 @@
                       (call $qa)
                       (block
                         (i32.store
-                          (get_local $48)
+                          (get_local $47)
                           (get_local $11)
                         )
                         (i32.store offset=24
                           (get_local $11)
-                          (get_local $55)
+                          (get_local $54)
                         )
                         (i32.store offset=12
                           (get_local $11)
@@ -5738,7 +5737,7 @@
                           (i32.ge_u
                             (tee_local $1
                               (i32.load
-                                (tee_local $5
+                                (tee_local $4
                                   (i32.add
                                     (get_local $31)
                                     (i32.const 8)
@@ -5763,7 +5762,7 @@
                             (get_local $11)
                           )
                           (i32.store
-                            (get_local $5)
+                            (get_local $4)
                             (get_local $11)
                           )
                           (i32.store offset=8
@@ -5833,7 +5832,7 @@
               )
               (loop $do-in
                 (i32.store offset=12
-                  (tee_local $12
+                  (tee_local $13
                     (i32.add
                       (i32.shl
                         (i32.shl
@@ -5845,11 +5844,11 @@
                       (i32.const 1248)
                     )
                   )
-                  (get_local $12)
+                  (get_local $13)
                 )
                 (i32.store offset=8
-                  (get_local $12)
-                  (get_local $12)
+                  (get_local $13)
+                  (get_local $13)
                 )
                 (br_if $do-in
                   (i32.ne
@@ -5868,7 +5867,7 @@
                 (tee_local $1
                   (i32.add
                     (get_local $20)
-                    (tee_local $12
+                    (tee_local $13
                       (select
                         (i32.and
                           (i32.sub
@@ -5900,7 +5899,7 @@
                       (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $12)
+                    (get_local $13)
                   )
                 )
               )
@@ -5934,7 +5933,7 @@
                 (i32.const 1220)
               )
             )
-            (get_local $4)
+            (get_local $5)
           )
           (block
             (i32.store
@@ -5942,7 +5941,7 @@
               (tee_local $31
                 (i32.sub
                   (get_local $11)
-                  (get_local $4)
+                  (get_local $5)
                 )
               )
             )
@@ -5955,7 +5954,7 @@
                       (i32.const 1232)
                     )
                   )
-                  (get_local $4)
+                  (get_local $5)
                 )
               )
             )
@@ -5969,7 +5968,7 @@
             (i32.store offset=4
               (get_local $11)
               (i32.or
-                (get_local $4)
+                (get_local $5)
                 (i32.const 3)
               )
             )
@@ -8691,23 +8690,22 @@
                     (i32.const 0)
                   )
                 )
-                (set_local $2
-                  (if i32
-                    (i32.gt_u
-                      (i32.load offset=20
-                        (get_local $1)
-                      )
-                      (i32.load offset=28
-                        (get_local $1)
-                      )
+                (if
+                  (i32.gt_u
+                    (i32.load offset=20
+                      (get_local $1)
                     )
+                    (i32.load offset=28
+                      (get_local $1)
+                    )
+                  )
+                  (set_local $2
                     (i32.or
                       (call $$a
                         (get_local $1)
                       )
                       (get_local $2)
                     )
-                    (get_local $2)
                   )
                 )
                 (if

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -133,7 +133,6 @@
     (local $52 i32)
     (local $53 i32)
     (local $54 i32)
-    (local $55 i32)
     (set_local $25
       (get_global $r)
     )
@@ -143,7 +142,7 @@
         (i32.const 16)
       )
     )
-    (set_local $12
+    (set_local $13
       (get_local $25)
     )
     (block $do-once
@@ -155,9 +154,9 @@
         (block
           (if
             (i32.and
-              (tee_local $4
+              (tee_local $5
                 (i32.shr_u
-                  (tee_local $5
+                  (tee_local $4
                     (i32.load
                       (i32.const 1208)
                     )
@@ -192,9 +191,9 @@
                 (i32.load
                   (tee_local $3
                     (i32.add
-                      (tee_local $4
+                      (tee_local $12
                         (i32.load
-                          (tee_local $13
+                          (tee_local $14
                             (i32.add
                               (tee_local $8
                                 (i32.add
@@ -204,7 +203,7 @@
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $4)
+                                              (get_local $5)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
@@ -237,7 +236,7 @@
                 (i32.store
                   (i32.const 1208)
                   (i32.and
-                    (get_local $5)
+                    (get_local $4)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
@@ -267,7 +266,7 @@
                           )
                         )
                       )
-                      (get_local $4)
+                      (get_local $12)
                     )
                     (block
                       (i32.store
@@ -275,7 +274,7 @@
                         (get_local $8)
                       )
                       (i32.store
-                        (get_local $13)
+                        (get_local $14)
                         (get_local $6)
                       )
                     )
@@ -284,7 +283,7 @@
                 )
               )
               (i32.store offset=4
-                (get_local $4)
+                (get_local $12)
                 (i32.or
                   (tee_local $6
                     (i32.shl
@@ -296,10 +295,10 @@
                 )
               )
               (i32.store
-                (tee_local $13
+                (tee_local $14
                   (i32.add
                     (i32.add
-                      (get_local $4)
+                      (get_local $12)
                       (get_local $6)
                     )
                     (i32.const 4)
@@ -307,7 +306,7 @@
                 )
                 (i32.or
                   (i32.load
-                    (get_local $13)
+                    (get_local $14)
                   )
                   (i32.const 1)
                 )
@@ -323,7 +322,7 @@
           (if
             (i32.gt_u
               (get_local $3)
-              (tee_local $13
+              (tee_local $14
                 (i32.load
                   (i32.const 1216)
                 )
@@ -331,7 +330,7 @@
             )
             (block
               (if
-                (get_local $4)
+                (get_local $5)
                 (block
                   (set_local $8
                     (i32.and
@@ -342,7 +341,7 @@
                               (tee_local $8
                                 (i32.and
                                   (i32.shl
-                                    (get_local $4)
+                                    (get_local $5)
                                     (get_local $0)
                                   )
                                   (i32.or
@@ -378,13 +377,13 @@
                         (i32.add
                           (tee_local $9
                             (i32.load
-                              (tee_local $16
+                              (tee_local $12
                                 (i32.add
                                   (tee_local $1
                                     (i32.add
                                       (i32.shl
                                         (i32.shl
-                                          (tee_local $15
+                                          (tee_local $16
                                             (i32.add
                                               (i32.or
                                                 (i32.or
@@ -439,7 +438,7 @@
                                                 (tee_local $1
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (tee_local $16
+                                                      (tee_local $12
                                                         (i32.shr_u
                                                           (get_local $1)
                                                           (get_local $9)
@@ -452,7 +451,7 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $16)
+                                                (get_local $12)
                                                 (get_local $1)
                                               )
                                             )
@@ -483,18 +482,18 @@
                       (i32.store
                         (i32.const 1208)
                         (i32.and
-                          (get_local $5)
+                          (get_local $4)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $15)
+                              (get_local $16)
                             )
                             (i32.const -1)
                           )
                         )
                       )
                       (set_local $34
-                        (get_local $13)
+                        (get_local $14)
                       )
                     )
                     (block
@@ -525,7 +524,7 @@
                             (get_local $1)
                           )
                           (i32.store
-                            (get_local $16)
+                            (get_local $12)
                             (get_local $8)
                           )
                           (set_local $34
@@ -546,7 +545,7 @@
                     )
                   )
                   (i32.store offset=4
-                    (tee_local $16
+                    (tee_local $12
                       (i32.add
                         (get_local $9)
                         (get_local $3)
@@ -556,7 +555,7 @@
                       (tee_local $8
                         (i32.sub
                           (i32.shl
-                            (get_local $15)
+                            (get_local $16)
                             (i32.const 3)
                           )
                           (get_local $3)
@@ -567,7 +566,7 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $16)
+                      (get_local $12)
                       (get_local $8)
                     )
                     (get_local $8)
@@ -580,11 +579,11 @@
                           (i32.const 1228)
                         )
                       )
-                      (set_local $5
+                      (set_local $4
                         (i32.add
                           (i32.shl
                             (i32.shl
-                              (tee_local $13
+                              (tee_local $14
                                 (i32.shr_u
                                   (get_local $34)
                                   (i32.const 3)
@@ -604,10 +603,10 @@
                               (i32.const 1208)
                             )
                           )
-                          (tee_local $4
+                          (tee_local $5
                             (i32.shl
                               (i32.const 1)
-                              (get_local $13)
+                              (get_local $14)
                             )
                           )
                         )
@@ -615,9 +614,9 @@
                           (i32.lt_u
                             (tee_local $0
                               (i32.load
-                                (tee_local $4
+                                (tee_local $5
                                   (i32.add
-                                    (get_local $5)
+                                    (get_local $4)
                                     (i32.const 8)
                                   )
                                 )
@@ -629,8 +628,8 @@
                           )
                           (call $qa)
                           (block
-                            (set_local $41
-                              (get_local $4)
+                            (set_local $40
+                              (get_local $5)
                             )
                             (set_local $35
                               (get_local $0)
@@ -642,22 +641,22 @@
                             (i32.const 1208)
                             (i32.or
                               (get_local $0)
-                              (get_local $4)
+                              (get_local $5)
                             )
                           )
-                          (set_local $41
+                          (set_local $40
                             (i32.add
-                              (get_local $5)
+                              (get_local $4)
                               (i32.const 8)
                             )
                           )
                           (set_local $35
-                            (get_local $5)
+                            (get_local $4)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $41)
+                        (get_local $40)
                         (get_local $1)
                       )
                       (i32.store offset=12
@@ -670,7 +669,7 @@
                       )
                       (i32.store offset=12
                         (get_local $1)
-                        (get_local $5)
+                        (get_local $4)
                       )
                     )
                   )
@@ -680,7 +679,7 @@
                   )
                   (i32.store
                     (i32.const 1228)
-                    (get_local $16)
+                    (get_local $12)
                   )
                   (set_global $r
                     (get_local $25)
@@ -691,22 +690,22 @@
                 )
               )
               (if
-                (tee_local $16
+                (tee_local $12
                   (i32.load
                     (i32.const 1212)
                   )
                 )
                 (block
-                  (set_local $16
+                  (set_local $12
                     (i32.and
                       (i32.shr_u
                         (tee_local $8
                           (i32.add
                             (i32.and
-                              (get_local $16)
+                              (get_local $12)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $16)
+                                (get_local $12)
                               )
                             )
                             (i32.const -1)
@@ -721,7 +720,7 @@
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (tee_local $13
+                          (tee_local $14
                             (i32.load
                               (i32.add
                                 (i32.shl
@@ -733,10 +732,10 @@
                                             (tee_local $8
                                               (i32.and
                                                 (i32.shr_u
-                                                  (tee_local $5
+                                                  (tee_local $4
                                                     (i32.shr_u
                                                       (get_local $8)
-                                                      (get_local $16)
+                                                      (get_local $12)
                                                     )
                                                   )
                                                   (i32.const 5)
@@ -744,14 +743,14 @@
                                                 (i32.const 8)
                                               )
                                             )
-                                            (get_local $16)
+                                            (get_local $12)
                                           )
-                                          (tee_local $5
+                                          (tee_local $4
                                             (i32.and
                                               (i32.shr_u
                                                 (tee_local $1
                                                   (i32.shr_u
-                                                    (get_local $5)
+                                                    (get_local $4)
                                                     (get_local $8)
                                                   )
                                                 )
@@ -767,7 +766,7 @@
                                               (tee_local $0
                                                 (i32.shr_u
                                                   (get_local $1)
-                                                  (get_local $5)
+                                                  (get_local $4)
                                                 )
                                               )
                                               (i32.const 1)
@@ -779,7 +778,7 @@
                                       (tee_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (tee_local $4
+                                            (tee_local $5
                                               (i32.shr_u
                                                 (get_local $0)
                                                 (get_local $1)
@@ -792,7 +791,7 @@
                                       )
                                     )
                                     (i32.shr_u
-                                      (get_local $4)
+                                      (get_local $5)
                                       (get_local $0)
                                     )
                                   )
@@ -808,31 +807,31 @@
                       (get_local $3)
                     )
                   )
-                  (set_local $4
-                    (get_local $13)
+                  (set_local $5
+                    (get_local $14)
                   )
                   (set_local $1
-                    (get_local $13)
+                    (get_local $14)
                   )
                   (loop $while-in
                     (block $while-out
                       (if
-                        (tee_local $13
+                        (tee_local $14
                           (i32.load offset=16
-                            (get_local $4)
+                            (get_local $5)
                           )
                         )
                         (set_local $6
-                          (get_local $13)
+                          (get_local $14)
                         )
                         (if
-                          (tee_local $5
+                          (tee_local $4
                             (i32.load offset=20
-                              (get_local $4)
+                              (get_local $5)
                             )
                           )
                           (set_local $6
-                            (get_local $5)
+                            (get_local $4)
                           )
                           (block
                             (set_local $6
@@ -845,9 +844,9 @@
                           )
                         )
                       )
-                      (set_local $5
+                      (set_local $4
                         (i32.lt_u
-                          (tee_local $13
+                          (tee_local $14
                             (i32.sub
                               (i32.and
                                 (i32.load offset=4
@@ -863,19 +862,19 @@
                       )
                       (set_local $0
                         (select
-                          (get_local $13)
+                          (get_local $14)
                           (get_local $0)
-                          (get_local $5)
+                          (get_local $4)
                         )
                       )
-                      (set_local $4
+                      (set_local $5
                         (get_local $6)
                       )
                       (set_local $1
                         (select
                           (get_local $6)
                           (get_local $1)
-                          (get_local $5)
+                          (get_local $4)
                         )
                       )
                       (br $while-in)
@@ -895,7 +894,7 @@
                   (if
                     (i32.ge_u
                       (get_local $2)
-                      (tee_local $4
+                      (tee_local $5
                         (i32.add
                           (get_local $2)
                           (get_local $3)
@@ -921,7 +920,7 @@
                       )
                       (block
                         (if
-                          (tee_local $15
+                          (tee_local $16
                             (i32.load
                               (tee_local $9
                                 (i32.add
@@ -932,18 +931,18 @@
                             )
                           )
                           (block
-                            (set_local $13
-                              (get_local $15)
+                            (set_local $14
+                              (get_local $16)
                             )
-                            (set_local $5
+                            (set_local $4
                               (get_local $9)
                             )
                           )
                           (if
                             (i32.eqz
-                              (tee_local $13
+                              (tee_local $14
                                 (i32.load
-                                  (tee_local $5
+                                  (tee_local $4
                                     (i32.add
                                       (get_local $2)
                                       (i32.const 16)
@@ -962,42 +961,42 @@
                         )
                         (loop $while-in7
                           (if
-                            (tee_local $15
+                            (tee_local $16
                               (i32.load
                                 (tee_local $9
                                   (i32.add
-                                    (get_local $13)
+                                    (get_local $14)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $13
-                                (get_local $15)
+                              (set_local $14
+                                (get_local $16)
                               )
-                              (set_local $5
+                              (set_local $4
                                 (get_local $9)
                               )
                               (br $while-in7)
                             )
                           )
                           (if
-                            (tee_local $15
+                            (tee_local $16
                               (i32.load
                                 (tee_local $9
                                   (i32.add
-                                    (get_local $13)
+                                    (get_local $14)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $13
-                                (get_local $15)
+                              (set_local $14
+                                (get_local $16)
                               )
-                              (set_local $5
+                              (set_local $4
                                 (get_local $9)
                               )
                               (br $while-in7)
@@ -1006,17 +1005,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $5)
+                            (get_local $4)
                             (get_local $1)
                           )
                           (call $qa)
                           (block
                             (i32.store
-                              (get_local $5)
+                              (get_local $4)
                               (i32.const 0)
                             )
                             (set_local $23
-                              (get_local $13)
+                              (get_local $14)
                             )
                           )
                         )
@@ -1036,7 +1035,7 @@
                         (if
                           (i32.ne
                             (i32.load
-                              (tee_local $15
+                              (tee_local $16
                                 (i32.add
                                   (get_local $9)
                                   (i32.const 12)
@@ -1050,7 +1049,7 @@
                         (if
                           (i32.eq
                             (i32.load
-                              (tee_local $5
+                              (tee_local $4
                                 (i32.add
                                   (get_local $7)
                                   (i32.const 8)
@@ -1061,11 +1060,11 @@
                           )
                           (block
                             (i32.store
-                              (get_local $15)
+                              (get_local $16)
                               (get_local $7)
                             )
                             (i32.store
-                              (get_local $5)
+                              (get_local $4)
                               (get_local $9)
                             )
                             (set_local $23
@@ -1280,7 +1279,7 @@
                         )
                       )
                       (i32.store offset=4
-                        (get_local $4)
+                        (get_local $5)
                         (i32.or
                           (get_local $6)
                           (i32.const 1)
@@ -1288,7 +1287,7 @@
                       )
                       (i32.store
                         (i32.add
-                          (get_local $4)
+                          (get_local $5)
                           (get_local $6)
                         )
                         (get_local $6)
@@ -1329,7 +1328,7 @@
                                   (i32.const 1208)
                                 )
                               )
-                              (tee_local $5
+                              (tee_local $4
                                 (i32.shl
                                   (i32.const 1)
                                   (get_local $7)
@@ -1340,7 +1339,7 @@
                               (i32.lt_u
                                 (tee_local $9
                                   (i32.load
-                                    (tee_local $5
+                                    (tee_local $4
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 8)
@@ -1354,8 +1353,8 @@
                               )
                               (call $qa)
                               (block
-                                (set_local $42
-                                  (get_local $5)
+                                (set_local $41
+                                  (get_local $4)
                                 )
                                 (set_local $27
                                   (get_local $9)
@@ -1367,10 +1366,10 @@
                                 (i32.const 1208)
                                 (i32.or
                                   (get_local $9)
-                                  (get_local $5)
+                                  (get_local $4)
                                 )
                               )
-                              (set_local $42
+                              (set_local $41
                                 (i32.add
                                   (get_local $1)
                                   (i32.const 8)
@@ -1382,7 +1381,7 @@
                             )
                           )
                           (i32.store
-                            (get_local $42)
+                            (get_local $41)
                             (get_local $0)
                           )
                           (i32.store offset=12
@@ -1405,7 +1404,7 @@
                       )
                       (i32.store
                         (i32.const 1228)
-                        (get_local $4)
+                        (get_local $5)
                       )
                     )
                   )
@@ -1419,12 +1418,12 @@
                     )
                   )
                 )
-                (set_local $4
+                (set_local $5
                   (get_local $3)
                 )
               )
             )
-            (set_local $4
+            (set_local $5
               (get_local $3)
             )
           )
@@ -1434,7 +1433,7 @@
             (get_local $0)
             (i32.const -65)
           )
-          (set_local $4
+          (set_local $5
             (i32.const -1)
           )
           (block
@@ -1456,7 +1455,7 @@
                 )
               )
               (block
-                (set_local $5
+                (set_local $4
                   (i32.sub
                     (i32.const 0)
                     (get_local $0)
@@ -1464,7 +1463,7 @@
                 )
                 (block $label$break$a
                   (if
-                    (tee_local $16
+                    (tee_local $12
                       (i32.load
                         (i32.add
                           (i32.shl
@@ -1487,7 +1486,7 @@
                                       (i32.shr_u
                                         (get_local $0)
                                         (i32.add
-                                          (tee_local $16
+                                          (tee_local $12
                                             (i32.add
                                               (i32.sub
                                                 (i32.const 14)
@@ -1497,7 +1496,7 @@
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (tee_local $15
+                                                            (tee_local $16
                                                               (i32.shl
                                                                 (get_local $7)
                                                                 (tee_local $1
@@ -1523,13 +1522,13 @@
                                                     )
                                                     (get_local $1)
                                                   )
-                                                  (tee_local $15
+                                                  (tee_local $16
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (tee_local $13
+                                                          (tee_local $14
                                                             (i32.shl
-                                                              (get_local $15)
+                                                              (get_local $16)
                                                               (get_local $7)
                                                             )
                                                           )
@@ -1544,8 +1543,8 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $13)
-                                                  (get_local $15)
+                                                  (get_local $14)
+                                                  (get_local $16)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -1557,7 +1556,7 @@
                                       (i32.const 1)
                                     )
                                     (i32.shl
-                                      (get_local $16)
+                                      (get_local $12)
                                       (i32.const 1)
                                     )
                                   )
@@ -1572,10 +1571,10 @@
                       )
                     )
                     (block
-                      (set_local $15
-                        (get_local $5)
+                      (set_local $16
+                        (get_local $4)
                       )
-                      (set_local $13
+                      (set_local $14
                         (i32.const 0)
                       )
                       (set_local $1
@@ -1598,7 +1597,7 @@
                         )
                       )
                       (set_local $7
-                        (get_local $16)
+                        (get_local $12)
                       )
                       (set_local $8
                         (i32.const 0)
@@ -1606,7 +1605,7 @@
                       (loop $while-in14
                         (if
                           (i32.lt_u
-                            (tee_local $4
+                            (tee_local $12
                               (i32.sub
                                 (tee_local $3
                                   (i32.and
@@ -1619,7 +1618,7 @@
                                 (get_local $0)
                               )
                             )
-                            (get_local $15)
+                            (get_local $16)
                           )
                           (if
                             (i32.eq
@@ -1628,7 +1627,7 @@
                             )
                             (block
                               (set_local $29
-                                (get_local $4)
+                                (get_local $12)
                               )
                               (set_local $28
                                 (get_local $7)
@@ -1642,8 +1641,8 @@
                               (br $label$break$a)
                             )
                             (block
-                              (set_local $15
-                                (get_local $4)
+                              (set_local $16
+                                (get_local $12)
                               )
                               (set_local $8
                                 (get_local $7)
@@ -1653,18 +1652,18 @@
                         )
                         (set_local $3
                           (select
-                            (get_local $13)
-                            (tee_local $4
+                            (get_local $14)
+                            (tee_local $12
                               (i32.load offset=20
                                 (get_local $7)
                               )
                             )
                             (i32.or
                               (i32.eqz
-                                (get_local $4)
+                                (get_local $12)
                               )
                               (i32.eq
-                                (get_local $4)
+                                (get_local $12)
                                 (tee_local $7
                                   (i32.load
                                     (i32.add
@@ -1687,16 +1686,16 @@
                           )
                         )
                         (if
-                          (tee_local $4
+                          (tee_local $12
                             (i32.eqz
                               (get_local $7)
                             )
                           )
                           (block
                             (set_local $36
-                              (get_local $15)
+                              (get_local $16)
                             )
-                            (set_local $37
+                            (set_local $5
                               (get_local $3)
                             )
                             (set_local $33
@@ -1707,7 +1706,7 @@
                             )
                           )
                           (block
-                            (set_local $13
+                            (set_local $14
                               (get_local $3)
                             )
                             (set_local $1
@@ -1715,7 +1714,7 @@
                                 (get_local $1)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $4)
+                                    (get_local $12)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
@@ -1729,9 +1728,9 @@
                     )
                     (block
                       (set_local $36
-                        (get_local $5)
+                        (get_local $4)
                       )
-                      (set_local $37
+                      (set_local $5
                         (i32.const 0)
                       )
                       (set_local $33
@@ -1753,7 +1752,7 @@
                       (if i32
                         (i32.and
                           (i32.eqz
-                            (get_local $37)
+                            (get_local $5)
                           )
                           (i32.eqz
                             (get_local $33)
@@ -1762,11 +1761,11 @@
                         (block i32
                           (if
                             (i32.eqz
-                              (tee_local $5
+                              (tee_local $4
                                 (i32.and
                                   (get_local $9)
                                   (i32.or
-                                    (tee_local $16
+                                    (tee_local $12
                                       (i32.shl
                                         (i32.const 2)
                                         (get_local $27)
@@ -1774,29 +1773,29 @@
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $16)
+                                      (get_local $12)
                                     )
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $4
+                              (set_local $5
                                 (get_local $0)
                               )
                               (br $do-once)
                             )
                           )
-                          (set_local $5
+                          (set_local $4
                             (i32.and
                               (i32.shr_u
-                                (tee_local $16
+                                (tee_local $12
                                   (i32.add
                                     (i32.and
-                                      (get_local $5)
+                                      (get_local $4)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $5)
+                                        (get_local $4)
                                       )
                                     )
                                     (i32.const -1)
@@ -1815,13 +1814,13 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (tee_local $16
+                                          (tee_local $12
                                             (i32.and
                                               (i32.shr_u
                                                 (tee_local $3
                                                   (i32.shr_u
-                                                    (get_local $16)
-                                                    (get_local $5)
+                                                    (get_local $12)
+                                                    (get_local $4)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -1829,15 +1828,15 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $5)
+                                          (get_local $4)
                                         )
                                         (tee_local $3
                                           (i32.and
                                             (i32.shr_u
-                                              (tee_local $4
+                                              (tee_local $5
                                                 (i32.shr_u
                                                   (get_local $3)
-                                                  (get_local $16)
+                                                  (get_local $12)
                                                 )
                                               )
                                               (i32.const 2)
@@ -1846,12 +1845,12 @@
                                           )
                                         )
                                       )
-                                      (tee_local $4
+                                      (tee_local $5
                                         (i32.and
                                           (i32.shr_u
                                             (tee_local $8
                                               (i32.shr_u
-                                                (get_local $4)
+                                                (get_local $5)
                                                 (get_local $3)
                                               )
                                             )
@@ -1867,7 +1866,7 @@
                                           (tee_local $1
                                             (i32.shr_u
                                               (get_local $8)
-                                              (get_local $4)
+                                              (get_local $5)
                                             )
                                           )
                                           (i32.const 1)
@@ -1887,7 +1886,7 @@
                             )
                           )
                         )
-                        (get_local $37)
+                        (get_local $5)
                       )
                     )
                     (block
@@ -1939,7 +1938,7 @@
                         (get_local $29)
                       )
                     )
-                    (set_local $4
+                    (set_local $5
                       (select
                         (get_local $8)
                         (get_local $29)
@@ -1961,7 +1960,7 @@
                       )
                       (block
                         (set_local $29
-                          (get_local $4)
+                          (get_local $5)
                         )
                         (set_local $28
                           (get_local $1)
@@ -1980,7 +1979,7 @@
                       )
                       (block
                         (set_local $29
-                          (get_local $4)
+                          (get_local $5)
                         )
                         (set_local $32
                           (get_local $8)
@@ -1989,7 +1988,7 @@
                       )
                       (block
                         (set_local $18
-                          (get_local $4)
+                          (get_local $5)
                         )
                         (set_local $10
                           (get_local $8)
@@ -2034,7 +2033,7 @@
                         )
                         (call $qa)
                       )
-                      (set_local $4
+                      (set_local $5
                         (i32.load offset=24
                           (get_local $10)
                         )
@@ -2051,7 +2050,7 @@
                           )
                           (block
                             (if
-                              (tee_local $5
+                              (tee_local $4
                                 (i32.load
                                   (tee_local $3
                                     (i32.add
@@ -2062,17 +2061,17 @@
                                 )
                               )
                               (block
-                                (set_local $13
-                                  (get_local $5)
+                                (set_local $14
+                                  (get_local $4)
                                 )
                                 (set_local $1
                                   (get_local $3)
                                 )
                               )
                               (if
-                                (tee_local $13
+                                (tee_local $14
                                   (i32.load
-                                    (tee_local $16
+                                    (tee_local $12
                                       (i32.add
                                         (get_local $10)
                                         (i32.const 16)
@@ -2081,7 +2080,7 @@
                                   )
                                 )
                                 (set_local $1
-                                  (get_local $16)
+                                  (get_local $12)
                                 )
                                 (block
                                   (set_local $22
@@ -2093,19 +2092,19 @@
                             )
                             (loop $while-in20
                               (if
-                                (tee_local $5
+                                (tee_local $4
                                   (i32.load
                                     (tee_local $3
                                       (i32.add
-                                        (get_local $13)
+                                        (get_local $14)
                                         (i32.const 20)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $13
-                                    (get_local $5)
+                                  (set_local $14
+                                    (get_local $4)
                                   )
                                   (set_local $1
                                     (get_local $3)
@@ -2114,19 +2113,19 @@
                                 )
                               )
                               (if
-                                (tee_local $5
+                                (tee_local $4
                                   (i32.load
                                     (tee_local $3
                                       (i32.add
-                                        (get_local $13)
+                                        (get_local $14)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $13
-                                    (get_local $5)
+                                  (set_local $14
+                                    (get_local $4)
                                   )
                                   (set_local $1
                                     (get_local $3)
@@ -2147,7 +2146,7 @@
                                   (i32.const 0)
                                 )
                                 (set_local $22
-                                  (get_local $13)
+                                  (get_local $14)
                                 )
                               )
                             )
@@ -2167,7 +2166,7 @@
                             (if
                               (i32.ne
                                 (i32.load
-                                  (tee_local $5
+                                  (tee_local $4
                                     (i32.add
                                       (get_local $3)
                                       (i32.const 12)
@@ -2181,7 +2180,7 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (tee_local $16
+                                  (tee_local $12
                                     (i32.add
                                       (get_local $1)
                                       (i32.const 8)
@@ -2192,11 +2191,11 @@
                               )
                               (block
                                 (i32.store
-                                  (get_local $5)
+                                  (get_local $4)
                                   (get_local $1)
                                 )
                                 (i32.store
-                                  (get_local $16)
+                                  (get_local $12)
                                   (get_local $3)
                                 )
                                 (set_local $22
@@ -2210,7 +2209,7 @@
                       )
                       (block $do-once21
                         (if
-                          (get_local $4)
+                          (get_local $5)
                           (block
                             (if
                               (i32.eq
@@ -2263,7 +2262,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $4)
+                                    (get_local $5)
                                     (i32.load
                                       (i32.const 1224)
                                     )
@@ -2275,7 +2274,7 @@
                                     (i32.load
                                       (tee_local $1
                                         (i32.add
-                                          (get_local $4)
+                                          (get_local $5)
                                           (i32.const 16)
                                         )
                                       )
@@ -2287,7 +2286,7 @@
                                     (get_local $22)
                                   )
                                   (i32.store offset=20
-                                    (get_local $4)
+                                    (get_local $5)
                                     (get_local $22)
                                   )
                                 )
@@ -2311,7 +2310,7 @@
                             )
                             (i32.store offset=24
                               (get_local $22)
-                              (get_local $4)
+                              (get_local $5)
                             )
                             (if
                               (tee_local $9
@@ -2376,7 +2375,7 @@
                             (i32.store offset=4
                               (get_local $10)
                               (i32.or
-                                (tee_local $4
+                                (tee_local $5
                                   (i32.add
                                     (get_local $18)
                                     (get_local $0)
@@ -2390,7 +2389,7 @@
                                 (i32.add
                                   (i32.add
                                     (get_local $10)
-                                    (get_local $4)
+                                    (get_local $5)
                                   )
                                   (i32.const 4)
                                 )
@@ -2437,7 +2436,7 @@
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $4
+                                (set_local $5
                                   (i32.add
                                     (i32.shl
                                       (i32.shl
@@ -2469,7 +2468,7 @@
                                         (i32.load
                                           (tee_local $3
                                             (i32.add
-                                              (get_local $4)
+                                              (get_local $5)
                                               (i32.const 8)
                                             )
                                           )
@@ -2499,12 +2498,12 @@
                                     )
                                     (set_local $19
                                       (i32.add
-                                        (get_local $4)
+                                        (get_local $5)
                                         (i32.const 8)
                                       )
                                     )
                                     (set_local $6
-                                      (get_local $4)
+                                      (get_local $5)
                                     )
                                   )
                                 )
@@ -2522,17 +2521,17 @@
                                 )
                                 (i32.store offset=12
                                   (get_local $8)
-                                  (get_local $4)
+                                  (get_local $5)
                                 )
                                 (br $do-once25)
                               )
                             )
-                            (set_local $16
+                            (set_local $12
                               (i32.add
                                 (i32.shl
-                                  (tee_local $15
+                                  (tee_local $16
                                     (if i32
-                                      (tee_local $4
+                                      (tee_local $5
                                         (i32.shr_u
                                           (get_local $18)
                                           (i32.const 8)
@@ -2549,24 +2548,24 @@
                                             (i32.shr_u
                                               (get_local $18)
                                               (i32.add
-                                                (tee_local $16
+                                                (tee_local $12
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (tee_local $4
+                                                          (tee_local $5
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
                                                                   (tee_local $3
                                                                     (i32.shl
-                                                                      (get_local $4)
+                                                                      (get_local $5)
                                                                       (tee_local $1
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $4)
+                                                                              (get_local $5)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -2592,7 +2591,7 @@
                                                                 (tee_local $9
                                                                   (i32.shl
                                                                     (get_local $3)
-                                                                    (get_local $4)
+                                                                    (get_local $5)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -2619,7 +2618,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $16)
+                                            (get_local $12)
                                             (i32.const 1)
                                           )
                                         )
@@ -2634,7 +2633,7 @@
                             )
                             (i32.store offset=28
                               (get_local $8)
-                              (get_local $15)
+                              (get_local $16)
                             )
                             (i32.store offset=4
                               (tee_local $3
@@ -2660,7 +2659,7 @@
                                   (tee_local $9
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $15)
+                                      (get_local $16)
                                     )
                                   )
                                 )
@@ -2674,12 +2673,12 @@
                                   )
                                 )
                                 (i32.store
-                                  (get_local $16)
+                                  (get_local $12)
                                   (get_local $8)
                                 )
                                 (i32.store offset=24
                                   (get_local $8)
-                                  (get_local $16)
+                                  (get_local $12)
                                 )
                                 (i32.store offset=12
                                   (get_local $8)
@@ -2700,12 +2699,12 @@
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $15)
+                                      (get_local $16)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $15)
+                                    (get_local $16)
                                     (i32.const 31)
                                   )
                                 )
@@ -2713,7 +2712,7 @@
                             )
                             (set_local $3
                               (i32.load
-                                (get_local $16)
+                                (get_local $12)
                               )
                             )
                             (loop $while-in28
@@ -2741,7 +2740,7 @@
                                 (if
                                   (tee_local $1
                                     (i32.load
-                                      (tee_local $16
+                                      (tee_local $12
                                         (i32.add
                                           (i32.add
                                             (get_local $3)
@@ -2772,9 +2771,9 @@
                                   )
                                   (block
                                     (set_local $21
-                                      (get_local $16)
+                                      (get_local $12)
                                     )
-                                    (set_local $14
+                                    (set_local $15
                                       (get_local $3)
                                     )
                                     (set_local $7
@@ -2804,7 +2803,7 @@
                                   )
                                   (i32.store offset=24
                                     (get_local $8)
-                                    (get_local $14)
+                                    (get_local $15)
                                   )
                                   (i32.store offset=12
                                     (get_local $8)
@@ -2884,16 +2883,16 @@
                         )
                       )
                     )
-                    (set_local $4
+                    (set_local $5
                       (get_local $0)
                     )
                   )
-                  (set_local $4
+                  (set_local $5
                     (get_local $0)
                   )
                 )
               )
-              (set_local $4
+              (set_local $5
                 (get_local $0)
               )
             )
@@ -2908,10 +2907,10 @@
             (i32.const 1216)
           )
         )
-        (get_local $4)
+        (get_local $5)
       )
       (block
-        (set_local $14
+        (set_local $15
           (i32.load
             (i32.const 1228)
           )
@@ -2921,7 +2920,7 @@
             (tee_local $17
               (i32.sub
                 (get_local $10)
-                (get_local $4)
+                (get_local $5)
               )
             )
             (i32.const 15)
@@ -2931,8 +2930,8 @@
               (i32.const 1228)
               (tee_local $21
                 (i32.add
-                  (get_local $14)
-                  (get_local $4)
+                  (get_local $15)
+                  (get_local $5)
                 )
               )
             )
@@ -2955,9 +2954,9 @@
               (get_local $17)
             )
             (i32.store offset=4
-              (get_local $14)
+              (get_local $15)
               (i32.or
-                (get_local $4)
+                (get_local $5)
                 (i32.const 3)
               )
             )
@@ -2972,7 +2971,7 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $14)
+              (get_local $15)
               (i32.or
                 (get_local $10)
                 (i32.const 3)
@@ -2982,7 +2981,7 @@
               (tee_local $17
                 (i32.add
                   (i32.add
-                    (get_local $14)
+                    (get_local $15)
                     (get_local $10)
                   )
                   (i32.const 4)
@@ -3002,7 +3001,7 @@
         )
         (return
           (i32.add
-            (get_local $14)
+            (get_local $15)
             (i32.const 8)
           )
         )
@@ -3010,20 +3009,20 @@
     )
     (if
       (i32.gt_u
-        (tee_local $14
+        (tee_local $15
           (i32.load
             (i32.const 1220)
           )
         )
-        (get_local $4)
+        (get_local $5)
       )
       (block
         (i32.store
           (i32.const 1220)
           (tee_local $17
             (i32.sub
-              (get_local $14)
-              (get_local $4)
+              (get_local $15)
+              (get_local $5)
             )
           )
         )
@@ -3031,12 +3030,12 @@
           (i32.const 1232)
           (tee_local $10
             (i32.add
-              (tee_local $14
+              (tee_local $15
                 (i32.load
                   (i32.const 1232)
                 )
               )
-              (get_local $4)
+              (get_local $5)
             )
           )
         )
@@ -3048,9 +3047,9 @@
           )
         )
         (i32.store offset=4
-          (get_local $14)
+          (get_local $15)
           (i32.or
-            (get_local $4)
+            (get_local $5)
             (i32.const 3)
           )
         )
@@ -3059,7 +3058,7 @@
         )
         (return
           (i32.add
-            (get_local $14)
+            (get_local $15)
             (i32.const 8)
           )
         )
@@ -3097,11 +3096,11 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $12)
-          (tee_local $14
+          (get_local $13)
+          (tee_local $15
             (i32.xor
               (i32.and
-                (get_local $12)
+                (get_local $13)
                 (i32.const -16)
               )
               (i32.const 1431655768)
@@ -3110,30 +3109,30 @@
         )
         (i32.store
           (i32.const 1680)
-          (get_local $14)
+          (get_local $15)
         )
       )
     )
-    (set_local $14
+    (set_local $15
       (i32.add
-        (get_local $4)
+        (get_local $5)
         (i32.const 48)
       )
     )
     (if
       (i32.le_u
-        (tee_local $12
+        (tee_local $13
           (i32.and
             (tee_local $10
               (i32.add
-                (tee_local $12
+                (tee_local $13
                   (i32.load
                     (i32.const 1688)
                   )
                 )
                 (tee_local $17
                   (i32.add
-                    (get_local $4)
+                    (get_local $5)
                     (i32.const 47)
                   )
                 )
@@ -3142,12 +3141,12 @@
             (tee_local $21
               (i32.sub
                 (i32.const 0)
-                (get_local $12)
+                (get_local $13)
               )
             )
           )
         )
-        (get_local $4)
+        (get_local $5)
       )
       (block
         (set_global $r
@@ -3169,15 +3168,15 @@
           (i32.le_u
             (tee_local $6
               (i32.add
-                (tee_local $15
+                (tee_local $16
                   (i32.load
                     (i32.const 1640)
                   )
                 )
-                (get_local $12)
+                (get_local $13)
               )
             )
-            (get_local $15)
+            (get_local $16)
           )
           (i32.gt_u
             (get_local $6)
@@ -3222,7 +3221,7 @@
                         (block $while-out31
                           (if
                             (i32.le_u
-                              (tee_local $15
+                              (tee_local $16
                                 (i32.load
                                   (get_local $6)
                                 )
@@ -3232,7 +3231,7 @@
                             (if
                               (i32.gt_u
                                 (i32.add
-                                  (get_local $15)
+                                  (get_local $16)
                                   (i32.load
                                     (tee_local $19
                                       (i32.add
@@ -3248,7 +3247,7 @@
                                 (set_local $0
                                   (get_local $6)
                                 )
-                                (set_local $5
+                                (set_local $4
                                   (get_local $19)
                                 )
                                 (br $while-out31)
@@ -3295,7 +3294,7 @@
                                 (get_local $0)
                               )
                               (i32.load
-                                (get_local $5)
+                                (get_local $4)
                               )
                             )
                           )
@@ -3370,7 +3369,7 @@
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $12)
+                                (get_local $13)
                                 (get_local $0)
                               )
                               (i32.and
@@ -3384,7 +3383,7 @@
                                 )
                               )
                             )
-                            (get_local $12)
+                            (get_local $13)
                           )
                         )
                         (set_local $0
@@ -3401,7 +3400,7 @@
                           (i32.and
                             (i32.gt_u
                               (get_local $3)
-                              (get_local $4)
+                              (get_local $5)
                             )
                             (i32.lt_u
                               (get_local $3)
@@ -3482,7 +3481,7 @@
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $14)
+                            (get_local $15)
                             (get_local $2)
                           )
                           (i32.and
@@ -3587,7 +3586,7 @@
       )
       (if
         (i32.lt_u
-          (get_local $12)
+          (get_local $13)
           (i32.const 2147483647)
         )
         (if
@@ -3595,10 +3594,10 @@
             (i32.lt_u
               (tee_local $1
                 (call $ta
-                  (get_local $12)
+                  (get_local $13)
                 )
               )
-              (tee_local $12
+              (tee_local $13
                 (call $ta
                   (i32.const 0)
                 )
@@ -3610,7 +3609,7 @@
                 (i32.const -1)
               )
               (i32.ne
-                (get_local $12)
+                (get_local $13)
                 (i32.const -1)
               )
             )
@@ -3619,12 +3618,12 @@
             (i32.gt_u
               (tee_local $11
                 (i32.sub
-                  (get_local $12)
+                  (get_local $13)
                   (get_local $1)
                 )
               )
               (i32.add
-                (get_local $4)
+                (get_local $5)
                 (i32.const 40)
               )
             )
@@ -3696,7 +3695,7 @@
                         )
                         (tee_local $17
                           (i32.load
-                            (tee_local $12
+                            (tee_local $13
                               (i32.add
                                 (get_local $2)
                                 (i32.const 4)
@@ -3707,16 +3706,16 @@
                       )
                     )
                     (block
-                      (set_local $49
+                      (set_local $48
                         (get_local $1)
                       )
-                      (set_local $50
-                        (get_local $12)
+                      (set_local $49
+                        (get_local $13)
                       )
-                      (set_local $51
+                      (set_local $50
                         (get_local $17)
                       )
-                      (set_local $52
+                      (set_local $51
                         (get_local $2)
                       )
                       (set_local $7
@@ -3743,7 +3742,7 @@
                   (i32.eqz
                     (i32.and
                       (i32.load offset=12
-                        (get_local $52)
+                        (get_local $51)
                       )
                       (i32.const 8)
                     )
@@ -3756,14 +3755,14 @@
                       )
                       (i32.ge_u
                         (get_local $11)
-                        (get_local $49)
+                        (get_local $48)
                       )
                     )
                     (block
                       (i32.store
-                        (get_local $50)
+                        (get_local $49)
                         (i32.add
-                          (get_local $51)
+                          (get_local $50)
                           (get_local $26)
                         )
                       )
@@ -3793,7 +3792,7 @@
                           )
                         )
                       )
-                      (set_local $12
+                      (set_local $13
                         (i32.add
                           (i32.sub
                             (get_local $26)
@@ -3810,19 +3809,19 @@
                       )
                       (i32.store
                         (i32.const 1220)
-                        (get_local $12)
+                        (get_local $13)
                       )
                       (i32.store offset=4
                         (get_local $2)
                         (i32.or
-                          (get_local $12)
+                          (get_local $13)
                           (i32.const 1)
                         )
                       )
                       (i32.store offset=4
                         (i32.add
                           (get_local $2)
-                          (get_local $12)
+                          (get_local $13)
                         )
                         (i32.const 40)
                       )
@@ -3837,11 +3836,11 @@
                   )
                 )
               )
-              (set_local $13
+              (set_local $14
                 (if i32
                   (i32.lt_u
                     (get_local $20)
-                    (tee_local $12
+                    (tee_local $13
                       (i32.load
                         (i32.const 1224)
                       )
@@ -3854,10 +3853,10 @@
                     )
                     (get_local $20)
                   )
-                  (get_local $12)
+                  (get_local $13)
                 )
               )
-              (set_local $12
+              (set_local $13
                 (i32.add
                   (get_local $20)
                   (get_local $26)
@@ -3873,13 +3872,13 @@
                       (i32.load
                         (get_local $2)
                       )
-                      (get_local $12)
+                      (get_local $13)
                     )
                     (block
-                      (set_local $53
+                      (set_local $52
                         (get_local $2)
                       )
-                      (set_local $43
+                      (set_local $42
                         (get_local $2)
                       )
                       (set_local $7
@@ -3908,7 +3907,7 @@
                 (if
                   (i32.and
                     (i32.load offset=12
-                      (get_local $43)
+                      (get_local $42)
                     )
                     (i32.const 8)
                   )
@@ -3917,13 +3916,13 @@
                   )
                   (block
                     (i32.store
-                      (get_local $53)
+                      (get_local $52)
                       (get_local $20)
                     )
                     (i32.store
                       (tee_local $2
                         (i32.add
-                          (get_local $43)
+                          (get_local $42)
                           (i32.const 4)
                         )
                       )
@@ -3960,14 +3959,14 @@
                     )
                     (set_local $1
                       (i32.add
-                        (get_local $12)
+                        (get_local $13)
                         (select
                           (i32.and
                             (i32.sub
                               (i32.const 0)
                               (tee_local $2
                                 (i32.add
-                                  (get_local $12)
+                                  (get_local $13)
                                   (i32.const 8)
                                 )
                               )
@@ -3985,22 +3984,22 @@
                     (set_local $2
                       (i32.add
                         (get_local $17)
-                        (get_local $4)
+                        (get_local $5)
                       )
                     )
-                    (set_local $14
+                    (set_local $15
                       (i32.sub
                         (i32.sub
                           (get_local $1)
                           (get_local $17)
                         )
-                        (get_local $4)
+                        (get_local $5)
                       )
                     )
                     (i32.store offset=4
                       (get_local $17)
                       (i32.or
-                        (get_local $4)
+                        (get_local $5)
                         (i32.const 3)
                       )
                     )
@@ -4018,7 +4017,7 @@
                                 (i32.load
                                   (i32.const 1220)
                                 )
-                                (get_local $14)
+                                (get_local $15)
                               )
                             )
                           )
@@ -4050,7 +4049,7 @@
                                     (i32.load
                                       (i32.const 1216)
                                     )
-                                    (get_local $14)
+                                    (get_local $15)
                                   )
                                 )
                               )
@@ -4091,7 +4090,7 @@
                                     (i32.const 1)
                                   )
                                   (block i32
-                                    (set_local $5
+                                    (set_local $4
                                       (i32.and
                                         (get_local $3)
                                         (i32.const -8)
@@ -4140,7 +4139,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $21)
-                                                    (get_local $13)
+                                                    (get_local $14)
                                                   )
                                                   (call $qa)
                                                 )
@@ -4186,7 +4185,7 @@
                                                 (get_local $10)
                                                 (get_local $19)
                                               )
-                                              (set_local $44
+                                              (set_local $43
                                                 (i32.add
                                                   (get_local $10)
                                                   (i32.const 8)
@@ -4196,7 +4195,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $10)
-                                                    (get_local $13)
+                                                    (get_local $14)
                                                   )
                                                   (call $qa)
                                                 )
@@ -4213,7 +4212,7 @@
                                                     (get_local $1)
                                                   )
                                                   (block
-                                                    (set_local $44
+                                                    (set_local $43
                                                       (get_local $0)
                                                     )
                                                     (br $do-once49)
@@ -4228,7 +4227,7 @@
                                             (get_local $10)
                                           )
                                           (i32.store
-                                            (get_local $44)
+                                            (get_local $43)
                                             (get_local $21)
                                           )
                                         )
@@ -4250,7 +4249,7 @@
                                               )
                                               (block
                                                 (if
-                                                  (tee_local $15
+                                                  (tee_local $16
                                                     (i32.load
                                                       (tee_local $6
                                                         (i32.add
@@ -4267,7 +4266,7 @@
                                                   )
                                                   (block
                                                     (set_local $3
-                                                      (get_local $15)
+                                                      (get_local $16)
                                                     )
                                                     (set_local $0
                                                       (get_local $6)
@@ -4297,7 +4296,7 @@
                                                 )
                                                 (loop $while-in54
                                                   (if
-                                                    (tee_local $15
+                                                    (tee_local $16
                                                       (i32.load
                                                         (tee_local $6
                                                           (i32.add
@@ -4309,7 +4308,7 @@
                                                     )
                                                     (block
                                                       (set_local $3
-                                                        (get_local $15)
+                                                        (get_local $16)
                                                       )
                                                       (set_local $0
                                                         (get_local $6)
@@ -4318,7 +4317,7 @@
                                                     )
                                                   )
                                                   (if
-                                                    (tee_local $15
+                                                    (tee_local $16
                                                       (i32.load
                                                         (tee_local $6
                                                           (i32.add
@@ -4330,7 +4329,7 @@
                                                     )
                                                     (block
                                                       (set_local $3
-                                                        (get_local $15)
+                                                        (get_local $16)
                                                       )
                                                       (set_local $0
                                                         (get_local $6)
@@ -4342,7 +4341,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $0)
-                                                    (get_local $13)
+                                                    (get_local $14)
                                                   )
                                                   (call $qa)
                                                   (block
@@ -4364,14 +4363,14 @@
                                                         (get_local $1)
                                                       )
                                                     )
-                                                    (get_local $13)
+                                                    (get_local $14)
                                                   )
                                                   (call $qa)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (tee_local $15
+                                                      (tee_local $16
                                                         (i32.add
                                                           (get_local $6)
                                                           (i32.const 12)
@@ -4396,7 +4395,7 @@
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $15)
+                                                      (get_local $16)
                                                       (get_local $0)
                                                     )
                                                     (i32.store
@@ -4576,15 +4575,15 @@
                                         )
                                       )
                                     )
-                                    (set_local $14
+                                    (set_local $15
                                       (i32.add
-                                        (get_local $5)
-                                        (get_local $14)
+                                        (get_local $4)
+                                        (get_local $15)
                                       )
                                     )
                                     (i32.add
                                       (get_local $1)
-                                      (get_local $5)
+                                      (get_local $4)
                                     )
                                   )
                                   (get_local $1)
@@ -4602,26 +4601,26 @@
                           (i32.store offset=4
                             (get_local $2)
                             (i32.or
-                              (get_local $14)
+                              (get_local $15)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
                               (get_local $2)
-                              (get_local $14)
+                              (get_local $15)
                             )
-                            (get_local $14)
+                            (get_local $15)
                           )
                           (set_local $0
                             (i32.shr_u
-                              (get_local $14)
+                              (get_local $15)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $14)
+                              (get_local $15)
                               (i32.const 256)
                             )
                             (block
@@ -4670,10 +4669,10 @@
                                         )
                                       )
                                       (block
-                                        (set_local $45
+                                        (set_local $44
                                           (get_local $0)
                                         )
-                                        (set_local $38
+                                        (set_local $37
                                           (get_local $19)
                                         )
                                         (br $do-once59)
@@ -4689,29 +4688,29 @@
                                         (get_local $0)
                                       )
                                     )
-                                    (set_local $45
+                                    (set_local $44
                                       (i32.add
                                         (get_local $3)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $38
+                                    (set_local $37
                                       (get_local $3)
                                     )
                                   )
                                 )
                               )
                               (i32.store
-                                (get_local $45)
+                                (get_local $44)
                                 (get_local $2)
                               )
                               (i32.store offset=12
-                                (get_local $38)
+                                (get_local $37)
                                 (get_local $2)
                               )
                               (i32.store offset=8
                                 (get_local $2)
-                                (get_local $38)
+                                (get_local $37)
                               )
                               (i32.store offset=12
                                 (get_local $2)
@@ -4723,12 +4722,12 @@
                           (set_local $0
                             (i32.add
                               (i32.shl
-                                (tee_local $5
+                                (tee_local $4
                                   (block $do-once61 i32
                                     (if i32
                                       (tee_local $0
                                         (i32.shr_u
-                                          (get_local $14)
+                                          (get_local $15)
                                           (i32.const 8)
                                         )
                                       )
@@ -4737,7 +4736,7 @@
                                           (br_if $do-once61
                                             (i32.const 31)
                                             (i32.gt_u
-                                              (get_local $14)
+                                              (get_local $15)
                                               (i32.const 16777215)
                                             )
                                           )
@@ -4745,7 +4744,7 @@
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $14)
+                                              (get_local $15)
                                               (i32.add
                                                 (tee_local $6
                                                   (i32.add
@@ -4757,7 +4756,7 @@
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (tee_local $5
+                                                                  (tee_local $4
                                                                     (i32.shl
                                                                       (get_local $0)
                                                                       (tee_local $10
@@ -4783,13 +4782,13 @@
                                                           )
                                                           (get_local $10)
                                                         )
-                                                        (tee_local $5
+                                                        (tee_local $4
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
                                                                 (tee_local $0
                                                                   (i32.shl
-                                                                    (get_local $5)
+                                                                    (get_local $4)
                                                                     (get_local $19)
                                                                   )
                                                                 )
@@ -4805,7 +4804,7 @@
                                                     (i32.shr_u
                                                       (i32.shl
                                                         (get_local $0)
-                                                        (get_local $5)
+                                                        (get_local $4)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4833,7 +4832,7 @@
                           )
                           (i32.store offset=28
                             (get_local $2)
-                            (get_local $5)
+                            (get_local $4)
                           )
                           (i32.store offset=4
                             (tee_local $3
@@ -4859,7 +4858,7 @@
                                 (tee_local $6
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $5)
+                                    (get_local $4)
                                   )
                                 )
                               )
@@ -4893,18 +4892,18 @@
                           )
                           (set_local $6
                             (i32.shl
-                              (get_local $14)
+                              (get_local $15)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $5)
+                                    (get_local $4)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $5)
+                                  (get_local $4)
                                   (i32.const 31)
                                 )
                               )
@@ -4925,10 +4924,10 @@
                                     )
                                     (i32.const -8)
                                   )
-                                  (get_local $14)
+                                  (get_local $15)
                                 )
                                 (block
-                                  (set_local $39
+                                  (set_local $38
                                     (get_local $3)
                                   )
                                   (set_local $7
@@ -4938,7 +4937,7 @@
                                 )
                               )
                               (if
-                                (tee_local $5
+                                (tee_local $4
                                   (i32.load
                                     (tee_local $0
                                       (i32.add
@@ -4965,15 +4964,15 @@
                                     )
                                   )
                                   (set_local $3
-                                    (get_local $5)
+                                    (get_local $4)
                                   )
                                   (br $while-in64)
                                 )
                                 (block
-                                  (set_local $46
+                                  (set_local $45
                                     (get_local $0)
                                   )
-                                  (set_local $54
+                                  (set_local $53
                                     (get_local $3)
                                   )
                                   (set_local $7
@@ -4990,7 +4989,7 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $46)
+                                (get_local $45)
                                 (i32.load
                                   (i32.const 1224)
                                 )
@@ -4998,12 +4997,12 @@
                               (call $qa)
                               (block
                                 (i32.store
-                                  (get_local $46)
+                                  (get_local $45)
                                   (get_local $2)
                                 )
                                 (i32.store offset=24
                                   (get_local $2)
-                                  (get_local $54)
+                                  (get_local $53)
                                 )
                                 (i32.store offset=12
                                   (get_local $2)
@@ -5027,21 +5026,21 @@
                                       (i32.load
                                         (tee_local $3
                                           (i32.add
-                                            (get_local $39)
+                                            (get_local $38)
                                             (i32.const 8)
                                           )
                                         )
                                       )
                                     )
-                                    (tee_local $5
+                                    (tee_local $4
                                       (i32.load
                                         (i32.const 1224)
                                       )
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $39)
-                                    (get_local $5)
+                                    (get_local $38)
+                                    (get_local $4)
                                   )
                                 )
                                 (block
@@ -5059,7 +5058,7 @@
                                   )
                                   (i32.store offset=12
                                     (get_local $2)
-                                    (get_local $39)
+                                    (get_local $38)
                                   )
                                   (i32.store offset=24
                                     (get_local $2)
@@ -5098,7 +5097,7 @@
                     )
                     (if
                       (i32.gt_u
-                        (tee_local $14
+                        (tee_local $15
                           (i32.add
                             (get_local $2)
                             (i32.load offset=4
@@ -5110,7 +5109,7 @@
                       )
                       (block
                         (set_local $0
-                          (get_local $14)
+                          (get_local $15)
                         )
                         (br $while-out65)
                       )
@@ -5124,7 +5123,7 @@
                   (br $while-in66)
                 )
               )
-              (set_local $14
+              (set_local $15
                 (i32.add
                   (tee_local $17
                     (i32.add
@@ -5147,13 +5146,13 @@
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $14)
+                                (get_local $15)
                               )
                               (i32.const 7)
                             )
                             (i32.const 0)
                             (i32.and
-                              (get_local $14)
+                              (get_local $15)
                               (i32.const 7)
                             )
                           )
@@ -5161,7 +5160,7 @@
                       )
                       (i32.lt_u
                         (get_local $2)
-                        (tee_local $14
+                        (tee_local $15
                           (i32.add
                             (get_local $11)
                             (i32.const 16)
@@ -5178,7 +5177,7 @@
                 (tee_local $1
                   (i32.add
                     (get_local $20)
-                    (tee_local $12
+                    (tee_local $13
                       (select
                         (i32.and
                           (i32.sub
@@ -5210,7 +5209,7 @@
                       (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $12)
+                    (get_local $13)
                   )
                 )
               )
@@ -5352,7 +5351,7 @@
                       (i32.const 256)
                     )
                     (block
-                      (set_local $12
+                      (set_local $13
                         (i32.add
                           (i32.shl
                             (i32.shl
@@ -5371,7 +5370,7 @@
                               (i32.const 1208)
                             )
                           )
-                          (tee_local $5
+                          (tee_local $4
                             (i32.shl
                               (i32.const 1)
                               (get_local $1)
@@ -5382,9 +5381,9 @@
                           (i32.lt_u
                             (tee_local $3
                               (i32.load
-                                (tee_local $5
+                                (tee_local $4
                                   (i32.add
-                                    (get_local $12)
+                                    (get_local $13)
                                     (i32.const 8)
                                   )
                                 )
@@ -5396,10 +5395,10 @@
                           )
                           (call $qa)
                           (block
-                            (set_local $47
-                              (get_local $5)
+                            (set_local $46
+                              (get_local $4)
                             )
-                            (set_local $40
+                            (set_local $39
                               (get_local $3)
                             )
                           )
@@ -5409,35 +5408,35 @@
                             (i32.const 1208)
                             (i32.or
                               (get_local $3)
-                              (get_local $5)
+                              (get_local $4)
                             )
                           )
-                          (set_local $47
+                          (set_local $46
                             (i32.add
-                              (get_local $12)
+                              (get_local $13)
                               (i32.const 8)
                             )
                           )
-                          (set_local $40
-                            (get_local $12)
+                          (set_local $39
+                            (get_local $13)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $47)
+                        (get_local $46)
                         (get_local $11)
                       )
                       (i32.store offset=12
-                        (get_local $40)
+                        (get_local $39)
                         (get_local $11)
                       )
                       (i32.store offset=8
                         (get_local $11)
-                        (get_local $40)
+                        (get_local $39)
                       )
                       (i32.store offset=12
                         (get_local $11)
-                        (get_local $12)
+                        (get_local $13)
                       )
                       (br $do-once38)
                     )
@@ -5447,7 +5446,7 @@
                       (i32.shl
                         (tee_local $3
                           (if i32
-                            (tee_local $12
+                            (tee_local $13
                               (i32.shr_u
                                 (get_local $2)
                                 (i32.const 8)
@@ -5470,18 +5469,18 @@
                                             (i32.const 14)
                                             (i32.or
                                               (i32.or
-                                                (tee_local $12
+                                                (tee_local $13
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (tee_local $5
+                                                        (tee_local $4
                                                           (i32.shl
-                                                            (get_local $12)
+                                                            (get_local $13)
                                                             (tee_local $3
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
-                                                                    (get_local $12)
+                                                                    (get_local $13)
                                                                     (i32.const 1048320)
                                                                   )
                                                                   (i32.const 16)
@@ -5500,14 +5499,14 @@
                                                 )
                                                 (get_local $3)
                                               )
-                                              (tee_local $5
+                                              (tee_local $4
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
                                                       (tee_local $1
                                                         (i32.shl
-                                                          (get_local $5)
-                                                          (get_local $12)
+                                                          (get_local $4)
+                                                          (get_local $13)
                                                         )
                                                       )
                                                       (i32.const 245760)
@@ -5522,7 +5521,7 @@
                                           (i32.shr_u
                                             (i32.shl
                                               (get_local $1)
-                                              (get_local $5)
+                                              (get_local $4)
                                             )
                                             (i32.const 15)
                                           )
@@ -5556,13 +5555,13 @@
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $14)
+                    (get_local $15)
                     (i32.const 0)
                   )
                   (if
                     (i32.eqz
                       (i32.and
-                        (tee_local $5
+                        (tee_local $4
                           (i32.load
                             (i32.const 1212)
                           )
@@ -5579,7 +5578,7 @@
                       (i32.store
                         (i32.const 1212)
                         (i32.or
-                          (get_local $5)
+                          (get_local $4)
                           (get_local $1)
                         )
                       )
@@ -5621,7 +5620,7 @@
                       )
                     )
                   )
-                  (set_local $5
+                  (set_local $4
                     (i32.load
                       (get_local $0)
                     )
@@ -5632,7 +5631,7 @@
                         (i32.eq
                           (i32.and
                             (i32.load offset=4
-                              (get_local $5)
+                              (get_local $4)
                             )
                             (i32.const -8)
                           )
@@ -5640,7 +5639,7 @@
                         )
                         (block
                           (set_local $31
-                            (get_local $5)
+                            (get_local $4)
                           )
                           (set_local $7
                             (i32.const 305)
@@ -5654,7 +5653,7 @@
                             (tee_local $0
                               (i32.add
                                 (i32.add
-                                  (get_local $5)
+                                  (get_local $4)
                                   (i32.const 16)
                                 )
                                 (i32.shl
@@ -5675,17 +5674,17 @@
                               (i32.const 1)
                             )
                           )
-                          (set_local $5
+                          (set_local $4
                             (get_local $3)
                           )
                           (br $while-in70)
                         )
                         (block
-                          (set_local $48
+                          (set_local $47
                             (get_local $0)
                           )
-                          (set_local $55
-                            (get_local $5)
+                          (set_local $54
+                            (get_local $4)
                           )
                           (set_local $7
                             (i32.const 302)
@@ -5701,7 +5700,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $48)
+                        (get_local $47)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -5709,12 +5708,12 @@
                       (call $qa)
                       (block
                         (i32.store
-                          (get_local $48)
+                          (get_local $47)
                           (get_local $11)
                         )
                         (i32.store offset=24
                           (get_local $11)
-                          (get_local $55)
+                          (get_local $54)
                         )
                         (i32.store offset=12
                           (get_local $11)
@@ -5736,7 +5735,7 @@
                           (i32.ge_u
                             (tee_local $1
                               (i32.load
-                                (tee_local $5
+                                (tee_local $4
                                   (i32.add
                                     (get_local $31)
                                     (i32.const 8)
@@ -5761,7 +5760,7 @@
                             (get_local $11)
                           )
                           (i32.store
-                            (get_local $5)
+                            (get_local $4)
                             (get_local $11)
                           )
                           (i32.store offset=8
@@ -5831,7 +5830,7 @@
               )
               (loop $do-in
                 (i32.store offset=12
-                  (tee_local $12
+                  (tee_local $13
                     (i32.add
                       (i32.shl
                         (i32.shl
@@ -5843,11 +5842,11 @@
                       (i32.const 1248)
                     )
                   )
-                  (get_local $12)
+                  (get_local $13)
                 )
                 (i32.store offset=8
-                  (get_local $12)
-                  (get_local $12)
+                  (get_local $13)
+                  (get_local $13)
                 )
                 (br_if $do-in
                   (i32.ne
@@ -5866,7 +5865,7 @@
                 (tee_local $1
                   (i32.add
                     (get_local $20)
-                    (tee_local $12
+                    (tee_local $13
                       (select
                         (i32.and
                           (i32.sub
@@ -5898,7 +5897,7 @@
                       (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $12)
+                    (get_local $13)
                   )
                 )
               )
@@ -5932,7 +5931,7 @@
                 (i32.const 1220)
               )
             )
-            (get_local $4)
+            (get_local $5)
           )
           (block
             (i32.store
@@ -5940,7 +5939,7 @@
               (tee_local $31
                 (i32.sub
                   (get_local $11)
-                  (get_local $4)
+                  (get_local $5)
                 )
               )
             )
@@ -5953,7 +5952,7 @@
                       (i32.const 1232)
                     )
                   )
-                  (get_local $4)
+                  (get_local $5)
                 )
               )
             )
@@ -5967,7 +5966,7 @@
             (i32.store offset=4
               (get_local $11)
               (i32.or
-                (get_local $4)
+                (get_local $5)
                 (i32.const 3)
               )
             )
@@ -8689,23 +8688,22 @@
                     (i32.const 0)
                   )
                 )
-                (set_local $2
-                  (if i32
-                    (i32.gt_u
-                      (i32.load offset=20
-                        (get_local $1)
-                      )
-                      (i32.load offset=28
-                        (get_local $1)
-                      )
+                (if
+                  (i32.gt_u
+                    (i32.load offset=20
+                      (get_local $1)
                     )
+                    (i32.load offset=28
+                      (get_local $1)
+                    )
+                  )
+                  (set_local $2
                     (i32.or
                       (call $$a
                         (get_local $1)
                       )
                       (get_local $2)
                     )
-                    (get_local $2)
                   )
                 )
                 (if

--- a/test/passes/coalesce-locals.txt
+++ b/test/passes/coalesce-locals.txt
@@ -982,4 +982,105 @@
       )
     )
   )
+  (func $if-copy1 (type $2)
+    (local $0 i32)
+    (local $1 i32)
+    (loop $top
+      (if
+        (i32.eqz
+          (i32.const 1)
+        )
+        (set_local $0
+          (get_local $1)
+        )
+      )
+      (drop
+        (get_local $0)
+      )
+      (drop
+        (get_local $1)
+      )
+      (br $top)
+    )
+  )
+  (func $if-copy2 (type $2)
+    (local $0 i32)
+    (local $1 i32)
+    (loop $top
+      (if
+        (i32.const 1)
+        (set_local $1
+          (get_local $0)
+        )
+      )
+      (drop
+        (get_local $1)
+      )
+      (drop
+        (get_local $0)
+      )
+      (br $top)
+    )
+  )
+  (func $if-copy3 (type $2)
+    (local $0 i32)
+    (local $1 i32)
+    (loop $top
+      (if
+        (i32.const 1)
+        (set_local $0
+          (unreachable)
+        )
+      )
+      (drop
+        (get_local $0)
+      )
+      (drop
+        (get_local $1)
+      )
+      (br $top)
+    )
+  )
+  (func $if-copy4 (type $2)
+    (local $0 i32)
+    (local $1 i32)
+    (loop $top
+      (set_local $1
+        (if i32
+          (i32.const 1)
+          (unreachable)
+          (get_local $0)
+        )
+      )
+      (drop
+        (get_local $1)
+      )
+      (drop
+        (get_local $0)
+      )
+      (br $top)
+    )
+  )
+  (func $if-copy-tee (type $2)
+    (local $0 i32)
+    (local $1 i32)
+    (loop $top
+      (drop
+        (if i32
+          (i32.const 1)
+          (get_local $0)
+          (tee_local $0
+            (i32.const 2)
+          )
+        )
+      )
+      (drop
+        (get_local $0)
+      )
+      (drop
+        (get_local $1)
+      )
+      (br $top)
+    )
+  )
 )

--- a/test/passes/coalesce-locals.wast
+++ b/test/passes/coalesce-locals.wast
@@ -993,4 +993,86 @@
       )
     )
   )
+  (func $if-copy1
+    (local $x i32)
+    (local $y i32)
+    (loop $top
+      (set_local $x
+        (if i32
+          (i32.const 1)
+          (get_local $x)
+          (get_local $y)
+        )
+      )
+      (drop (get_local $x))
+      (drop (get_local $y))
+      (br $top)
+    )
+  )
+  (func $if-copy2
+    (local $x i32)
+    (local $y i32)
+    (loop $top
+      (set_local $x
+        (if i32
+          (i32.const 1)
+          (get_local $y)
+          (get_local $x)
+        )
+      )
+      (drop (get_local $x))
+      (drop (get_local $y))
+      (br $top)
+    )
+  )
+  (func $if-copy3
+    (local $x i32)
+    (local $y i32)
+    (loop $top
+      (set_local $x
+        (if i32
+          (i32.const 1)
+          (unreachable)
+          (get_local $x)
+        )
+      )
+      (drop (get_local $x))
+      (drop (get_local $y))
+      (br $top)
+    )
+  )
+  (func $if-copy4
+    (local $x i32)
+    (local $y i32)
+    (loop $top
+      (set_local $x
+        (if i32
+          (i32.const 1)
+          (unreachable)
+          (get_local $y)
+        )
+      )
+      (drop (get_local $x))
+      (drop (get_local $y))
+      (br $top)
+    )
+  )
+  (func $if-copy-tee
+    (local $x i32)
+    (local $y i32)
+    (loop $top
+      (drop
+        (tee_local $x
+          (if i32
+            (i32.const 1)
+            (get_local $x)
+            (i32.const 2)
+          )
+        )
+      )
+      (drop (get_local $x))
+      (drop (get_local $y))
+      (br $top)
+    )
+  )
 )


### PR DESCRIPTION
Optimize out local copies in an if (i.e., `set_local` of an `if` where one arm is a `get_local` of the same local). Such opportunities can arise after simplify-locals creates an if with a return value, and coalesce-locals merges the locals.

Noticed on the `corrections` benchmark.